### PR TITLE
Use block manager MAX_FILE_PATH_LENGTH where applicable instead of fi…

### DIFF
--- a/code_formatter.sh
+++ b/code_formatter.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Before submitting a PR, run this script to format the source code.
+
 EXCLUDE_DIRS="external\|cmake-build-debug\|.idea|build|cmake"
 
 find . -type f -name "*.c" -o -name "*.h" | grep -v "$EXCLUDE_DIRS" | xargs clang-format -i

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -28,12 +28,13 @@
 #include "err.h"
 #include "skip_list.h"
 
-#define WAL_EXT                       ".wal"     /* extension for the write-ahead log file */
-#define SSTABLE_EXT                   ".sst"     /* extension for the SSTable file */
-#define COLUMN_FAMILY_CONFIG_FILE_EXT ".cfc"     /* configuration file for the column family */
-#define TOMBSTONE                     0xDEADBEEF /* tombstone value for deleted keys */
-#define SYNC_INTERVAL                 0.24       /* interval for syncing mainly WAL */
-#define BLOOMFILTER_P                 0.01       /*  the false positive rate for bloom filter */
+#define TDB_WAL_EXT                       ".wal"     /* extension for the write-ahead log file */
+#define TDB_SSTABLE_EXT                   ".sst"     /* extension for the SSTable file */
+#define TDB_COLUMN_FAMILY_CONFIG_FILE_EXT ".cfc"     /* configuration file for the column family */
+#define TDB_TOMBSTONE                     0xDEADBEEF /* tombstone value for deleted keys */
+#define TDB_SYNC_INTERVAL                 0.24       /* interval for syncing mainly WAL */
+#define TDB_BLOOMFILTER_P                 0.01       /*  the false positive rate for bloom filter */
+#define TDB_SSTABLE_PREFIX                "sstable_" /* prefix for SSTable files */
 
 /*
  * tidesdb_compression_algo_t


### PR DESCRIPTION
Use block manager MAX_FILE_PATH_LENGTH where applicable instead of fixed and linux max path.  Added TDB_SSTABLE_PREFIX constant to modularize the sstable name prefix to be whatever you want.  I also changed those definitions to use TDB_ prefix which is easier to justify whats tied to TidesDB.