### PR TITLE
Furthering tdb to initial version

### DIFF
--- a/src/bloomfilter.c
+++ b/src/bloomfilter.c
@@ -17,12 +17,12 @@
  * limitations under the License.
  */
 #include "bloomfilter.h"
-unsigned int hash1(const unsigned char *data, unsigned int data_len)
+unsigned int hash1(const uint8_t *data, unsigned int data_len)
 {
     return XXH32(data, data_len, 0);
 }
 
-unsigned int hash2(const unsigned char *data, unsigned int data_len)
+unsigned int hash2(const uint8_t *data, unsigned int data_len)
 {
     return XXH32(data, data_len, 1);
 }
@@ -62,7 +62,7 @@ void bloomfilter_destroy(bloomfilter *bf)
     }
 }
 
-bool bloomfilter_check(bloomfilter *bf, const unsigned char *data, unsigned int data_len)
+bool bloomfilter_check(bloomfilter *bf, const uint8_t *data, unsigned int data_len)
 {
     unsigned int hash_value1 = hash1(data, data_len);
     unsigned int hash_value2 = hash2(data, data_len);
@@ -87,7 +87,7 @@ bool bloomfilter_is_full(bloomfilter *bf)
     return true;
 }
 
-int bloomfilter_add(bloomfilter *bf, const unsigned char *data, unsigned int data_len)
+int bloomfilter_add(bloomfilter *bf, const uint8_t *data, unsigned int data_len)
 {
     unsigned int hash_value1 = hash1(data, data_len);
     unsigned int hash_value2 = hash2(data, data_len);

--- a/src/bloomfilter.h
+++ b/src/bloomfilter.h
@@ -74,7 +74,7 @@ bool bloomfilter_is_full(bloomfilter *bf);
  * @param data the data to add
  * @param data_len the length of the data
  */
-int bloomfilter_add(bloomfilter *bf, const unsigned char *data, unsigned int data_len);
+int bloomfilter_add(bloomfilter *bf, const uint8_t *data, unsigned int data_len);
 
 /*
  * bloomfilter_check
@@ -83,7 +83,7 @@ int bloomfilter_add(bloomfilter *bf, const unsigned char *data, unsigned int dat
  * @param data the data to check
  * @param data_len the length of the data
  */
-bool bloomfilter_check(bloomfilter *bf, const unsigned char *data, unsigned int data_len);
+bool bloomfilter_check(bloomfilter *bf, const uint8_t *data, unsigned int data_len);
 
 /*
  * hash1
@@ -91,7 +91,7 @@ bool bloomfilter_check(bloomfilter *bf, const unsigned char *data, unsigned int 
  * @param data the data to hash
  * @param data_len the length of the data
  */
-unsigned int hash1(const unsigned char *data, unsigned int data_len);
+unsigned int hash1(const uint8_t *data, unsigned int data_len);
 
 /*
  * hash2
@@ -99,7 +99,7 @@ unsigned int hash1(const unsigned char *data, unsigned int data_len);
  * @param data the data to hash
  * @param data_len the length of the data
  */
-unsigned int hash2(const unsigned char *data, unsigned int data_len);
+unsigned int hash2(const uint8_t *data, unsigned int data_len);
 
 /*
  * bloomfilter_get_size

--- a/src/pager.c
+++ b/src/pager.c
@@ -482,6 +482,18 @@ bool pager_size(pager* p, size_t* size)
     return true;
 }
 
+void sleep_ms(int milliseconds)
+{
+#ifdef _WIN32
+    Sleep(milliseconds);
+#else
+    struct timespec ts;
+    ts.tv_sec = milliseconds / 1000;
+    ts.tv_nsec = (milliseconds % 1000) * 1000000;
+    nanosleep(&ts, NULL);
+#endif
+}
+
 void* pager_sync_thread(void* arg)
 {
     pager* p = arg;

--- a/src/pager.h
+++ b/src/pager.h
@@ -23,7 +23,8 @@
 #define PAGE_BODY       1024 /* The page body is used to store the actual data */
 #define PAGE_SIZE       (PAGE_HEADER + PAGE_BODY) /* The page size is the sum of the header and body */
 #define SYNC_INTERVAL   24576                     /* Sync every 24576 writes */
-#define SYNC_ESCALATION 2 /* We sync when we hit sync escalation or when we hit sync interval */
+#define SYNC_ESCALATION 0.128 /* We sync when we hit sync escalation or when we hit sync interval \
+                               */
 
 #include <errno.h>
 #include <pthread.h>
@@ -33,7 +34,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
-#include <time.h>
 #include <unistd.h>
 
 /*
@@ -201,5 +201,12 @@ bool pager_pages_count(pager* p, size_t* num_pages);
  * @return bool true if the size was retrieved successfully, false otherwise
  */
 bool pager_size(pager* p, size_t* size);
+
+/*
+ * sleep_ms
+ * sleeps for the given number of milliseconds
+ * @param milliseconds the number of milliseconds to sleep
+ */
+void sleep_ms(int milliseconds);
 
 #endif /* PAGER_H */

--- a/src/skiplist.h
+++ b/src/skiplist.h
@@ -44,9 +44,9 @@ typedef struct skiplist_node skiplist_node;
  */
 struct skiplist_node
 {
-    unsigned char *key;       /* the key for the node */
+    uint8_t *key;       /* the key for the node */
     size_t key_size;          /* the key size */
-    unsigned char *value;     /* the value for the node */
+    uint8_t *value;     /* the value for the node */
     size_t value_size;        /* the value size */
     time_t ttl;               /* an expiration time for the node (optional) */
     skiplist_node *forward[]; /* the forward pointers for the node */
@@ -97,8 +97,8 @@ typedef struct
  * @param ttl an expiration time for the node (optional)
  * @return the new skiplist node
  */
-skiplist_node *skiplist_create_node(int level, const unsigned char *key, size_t key_size,
-                                    const unsigned char *value, size_t value_size, time_t ttl);
+skiplist_node *skiplist_create_node(int level, const uint8_t *key, size_t key_size,
+                                    const uint8_t *value, size_t value_size, time_t ttl);
 
 /*
  * skiplist_destroy_node
@@ -142,7 +142,7 @@ int skiplist_random_level(skiplist *list);
  * @param key2_size the second key size
  * @return 0 if the keys are equal, -1 if key1 is less than key2, 1 if key1 is greater than key2
  */
-int skiplist_compare_keys(const unsigned char *key1, size_t key1_size, const unsigned char *key2,
+int skiplist_compare_keys(const uint8_t *key1, size_t key1_size, const uint8_t *key2,
                           size_t key2_size);
 
 /*
@@ -153,7 +153,7 @@ int skiplist_compare_keys(const unsigned char *key1, size_t key1_size, const uns
  * @param key_size the key size
  * @return true if the key was deleted successfully, false otherwise
  */
-bool skiplist_delete(skiplist *list, const unsigned char *key, size_t key_size);
+bool skiplist_delete(skiplist *list, const uint8_t *key, size_t key_size);
 
 /*
  * skiplist_put
@@ -166,8 +166,8 @@ bool skiplist_delete(skiplist *list, const unsigned char *key, size_t key_size);
  * @param ttl an expiration time for the node (optional)
  * @return true if the key-value pair was put successfully, false otherwise
  */
-bool skiplist_put(skiplist *list, const unsigned char *key, size_t key_size,
-                  const unsigned char *value, size_t value_size, time_t ttl);
+bool skiplist_put(skiplist *list, const uint8_t *key, size_t key_size,
+                  const uint8_t *value, size_t value_size, time_t ttl);
 
 /*
  * skiplist_get
@@ -179,7 +179,7 @@ bool skiplist_put(skiplist *list, const unsigned char *key, size_t key_size,
  * @param value_size the value size
  * @return true if the value was retrieved successfully, false otherwise
  */
-bool skiplist_get(skiplist *list, const unsigned char *key, size_t key_size, unsigned char **value,
+bool skiplist_get(skiplist *list, const uint8_t *key, size_t key_size, uint8_t **value,
                   size_t *value_size);
 
 /*

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -281,8 +281,8 @@ tidesdb_err* tidesdb_compact_sstables(tidesdb* tdb, column_family* cf, int max_t
  * @param ttl the time-to-live for the key-value pair
  * @return error or NULL
  */
-tidesdb_err* tidesdb_put(tidesdb* tdb, const char* column_family_name, const unsigned char* key,
-                         size_t key_size, const unsigned char* value, size_t value_size,
+tidesdb_err* tidesdb_put(tidesdb* tdb, const char* column_family_name, const uint8_t* key,
+                         size_t key_size, const uint8_t* value, size_t value_size,
                          time_t ttl);
 
 /*
@@ -296,8 +296,8 @@ tidesdb_err* tidesdb_put(tidesdb* tdb, const char* column_family_name, const uns
  * @param value_size the size of the value
  * @return error or NULL
  */
-tidesdb_err* tidesdb_get(tidesdb* tdb, const char* column_family_name, const unsigned char* key,
-                         size_t key_size, unsigned char** value, size_t* value_size);
+tidesdb_err* tidesdb_get(tidesdb* tdb, const char* column_family_name, const uint8_t* key,
+                         size_t key_size, uint8_t** value, size_t* value_size);
 
 /*
  * tidesdb_delete
@@ -308,7 +308,7 @@ tidesdb_err* tidesdb_get(tidesdb* tdb, const char* column_family_name, const uns
  * @param key_size the size of the key
  * @return error or NULL
  */
-tidesdb_err* tidesdb_delete(tidesdb* tdb, const char* column_family_name, const unsigned char* key,
+tidesdb_err* tidesdb_delete(tidesdb* tdb, const char* column_family_name, const uint8_t* key,
                             size_t key_size);
 
 /*
@@ -331,8 +331,8 @@ tidesdb_err* tidesdb_txn_begin(txn** transaction, const char* column_family);
  * @param ttl the time-to-live for the key-value pair
  * @return error or NULL
  */
-tidesdb_err* tidesdb_txn_put(txn* transaction, const unsigned char* key, size_t key_size,
-                             const unsigned char* value, size_t value_size, time_t ttl);
+tidesdb_err* tidesdb_txn_put(txn* transaction, const uint8_t* key, size_t key_size,
+                             const uint8_t* value, size_t value_size, time_t ttl);
 
 /*
  * tidesdb_txn_delete
@@ -342,7 +342,7 @@ tidesdb_err* tidesdb_txn_put(txn* transaction, const unsigned char* key, size_t 
  * @param key_size the size of the key
  * @return error or NULL
  */
-tidesdb_err* tidesdb_txn_delete(txn* transaction, const unsigned char* key, size_t key_size);
+tidesdb_err* tidesdb_txn_delete(txn* transaction, const uint8_t* key, size_t key_size);
 
 /*
  * tidesdb_txn_commit
@@ -466,8 +466,8 @@ const char* _get_path_seperator();
  * @param cf the column family
  * @return whether the operation was appended to the wal
  */
-bool _append_to_wal(tidesdb* tdb, wal* wal, const unsigned char* key, size_t key_size,
-                    const unsigned char* value, size_t value_size, time_t ttl, enum OP_CODE op_code,
+bool _append_to_wal(tidesdb* tdb, wal* wal, const uint8_t* key, size_t key_size,
+                    const uint8_t* value, size_t value_size, time_t ttl, enum OP_CODE op_code,
                     const char* cf);
 
 /*
@@ -546,7 +546,7 @@ void* _flush_memtable_thread(void* arg);
  * @param value_size the size of the value
  * @return whether the value is a tombstone
  */
-bool _is_tombstone(const unsigned char* value, size_t value_size);
+bool _is_tombstone(const uint8_t* value, size_t value_size);
 
 /*
  * _load_sstables
@@ -593,5 +593,30 @@ sstable* _merge_sstables(sstable* sst1, sstable* sst2, column_family* cf);
  * @param tdb the TidesDB instance
  */
 void _free_column_families(tidesdb* tdb);
+
+/*
+ * _free_key_value_pair
+ * free the memory for a key-value pair
+ * @param kv the key-value pair
+ */
+void _free_key_value_pair(key_value_pair* kv);
+
+/*
+ * _free_operation
+ * free the memory for an operation
+ * @param op the operation
+ */
+void _free_operation(operation* op);
+
+/*
+ * _compare_keys
+ * compare two keys
+ * @param key1 the first key
+ * @param key1_size the size of the first key
+ * @param key2 the second key
+ * @param key2_size the size of the second key
+ * @return the comparison
+ */
+int _compare_keys(const uint8_t* key1, size_t key1_size, const uint8_t* key2, size_t key2_size);
 
 #endif /* TIDESDB_H */

--- a/test/bloomfilter__tests.c
+++ b/test/bloomfilter__tests.c
@@ -56,8 +56,8 @@ void test_bloomfilter_add_check()
     /* we create a bloom filter with size 1024 */
     bloomfilter *bf = bloomfilter_create(1024);
 
-    const unsigned char data1[] = "test1"; /* the entry that will be in bf */
-    const unsigned char data2[] = "test2"; /* the entry that will not be in bf */
+    const uint8_t data1[] = "test1"; /* the entry that will be in bf */
+    const uint8_t data2[] = "test2"; /* the entry that will not be in bf */
 
     /* we add data1 to the bloom filter */
     assert(bloomfilter_add(bf, data1, strlen((const char *)data1)) == 0);
@@ -82,7 +82,7 @@ void test_bloomfilter_is_full()
 
     for (int i = 0; i < 16; i++)
     {
-        unsigned char data[2] = {(unsigned char)i, '\0'};
+        uint8_t data[2] = {(uint8_t)i, '\0'};
         bloomfilter_add(bf, data, 1);
     }
 
@@ -96,12 +96,12 @@ void test_bloomfilter_is_full()
 void test_bloomfilter_chaining()
 {
     bloomfilter *bf = bloomfilter_create(8); /* Small size for testing */
-    const unsigned char data1[] = "test1";
-    const unsigned char data2[] = "test2";
+    const uint8_t data1[] = "test1";
+    const uint8_t data2[] = "test2";
 
     for (int i = 0; i < 256; i++)
     {
-        unsigned char data[256] = {(unsigned char)i, '\0'};
+        uint8_t data[256] = {(uint8_t)i, '\0'};
         bloomfilter_add(bf, data, 1);
     }
 
@@ -112,7 +112,7 @@ void test_bloomfilter_chaining()
     /* check if all the data is in the bloom filter */
     for (int i = 0; i < 256; i++)
     {
-        unsigned char data[256] = {(unsigned char)i, '\0'};
+        uint8_t data[256] = {(uint8_t)i, '\0'};
         assert(bloomfilter_check(bf, data, 1) == true);
     }
 

--- a/test/skiplist__tests.c
+++ b/test/skiplist__tests.c
@@ -27,8 +27,8 @@
 
 void test_skiplist_create_node()
 {
-    unsigned char key[] = "key";
-    unsigned char value[] = "value";
+    uint8_t key[] = "key";
+    uint8_t value[] = "value";
     skiplist_node *node = skiplist_create_node(3, key, sizeof(key), value, sizeof(value), -1);
     assert(node != NULL);
     assert(memcmp(node->key, key, sizeof(key)) == 0);
@@ -55,11 +55,11 @@ void test_new_skiplist()
 void test_skiplist_put_get()
 {
     skiplist *list = new_skiplist(12, 0.24f);
-    unsigned char key[] = "key";
-    unsigned char value[] = "value";
+    uint8_t key[] = "key";
+    uint8_t value[] = "value";
     assert(skiplist_put(list, key, sizeof(key), value, sizeof(value), -1) == true);
 
-    unsigned char *retrieved_value;
+    uint8_t *retrieved_value;
     size_t retrieved_value_size;
     assert(skiplist_get(list, key, sizeof(key), &retrieved_value, &retrieved_value_size) == true);
     assert(memcmp(retrieved_value, value, sizeof(value)) == 0);
@@ -72,12 +72,12 @@ void test_skiplist_put_get()
 void test_skiplist_delete()
 {
     skiplist *list = new_skiplist(12, 0.24f);
-    unsigned char key[] = "key";
-    unsigned char value[] = "value";
+    uint8_t key[] = "key";
+    uint8_t value[] = "value";
     assert(skiplist_put(list, key, sizeof(key), value, sizeof(value), -1) == true);
     assert(skiplist_delete(list, key, sizeof(key)) == true);
 
-    unsigned char *retrieved_value;
+    uint8_t *retrieved_value;
     size_t retrieved_value_size;
     assert(skiplist_get(list, key, sizeof(key), &retrieved_value, &retrieved_value_size) == false);
 
@@ -89,12 +89,12 @@ void test_skiplist_delete()
 void test_skiplist_clear()
 {
     skiplist *list = new_skiplist(12, 0.24f);
-    unsigned char key[] = "key";
-    unsigned char value[] = "value";
+    uint8_t key[] = "key";
+    uint8_t value[] = "value";
     assert(skiplist_put(list, key, sizeof(key), value, sizeof(value), -1) == true);
     assert(skiplist_clear(list) == 0);
 
-    unsigned char *retrieved_value;
+    uint8_t *retrieved_value;
     size_t retrieved_value_size;
     assert(skiplist_get(list, key, sizeof(key), &retrieved_value, &retrieved_value_size) == false);
 
@@ -106,10 +106,10 @@ void test_skiplist_clear()
 void test_skiplist_cursor()
 {
     skiplist *list = new_skiplist(12, 0.24f);
-    unsigned char key1[] = "key1";
-    unsigned char value1[] = "value1";
-    unsigned char key2[] = "key2";
-    unsigned char value2[] = "value2";
+    uint8_t key1[] = "key1";
+    uint8_t value1[] = "value1";
+    uint8_t key2[] = "key2";
+    uint8_t value2[] = "value2";
     assert(skiplist_put(list, key1, sizeof(key1), value1, sizeof(value1), -1) == true);
     assert(skiplist_put(list, key2, sizeof(key2), value2, sizeof(value2), -1) == true);
 
@@ -133,13 +133,13 @@ void test_skiplist_cursor()
 void test_skiplist_ttl()
 {
     skiplist *list = new_skiplist(12, 0.24f);
-    unsigned char key[] = "key";
-    unsigned char value[] = "value";
+    uint8_t key[] = "key";
+    uint8_t value[] = "value";
     time_t ttl = 1; /* 1 second TTL */
 
     assert(skiplist_put(list, key, sizeof(key), value, sizeof(value), time(NULL) + ttl) == true);
 
-    unsigned char *retrieved_value;
+    uint8_t *retrieved_value;
     size_t retrieved_value_size;
     assert(skiplist_get(list, key, sizeof(key), &retrieved_value, &retrieved_value_size) == true);
     assert(memcmp(retrieved_value, value, sizeof(value)) == 0);
@@ -172,14 +172,14 @@ void *thread_func(void *arg)
 
     for (int i = 0; i < CONCURRENT_NUM_OPERATIONS; i++)
     {
-        unsigned char key[16];
-        unsigned char value[16];
+        uint8_t key[16];
+        uint8_t value[16];
         snprintf((char *)key, sizeof(key), "key%d_%d", thread_id, i);
         snprintf((char *)value, sizeof(value), "value%d_%d", thread_id, i);
 
         skiplist_put(list, key, strlen((char *)key) + 1, value, strlen((char *)value) + 1, -1);
 
-        unsigned char *retrieved_value;
+        uint8_t *retrieved_value;
         size_t retrieved_value_size;
         skiplist_get(list, key, strlen((char *)key) + 1, &retrieved_value, &retrieved_value_size);
 
@@ -212,17 +212,17 @@ void test_skiplist_concurrency()
 void test_skiplist_copy()
 {
     skiplist *list = new_skiplist(12, 0.24f);
-    unsigned char key1[] = "key1";
-    unsigned char value1[] = "value1";
-    unsigned char key2[] = "key2";
-    unsigned char value2[] = "value2";
+    uint8_t key1[] = "key1";
+    uint8_t value1[] = "value1";
+    uint8_t key2[] = "key2";
+    uint8_t value2[] = "value2";
     assert(skiplist_put(list, key1, sizeof(key1), value1, sizeof(value1), -1) == true);
     assert(skiplist_put(list, key2, sizeof(key2), value2, sizeof(value2), -1) == true);
 
     skiplist *copied_list = skiplist_copy(list);
     assert(copied_list != NULL);
 
-    unsigned char *retrieved_value;
+    uint8_t *retrieved_value;
     size_t retrieved_value_size;
     assert(skiplist_get(copied_list, key1, sizeof(key1), &retrieved_value, &retrieved_value_size) ==
            true);


### PR DESCRIPTION
- tidesdb__tests fsanitize passing tests
- pager to escalation every 128ms as opposed to 2s
- use uint8_t* instead of unsigned char* for keys and their values
- tidesdb_get logic corrections and memory safety corrections