### PR TITLE
- tidesdb_get use skip list or hash table for retrieval for memtable

### DIFF
--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -107,7 +107,15 @@ int hash_table_get(hash_table_t *ht, const uint8_t *key, size_t key_size, uint8_
         return -1;
     }
 
-    *value = bucket->value;
+    *value = malloc(bucket->value_size);
+    if (*value == NULL)
+    {
+        return -1;
+    }
+
+    /* we copy the value */
+    memcpy(*value, bucket->value, bucket->value_size);
+
     *value_size = bucket->value_size;
     return 0;
 }


### PR DESCRIPTION
- tidesdb_get use skip list or hash table for retrieval for memtable
- _tidesdb_replay_from_wal. populates skip list or hash table