### PR TITLE
Corrections, further implementation and todo's

### DIFF
--- a/src/pager.c
+++ b/src/pager.c
@@ -195,14 +195,14 @@ bool pager_close(pager* p) {
     return true;
 }
 
-bool pager_write(pager* p, unsigned char* data, size_t data_len, unsigned int* init_page_number) {
+bool pager_write(pager* p, uint8_t* data, size_t data_len, unsigned int* init_page_number) {
     if (!p || !p->file || !p->page_locks || !data || data_len == 0) {
         return false;
     }
 
     size_t pages_needed = (data_len + PAGE_BODY - 1) / PAGE_BODY;
     size_t remaining_data = data_len;
-    unsigned char buffer[PAGE_SIZE];
+    uint8_t buffer[PAGE_SIZE];
     size_t offset = 0;
 
     long page_number = p->num_pages;  // Start from the current number of pages
@@ -281,14 +281,13 @@ bool pager_write(pager* p, unsigned char* data, size_t data_len, unsigned int* i
     return true;
 }
 
-bool pager_read(pager* p, unsigned int start_page_number, unsigned char** buffer,
-                size_t* buffer_len) {
+bool pager_read(pager* p, unsigned int start_page_number, uint8_t** buffer, size_t* buffer_len) {
     if (!p || !p->file || !p->page_locks || !buffer || !buffer_len) {
         return false;
     }
 
     size_t offset = 0;
-    unsigned char page_buffer[PAGE_SIZE];
+    uint8_t page_buffer[PAGE_SIZE];
     long page_number = start_page_number;
     size_t actual_data_len = 0;
 
@@ -310,7 +309,7 @@ bool pager_read(pager* p, unsigned int start_page_number, unsigned char** buffer
 
         size_t chunk_size = PAGE_SIZE - PAGE_HEADER;
         *buffer_len = offset + chunk_size;
-        unsigned char* new_buffer = (unsigned char*)realloc(*buffer, *buffer_len);
+        uint8_t* new_buffer = (uint8_t*)realloc(*buffer, *buffer_len);
         if (new_buffer == NULL) {
             free(*buffer);
             return false;
@@ -362,7 +361,7 @@ bool pager_cursor_next(pager_cursor* cursor) {
 
     while (cursor->page_number < (long)cursor->pager->num_pages - 1) {
         cursor->page_number++;
-        unsigned char page_buffer[PAGE_SIZE];
+        uint8_t page_buffer[PAGE_SIZE];
         pthread_rwlock_rdlock(&cursor->pager->page_locks[cursor->page_number]);
         if (fseek(cursor->pager->file, cursor->page_number * PAGE_SIZE, SEEK_SET) != 0) {
             pthread_rwlock_unlock(&cursor->pager->page_locks[cursor->page_number]);
@@ -391,7 +390,7 @@ bool pager_cursor_prev(pager_cursor* cursor) {
 
     while (cursor->page_number > 0) {
         cursor->page_number--;
-        unsigned char page_buffer[PAGE_SIZE];
+        uint8_t page_buffer[PAGE_SIZE];
         pthread_rwlock_rdlock(&cursor->pager->page_locks[cursor->page_number]);
         if (fseek(cursor->pager->file, cursor->page_number * PAGE_SIZE, SEEK_SET) != 0) {
             pthread_rwlock_unlock(&cursor->pager->page_locks[cursor->page_number]);

--- a/src/pager.h
+++ b/src/pager.h
@@ -28,6 +28,7 @@
 #include <errno.h>
 #include <pthread.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -90,7 +91,7 @@ bool pager_close(pager* p);
  * @param init_page_number the page number of the page written
  * @return bool true if the write was successful, false otherwise
  */
-bool pager_write(pager* p, unsigned char* data, size_t data_len, unsigned int* init_page_number);
+bool pager_write(pager* p, uint8_t* data, size_t data_len, unsigned int* init_page_number);
 
 /*
  * pager_read
@@ -101,8 +102,7 @@ bool pager_write(pager* p, unsigned char* data, size_t data_len, unsigned int* i
  * @param buffer_len the length of the buffer
  * @return bool true if the read was successful, false otherwise
  */
-bool pager_read(pager* p, unsigned int start_page_number, unsigned char** buffer,
-                size_t* buffer_len);
+bool pager_read(pager* p, unsigned int start_page_number, uint8_t** buffer, size_t* buffer_len);
 
 /*
  * pager_cursor_init

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -571,24 +571,4 @@ void* _compact_sstables_thread(void* arg);
  */
 sstable* _merge_sstables(sstable* sst1, sstable* sst2, column_family* cf);
 
-/*
- * _uchar_arr_to_uint8
- * unsigned char array to uint8_t array
- * @param uchar_arr the unsigned char array
- * @param length the length of the array
- * @param uint8_arr the uint8_t array
- * @return whether the conversion was successful
- */
-bool _uchar_arr_to_uint8(const unsigned char** uchar_arr, size_t* length, uint8_t** uint8_arr);
-
-/*
- * _uint8_arr_to_uchar
- * convert uint8_t array to unsigned char array
- * @param uint8_arr the uint8_t array
- * @param length the length of the array
- * @param uchar_arr the unsigned char array
- * @return whether the conversion was successful
- */
-bool _uint8_arr_to_uchar(const uint8_t** uint8_arr, size_t* length, unsigned char** uchar_arr);
-
 #endif  // TIDESDB_H

--- a/test/pager__tests.c
+++ b/test/pager__tests.c
@@ -41,13 +41,13 @@ void test_pager_write_read() {
     assert(pager_open("test.db", &p) == true);
     assert(p != NULL);
 
-    unsigned char key[] = "key";
+    uint8_t key[] = "key";
     unsigned int key_size = sizeof(key);
     unsigned int page_num = 0;
 
     assert(pager_write(p, key, key_size, &page_num) == true);
 
-    unsigned char* read_key = NULL;
+    uint8_t* read_key = NULL;
     size_t read_key_size = 0;
 
     assert(pager_read(p, page_num, &read_key, &read_key_size) == true);
@@ -67,19 +67,19 @@ void test_pager_write_reopen_read() {
     assert(pager_open("test.db", &p) == true);
     assert(p != NULL);
 
-    unsigned char key[] = "key";
+    uint8_t key[] = "key";
     unsigned int key_size = sizeof(key);
     unsigned int page_num = 0;
 
     assert(pager_write(p, key, key_size, &page_num) == true);
 
-    unsigned char key2[] = "key2";
+    uint8_t key2[] = "key2";
     unsigned int key_size2 = sizeof(key2);
     unsigned int page_num2 = 0;
 
     assert(pager_write(p, key2, key_size2, &page_num2) == true);
 
-    unsigned char* read_key = NULL;
+    uint8_t* read_key = NULL;
     size_t read_key_size = 0;
 
     assert(pager_read(p, page_num2, &read_key, &read_key_size) == true);
@@ -93,7 +93,7 @@ void test_pager_write_reopen_read() {
     // reopen
     assert(pager_open("test.db", &p) == true);
 
-    unsigned char* read_key2 = NULL;
+    uint8_t* read_key2 = NULL;
     size_t read_key_size2 = 0;
 
     assert(pager_read(p, page_num2, &read_key2, &read_key_size2) == true);
@@ -115,7 +115,7 @@ void test_pager_overflowed_write_read() {
     assert(pager_open("test.db", &p) == true);
     assert(p != NULL);
 
-    unsigned char value[] =
+    uint8_t value[] =
         "In the realm of the dark, where silence reigns, A world unseen by eyes, where logic "
         "remains. A whispering hum in the wires and boards, Where every signal is a tale that "
         "accords. It starts with a flicker, a pulse, a shift, In the lowest of levels, a binary "
@@ -151,7 +151,7 @@ void test_pager_overflowed_write_read() {
 
     assert(pager_write(p, value, value_size, &page_num) == true);
 
-    unsigned char* read_value = NULL;
+    uint8_t* read_value = NULL;
     size_t read_value_size = 0;
 
     assert(pager_read(p, page_num, &read_value, &read_value_size) == true);
@@ -173,7 +173,7 @@ void test_pager_cursor() {
     assert(pager_open("test.db", &p) == true);
     assert(p != NULL);
 
-    unsigned char value[] =
+    uint8_t value[] =
         "In the realm of the dark, where silence reigns, A world unseen by eyes, where logic "
         "remains. A whispering hum in the wires and boards, Where every signal is a tale that "
         "accords. It starts with a flicker, a pulse, a shift, In the lowest of levels, a binary "
@@ -209,7 +209,7 @@ void test_pager_cursor() {
 
     assert(pager_write(p, value, value_size, &page_num) == true);
 
-    unsigned char value2[] = "value 2";
+    uint8_t value2[] = "value 2";
     unsigned int value_size2 = sizeof(value2);
     unsigned int page_num2 = 0;
 
@@ -219,7 +219,7 @@ void test_pager_cursor() {
 
     assert(pager_cursor_init(p, &cursor) == true);
 
-    unsigned char* read_value = NULL;
+    uint8_t* read_value = NULL;
     size_t read_value_size = 0;
 
     assert(pager_read(p, page_num, &read_value, &read_value_size) == true);
@@ -255,7 +255,7 @@ void test_pager_pages_count() {
     assert(p != NULL);
 
     for (int i = 0; i < 1000; i++) {
-        unsigned char value[] = "value";
+        uint8_t value[] = "value";
         unsigned int value_size = sizeof(value);
         unsigned int page_num = 0;
 
@@ -284,7 +284,7 @@ void test_pager_pager_size() {
     assert(p != NULL);
 
     for (int i = 0; i < 1000; i++) {
-        unsigned char value[] = "value";
+        uint8_t value[] = "value";
         unsigned int value_size = sizeof(value);
         unsigned int page_num = 0;
 
@@ -313,7 +313,7 @@ void test_pager_truncate() {
     assert(p != NULL);
 
     for (int i = 0; i < 1000; i++) {
-        unsigned char value[] = "value";
+        uint8_t value[] = "value";
         unsigned int value_size = sizeof(value);
         unsigned int page_num = 0;
 

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -347,6 +347,7 @@ void test_put_flush_get() {
         assert(value_len == strlen((char*)value));
         assert(strncmp((char*)value_out, (char*)value, value_len) == 0);
 
+        free(value_out);  // Free the value_out pointer
         free(e);
         e = NULL;
     }
@@ -359,6 +360,110 @@ void test_put_flush_get() {
     printf(GREEN "test_put_flush_get passed\n" RESET);
 }
 
+// this test puts 240 key-value pairs, closes the database, reopens it, and gets the key-value pairs
+// by doing this we are testing the WAL recovery as we are not hitting the flush threshold, we are
+// replaying the WAL and populate the memtable with the key-value pairs
+void test_put_reopen_get() {
+    tidesdb_config* tdb_config = (tidesdb_config*)malloc(sizeof(tidesdb_config));
+    if (tdb_config == NULL) {
+        printf(RED "Error: Failed to allocate memory for tdb_config\n" RESET);
+        return;
+    }
+
+    tdb_config->db_path = "testdb";
+    tdb_config->compressed_wal = false;
+
+    tidesdb* tdb = NULL;
+
+    tidesdb_err* e = tidesdb_open(tdb_config, &tdb);
+    assert(e == NULL);
+    assert(tdb != NULL);
+
+    free(e);
+    e = NULL;
+
+    // Create a column family
+    e = tidesdb_create_column_family(tdb, "test_cf", 1024 * 1024, 12, 0.24f);
+    if (e != NULL) {
+        printf(RED "Error: %s\n" RESET, e->message);
+    }
+    assert(e == NULL);
+
+    free(e);
+    e = NULL;
+
+    column_family* cf = NULL;
+
+    // we should be able to get the column family
+    assert(_get_column_family(tdb, "test_cf", &cf) == 1);
+
+    // put 240 key-value pairs
+    for (int i = 0; i < 240; i++) {
+        char key[48];
+        char value[48];
+        snprintf(key, sizeof(key), "key%d", i);
+        snprintf(value, sizeof(value), "value%d", i);
+
+        e = tidesdb_put(tdb, cf->config.name, key, strlen(key), value, strlen(value), -1);
+        if (e != NULL) {
+            printf(RED "Error: %s\n" RESET, e->message);
+            break;
+        }
+
+        assert(e == NULL);
+        free(e);
+        e = NULL;
+    }
+
+    printf("done putting\n");
+
+    tidesdb_close(tdb);
+
+    e = tidesdb_open(tdb_config, &tdb);
+    if (e != NULL) {
+        printf(RED "Error: %s\n" RESET, e->message);
+    }
+
+    assert(e == NULL);
+    assert(tdb != NULL);
+
+    free(e);
+    e = NULL;
+
+    // we get the key-value pairs
+    for (int i = 0; i < 240; i++) {
+        unsigned char key[48];
+        unsigned char value[48];
+        snprintf(key, sizeof(key), "key%d", i);
+        snprintf(value, sizeof(value), "value%d", i);
+
+        size_t value_len = 0;
+        unsigned char* value_out = NULL;
+
+        e = tidesdb_get(tdb, cf->config.name, key, strlen(key), &value_out, &value_len);
+        if (e != NULL) {
+            printf(RED "Error: %s\n" RESET, e->message);
+            free(e);
+            e = NULL;
+            continue;
+        }
+
+        assert(e == NULL);
+        assert(value_len == strlen((char*)value));
+        assert(strncmp((char*)value_out, (char*)value, value_len) == 0);
+
+        free(e);
+        e = NULL;
+    }
+
+    tidesdb_close(tdb);
+    free(tdb_config);
+
+    remove_directory("testdb");
+
+    printf(GREEN "test_put_get_reopen passed\n" RESET);
+}
+
 int main(void) {
     test_open_close();
     test_create_column_family();
@@ -366,11 +471,13 @@ int main(void) {
     test_put();
     test_put_get();
     test_put_flush_get();
-    // @todo test_put_get_reopen
+    test_put_reopen_get();
     // @todo test_put_get_delete
     // @todo test_put_compact_get
     // @todo test_put_compact_get_reopen
     // @todo test_cursor
+    // @todo test_concurrent_put_get
+    // @todo test_txn_put_delete_get
 
     return 0;
 }


### PR DESCRIPTION
- test_put_flush_get correction
- adding todos to tidesdb__tests.c
- _load_column_families correction 'closedir(tdb_dir)'
- _replay_from_wal should truncate after completion
- pager to use uint8_t instead of unsigned char
- remove _uchar_arr_to_uint8, _uint8_arr_to_uchar