### PR TITLE
link dependent libraries to tidesdb library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,11 @@ endif()
 add_library(tidesdb SHARED src/tidesdb.c src/err.c src/block_manager.c src/skip_list.c src/compress.c src/bloom_filter.c src/hash_table.c src/compat.h)
 
 target_include_directories(tidesdb PRIVATE src)
+target_link_libraries(tidesdb PRIVATE zstd snappy lz4)
+find_library(MATH_LIBRARY m)
+if(MATH_LIBRARY)
+    target_link_libraries(tidesdb PRIVATE ${MATH_LIBRARY})
+endif()
 
 install(TARGETS tidesdb
         LIBRARY DESTINATION lib
@@ -47,14 +52,14 @@ if(TIDESDB_BUILD_TESTS) # enable building tests and benchmarks
         add_executable(tidesdb_tests test/tidesdb__tests.c)
         add_executable(tidesdb_bench bench/tidesdb__bench.c)
 
-        target_link_libraries(err_tests tidesdb m zstd snappy lz4)
-        target_link_libraries(block_manager_tests tidesdb m zstd snappy lz4)
-        target_link_libraries(skip_list_tests tidesdb m zstd snappy lz4)
-        target_link_libraries(hash_table_tests tidesdb m zstd snappy lz4)
-        target_link_libraries(compress_tests tidesdb m zstd snappy lz4)
-        target_link_libraries(bloom_filter_tests tidesdb m zstd snappy lz4)
-        target_link_libraries(tidesdb_tests tidesdb m zstd snappy lz4)
-        target_link_libraries(tidesdb_bench tidesdb m zstd snappy lz4)
+        target_link_libraries(err_tests tidesdb)
+        target_link_libraries(block_manager_tests tidesdb)
+        target_link_libraries(skip_list_tests tidesdb)
+        target_link_libraries(hash_table_tests tidesdb)
+        target_link_libraries(compress_tests tidesdb)
+        target_link_libraries(bloom_filter_tests tidesdb)
+        target_link_libraries(tidesdb_tests tidesdb)
+        target_link_libraries(tidesdb_bench tidesdb)
 
         add_test(NAME err_tests COMMAND err_tests)
         add_test(NAME block_manager_tests COMMAND block_manager_tests)


### PR DESCRIPTION
Unless there is a clear reason to do so, it is better to link dependent libraries to the libraries to be built.

If there is a clear reason to keep them separate, I will take them down.
