### PR TITLE
Correct all build errors on linux(gcc version 12.3.0 (Ubuntu 12.3.0_1…

### DIFF
--- a/bench/tidesdb__bench.c
+++ b/bench/tidesdb__bench.c
@@ -58,6 +58,18 @@ void pad_key_with_nines(uint8_t *key, size_t target_len)
     }
 }
 
+void create_key(uint8_t *key, int index)
+{
+    snprintf((char *)key, SIZE, "key%03d", index);
+    pad_key_with_nines(key, SIZE - 1);
+}
+
+void create_value(uint8_t *value, int index, int thread_id)
+{
+    snprintf((char *)value, SIZE, "value%03d_%d", index, thread_id);
+    pad_key_with_nines(value, SIZE - 1);
+}
+
 void *benchmark_put(void *arg)
 {
     thread_arg_t *targ = arg;
@@ -69,12 +81,11 @@ void *benchmark_put(void *arg)
     {
         uint8_t key[SIZE];
         uint8_t value[SIZE];
-        snprintf(key, sizeof(key), "key%03d", i);
-        snprintf(value, sizeof(value), "value%03d_%d", i, thread_id);
-        pad_key_with_nines(key, SIZE - 1);
-        pad_key_with_nines(value, SIZE - 1);
+        create_key(key, i);
+        create_value(value, i, thread_id);
 
-        tidesdb_err_t *err = tidesdb_put(tdb, cf_name, key, strlen(key), value, strlen(value), -1);
+        tidesdb_err_t *err =
+            tidesdb_put(tdb, cf_name, key, strlen((char *)key), value, strlen((char *)value), -1);
         if (err != NULL)
         {
             printf(RED "Error: %s\n" RESET, err->message);
@@ -95,12 +106,11 @@ void *benchmark_put_compact(void *arg)
     {
         uint8_t key[SIZE];
         uint8_t value[SIZE];
-        snprintf(key, sizeof(key), "key%03d", i);
-        snprintf(value, sizeof(value), "value%03d_%d", i, thread_id);
-        pad_key_with_nines(key, SIZE - 1);
-        pad_key_with_nines(value, SIZE - 1);
+        create_key(key, i);
+        create_value(value, i, thread_id);
 
-        tidesdb_err_t *err = tidesdb_put(tdb, cf_name, key, strlen(key), value, strlen(value), -1);
+        tidesdb_err_t *err =
+            tidesdb_put(tdb, cf_name, key, strlen((char *)key), value, strlen((char *)value), -1);
         if (err != NULL)
         {
             printf(RED "Error: %s\n" RESET, err->message);
@@ -131,12 +141,12 @@ void *benchmark_get(void *arg)
     for (int i = 0; i < NUM_OPERATIONS; i++)
     {
         uint8_t key[SIZE];
-        snprintf(key, sizeof(key), "key%03d", i);
-        pad_key_with_nines(key, SIZE - 1);
+        create_key(key, i);
 
         uint8_t *value = NULL;
         size_t value_size = 0;
-        tidesdb_err_t *err = tidesdb_get(tdb, cf_name, key, strlen(key), &value, &value_size);
+        tidesdb_err_t *err =
+            tidesdb_get(tdb, cf_name, key, strlen((char *)key), &value, &value_size);
         if (err != NULL)
         {
             printf(RED "Error: %s\n" RESET, err->message);
@@ -157,15 +167,14 @@ void *benchmark_delete(void *arg)
     thread_arg_t *targ = arg;
     tidesdb_t *tdb = targ->tdb;
     const char *cf_name = targ->column_family_name;
-    int thread_id = targ->thread_id; /* could be used for debugging if need be */
+    /* int thread_id = targ->thread_id; could be used for debugging if need be */
 
     for (int i = 0; i < NUM_OPERATIONS; i++)
     {
         uint8_t key[SIZE];
-        snprintf(key, sizeof(key), "key%03d", i);
-        pad_key_with_nines(key, SIZE - 1);
+        create_key(key, i);
 
-        tidesdb_err_t *err = tidesdb_delete(tdb, cf_name, key, strlen(key));
+        tidesdb_err_t *err = tidesdb_delete(tdb, cf_name, key, strlen((char *)key));
         if (err != NULL)
         {
             printf(RED "Error: %s\n" RESET, err->message);

--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -246,11 +246,6 @@ int hash_table_cursor_get(hash_table_cursor_t *cursor, uint8_t **key, size_t *ke
         return -1; /* we are at the end */
     }
 
-    if (cursor->current_bucket_index < 0)
-    {
-        return -1; /* we are at the beginning */
-    }
-
     hash_table_bucket_t *bucket = cursor->ht->buckets[cursor->current_bucket_index];
     /* we check if the bucket is not null and not a tombstone */
     if (bucket != NULL)

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -3897,7 +3897,7 @@ tidesdb_err_t *tidesdb_cursor_prev(tidesdb_cursor_t *cursor)
         }
 
         /* if sstable is exhausted we move to the previous sstable */
-        if (cursor->sstable_index < (size_t)(cursor->cf->num_sstables - 1))
+        if ((size_t)cursor->sstable_index < (size_t)(cursor->cf->num_sstables - 1))
         {
             if (cursor->sstable_cursor != NULL)
             {
@@ -4045,6 +4045,7 @@ tidesdb_err_t *tidesdb_cursor_get(tidesdb_cursor_t *cursor, uint8_t **key, size_
                     return NULL;
                 }
             }
+            break;
         default:
             return tidesdb_err_from_code(TIDESDB_ERR_INVALID_MEMTABLE_DATA_STRUCTURE);
     }

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -16,7 +16,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 #include <assert.h>
 
 #include "../src/tidesdb.h"
@@ -46,8 +45,8 @@ void test_tidesdb_serialize_deserialize_key_value_pair(bool compress,
     _tidesdb_free_key_value_pair(deserialized);
     free(serialized);
 
-    printf(GREEN "test_tidesdb_serialize_deserialize_key_value_pair %s passed\n",
-           compress ? "with compression" : "", RESET);
+    printf(GREEN "test_tidesdb_serialize_deserialize_key_value_pair %s passed\n" RESET,
+           compress ? "with compression" : "");
 }
 
 void test_tidesdb_serialize_deserialize_column_family_config()
@@ -111,8 +110,8 @@ void test_tidesdb_serialize_deserialize_operation(bool compress, tidesdb_compres
     _tidesdb_free_operation(deserialized);
     free(serialized);
 
-    printf(GREEN "test_tidesdb_serialize_deserialize_operation %s passed\n",
-           compress ? "with compression" : "", RESET);
+    printf(GREEN "test_tidesdb_serialize_deserialize_operation %s passed\n" RESET,
+           compress ? "with compression" : "");
 }
 
 void test_tidesdb_tidesdb_open_close()


### PR DESCRIPTION
Correct all build errors on linux(gcc version 12.3.0 (Ubuntu 12.3.0_1ubuntu1_23.04)).  Mainly from bench, hash table, and tidesdb cursor.