### PR TITLE
bloomfilter implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ add_executable(runTests ${TEST_SRC}
         tests/put_batch.cpp
         tests/delete_batch.cpp
         tests/lsmt_log.cpp
+        tests/bloomfilter.cpp
 )
 
 # Link the test executable with Google Test and tidesdb

--- a/tests/bloomfilter.cpp
+++ b/tests/bloomfilter.cpp
@@ -1,0 +1,87 @@
+#include <gtest/gtest.h>
+
+#include "../libtidesdb.hpp"
+
+TEST(BloomFilterTest, AddAndContains) {
+    TidesDB::BloomFilter bloomFilter(1000, 3);
+
+    std::vector<uint8_t> key1 = {1, 2, 3, 4};
+    std::vector<uint8_t> key2 = {5, 6, 7, 8};
+
+    bloomFilter.add(key1);
+
+    EXPECT_TRUE(bloomFilter.contains(key1));
+    EXPECT_FALSE(bloomFilter.contains(key2));
+}
+
+TEST(BloomFilterTest, MultipleKeys) {
+    TidesDB::BloomFilter bloomFilter(1000, 3);
+
+    std::vector<uint8_t> key1 = {1, 2, 3, 4};
+    std::vector<uint8_t> key2 = {5, 6, 7, 8};
+    std::vector<uint8_t> key3 = {9, 10, 11, 12};
+
+    bloomFilter.add(key1);
+    bloomFilter.add(key2);
+
+    EXPECT_TRUE(bloomFilter.contains(key1));
+    EXPECT_TRUE(bloomFilter.contains(key2));
+    EXPECT_FALSE(bloomFilter.contains(key3));
+}
+
+TEST(BloomFilterTest, FalsePositives) {
+    TidesDB::BloomFilter bloomFilter(1000, 3);
+
+    std::vector<uint8_t> key1 = {1, 2, 3, 4};
+    std::vector<uint8_t> key2 = {5, 6, 7, 8};
+
+    bloomFilter.add(key1);
+
+    // Since Bloom filters can have false positives, we cannot assert that key2 is definitely not in
+    // the filter. Instead, we check that key1 is definitely in the filter.
+    EXPECT_TRUE(bloomFilter.contains(key1));
+}
+
+TEST(BloomFilterTest, SerializeDeserialize) {
+    TidesDB::BloomFilter bloomFilter(1000, 3);
+
+    std::vector<uint8_t> key1 = {1, 2, 3, 4};
+    std::vector<uint8_t> key2 = {5, 6, 7, 8};
+
+    bloomFilter.add(key1);
+    bloomFilter.add(key2);
+
+    std::vector<uint8_t> serializedData = bloomFilter.serialize();
+    TidesDB::BloomFilter deserializedBloomFilter =
+        TidesDB::BloomFilter::deserialize(serializedData);
+
+    EXPECT_TRUE(deserializedBloomFilter.contains(key1));
+    EXPECT_TRUE(deserializedBloomFilter.contains(key2));
+}
+
+TEST(BloomFilterTest, SerializeEmptyFilter) {
+    TidesDB::BloomFilter bloomFilter(1000, 3);
+
+    std::vector<uint8_t> serializedData = bloomFilter.serialize();
+    TidesDB::BloomFilter deserializedBloomFilter =
+        TidesDB::BloomFilter::deserialize(serializedData);
+
+    std::vector<uint8_t> key = {1, 2, 3, 4};
+    EXPECT_FALSE(deserializedBloomFilter.contains(key));
+}
+
+TEST(BloomFilterTest, SerializePartialFilter) {
+    TidesDB::BloomFilter bloomFilter(1000, 3);
+
+    std::vector<uint8_t> key1 = {1, 2, 3, 4};
+    std::vector<uint8_t> key2 = {5, 6, 7, 8};
+
+    bloomFilter.add(key1);
+
+    std::vector<uint8_t> serializedData = bloomFilter.serialize();
+    TidesDB::BloomFilter deserializedBloomFilter =
+        TidesDB::BloomFilter::deserialize(serializedData);
+
+    EXPECT_TRUE(deserializedBloomFilter.contains(key1));
+    EXPECT_FALSE(deserializedBloomFilter.contains(key2));
+}

--- a/tests/lsmt.cpp
+++ b/tests/lsmt.cpp
@@ -60,6 +60,25 @@ TEST_F(LSMTTest, CloseTest) {
     auto lsmt = TidesDB::LSMT::New(testDirectory, std::filesystem::perms::all, 1024, 10);
     std::vector<uint8_t> key = {'k', 'e', 'y'};
     std::vector<uint8_t> value = {'v', 'a', 'l', 'u', 'e'};
+    std::vector<uint8_t> key2 = {'k', 'e', 'y', '2'};
+    std::vector<uint8_t> value2 = {'v', 'a', 'l', 'u', 'e', '2'};
+
+    ASSERT_TRUE(lsmt->Put(key, value));
+    ASSERT_TRUE(lsmt->Put(key2, value2));
+    lsmt->Close();
+
+    auto lsmt2 = TidesDB::LSMT::New(testDirectory, std::filesystem::perms::all, 1024, 10);
+    auto retrievedValue = lsmt2->Get(key2);
+    ASSERT_EQ(retrievedValue, value2);
+
+    // Close the LSMT
+    lsmt2->Close();
+}
+
+TEST_F(LSMTTest, CloseTest2) {
+    auto lsmt = TidesDB::LSMT::New(testDirectory, std::filesystem::perms::all, 1024, 10);
+    std::vector<uint8_t> key = {'k', 'e', 'y'};
+    std::vector<uint8_t> value = {'v', 'a', 'l', 'u', 'e'};
 
     ASSERT_TRUE(lsmt->Put(key, value));
     lsmt->Close();

--- a/tests/pager_overflows.cpp
+++ b/tests/pager_overflows.cpp
@@ -36,8 +36,8 @@ TEST_F(PagerTest, WriteAndReadMultiplePages) {
 
 TEST_F(PagerTest, WriteAndReadWithOverflow) {
     TidesDB::Pager pager(testFileName, std::ios::out | std::ios::in | std::ios::binary);
-    std::vector<uint8_t> largeData(
-        8192, 'b');  // Page size is 4096 bytes, this will overflow to 2 pages
+    std::vector<uint8_t> largeData(8192,
+                                   'b');  // Page size is 4096 bytes, this will overflow to 2 pages
     int64_t pageNumber = pager.Write(largeData);
 
     std::vector<uint8_t> readData = pager.Read(pageNumber);

--- a/tests/sstable.cpp
+++ b/tests/sstable.cpp
@@ -25,8 +25,6 @@ TEST_F(SSTableTest, ConstructorInitializesCorrectly) {
     TidesDB::SSTable sstable(pager);
 
     EXPECT_EQ(sstable.pager, pager);
-    EXPECT_TRUE(sstable.minKey.empty());
-    EXPECT_TRUE(sstable.maxKey.empty());
 }
 
 TEST_F(SSTableTest, GetFilePathReturnsCorrectPath) {


### PR DESCRIPTION
Replacing min-max with paged bloomfilter for sstables.
- on constructing lsmt we should create log file 
- handle flush when there is only 1 key (mainly on close)
- bloomfilter implementation, the bloom filter for an sstable is stored on the inital pages of an sstable and read into memory to check existence of key