### PR TITLE
cmake error corrections

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(serialize_tests test/serialize__tests.c)
 add_executable(tidesdb_tests test/tidesdb__tests.c)
 
 target_link_libraries(tidesdb xxhash zstd)
+target_link_libraries(err_tests tidesdb)
 target_link_libraries(pager_tests tidesdb)
 target_link_libraries(skiplist_tests tidesdb)
 target_link_libraries(queue_tests tidesdb)

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -487,8 +487,8 @@ sstable* _merge_sstables(sstable* sst1, sstable* sst2, column_family* cf) {
 
     pager* new_pager = NULL;
     char new_sstable_name[PATH_MAX];
-    char numeric_part1[PATH_MAX];
-    char numeric_part2[PATH_MAX];
+    char numeric_part1[PATH_MAX/4];
+    char numeric_part2[PATH_MAX/4];
     _sst_extract_numeric_parts(sst1->pager->filename, numeric_part1);
     _sst_extract_numeric_parts(sst2->pager->filename, numeric_part2);
 


### PR DESCRIPTION
- new_sstable_name correction overflow
- cmake error on err__tests corrections