### PR TITLE
correct column family serialization pointer advancement.  Was from co…

### DIFF
--- a/src/hash_table.h
+++ b/src/hash_table.h
@@ -24,8 +24,8 @@
  * unknown type name time_t were coming so had to include for macos
  *
  */
-#include <time.h>
 #include <stdint.h>
+#include <time.h>
 #endif
 
 #define TOMBSTONE                                                                                 \

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -254,6 +254,7 @@ uint8_t *_tidesdb_serialize_column_family_config(tidesdb_column_family_config_t 
 
     /* serialize compression_algo */
     memcpy(ptr, &config->compress_algo, sizeof(tidesdb_compression_algo_t));
+    ptr += sizeof(tidesdb_compression_algo_t);
 
     /* serialize memtable_ds */
     memcpy(ptr, &config->memtable_ds, sizeof(tidesdb_memtable_ds_t));
@@ -304,6 +305,7 @@ tidesdb_column_family_config_t *_tidesdb_deserialize_column_family_config(const 
     /* deserialize compression_algo */
     tidesdb_compression_algo_t compress_algo;
     memcpy(&compress_algo, ptr, sizeof(tidesdb_compression_algo_t));
+    ptr += sizeof(tidesdb_compression_algo_t);
 
     /* deserialize memtable_ds */
     tidesdb_memtable_ds_t memtable_ds;


### PR DESCRIPTION
Correct column family serialization pointer advancement.  Was from configuration changes in earlier PRs.  Was failing test_tidesdb_serialize_deserialize_column_family_config test, this PR corrects this.