### PR TITLE
Sanitizer run corrections and start of windows support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,12 +12,18 @@ find_package(zstd REQUIRED)
 add_library(xxhash STATIC external/xxhash.c)
 add_library(tidesdb SHARED src/tidesdb.c src/tidesdb.h src/err.c src/err.h src/pager.c src/pager.h src/skiplist.c src/skiplist.h src/queue.c src/queue.h src/bloomfilter.c src/bloomfilter.h src/serializable_structures.h src/serialize.c src/serialize.h src/id_gen.c src/id_gen.h)
 
+
+
 install(TARGETS tidesdb
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib)
 
+
+
 install(FILES src/tidesdb.h src/err.h src/pager.h src/skiplist.h src/queue.h src/bloomfilter.h external/xxhash.h src/serializable_structures.h src/serialize.h src/id_gen.h DESTINATION include)
 enable_testing()
+
+
 
 add_executable(err_tests test/err__tests.c)
 add_executable(pager_tests test/pager__tests.c)

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ It is not a full-featured database, but rather a library that can be used to bui
 | 1064       | Key has a tombstone value.  To be deleted on next compaction         |
 | 1065       | Key has expired.  To be deleted on next compaction                   |
 | 1066       | Key's value cannot be a tombstone                                    |
+| 1067       | Failed to allocate memory for wal                                    |
 ```
 
 ## License

--- a/src/bloomfilter.c
+++ b/src/bloomfilter.c
@@ -51,6 +51,13 @@ void bloomfilter_destroy(bloomfilter *bf)
     while (bf != NULL)
     {
         bloomfilter *next = bf->next;
+
+        if (bf->set != NULL)
+        {
+            free(bf->set);
+            bf->set = NULL;
+        }
+
         free(bf);
         bf = next;
     }

--- a/src/bloomfilter.h
+++ b/src/bloomfilter.h
@@ -25,7 +25,6 @@
 #include <string.h>
 
 #include "../external/xxhash.h"
-#include "endian.h"
 
 /* we define the bloomfilter struct here so
  * we can use it in the struct definition for the next member */

--- a/src/id_gen.h
+++ b/src/id_gen.h
@@ -19,11 +19,15 @@
 #ifndef ID_GEN_H
 #define ID_GEN_H
 
+#if defined(_WIN32) || defined(_WIN64)
+#include <windows.h>
+#elif __linux__ || defined(__unix__) || defined(__APPLE__)
 #include <pthread.h>
+#endif
+
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <time.h>
 
 #define M ((uint64_t)9223372036854775808ULL) /* 2^63 */
 #define A ((uint64_t)6364136223846793005ULL)
@@ -34,11 +38,19 @@
  * @param state the state of the id generator
  * @param lock the lock for the id generator
  */
+#if defined(_WIN32) || defined(_WIN64)
+typedef struct
+{
+    uint64_t state;
+    CRITICAL_SECTION lock;
+} id_gen;
+#elif __linux__ || defined(__unix__) || defined(__APPLE__)
 typedef struct
 {
     uint64_t state;
     pthread_mutex_t lock;
 } id_gen;
+#endif
 
 /* id_gen_init
  * creates a new id generator

--- a/src/pager.c
+++ b/src/pager.c
@@ -153,6 +153,9 @@ bool pager_close(pager* p)
     /* we close the file */
     if (fclose(p->file) != 0) return false;
 
+    /* free filename */
+    free(p->filename);
+
     /* we destroy the file lock */
     if (pthread_rwlock_destroy(&p->file_lock) != 0) return false;
 

--- a/src/queue.c
+++ b/src/queue.c
@@ -18,6 +18,19 @@
  */
 #include "queue.h"
 
+#if defined(_WIN32) || defined(_WIN64)
+queue *queue_new()
+{
+    queue *q = malloc(sizeof(queue));
+    if (q == NULL) return NULL;
+
+    q->head = NULL;
+    q->tail = NULL;
+    q->size = 0;
+    InitializeCriticalSection(&q->lock);
+    return q;
+}
+#elif __linux__ || defined(__unix__) || defined(__APPLE__)
 queue *queue_new()
 {
     queue *q = malloc(sizeof(queue));
@@ -29,7 +42,34 @@ queue *queue_new()
     pthread_rwlock_init(&q->lock, NULL);
     return q;
 }
+#endif
 
+#if defined(_WIN32) || defined(_WIN64)
+bool queue_enqueue(queue *q, void *data)
+{
+    queue_node *new_node = malloc(sizeof(queue_node));
+    if (new_node == NULL) return false;
+
+    new_node->data = data;
+    new_node->next = NULL;
+
+    EnterCriticalSection(&q->lock);
+    if (q->tail == NULL)
+    {
+        q->head = new_node;
+        q->tail = new_node;
+    }
+    else
+    {
+        q->tail->next = new_node;
+        q->tail = new_node;
+    }
+    q->size++;
+    LeaveCriticalSection(&q->lock);
+
+    return true;
+}
+#elif __linux__ || defined(__unix__) || defined(__APPLE__)
 bool queue_enqueue(queue *q, void *data)
 {
     queue_node *new_node = malloc(sizeof(queue_node));
@@ -54,7 +94,31 @@ bool queue_enqueue(queue *q, void *data)
 
     return true;
 }
+#endif
 
+#if defined(_WIN32) || defined(_WIN64)
+void *queue_dequeue(queue *q)
+{
+    EnterCriticalSection(&q->lock);
+    if (q->head == NULL)
+    {
+        LeaveCriticalSection(&q->lock);
+        return NULL;
+    }
+
+    queue_node *node = q->head;
+    void *data = node->data;
+    q->head = q->head->next;
+
+    if (q->head == NULL) q->tail = NULL;
+
+    q->size--;
+    LeaveCriticalSection(&q->lock);
+
+    free(node);
+    return data;
+}
+#elif __linux__ || defined(__unix__) || defined(__APPLE__)
 void *queue_dequeue(queue *q)
 {
     pthread_rwlock_wrlock(&q->lock);
@@ -76,7 +140,17 @@ void *queue_dequeue(queue *q)
     free(node);
     return data;
 }
+#endif
 
+#if defined(_WIN32) || defined(_WIN64)
+size_t queue_size(queue *q)
+{
+    EnterCriticalSection(&q->lock);
+    size_t size = q->size;
+    LeaveCriticalSection(&q->lock);
+    return size;
+}
+#elif __linux__ || defined(__unix__) || defined(__APPLE__)
 size_t queue_size(queue *q)
 {
     pthread_rwlock_rdlock(&q->lock);
@@ -84,6 +158,7 @@ size_t queue_size(queue *q)
     pthread_rwlock_unlock(&q->lock);
     return size;
 }
+#endif
 
 void free_queue_node(queue_node *node)
 {
@@ -93,6 +168,25 @@ void free_queue_node(queue_node *node)
     node = NULL;
 }
 
+#if defined(_WIN32) || defined(_WIN64)
+void queue_destroy(queue *q)
+{
+    EnterCriticalSection(&q->lock);
+    queue_node *current = q->head;
+
+    while (current != NULL)
+    {
+        queue_node *next = current->next;
+        free_queue_node(current);
+        current = next;
+    }
+
+    LeaveCriticalSection(&q->lock);
+    DeleteCriticalSection(&q->lock);
+    free(q);
+    q = NULL;
+}
+#elif __linux__ || defined(__unix__) || defined(__APPLE__)
 void queue_destroy(queue *q)
 {
     pthread_rwlock_wrlock(&q->lock);
@@ -110,3 +204,4 @@ void queue_destroy(queue *q)
     free(q);
     q = NULL;
 }
+#endif

--- a/src/queue.h
+++ b/src/queue.h
@@ -18,7 +18,12 @@
  */
 #ifndef QUEUE_H
 #define QUEUE_H
+
+#if defined(_WIN32) || defined(_WIN64)
+#include <windows.h>
+#elif __linux__ || defined(__unix__) || defined(__APPLE__)
 #include <pthread.h>
+#endif
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdlib.h>
@@ -45,6 +50,15 @@ struct queue_node
  * @param size size of queue
  * @param lock rw lock for queue
  */
+#if defined(_WIN32) || defined(_WIN64)
+typedef struct queue
+{
+    queue_node *head;      /* head of queue */
+    queue_node *tail;      /* tail of queue */
+    size_t size;           /* size of queue */
+    CRITICAL_SECTION lock; /* rw lock for queue */
+} queue;
+#elif __linux__ || defined(__unix__) || defined(__APPLE__)
 typedef struct queue
 {
     queue_node *head;      /* head of queue */
@@ -52,6 +66,7 @@ typedef struct queue
     size_t size;           /* size of queue */
     pthread_rwlock_t lock; /* rw lock for queue */
 } queue;
+#endif
 
 /*
  * queue_new

--- a/src/serializable_structures.h
+++ b/src/serializable_structures.h
@@ -19,7 +19,6 @@
 #ifndef SERIALIZABLE_STRUCTURES_H
 #define SERIALIZABLE_STRUCTURES_H
 #include <stdbool.h>
-#include <time.h>
 
 /*
  * OP_CODE

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -238,7 +238,7 @@ tidesdb_err* tidesdb_close(tidesdb* tdb);
  * @return error or NULL
  */
 tidesdb_err* tidesdb_create_column_family(tidesdb* tdb, const char* name, int flush_threshold,
-                                          int max_level, float probability);
+                                          int max_level, float probability, bool compressed);
 
 /*
  * tidesdb_drop_column_family
@@ -426,7 +426,7 @@ tidesdb_err* tidesdb_cursor_free(tidesdb_cursor* cursor);
  * @return whether the column family was created
  */
 bool _new_column_family(const char* db_path, const char* name, int flush_threshold, int max_level,
-                        float probability, column_family** cf);
+                        float probability, column_family** cf, bool compressed);
 
 /*
  * _add_column_family
@@ -586,5 +586,12 @@ void* _compact_sstables_thread(void* arg);
  * @param cf the column family
  */
 sstable* _merge_sstables(sstable* sst1, sstable* sst2, column_family* cf);
+
+/*
+ * _free_column_families
+ * free the memory for the column families
+ * @param tdb the TidesDB instance
+ */
+void _free_column_families(tidesdb* tdb);
 
 #endif /* TIDESDB_H */

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -37,7 +37,10 @@ void test_open_close()
     tidesdb* tdb = NULL;
 
     tidesdb_err* e = tidesdb_open(tdb_config, &tdb);
-    if (e != NULL) printf(RED "Error: %s\n" RESET, e->message);
+    if (e != NULL)
+    {
+        printf(RED "Error: %s\n" RESET, e->message);
+    }
 
     assert(e == NULL);
 
@@ -53,6 +56,8 @@ void test_open_close()
     tidesdb_err_free(e);
 
     remove_directory("testdb");
+
+    free(tdb_config);
 
     printf(GREEN "test_open_close passed\n" RESET);
 }
@@ -81,7 +86,7 @@ void test_create_column_family()
     tidesdb_err_free(e);
 
     /* create a column family */
-    e = tidesdb_create_column_family(tdb, "test_cf", 1024 * 1024, 12, 0.24f);
+    e = tidesdb_create_column_family(tdb, "test_cf", 1024 * 1024, 12, 0.24f, false);
     if (e != NULL) printf(RED "Error: %s\n" RESET, e->message);
 
     assert(e == NULL);
@@ -97,6 +102,8 @@ void test_create_column_family()
     if (e != NULL) printf(RED "Error: %s\n" RESET, e->message);
 
     tidesdb_err_free(e);
+
+    free(tdb_config);
 
     remove_directory("testdb");
 
@@ -127,7 +134,7 @@ void test_drop_column_family()
     tidesdb_err_free(e);
 
     /* create a column family */
-    e = tidesdb_create_column_family(tdb, "test_cf", 1024 * 1024, 12, 0.24f);
+    e = tidesdb_create_column_family(tdb, "test_cf", 1024 * 1024, 12, 0.24f, false);
     if (e != NULL) printf(RED "Error: %s\n" RESET, e->message);
 
     assert(e == NULL);
@@ -157,6 +164,8 @@ void test_drop_column_family()
 
     remove_directory("testdb");
 
+    free(tdb_config);
+
     printf(GREEN "test_drop_column_family passed\n" RESET);
 }
 
@@ -184,7 +193,7 @@ void test_put()
     tidesdb_err_free(e);
 
     /* create a column family */
-    e = tidesdb_create_column_family(tdb, "test_cf", 1024 * 1024, 12, 0.24f);
+    e = tidesdb_create_column_family(tdb, "test_cf", 1024 * 1024, 12, 0.24f, false);
     if (e != NULL) printf(RED "Error: %s\n" RESET, e->message);
 
     assert(e == NULL);
@@ -222,6 +231,8 @@ void test_put()
 
     remove_directory("testdb");
 
+    free(tdb_config);
+
     printf(GREEN "test_put passed\n" RESET);
 }
 
@@ -246,7 +257,7 @@ void test_put_get()
     tidesdb_err_free(e);
 
     /* create a column family */
-    e = tidesdb_create_column_family(tdb, "test_cf", 1024 * 1024, 12, 0.24f);
+    e = tidesdb_create_column_family(tdb, "test_cf", 1024 * 1024, 12, 0.24f, false);
     if (e != NULL) printf(RED "Error: %s\n" RESET, e->message);
 
     assert(e == NULL);
@@ -329,7 +340,7 @@ void test_put_flush_get()
     tidesdb_err_free(e);
 
     /* create a column family */
-    e = tidesdb_create_column_family(tdb, "test_cf", 1024 * 1024, 12, 0.24f);
+    e = tidesdb_create_column_family(tdb, "test_cf", 1024 * 1024, 12, 0.24f, false);
     if (e != NULL) printf(RED "Error: %s\n" RESET, e->message);
 
     assert(e == NULL);
@@ -430,7 +441,7 @@ void test_put_reopen_get()
     e = NULL;
 
     /* create a column family */
-    e = tidesdb_create_column_family(tdb, "test_cf", 1024 * 1024, 12, 0.24f);
+    e = tidesdb_create_column_family(tdb, "test_cf", 1024 * 1024, 12, 0.24f, false);
     if (e != NULL) printf(RED "Error: %s\n" RESET, e->message);
 
     assert(e == NULL);
@@ -539,7 +550,7 @@ void test_put_get_delete()
     tidesdb_err_free(e);
 
     /* create a column family */
-    e = tidesdb_create_column_family(tdb, "test_cf", 1024 * 1024, 12, 0.24f);
+    e = tidesdb_create_column_family(tdb, "test_cf", 1024 * 1024, 12, 0.24f, false);
     if (e != NULL) printf(RED "Error: %s\n" RESET, e->message);
 
     assert(e == NULL);
@@ -640,7 +651,7 @@ void test_txn_put_delete_get()
     tidesdb_err_free(e);
 
     /* create a column family */
-    e = tidesdb_create_column_family(tdb, "test_cf", 1024 * 1024, 12, 0.24f);
+    e = tidesdb_create_column_family(tdb, "test_cf", 1024 * 1024, 12, 0.24f, false);
     if (e != NULL) printf(RED "Error: %s\n" RESET, e->message);
 
     assert(e == NULL);
@@ -766,7 +777,7 @@ void test_put_compact()
     tidesdb_err_free(e);
 
     /* create a column family */
-    e = tidesdb_create_column_family(tdb, "test_cf", 1024 * 1024, 12, 0.24f);
+    e = tidesdb_create_column_family(tdb, "test_cf", 1024 * 1024, 12, 0.24f, false);
     if (e != NULL) printf(RED "Error: %s\n" RESET, e->message);
 
     assert(e == NULL);
@@ -841,7 +852,7 @@ void test_put_compact_get()
     tidesdb_err_free(e);
 
     /* create a column family */
-    e = tidesdb_create_column_family(tdb, "test_cf", 1024 * 1024, 12, 0.24f);
+    e = tidesdb_create_column_family(tdb, "test_cf", 1024 * 1024, 12, 0.24f, false);
     if (e != NULL) printf(RED "Error: %s\n" RESET, e->message);
 
     assert(e == NULL);
@@ -935,7 +946,7 @@ void test_put_compact_get_reopen()
     tidesdb_err_free(e);
 
     /* create a column family */
-    e = tidesdb_create_column_family(tdb, "test_cf", 1024 * 1024, 12, 0.24f);
+    e = tidesdb_create_column_family(tdb, "test_cf", 1024 * 1024, 12, 0.24f, false);
     if (e != NULL) printf(RED "Error: %s\n" RESET, e->message);
 
     assert(e == NULL);
@@ -1118,7 +1129,7 @@ void test_concurrent_put_get()
     tidesdb_err_free(e);
 
     /* create a column family */
-    e = tidesdb_create_column_family(tdb, "test_cf", 1024 * 1024, 12, 0.24f);
+    e = tidesdb_create_column_family(tdb, "test_cf", 1024 * 1024, 12, 0.24f, false);
     if (e != NULL) printf(RED "Error: %s\n" RESET, e->message);
 
     assert(e == NULL);
@@ -1169,7 +1180,7 @@ void test_cursor()
     tidesdb_err_free(e);
 
     /* create a column family */
-    e = tidesdb_create_column_family(tdb, "test_cf", 1024 * 1024, 12, 0.24f);
+    e = tidesdb_create_column_family(tdb, "test_cf", 1024 * 1024, 12, 0.24f, false);
     if (e != NULL)
     {
         printf(RED "Error: %s\n" RESET, e->message);
@@ -1313,6 +1324,7 @@ void test_cursor()
     printf(GREEN "test_cursor passed\n" RESET);
 }
 
+/** OR cc -g3 -fsanitize=address,undefined src/*.c external/*.c test/tidesdb__tests.c -lzstd **/
 int main(void)
 {
     test_open_close();


### PR DESCRIPTION
- tidesdb_open better memory handling after running LeakSanitizer on tidesdb_open
- split logic for freeing column families into _free_column_families
- windows support on id_gen library
- windows support on queue library
- _open_wal remove useless reallocation causing sanitization error
- pager_close correction to free filename causing sanitization error
- tidesdb__tests memory leak corrections based on LeakSanitizer
- tidesdb_create_column_family correction, adding compressed bool arg
- _new_column_family adding compressed arg