### PR TITLE
update read me, minor corrections on cursor.  The cursor still seems …

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It is not a full-featured database, but rather a library that can be used to bui
 
 ## Features
 - [x] **ACID** transactions are atomic, consistent, isolated, and durable.  Transactions are tied to their respective column family.
-- [x] **Concurrent** multiple threads can read and write to the storage engine. Column families use a read-write lock thus allowing multiple readers and a single writer per column family.  Transactions block other threads from reading or writing to the column family until the transaction is committed or rolled back.  A transaction is thread safe.
+- [x] **Concurrent** multiple threads can read and write to the storage engine. Column families use a read-write lock thus allowing multiple readers and a single writer per column family.  Transactions on commit block other threads from reading or writing to the column family until the transaction is completed.  A transaction is thread safe.
 - [x] **Column Families** store data in separate key-value stores.  Each column family has their own memtable and sstables.
 - [x] **Atomic Transactions** commit or rollback multiple operations atomically.  When a transaction fails, it rolls back all operations.
 - [x] **Cursor** iterate over key-value pairs forward and backward.
@@ -21,7 +21,7 @@ It is not a full-featured database, but rather a library that can be used to bui
 - [x] **Bloom Filters** reduce disk reads by reading initial blocks of sstables to check key existence.
 - [x] **Compression** compression is achieved with Snappy, or LZ4, or ZSTD.  SStable entries can be compressed as well as WAL entries.
 - [x] **TTL** time-to-live for key-value pairs.
-- [x] **Configurable** column families are configurable with memtable flush threshold, skiplist max level, skiplist probability, compression, and bloom filters.
+- [x] **Configurable** column families are configurable with memtable flush threshold, skip list max level, skip list probability, compression, and bloom filters.
 - [x] **Error Handling** API functions return an error code and message.
 - [x] **Easy API** simple and easy to use api.
 
@@ -98,8 +98,8 @@ In order to store data in TidesDB you need a column family.  This is by design.
 - the database you want to create the column family in.  Must be open
 - the name of the column family
 - memtable flush threshold in bytes.  Example below is 128MB
-- skiplist max level.  Example below is 12
-- skiplist probability.  Example below is 0.24
+- skip list max level.  Example below is 12
+- skip list probability.  Example below is 0.24
 - whether column family sstable data is compressed
 - the compression algorithim to use [`TDB_NO_COMPRESSION`, `TDB_COMPRESS_SNAPPY`, `TDB_COMPRESS_LZ4`, `TDB_COMPRESS_ZSTD`]
 - whether to use bloom filters

--- a/bench/tidesdb__bench.c
+++ b/bench/tidesdb__bench.c
@@ -28,11 +28,11 @@
 #include "../test/test_utils.h"
 
 /* test constants */
-#define NUM_OPERATIONS         10000 /* number of operations per thread */
-#define NUM_THREADS            1 /* you can increase this to test with more threads, usually slower */
-#define SIZE                   512 /* key and value size */
+#define NUM_OPERATIONS         500000 /* number of operations per thread */
+#define NUM_THREADS            2 /* you can increase this to test with more threads, usually slower */
+#define SIZE                   (1024 * 1024) /* key and value size, 1MB */
 #define DIR                    "benchmark_db"
-#define FLUSH_THRESHOLD        ((1024 * 1024) * 1)
+#define FLUSH_THRESHOLD        ((1024 * 1024) * 64)
 #define THREADS_FOR_COMPACTION 2
 
 /*


### PR DESCRIPTION
update read me, minor corrections on cursor.  The cursor still seems to be skipping entries on sstables.  It's a rather interesting bug.  The logic for the cursor methods seem to be fine reading through them but I may be missing something.  It seems we are mainly missing keys from the initial sstable once we get to end of forward iteration.  The previous logic is correct, we always start at last block per sstable going backwards.  The memtable cursor keeps state of where you are in the cursor which is good but the sstables are a bit tricky.