### PR TITLE
- correction within LSMT::flushMemtable to set and deset isFlushing

### DIFF
--- a/libtidesdb.h
+++ b/libtidesdb.h
@@ -465,8 +465,6 @@ class LSMT {
         flushThread = std::thread(&LSMT::flushThreadFunc, this);
 
         stopBackgroundThreads.store(false);
-
-
     }
 
     // Destructor

--- a/tests/lsmt_flush/lsmt_flush_test.cpp
+++ b/tests/lsmt_flush/lsmt_flush_test.cpp
@@ -1,6 +1,8 @@
+#include <chrono>  // Include for std::chrono::seconds
 #include <filesystem>
 #include <iostream>
 #include <string>
+#include <thread>  // Include for std::this_thread::sleep_for
 #include <vector>
 
 #include "../../libtidesdb.h"
@@ -30,6 +32,9 @@ int main() {
             lsmTree->Put(key, value);
         }
 
+        // Sleep for a while to let the background thread complete the flush
+        std::this_thread::sleep_for(std::chrono::milliseconds(755));
+
         // Check for all 12 keys
         for (int i = 0; i < 12; i++) {
             std::vector<uint8_t> key = {
@@ -49,7 +54,7 @@ int main() {
         lsmTree->Close();
 
         // Remove the directory
-        std::filesystem::remove_all(directory);
+        // std::filesystem::remove_all(directory);
 
         return 0;
 


### PR DESCRIPTION
- correction on within LSMT::flushMemtable to use std::atomic<int32_t> isFlushing. This is to prevent multiple threads from flushing the memtable concurrently and also other operations that require the memtable.
- remove std::cout's
- formatted