### PR TITLE
Fix compilation error on TIDESDB_OP_DELETE

### DIFF
--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -1034,6 +1034,7 @@ int _tidesdb_replay_from_wal(tidesdb_column_family_t *cf)
 
                 break;
             case TIDESDB_OP_DELETE:
+            {
                 uint8_t *tombstone = malloc(4);
                 if (tombstone == NULL) continue;
 
@@ -1057,7 +1058,8 @@ int _tidesdb_replay_from_wal(tidesdb_column_family_t *cf)
                 }
 
                 free(tombstone);
-                break;
+            }
+            break;
             default:
                 break;
         }


### PR DESCRIPTION
I met compilation erros in apple-clang 16.0.0.

```
src/tidesdb.c:983:17: error: expected expression
  983 |                 uint8_t *tombstone = malloc(4);
      |                 ^
src/tidesdb.c:984:21: error: use of undeclared identifier 'tombstone'
  984 |                 if (tombstone == NULL) continue;
      |                     ^
src/tidesdb.c:987:24: error: use of undeclared identifier 'tombstone'
  987 |                 memcpy(tombstone, &tombstone_value, sizeof(uint32_t));
      |                        ^
src/tidesdb.c:987:24: error: use of undeclared identifier 'tombstone'
src/tidesdb.c:989:82: error: use of undeclared identifier 'tombstone'
  989 |                 (void)skip_list_put(cf->memtable, op->kv->key, op->kv->key_size, tombstone, 4,
      |                                                                                  ^
src/tidesdb.c:991:22: error: use of undeclared identifier 'tombstone'
  991 |                 free(tombstone);
      |                      ^
```
Note: line number is for 0.2.0b.

Adding block definition solves these errors.
