### PR TITLE
Serialization reformating, bloom filter corrections, test corrections, fsanitize passing across all tests but tidesdb__tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ It is not a full-featured database, but rather a library that can be used to bui
 - [x] **Configurable** many options are configurable for the engine, and column families.
 - [x] **Error Handling** majority of functions return an error code.
 - [x] **Easy API** simple and easy to use api.
+
 ## Errors
 ```
 | Error Code | Error Message                                                        |

--- a/src/bloomfilter.c
+++ b/src/bloomfilter.c
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 #include "bloomfilter.h"
-
 unsigned int hash1(const unsigned char *data, unsigned int data_len)
 {
     return XXH32(data, data_len, 0);
@@ -61,8 +60,6 @@ void bloomfilter_destroy(bloomfilter *bf)
         free(bf);
         bf = next;
     }
-
-    bf = NULL;
 }
 
 bool bloomfilter_check(bloomfilter *bf, const unsigned char *data, unsigned int data_len)
@@ -72,8 +69,8 @@ bool bloomfilter_check(bloomfilter *bf, const unsigned char *data, unsigned int 
 
     while (bf != NULL)
     {
-        if ((bf->set[hash_value1 % bf->size / 8] & (1 << (hash_value1 % 8))) &&
-            (bf->set[hash_value2 % bf->size / 8] & (1 << (hash_value2 % 8))))
+        if ((bf->set[(hash_value1 % bf->size) / 8] & (1 << (hash_value1 % 8))) &&
+            (bf->set[(hash_value2 % bf->size) / 8] & (1 << (hash_value2 % 8))))
         {
             return true;
         }
@@ -110,8 +107,8 @@ int bloomfilter_add(bloomfilter *bf, const unsigned char *data, unsigned int dat
         current = new_bf;
     }
 
-    current->set[hash_value1 % current->size / 8] |= (1 << (hash_value1 % 8));
-    current->set[hash_value2 % current->size / 8] |= (1 << (hash_value2 % 8));
+    current->set[(hash_value1 % current->size) / 8] |= (1 << (hash_value1 % 8));
+    current->set[(hash_value2 % current->size) / 8] |= (1 << (hash_value2 % 8));
     current->count++;
 
     return 0;

--- a/test/bloomfilter__tests.c
+++ b/test/bloomfilter__tests.c
@@ -121,6 +121,7 @@ void test_bloomfilter_chaining()
     printf(GREEN "test_bloomfilter_chaining passed\n" RESET);
 }
 
+/** OR cc -g3 -fsanitize=address,undefined src/*.c external/*.c test/bloomfilter__tests.c -lzstd **/
 int main(void)
 {
     test_bloomfilter_create();

--- a/test/err__tests.c
+++ b/test/err__tests.c
@@ -23,6 +23,7 @@
 #include "../src/err.h"
 #include "test_macros.h"
 
+/** OR cc -g3 -fsanitize=address,undefined src/*.c external/*.c test/err__tests.c -lzstd **/
 void test_tidesdb_err_new()
 {
     tidesdb_err* e = tidesdb_err_new(1, "message");

--- a/test/id_gen__tests.c
+++ b/test/id_gen__tests.c
@@ -52,7 +52,7 @@ void* generate_ids(void* arg)
     for (int i = 0; i < 10; ++i)
     {
         uint64_t id = id_gen_new(gen);
-        printf("Generated ID: %llu\n", id);
+        printf("Generated ID: %lu\n", id);
     }
     return NULL;
 }
@@ -77,6 +77,7 @@ void test_id_gen_thread_safety()
     printf(GREEN "test_id_gen_thread_safety passed\n" RESET);
 }
 
+/** OR cc -g3 -fsanitize=address,undefined src/*.c external/*.c test/id_gen__tests.c -lzstd **/
 int main(void)
 {
     test_id_gen_init();

--- a/test/pager__tests.c
+++ b/test/pager__tests.c
@@ -371,6 +371,7 @@ void test_get_last_modified()
     printf(GREEN "test_get_last_modified passed\n" RESET);
 }
 
+/** OR cc -g3 -fsanitize=address,undefined src/*.c external/*.c test/pager__tests.c -lzstd **/
 int main(void)
 {
     test_get_last_modified();

--- a/test/queue__tests.c
+++ b/test/queue__tests.c
@@ -109,6 +109,7 @@ void test_dequeue_no_entries()
     printf(GREEN "test_dequeue_no_entries passed\n" RESET);
 }
 
+/** OR cc -g3 -fsanitize=address,undefined src/*.c external/*.c test/queue__tests.c -lzstd **/
 int main(void)
 {
     test_queue_new();

--- a/test/serialize__tests.c
+++ b/test/serialize__tests.c
@@ -26,13 +26,15 @@
 
 void test_serialize_key_value_pair_no_compression()
 {
-    key_value_pair kvp = {.key = (uint8_t *)"key",
-                          .key_size = 3,
-                          .value = (uint8_t *)"value",
-                          .value_size = 5,
-                          .ttl = 12345};
-    uint8_t *buffer;
-    size_t encoded_size;
+    key_value_pair kvp;
+    kvp.key = (uint8_t *)"test_key";
+    kvp.key_size = strlen((char *)kvp.key);
+    kvp.value = (uint8_t *)"test_value";
+    kvp.value_size = strlen((char *)kvp.value);
+    kvp.ttl = 123456789;
+
+    uint8_t *buffer = NULL;
+    size_t encoded_size = 0;
 
     assert(serialize_key_value_pair(&kvp, &buffer, &encoded_size, false) == true);
     assert(encoded_size > 0);
@@ -43,13 +45,15 @@ void test_serialize_key_value_pair_no_compression()
 
 void test_deserialize_key_value_pair_no_compression()
 {
-    key_value_pair kvp = {.key = (uint8_t *)"key",
-                          .key_size = 3,
-                          .value = (uint8_t *)"value",
-                          .value_size = 5,
-                          .ttl = 12345};
-    uint8_t *buffer;
-    size_t encoded_size;
+    key_value_pair kvp;
+    kvp.key = (uint8_t *)"test_key";
+    kvp.key_size = strlen((char *)kvp.key);
+    kvp.value = (uint8_t *)"test_value";
+    kvp.value_size = strlen((char *)kvp.value);
+    kvp.ttl = 123456789;
+
+    uint8_t *buffer = NULL;
+    size_t encoded_size = 0;
 
     serialize_key_value_pair(&kvp, &buffer, &encoded_size, false);
 
@@ -65,98 +69,9 @@ void test_deserialize_key_value_pair_no_compression()
     free(buffer);
     free(deserialized_kvp->key);
     free(deserialized_kvp->value);
+    free(deserialized_kvp);
 
     printf(GREEN "test_deserialize_key_value_pair_no_compression passed\n" RESET);
-}
-
-void test_serialize_bloomfilter_no_compression()
-{
-    bloomfilter bf = {.size = 8, .count = 0, .set = (uint8_t *)calloc(1, 1)};
-    uint8_t *buffer;
-    size_t encoded_size;
-
-    assert(serialize_bloomfilter(&bf, &buffer, &encoded_size, false) == true);
-    assert(encoded_size > 0);
-    free(buffer);
-    free(bf.set);
-
-    printf(GREEN "test_serialize_bloomfilter_no_compression passed\n" RESET);
-}
-
-void test_deserialize_bloomfilter_no_compression()
-{
-    bloomfilter bf = {.size = 8, .count = 0, .set = (uint8_t *)calloc(1, 1)};
-    uint8_t *buffer;
-    size_t encoded_size;
-
-    serialize_bloomfilter(&bf, &buffer, &encoded_size, false);
-
-    bloomfilter *deserialized_bf = NULL;
-    assert(deserialize_bloomfilter(buffer, encoded_size, &deserialized_bf, false) == true);
-    assert(deserialized_bf->size == bf.size);
-    assert(deserialized_bf->count == bf.count);
-    assert(memcmp(deserialized_bf->set, bf.set, (bf.size + 7) / 8) == 0);
-
-    free(buffer);
-    free(bf.set);
-    free(deserialized_bf->set);
-
-    printf(GREEN "test_deserialize_bloomfilter_no_compression passed\n" RESET);
-}
-
-void test_serialize_deserialize_full_bloomfilter_no_compression()
-{
-    bloomfilter *bf = bloomfilter_create(8); /* small size for testing */
-    const uint8_t data1[] = "test1";
-    const uint8_t data2[] = "test2";
-
-    for (int i = 0; i < 256; i++)
-    {
-        uint8_t data[2] = {(uint8_t)i, '\0'};
-        bloomfilter_add(bf, data, 1);
-    }
-
-    assert(bf->next != NULL);
-    assert(bloomfilter_add(bf, data2, strlen((const char *)data2)) == 0);
-    assert(bloomfilter_check(bf, data2, strlen((const char *)data2)) == true);
-
-    /* check if all the data is in the bloom filter */
-    for (int i = 0; i < 256; i++)
-    {
-        uint8_t data[2] = {(uint8_t)i, '\0'};
-        assert(bloomfilter_check(bf, data, 1) == true);
-    }
-
-    /* serialize the bloom filter */
-    uint8_t *buffer;
-    size_t encoded_size;
-    assert(serialize_bloomfilter(bf, &buffer, &encoded_size, false) == true);
-    assert(encoded_size > 0);
-
-    /* deserialize the bloom filter */
-    bloomfilter *deserialized_bf = NULL;
-    assert(deserialize_bloomfilter(buffer, encoded_size, &deserialized_bf, false) == true);
-
-    /* verify the deserialized bloom filter */
-    assert(deserialized_bf->size == bf->size);
-    assert(deserialized_bf->count == bf->count);
-    assert(memcmp(deserialized_bf->set, bf->set, (bf->size + 7) / 8) == 0);
-
-    bloomfilter_destroy(bf);
-
-    for (int i = 0; i < 256; i++)
-    {
-        uint8_t data[2] = {(uint8_t)i, '\0'};
-        assert(bloomfilter_check(deserialized_bf, data, 1) == true);
-    }
-    assert(bloomfilter_check(deserialized_bf, data2, strlen((const char *)data2)) == true);
-
-    /* clean up */
-    free(buffer);
-
-    bloomfilter_destroy(deserialized_bf);
-
-    printf(GREEN "test_serialize_deserialize_full_bloomfilter_no_compression passed\n" RESET);
 }
 
 void test_serialize_key_value_pair_compression()
@@ -200,98 +115,9 @@ void test_deserialize_key_value_pair_compression()
     free(buffer);
     free(deserialized_kvp->key);
     free(deserialized_kvp->value);
+    free(deserialized_kvp);
 
     printf(GREEN "test_deserialize_key_value_pair_compression passed\n" RESET);
-}
-
-void test_serialize_bloomfilter_compression()
-{
-    bloomfilter bf = {.size = 8, .count = 0, .set = (uint8_t *)calloc(1, 1)};
-    uint8_t *buffer;
-    size_t encoded_size;
-
-    assert(serialize_bloomfilter(&bf, &buffer, &encoded_size, true) == true);
-    assert(encoded_size > 0);
-    free(buffer);
-    free(bf.set);
-
-    printf(GREEN "test_serialize_bloomfilter_compression passed\n" RESET);
-}
-
-void test_deserialize_bloomfilter_compression()
-{
-    bloomfilter bf = {.size = 8, .count = 0, .set = (uint8_t *)calloc(1, 1)};
-    uint8_t *buffer;
-    size_t encoded_size;
-
-    serialize_bloomfilter(&bf, &buffer, &encoded_size, true);
-
-    bloomfilter *deserialized_bf = NULL;
-    assert(deserialize_bloomfilter(buffer, encoded_size, &deserialized_bf, true) == true);
-    assert(deserialized_bf->size == bf.size);
-    assert(deserialized_bf->count == bf.count);
-    assert(memcmp(deserialized_bf->set, bf.set, (bf.size + 7) / 8) == 0);
-
-    free(buffer);
-    free(bf.set);
-    free(deserialized_bf->set);
-
-    printf(GREEN "test_deserialize_bloomfilter_compression passed\n" RESET);
-}
-
-void test_serialize_deserialize_full_bloomfilter_compression()
-{
-    bloomfilter *bf = bloomfilter_create(8); /* small size for testing */
-    const uint8_t data1[] = "test1";
-    const uint8_t data2[] = "test2";
-
-    for (int i = 0; i < 256; i++)
-    {
-        uint8_t data[2] = {(uint8_t)i, '\0'};
-        bloomfilter_add(bf, data, 1);
-    }
-
-    assert(bf->next != NULL);
-    assert(bloomfilter_add(bf, data2, strlen((const char *)data2)) == 0);
-    assert(bloomfilter_check(bf, data2, strlen((const char *)data2)) == true);
-
-    /* check if all the data is in the bloom filter */
-    for (int i = 0; i < 256; i++)
-    {
-        uint8_t data[2] = {(uint8_t)i, '\0'};
-        assert(bloomfilter_check(bf, data, 1) == true);
-    }
-
-    /* serialize the bloom filter */
-    uint8_t *buffer;
-    size_t encoded_size;
-    assert(serialize_bloomfilter(bf, &buffer, &encoded_size, true) == true);
-    assert(encoded_size > 0);
-
-    /* deserialize the bloom filter */
-    bloomfilter *deserialized_bf = NULL;
-    assert(deserialize_bloomfilter(buffer, encoded_size, &deserialized_bf, true) == true);
-
-    /* verify the deserialized bloom filter */
-    assert(deserialized_bf->size == bf->size);
-    assert(deserialized_bf->count == bf->count);
-    assert(memcmp(deserialized_bf->set, bf->set, (bf->size + 7) / 8) == 0);
-
-    bloomfilter_destroy(bf);
-
-    for (int i = 0; i < 256; i++)
-    {
-        uint8_t data[2] = {(uint8_t)i, '\0'};
-        assert(bloomfilter_check(deserialized_bf, data, 1) == true);
-    }
-    assert(bloomfilter_check(deserialized_bf, data2, strlen((const char *)data2)) == true);
-
-    /* clean up */
-    free(buffer);
-
-    bloomfilter_destroy(deserialized_bf);
-
-    printf(GREEN "test_serialize_deserialize_full_bloomfilter_compression passed\n" RESET);
 }
 
 void test_serialize_operation_compression()
@@ -384,6 +210,7 @@ void test_deserialize_column_family_config_no_compression()
 
     free(buffer);
     free(deserialized_config->name);
+    free(deserialized_config);
 
     printf(GREEN "test_deserialize_column_family_config_no_compression passed\n" RESET);
 }
@@ -434,27 +261,156 @@ void test_deserialize_operation_no_compression()
     free(deserialized_op->kv->value);
     free(deserialized_op->kv);
     free(deserialized_op->column_family);
+    free(deserialized_op);
 
     printf(GREEN "test_deserialize_operation_no_compression passed\n" RESET);
 }
 
+void test_serialize_deserialize_full_bloomfilter_no_compression()
+{
+    /* create a bloom filter with an initial size of 8 */
+    bloomfilter *bf = bloomfilter_create(8);
+    assert(bf != NULL); /* assert creation success */
+
+    const uint8_t data2[] = "test2";
+
+    /* add 256 elements to the bloom filter */
+    for (int i = 0; i < 256; i++)
+    {
+        uint8_t data[2] = {(uint8_t)i, '\0'};
+        assert(bloomfilter_add(bf, data, 1) == 0); /* assert add success */
+    }
+
+    /* assert that the bloom filter has chained */
+    assert(bf->next != NULL);
+
+    /* add another element and check its presence */
+    assert(bloomfilter_add(bf, data2, strlen((const char *)data2)) == 0);
+    assert(bloomfilter_check(bf, data2, strlen((const char *)data2)) == true);
+
+    /* check if all the data is in the bloom filter */
+    for (int i = 0; i < 256; i++)
+    {
+        uint8_t data[2] = {(uint8_t)i, '\0'};
+        assert(bloomfilter_check(bf, data, 1) == true);
+    }
+
+    /* serialize the bloom filter */
+    uint8_t *buffer = NULL;
+    size_t encoded_size;
+    assert(serialize_bloomfilter(bf, &buffer, &encoded_size, false) == true);
+    assert(buffer != NULL);   /* assert buffer is not NULL */
+    assert(encoded_size > 0); /*ssert encoded size is greater than 0*/
+
+    /* deserialize the bloom filter */
+    bloomfilter *deserialized_bf = NULL;
+    assert(deserialize_bloomfilter(buffer, encoded_size, &deserialized_bf, false) == true);
+    assert(deserialized_bf != NULL);
+
+    /* verify the deserialized bloom filter */
+    assert(deserialized_bf->size == bf->size);
+    assert(deserialized_bf->count == bf->count);
+    assert(memcmp(deserialized_bf->set, bf->set, (bf->size + 7) / 8) == 0);
+
+    /* destroy the original bloom filter */
+    bloomfilter_destroy(bf);
+
+    /* check if all the data is in the deserialized bloom filter */
+    for (int i = 0; i < 256; i++)
+    {
+        uint8_t data[2] = {(uint8_t)i, '\0'};
+        assert(bloomfilter_check(deserialized_bf, data, 1) == true);
+    }
+    assert(bloomfilter_check(deserialized_bf, data2, strlen((const char *)data2)) == true);
+
+    /* clean upp */
+    free(buffer);
+    bloomfilter_destroy(deserialized_bf);
+
+    printf(GREEN "test_serialize_deserialize_full_bloomfilter_no_compression passed\n" RESET);
+}
+
+void test_serialize_deserialize_full_bloomfilter_compression()
+{
+    /* create a bloom filter with an initial size of 8 */
+    bloomfilter *bf = bloomfilter_create(8);
+    assert(bf != NULL); /* assert creation success */
+
+    const uint8_t data2[] = "test2";
+
+    /* add 256 elements to the bloom filter */
+    for (int i = 0; i < 256; i++)
+    {
+        uint8_t data[2] = {(uint8_t)i, '\0'};
+        assert(bloomfilter_add(bf, data, 1) == 0); /* assert add success */
+    }
+
+    /* assert that the bloom filter has chained */
+    assert(bf->next != NULL);
+
+    /* add another element and check its presence */
+    assert(bloomfilter_add(bf, data2, strlen((const char *)data2)) == 0);
+    assert(bloomfilter_check(bf, data2, strlen((const char *)data2)) == true);
+
+    /* check if all the data is in the bloom filter */
+    for (int i = 0; i < 256; i++)
+    {
+        uint8_t data[2] = {(uint8_t)i, '\0'};
+        assert(bloomfilter_check(bf, data, 1) == true);
+    }
+
+    /* serialize the bloom filter */
+    uint8_t *buffer = NULL;
+    size_t encoded_size;
+    assert(serialize_bloomfilter(bf, &buffer, &encoded_size, true) == true);
+    assert(buffer != NULL);   /* assert buffer is not NULL */
+    assert(encoded_size > 0); /* assert encoded size is greater than 0 */
+
+    /* deserialize the bloom filter */
+    bloomfilter *deserialized_bf = NULL;
+    assert(deserialize_bloomfilter(buffer, encoded_size, &deserialized_bf, true) == true);
+    assert(deserialized_bf != NULL); /* assert deserialization success */
+
+    /* verify the deserialized bloom filter */
+    assert(deserialized_bf->size == bf->size);
+    assert(deserialized_bf->count == bf->count);
+    assert(memcmp(deserialized_bf->set, bf->set, (bf->size + 7) / 8) == 0);
+
+    /* destroy the original bloom filter */
+    bloomfilter_destroy(bf);
+
+    /* check if all the data is in the deserialized bloom filter */
+    for (int i = 0; i < 256; i++)
+    {
+        uint8_t data[2] = {(uint8_t)i, '\0'};
+        assert(bloomfilter_check(deserialized_bf, data, 1) == true);
+    }
+    assert(bloomfilter_check(deserialized_bf, data2, strlen((const char *)data2)) == true);
+
+    /* clean up */
+    free(buffer);
+    bloomfilter_destroy(deserialized_bf);
+
+    printf(GREEN "test_serialize_deserialize_full_bloomfilter_compression passed\n" RESET);
+}
+
+/* cc -g3 -fsanitize=address,undefined src/*.c external/*.c test/serialize__tests.c -lzstd */
 int main(void)
 {
     test_serialize_key_value_pair_no_compression();
     test_deserialize_key_value_pair_no_compression();
+
     test_serialize_key_value_pair_compression();
     test_deserialize_key_value_pair_compression();
+
     test_serialize_operation_no_compression();
     test_deserialize_operation_no_compression();
     test_serialize_operation_compression();
     test_deserialize_operation_compression();
+
     test_serialize_column_family_config_no_compression();
     test_deserialize_column_family_config_no_compression();
 
-    test_serialize_bloomfilter_no_compression();
-    test_deserialize_bloomfilter_no_compression();
-    test_serialize_bloomfilter_compression();
-    test_deserialize_bloomfilter_compression();
     test_serialize_deserialize_full_bloomfilter_no_compression();
     test_serialize_deserialize_full_bloomfilter_compression();
 

--- a/test/skiplist__tests.c
+++ b/test/skiplist__tests.c
@@ -237,6 +237,7 @@ void test_skiplist_copy()
     printf(GREEN "test_skiplist_copy passed\n" RESET);
 }
 
+/** OR cc -g3 -fsanitize=address,undefined src/*.c external/*.c test/skiplist__tests.c -lzstd **/
 int main(void)
 {
     test_skiplist_create_node();


### PR DESCRIPTION
Working towards initial release.
- id_gen__tests.c corrections after fsanitize
- bloom filter corrections
- serialization reformatting
- pass fsanitize with skiplist__tests.c ,serialize__tests.c ,queue__tests.c ,pager__tests.c ,id_gen__tests.c ,err__tests.c ,bloomfilter__tests.c