### PR TITLE
- Switch over to using compact.h in tides.h so we can now achieve cro…

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ It is not a full-featured database, but rather a library that can be used to bui
 - [x] **Error Handling** API functions return an error code and message.
 - [x] **Easy API** simple and easy to use api.
 - [x] **Multiple Memtable Data Structures** memtable can be a skip list or hash table.
+- [x] **Multiplatform** Linux, MacOS, and Windows support.
 
 ## Building
 Using cmake to build the shared library.
@@ -94,9 +95,6 @@ Bindings are in the works in various languages.
 
 ## Discord Community
 Join the [TidesDB Discord Community](https://discord.gg/VsafJxtj) to ask questions, work on development, and discuss the future of TidesDB.
-
-## What's coming ?
-- [ ] **Windows Support** - Windows support is coming soon.
 
 ## Dependencies
 - [Snappy](https://github.com/google/snappy)

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -19,14 +19,12 @@
 #ifndef __TIDESDB_H__
 #define __TIDESDB_H__
 
-#include <dirent.h>
-#include <pthread.h>
-#include <semaphore.h>
 #include <stdbool.h>
 #include <sys/stat.h>
 
 #include "block_manager.h"
 #include "bloom_filter.h"
+#include "compat.h"
 #include "compress.h"
 #include "err.h"
 #include "hash_table.h"

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -210,10 +210,10 @@ void test_tidesdb_create_drop_column_family(bool compress, tidesdb_compression_a
     assert(err == NULL);
 
     _tidesdb_remove_directory("test_db");
-    printf(GREEN "test_tidesdb_create_drop_column_family %s %s %s passed\n" RESET,
-           compress ? "with compression" : "", bloom_filter ? "with bloom filter" : "",
-           memtable_ds == TDB_MEMTABLE_SKIP_LIST ? "with skip list memtable"
-                                                 : "with hash table memtable");
+    printf(GREEN "test_tidesdb_create_drop_column_family%s%s%s passed\n" RESET,
+           compress ? " with compression" : "", bloom_filter ? " with bloom filter" : "",
+           memtable_ds == TDB_MEMTABLE_SKIP_LIST ? " with skip list memtable"
+                                                 : " with hash table memtable");
 }
 
 void test_tidesdb_put_get_memtable(bool compress, tidesdb_compression_algo_t algo,
@@ -278,10 +278,10 @@ void test_tidesdb_put_get_memtable(bool compress, tidesdb_compression_algo_t alg
     assert(err == NULL);
 
     _tidesdb_remove_directory("test_db");
-    printf(GREEN "test_tidesdb_put_get_memtable %s %s %s passed\n" RESET,
-           compress ? "with compression" : "", bloom_filter ? "with bloom filter" : "",
-           memtable_ds == TDB_MEMTABLE_SKIP_LIST ? "with skip list memtable"
-                                                 : "with hash table memtable");
+    printf(GREEN "test_tidesdb_put_get_memtable%s%s%s passed\n" RESET,
+           compress ? " with compression" : "", bloom_filter ? " with bloom filter" : "",
+           memtable_ds == TDB_MEMTABLE_SKIP_LIST ? " with skip list memtable"
+                                                 : " with hash table memtable");
 }
 
 /* we put a value, we close the db, we reopen it and we should be able to get the value as the write
@@ -363,10 +363,10 @@ void test_tidesdb_put_close_replay_get(bool compress, tidesdb_compression_algo_t
     assert(err == NULL);
 
     _tidesdb_remove_directory("test_db");
-    printf(GREEN "test_tidesdb_put_close_replay_get %s %s %s passed\n" RESET,
-           compress ? "with compression" : "", bloom_filter ? "with bloom filter" : "",
-           memtable_ds == TDB_MEMTABLE_SKIP_LIST ? "with skip list memtable"
-                                                 : "with hash table memtable");
+    printf(GREEN "test_tidesdb_put_close_replay_get%s%s%s passed\n" RESET,
+           compress ? " with compression" : "", bloom_filter ? " with bloom filter" : "",
+           memtable_ds == TDB_MEMTABLE_SKIP_LIST ? " with skip list memtable"
+                                                 : " with hash table memtable");
 }
 
 void test_tidesdb_put_flush_get(bool compress, tidesdb_compression_algo_t algo, bool bloom_filter,
@@ -493,10 +493,10 @@ void test_tidesdb_put_flush_get(bool compress, tidesdb_compression_algo_t algo, 
     assert(err == NULL);
 
     _tidesdb_remove_directory("test_db");
-    printf(GREEN "test_tidesdb_put_flush_get %s %s %s passed\n" RESET,
-           compress ? "with compression" : "", bloom_filter ? "with bloom filter" : "",
-           memtable_ds == TDB_MEMTABLE_SKIP_LIST ? "with skip list memtable"
-                                                 : "with hash table memtable");
+    printf(GREEN "test_tidesdb_put_flush_get%s%s%s passed\n" RESET,
+           compress ? " with compression" : "", bloom_filter ? " with bloom filter" : "",
+           memtable_ds == TDB_MEMTABLE_SKIP_LIST ? " with skip list memtable"
+                                                 : " with hash table memtable");
 }
 
 void test_tidesdb_put_flush_close_get(bool compress, tidesdb_compression_algo_t algo,
@@ -639,10 +639,10 @@ void test_tidesdb_put_flush_close_get(bool compress, tidesdb_compression_algo_t 
     assert(err == NULL);
 
     _tidesdb_remove_directory("test_db");
-    printf(GREEN "test_tidesdb_put_flush_close_get %s %s %s passed\n" RESET,
-           compress ? "with compression" : "", bloom_filter ? "with bloom filter" : "",
-           memtable_ds == TDB_MEMTABLE_SKIP_LIST ? "with skip list memtable"
-                                                 : "with hash table memtable");
+    printf(GREEN "test_tidesdb_put_flush_close_get%s%s%s passed\n" RESET,
+           compress ? " with compression" : "", bloom_filter ? " with bloom filter" : "",
+           memtable_ds == TDB_MEMTABLE_SKIP_LIST ? " with skip list memtable"
+                                                 : " with hash table memtable");
 }
 
 void test_tidesdb_put_delete_get(bool compress, tidesdb_compression_algo_t algo, bool bloom_filter,
@@ -719,10 +719,10 @@ void test_tidesdb_put_delete_get(bool compress, tidesdb_compression_algo_t algo,
     assert(err == NULL);
 
     _tidesdb_remove_directory("test_db");
-    printf(GREEN "test_tidesdb_put_delete_get %s %s %s passed\n" RESET,
-           compress ? "with compression" : "", bloom_filter ? "with bloom filter" : "",
-           memtable_ds == TDB_MEMTABLE_SKIP_LIST ? "with skip list memtable"
-                                                 : "with hash table memtable");
+    printf(GREEN "test_tidesdb_put_delete_get%s%s%s passed\n" RESET,
+           compress ? " with compression" : "", bloom_filter ? " with bloom filter" : "",
+           memtable_ds == TDB_MEMTABLE_SKIP_LIST ? " with skip list memtable"
+                                                 : " with hash table memtable");
 }
 
 void test_tidesdb_put_flush_delete_get(bool compress, tidesdb_compression_algo_t algo,
@@ -849,10 +849,10 @@ void test_tidesdb_put_flush_delete_get(bool compress, tidesdb_compression_algo_t
     assert(err == NULL);
 
     _tidesdb_remove_directory("test_db");
-    printf(GREEN "test_tidesdb_put_flush_delete_get %s %s %s passed\n" RESET,
-           compress ? "with compression" : "", bloom_filter ? "with bloom filter" : "",
-           memtable_ds == TDB_MEMTABLE_SKIP_LIST ? "with skip list memtable"
-                                                 : "with hash table memtable");
+    printf(GREEN "test_tidesdb_put_flush_delete_get%s%s%s passed\n" RESET,
+           compress ? " with compression" : "", bloom_filter ? " with bloom filter" : "",
+           memtable_ds == TDB_MEMTABLE_SKIP_LIST ? " with skip list memtable"
+                                                 : " with hash table memtable");
 }
 
 void test_tidesdb_put_many_flush_get(bool compress, tidesdb_compression_algo_t algo,
@@ -925,10 +925,10 @@ void test_tidesdb_put_many_flush_get(bool compress, tidesdb_compression_algo_t a
     assert(err == NULL);
 
     _tidesdb_remove_directory("test_db");
-    printf(GREEN "test_tidesdb_put_flush_compact_get %s %s %s passed\n" RESET,
-           compress ? "with compression" : "", bloom_filter ? "with bloom filter" : "",
-           memtable_ds == TDB_MEMTABLE_SKIP_LIST ? "with skip list memtable"
-                                                 : "with hash table memtable");
+    printf(GREEN "test_tidesdb_put_flush_compact_get%s%s%s passed\n" RESET,
+           compress ? " with compression" : "", bloom_filter ? " with bloom filter" : "",
+           memtable_ds == TDB_MEMTABLE_SKIP_LIST ? " with skip list memtable"
+                                                 : " with hash table memtable");
 }
 
 void test_tidesdb_put_flush_compact_get(bool compress, tidesdb_compression_algo_t algo,
@@ -1010,10 +1010,10 @@ void test_tidesdb_put_flush_compact_get(bool compress, tidesdb_compression_algo_
     assert(err == NULL);
 
     _tidesdb_remove_directory("test_db");
-    printf(GREEN "test_tidesdb_put_flush_compact_get %s %s %s passed\n" RESET,
-           compress ? "with compression" : "", bloom_filter ? "with bloom filter" : "",
-           memtable_ds == TDB_MEMTABLE_SKIP_LIST ? "with skip list memtable"
-                                                 : "with hash table memtable");
+    printf(GREEN "test_tidesdb_put_flush_compact_get%s%s%s passed\n" RESET,
+           compress ? " with compression" : "", bloom_filter ? " with bloom filter" : "",
+           memtable_ds == TDB_MEMTABLE_SKIP_LIST ? " with skip list memtable"
+                                                 : " with hash table memtable");
 }
 
 void test_tidesdb_txn_put_get(bool compress, tidesdb_compression_algo_t algo, bool bloom_filter,
@@ -1095,10 +1095,10 @@ void test_tidesdb_txn_put_get(bool compress, tidesdb_compression_algo_t algo, bo
     assert(err == NULL);
 
     _tidesdb_remove_directory("test_db");
-    printf(GREEN "test_tidesdb_txn_put_get %s %s %s passed\n" RESET,
-           compress ? "with compression" : "", bloom_filter ? "with bloom filter" : "",
-           memtable_ds == TDB_MEMTABLE_SKIP_LIST ? "with skip list memtable"
-                                                 : "with hash table memtable");
+    printf(GREEN "test_tidesdb_txn_put_get%s%s%s passed\n" RESET,
+           compress ? " with compression" : "", bloom_filter ? " with bloom filter" : "",
+           memtable_ds == TDB_MEMTABLE_SKIP_LIST ? " with skip list memtable"
+                                                 : " with hash table memtable");
 }
 
 void test_tidesdb_txn_put_get_rollback_get(bool compress, tidesdb_compression_algo_t algo,
@@ -1191,10 +1191,10 @@ void test_tidesdb_txn_put_get_rollback_get(bool compress, tidesdb_compression_al
     assert(err == NULL);
 
     _tidesdb_remove_directory("test_db");
-    printf(GREEN "test_tidesdb_txn_put_get_rollback_get %s %s %s passed\n" RESET,
-           compress ? "with compression" : "", bloom_filter ? "with bloom filter" : "",
-           memtable_ds == TDB_MEMTABLE_SKIP_LIST ? "with skip list memtable"
-                                                 : "with hash table memtable");
+    printf(GREEN "test_tidesdb_txn_put_get_rollback_get%s%s%s passed\n" RESET,
+           compress ? " with compression" : "", bloom_filter ? " with bloom filter" : "",
+           memtable_ds == TDB_MEMTABLE_SKIP_LIST ? " with skip list memtable"
+                                                 : " with hash table memtable");
 }
 
 void test_tidesdb_txn_put_put_delete_get(bool compress, tidesdb_compression_algo_t algo,
@@ -1298,10 +1298,10 @@ void test_tidesdb_txn_put_put_delete_get(bool compress, tidesdb_compression_algo
     assert(err == NULL);
 
     _tidesdb_remove_directory("test_db");
-    printf(GREEN "test_tidesdb_txn_put_put_delete_get %s %s %s passed\n" RESET,
-           compress ? "with compression" : "", bloom_filter ? "with bloom filter" : "",
-           memtable_ds == TDB_MEMTABLE_SKIP_LIST ? "with skip list memtable"
-                                                 : "with hash table memtable");
+    printf(GREEN "test_tidesdb_txn_put_put_delete_get%s%s%s passed\n" RESET,
+           compress ? " with compression" : "", bloom_filter ? " with bloom filter" : "",
+           memtable_ds == TDB_MEMTABLE_SKIP_LIST ? " with skip list memtable"
+                                                 : " with hash table memtable");
 }
 
 /* mainly test going forward and backwards through column family memtable
@@ -1639,10 +1639,10 @@ void test_tidesdb_cursor_memtable_sstables(bool compress, tidesdb_compression_al
     assert(err == NULL);
 
     _tidesdb_remove_directory("test_db");
-    printf(GREEN "test_tidesdb_cursor_memtable_sstables %s %s %s passed\n" RESET,
-           compress ? "with compression" : "", bloom_filter ? "with bloom filter" : "",
-           memtable_ds == TDB_MEMTABLE_SKIP_LIST ? "with skip list memtable"
-                                                 : "with hash table memtable");
+    printf(GREEN "test_tidesdb_cursor_memtable_sstables%s%s%s passed\n" RESET,
+           compress ? " with compression" : "", bloom_filter ? " with bloom filter" : "",
+           memtable_ds == TDB_MEMTABLE_SKIP_LIST ? " with skip list memtable"
+                                                 : " with hash table memtable");
 }
 
 int main(void)


### PR DESCRIPTION
- Switch over to using compact.h in tides.h so we can now achieve cross platform support.
- Update read me
- Correct spacing on prints within TidesDB tests