### PR TITLE
new id generator internal library.  This library is used for sstable …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,13 +10,13 @@ set(PROJECT_VERSION 0.1.0) # TidesDB v0.1.0 (working towards)
 find_package(zstd REQUIRED)
 
 add_library(xxhash STATIC external/xxhash.c)
-add_library(tidesdb SHARED src/tidesdb.c src/tidesdb.h src/err.c src/err.h src/pager.c src/pager.h src/skiplist.c src/skiplist.h src/queue.c src/queue.h src/bloomfilter.c src/bloomfilter.h src/serializable_structures.h src/serialize.c src/serialize.h)
+add_library(tidesdb SHARED src/tidesdb.c src/tidesdb.h src/err.c src/err.h src/pager.c src/pager.h src/skiplist.c src/skiplist.h src/queue.c src/queue.h src/bloomfilter.c src/bloomfilter.h src/serializable_structures.h src/serialize.c src/serialize.h src/id_gen.c src/id_gen.h)
 
 install(TARGETS tidesdb
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib)
 
-install(FILES src/tidesdb.h src/err.h src/pager.h src/skiplist.h src/queue.h src/bloomfilter.h external/xxhash.h src/serializable_structures.h src/serialize.h DESTINATION include)
+install(FILES src/tidesdb.h src/err.h src/pager.h src/skiplist.h src/queue.h src/bloomfilter.h external/xxhash.h src/serializable_structures.h src/serialize.h src/id_gen.h DESTINATION include)
 enable_testing()
 
 add_executable(err_tests test/err__tests.c)
@@ -25,6 +25,7 @@ add_executable(skiplist_tests test/skiplist__tests.c)
 add_executable(queue_tests test/queue__tests.c)
 add_executable(bloomfilter_tests test/bloomfilter__tests.c)
 add_executable(serialize_tests test/serialize__tests.c)
+add_executable(id_gen_tests test/id_gen__tests.c)
 add_executable(tidesdb_tests test/tidesdb__tests.c)
 
 target_link_libraries(tidesdb xxhash zstd)
@@ -34,6 +35,7 @@ target_link_libraries(skiplist_tests tidesdb)
 target_link_libraries(queue_tests tidesdb)
 target_link_libraries(bloomfilter_tests tidesdb xxhash)
 target_link_libraries(serialize_tests tidesdb)
+target_link_libraries(id_gen_tests tidesdb)
 target_link_libraries(tidesdb_tests tidesdb xxhash zstd)
 
 add_test(NAME err_tests COMMAND err_tests)
@@ -42,6 +44,7 @@ add_test(NAME skiplist_tests COMMAND skiplist_tests)
 add_test(NAME queue_tests COMMAND queue_tests)
 add_test(NAME bloomfilter_tests COMMAND bloomfilter_tests)
 add_test(NAME serialize_tests COMMAND serialize_tests)
+add_test(NAME id_gen_tests COMMAND id_gen_tests)
 add_test(NAME tidesdb_test COMMAND tidesdb_tests)
 
 include(CMakePackageConfigHelpers)

