### PR TITLE
add options for sanitizer and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,13 +7,18 @@ project(tidesdb C)
 set(CMAKE_C_STANDARD 23)
 set(PROJECT_VERSION 0.2.0) # TidesDB v0.2.0
 
+option(TIDESDB_WITH_SANITIZER "build with sanitizer in tidesdb" ON)
+option(TIDESDB_BUILD_TESTS "enable building tests in tidesdb" ON)
+
 #find_package(zstd REQUIRED)
 #find_package(snappy REQUIRED)
 #find_package(lz4 REQUIRED)
 
 # For development, we want to enable all warnings and sanitizers
-add_compile_options(-Wextra -Wall -fsanitize=address,undefined)
-add_link_options(-fsanitize=address,undefined)
+if(TIDESDB_WITH_SANITIZER)
+        add_compile_options(-Wextra -Wall -fsanitize=address,undefined)
+        add_link_options(-fsanitize=address,undefined)
+endif()
 
 add_library(tidesdb SHARED src/tidesdb.c src/err.c src/block_manager.c src/skip_list.c src/compress.c src/bloom_filter.c)
 
@@ -24,28 +29,31 @@ install(TARGETS tidesdb
         ARCHIVE DESTINATION lib)
 
 install(FILES src/tidesdb.h src/err.h src/block_manager.h src/skip_list.h src/compress.h src/bloom_filter.h DESTINATION include)
-enable_testing()
 
-add_executable(err_tests test/err__tests.c)
-add_executable(block_manager_tests test/block_manager__tests.c)
-add_executable(skip_list_tests test/skip_list__tests.c)
-add_executable(compress_tests test/compress__tests.c)
-add_executable(bloom_filter_tests test/bloom_filter__tests.c)
-add_executable(tidesdb_tests test/tidesdb__tests.c)
+if(TIDESDB_BUILD_TESTS)
+        enable_testing()
 
-target_link_libraries(err_tests tidesdb m zstd snappy lz4)
-target_link_libraries(block_manager_tests tidesdb m zstd snappy lz4)
-target_link_libraries(skip_list_tests tidesdb m zstd snappy lz4)
-target_link_libraries(compress_tests tidesdb m zstd snappy lz4)
-target_link_libraries(bloom_filter_tests tidesdb m zstd snappy lz4)
-target_link_libraries(tidesdb_tests tidesdb m zstd snappy lz4)
+        add_executable(err_tests test/err__tests.c)
+        add_executable(block_manager_tests test/block_manager__tests.c)
+        add_executable(skip_list_tests test/skip_list__tests.c)
+        add_executable(compress_tests test/compress__tests.c)
+        add_executable(bloom_filter_tests test/bloom_filter__tests.c)
+        add_executable(tidesdb_tests test/tidesdb__tests.c)
 
-add_test(NAME err_tests COMMAND err_tests)
-add_test(NAME block_manager_tests COMMAND block_manager_tests)
-add_test(NAME skip_list_tests COMMAND skip_list_tests)
-add_test(NAME compress_tests COMMAND compress_tests)
-add_test(NAME bloom_filter_tests COMMAND bloom_filter_tests)
-add_test(NAME tidesdb_tests COMMAND tidesdb_tests)
+        target_link_libraries(err_tests tidesdb m zstd snappy lz4)
+        target_link_libraries(block_manager_tests tidesdb m zstd snappy lz4)
+        target_link_libraries(skip_list_tests tidesdb m zstd snappy lz4)
+        target_link_libraries(compress_tests tidesdb m zstd snappy lz4)
+        target_link_libraries(bloom_filter_tests tidesdb m zstd snappy lz4)
+        target_link_libraries(tidesdb_tests tidesdb m zstd snappy lz4)
+
+        add_test(NAME err_tests COMMAND err_tests)
+        add_test(NAME block_manager_tests COMMAND block_manager_tests)
+        add_test(NAME skip_list_tests COMMAND skip_list_tests)
+        add_test(NAME compress_tests COMMAND compress_tests)
+        add_test(NAME bloom_filter_tests COMMAND bloom_filter_tests)
+        add_test(NAME tidesdb_tests COMMAND tidesdb_tests)
+endif()
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(


### PR DESCRIPTION
In a common CMake project, SANITIZER and TEST are controlled ON/OFF by option.
I would like to incorporate tidesdb into conan package system and would like to control the compilation of these.

If  option names are not appropriate, please let me know.
I will gladly follow tidesdb's naming conventions.
