### PR TITLE
tidesdb: flush with hash table implementation _tidesdb_flush_memtable…

### DIFF
--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -238,7 +238,7 @@ int hash_table_cursor_prev(hash_table_cursor_t *cursor)
 }
 
 int hash_table_cursor_get(hash_table_cursor_t *cursor, uint8_t **key, size_t *key_size,
-                          uint8_t **value, size_t *value_size)
+                          uint8_t **value, size_t *value_size, time_t *ttl)
 {
     if (cursor->current_bucket_index >= cursor->ht->bucket_count)
     {
@@ -264,6 +264,7 @@ int hash_table_cursor_get(hash_table_cursor_t *cursor, uint8_t **key, size_t *ke
         *key_size = bucket->key_size;
         *value = bucket->value;
         *value_size = bucket->value_size;
+        *ttl = bucket->ttl;
         return 0;
     }
     return -1;

--- a/src/hash_table.h
+++ b/src/hash_table.h
@@ -170,10 +170,11 @@ int hash_table_cursor_prev(hash_table_cursor_t *cursor);
  * @param key_size the size of the key
  * @param value the value to be returned
  * @param value_size the size of the value
+ * @param ttl the time to live of the key-value pair
  * @return 0 if successful, -1 if not
  */
 int hash_table_cursor_get(hash_table_cursor_t *cursor, uint8_t **key, size_t *key_size,
-                          uint8_t **value, size_t *value_size);
+                          uint8_t **value, size_t *value_size, time_t *ttl);
 
 /**
  * hash_table_cursor_destroy

--- a/test/hash_table__tests.c
+++ b/test/hash_table__tests.c
@@ -111,10 +111,11 @@ void test_hash_table_cursor()
     size_t retrieved_key_size;
     uint8_t *retrieved_value;
     size_t retrieved_value_size;
+    time_t retrieved_ttl;
     do
     {
         if (hash_table_cursor_get(cursor, &retrieved_key, &retrieved_key_size, &retrieved_value,
-                                  &retrieved_value_size) == 0)
+                                  &retrieved_value_size, &retrieved_ttl) == 0)
         {
             assert(retrieved_key_size == sizeof(key));
             assert(memcmp(retrieved_key, key, retrieved_key_size) == 0);


### PR DESCRIPTION
Finishing up _tidesdb_flush_memtable_f_hash_table which flushes a column family memtable that is a hash table data structure.