### PR TITLE
column family type to use void pointer for memtable and we cast based…

### DIFF
--- a/src/err.h
+++ b/src/err.h
@@ -95,6 +95,7 @@ typedef enum
     TIDESDB_ERR_INVALID_COMPRESSION_ALGO,
     TIDESDB_ERR_FAILED_TO_DESERIALIZE_BLOOM_FILTER,
     TIDESDB_ERR_NOT_IMPLEMENTED,
+    TIDESDB_ERR_INVALID_MEMTABLE_DATA_STRUCTURE,
 } TIDESDB_ERR_CODE;
 
 /* TidesDB error messages */
@@ -138,6 +139,7 @@ static const tidesdb_err_info_t tidesdb_err_messages[] = {
     {TIDESDB_ERR_INVALID_COMPRESSION_ALGO, "Invalid compression algorithm.\n"},
     {TIDESDB_ERR_FAILED_TO_DESERIALIZE_BLOOM_FILTER, "Failed to deserialize bloom filter.\n"},
     {TIDESDB_ERR_NOT_IMPLEMENTED, "Not implemented.\n"},
+    {TIDESDB_ERR_INVALID_MEMTABLE_DATA_STRUCTURE, "Invalid memtable data structure.\n"},
 
 };
 

--- a/src/hash_table.h
+++ b/src/hash_table.h
@@ -23,8 +23,9 @@
 #define TOMBSTONE                                                                                 \
     0xDEADBEEF /* On expiration of a bucket if time to live is set we set the key's value to this \
                 */
-#define BUCKETS 1048576 /* the size of the hash table buckets.  We have this fixed for
-                         * now but we should make it so the hashtable can ultimately resize itself */
+#define BUCKETS                                                            \
+    1048576 /* the size of the hash table buckets.  We have this fixed for \
+             * now but we should make it so the hashtable can ultimately resize itself */
 
 /**
  * hash_table_bucket_t
@@ -74,9 +75,10 @@ int hash_table_new(hash_table_t **ht);
  * @param value the value to put
  * @param value_size the size of the value
  * @param ttl the time to live for the key-value pair. -1 if no ttl
+ * @return 0 if successful, -1 if not
  */
-void hash_table_put(hash_table_t *ht, const uint8_t *key, size_t key_size, const uint8_t *value,
-                    size_t value_size, time_t ttl);
+int hash_table_put(hash_table_t *ht, const uint8_t *key, size_t key_size, const uint8_t *value,
+                   size_t value_size, time_t ttl);
 
 /**
  * hash_table_get

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -29,6 +29,7 @@
 #include "bloom_filter.h"
 #include "compress.h"
 #include "err.h"
+#include "hash_table.h"
 #include "skip_list.h"
 
 /* TidesDB uses tidesdb, _tidesdb_, and TDB as prefixes for functions, types, and constants */
@@ -133,7 +134,7 @@ typedef struct
     tidesdb_sstable_t **sstables;
     int num_sstables;
     pthread_rwlock_t rwlock;
-    skip_list_t *memtable;
+    void *memtable; /* can be a skip list or hash table */
     tidesdb_wal_t *wal;
 } tidesdb_column_family_t;
 


### PR DESCRIPTION
column family type to use void pointer for memtable and we cast based on column family data structure config.  Essentially if a skip list we use skip list methods based on switch, if hash table we use a hash table.  I've completed all write methods essentially currently besides flush, get, and compaction these will be done next.  I want to be sure to complete the hash table first so switch between the two data structures isn't too complicated.  Currently they are quite similar in regards to api design but I gotta go through that and make sure and also add dynamic resizing of hash table if exceeds size