### PR TITLE
Corrections tidesdb.c, and tidesdb__tests

### DIFF
--- a/src/bloomfilter.c
+++ b/src/bloomfilter.c
@@ -54,6 +54,8 @@ void bloomfilter_destroy(bloomfilter *bf)
         free(bf);
         bf = next;
     }
+
+    bf = NULL;
 }
 
 bool bloomfilter_check(bloomfilter *bf, const unsigned char *data, unsigned int data_len)


### PR DESCRIPTION
- _get_column_family additional to check for column family name
- test_put_reopen_get
- test_txn_put_delete_get correction
- tidesdb_txn_free corrections
- test_concurrent_put_get correction. get_thread should keep retrying until put thread completes its work.