--- a/src/bloomfilter.c
+++ b/src/bloomfilter.c
@@ -48,7 +48,8 @@ bloomfilter *bloomfilter_create(unsigned int size)
 
 void bloomfilter_destroy(bloomfilter *bf)
 {
-    while (bf != NULL) {
+    while (bf != NULL)
+    {
         bloomfilter *next = bf->next;
         free(bf);
         bf = next;

--- a/src/err.h
+++ b/src/err.h
@@ -49,4 +49,4 @@ tidesdb_err* tidesdb_err_new(int code, char* message);
  */
 void tidesdb_err_free(tidesdb_err* e);
 
-#endif  /* TIDESDB_ERR_H */
+#endif /* TIDESDB_ERR_H */

--- a/src/id_gen.c
+++ b/src/id_gen.c
@@ -1,0 +1,65 @@
+/*
+ *
+ * Copyright (C) TidesDB
+ *
+ * Original Author: Alex Gaetano Padula
+ *
+ * Licensed under the Mozilla Public License, v. 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.mozilla.org/en-US/MPL/2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "id_gen.h"
+
+id_gen* id_gen_init(uint64_t seed)
+{
+    id_gen* gen = malloc(sizeof(id_gen)); /* allocate memory for the id generator */
+    /* check if successful */
+    if (gen == NULL)
+    {
+        return NULL;
+    }
+    /* set the state of the id generator */
+    gen->state = seed;
+
+    /* initialize the lock for the id generator */
+    pthread_mutex_init(&gen->lock, NULL);
+    return gen;
+}
+
+uint64_t id_gen_new(id_gen* gen)
+{
+    uint64_t id; /* the new id */
+
+    /* Define the constants for the LCG */
+    const uint64_t m = 9223372036854775808ULL; /* 2^63 */
+    const uint64_t a = 6364136223846793005ULL;
+    const uint64_t c = 1;
+
+    /* lock the id generator */
+    pthread_mutex_lock(&gen->lock);
+
+    /* generate a new id using the LCG formula */
+    gen->state = (a * gen->state + c) % m;
+    id = gen->state;
+
+    /* unlock the id generator */
+    pthread_mutex_unlock(&gen->lock);
+
+    return id;
+}
+
+void id_gen_destroy(id_gen* gen)
+{
+    /* destroy the lock */
+    pthread_mutex_destroy(&gen->lock);
+    /* free the memory allocated for the id generator */
+    free(gen);
+}

--- a/src/id_gen.h
+++ b/src/id_gen.h
@@ -1,0 +1,59 @@
+/*
+ *
+ * Copyright (C) TidesDB
+ *
+ * Original Author: Alex Gaetano Padula
+ *
+ * Licensed under the Mozilla Public License, v. 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.mozilla.org/en-US/MPL/2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef ID_GEN_H
+#define ID_GEN_H
+
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+/* id_gen
+ * generates unique ids
+ * @param state the state of the id generator
+ * @param lock the lock for the id generator
+ */
+typedef struct
+{
+    uint64_t state;
+    pthread_mutex_t lock;
+} id_gen;
+
+/* id_gen_init
+ * creates a new id generator
+ * @param seed the seed for the id generator
+ * @return the new id generator
+ */
+id_gen* id_gen_init(uint64_t seed);
+
+/* id_gen_new
+ * generates a new id
+ * @param gen the id generator
+ * @return the new id
+ */
+uint64_t id_gen_new(id_gen* gen);
+
+/* id_gen_destroy
+ * destroys the id generator
+ * @param gen the id generator
+ */
+void id_gen_destroy(id_gen* gen);
+
+#endif /* ID_GEN_H */

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -30,6 +30,7 @@
 
 #include "bloomfilter.h"
 #include "err.h"
+#include "id_gen.h"
 #include "pager.h"
 #include "queue.h"
 #include "serialize.h"
@@ -86,6 +87,7 @@ typedef struct
  * @param num_sstables the number of sstables for the column family
  * @param sstables_lock Read-write lock for SSTables mainly for when adding a new sstable
  * @param memtable the memtable for the column family
+ * @param id_gen id generator for the column family; mainly used for sstable filenames
  */
 typedef struct
 {
@@ -96,6 +98,7 @@ typedef struct
     pthread_rwlock_t
         sstables_lock;  /* Read-write lock for SSTables mainly for when adding a new sstable */
     skiplist* memtable; /* the memtable for the column family */
+    id_gen* id_gen;     /* id generator for the column family; mainly used for sstable filenames */
 } column_family;
 
 /*

--- a/test/id_gen__tests.c
+++ b/test/id_gen__tests.c
@@ -1,0 +1,86 @@
+/*
+ *
+ * Copyright (C) TidesDB
+ *
+ * Original Author: Alex Gaetano Padula
+ *
+ * Licensed under the Mozilla Public License, v. 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.mozilla.org/en-US/MPL/2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <assert.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "../src/id_gen.h"
+#include "test_macros.h"
+
+void test_id_gen_init()
+{
+    id_gen* gen = id_gen_init(12345);
+    assert(gen != NULL);
+    assert(gen->state == 12345);
+    id_gen_destroy(gen);
+
+    printf(GREEN "test_id_gen_init passed\n" RESET);
+}
+
+void test_id_gen_new()
+{
+    id_gen* gen = id_gen_init(12345);
+    uint64_t id1 = id_gen_new(gen);
+    uint64_t id2 = id_gen_new(gen);
+    assert(id1 != id2);
+    id_gen_destroy(gen);
+
+    printf(GREEN "test_id_gen_new passed\n" RESET);
+}
+
+/* helper */
+void* generate_ids(void* arg)
+{
+    id_gen* gen = (id_gen*)arg;
+    for (int i = 0; i < 10; ++i)
+    {
+        uint64_t id = id_gen_new(gen);
+        printf("Generated ID: %llu\n", id);
+    }
+    return NULL;
+}
+
+void test_id_gen_thread_safety()
+{
+    id_gen* gen = id_gen_init(12345);
+    pthread_t threads[4];
+
+    for (int i = 0; i < 4; ++i)
+    {
+        pthread_create(&threads[i], NULL, generate_ids, gen);
+    }
+
+    for (int i = 0; i < 4; ++i)
+    {
+        pthread_join(threads[i], NULL);
+    }
+
+    id_gen_destroy(gen);
+
+    printf(GREEN "test_id_gen_thread_safety passed\n" RESET);
+}
+
+int main(void)
+{
+    test_id_gen_init();
+    test_id_gen_new();
+    test_id_gen_thread_safety();
+    return 0;
+}

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -334,7 +334,6 @@ void test_put_flush_get()
             tidesdb_err_free(e);
             break;
         }
-
     }
 
     sleep(3); /* wait for the SST file to be written */


### PR DESCRIPTION
New id generator internal library.  This library is used for sstable filenames mainly on flush and compaction.  I have also implemented into TidesDB source code to supercede the implementation before where we concatenated pretty much and used sstable array size for name.  

The id generator is concurrent safe, not that we can do much on flush and compaction currently but we could down the line.  