### PR TITLE
simplify CMakeLists.txt by linking tidesdb lib only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,10 +30,10 @@ add_library(tidesdb SHARED src/tidesdb.c src/err.c src/block_manager.c src/skip_
 target_include_directories(tidesdb PRIVATE src)
 if(APPLE AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
         # For Apple Silicon Macs, Homebrew installs packages in /opt/homebrew
-        target_include_directories(tidesdb PRIVATE /opt/homebrew/include)
-        target_link_directories(tidesdb PRIVATE /opt/homebrew/lib)
+        target_include_directories(tidesdb PUBLIC /opt/homebrew/include)
+        target_link_directories(tidesdb PUBLIC /opt/homebrew/lib)
         # Link against compression libraries for Apple Silicon
-        target_link_libraries(tidesdb PRIVATE
+        target_link_libraries(tidesdb PUBLIC
                 m       # math library
                 lz4     # LZ4 compression
                 zstd    # Zstandard compression
@@ -41,20 +41,21 @@ if(APPLE AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
         )
 elseif(APPLE)
         # For Intel Macs, Homebrew typically installs in /usr/local
-        target_include_directories(tidesdb PRIVATE /usr/local/include)
-        target_link_directories(tidesdb PRIVATE /usr/local/lib)
+        target_include_directories(tidesdb PUBLIC /usr/local/include)
+        target_link_directories(tidesdb PUBLIC /usr/local/lib)
         # Link against compression libraries for Intel Mac
-        target_link_libraries(tidesdb PRIVATE
+        target_link_libraries(tidesdb PUBLIC
                 m       # math library
                 lz4     # LZ4 compression
                 zstd    # Zstandard compression
                 snappy  # Snappy compression
         )
-endif()
-target_link_libraries(tidesdb PRIVATE zstd snappy lz4)
-find_library(MATH_LIBRARY m)
-if(MATH_LIBRARY)
-    target_link_libraries(tidesdb PRIVATE ${MATH_LIBRARY})
+else()
+        target_link_libraries(tidesdb PUBLIC zstd snappy lz4)
+        find_library(MATH_LIBRARY m)
+        if(MATH_LIBRARY)
+                target_link_libraries(tidesdb PUBLIC ${MATH_LIBRARY})
+        endif()
 endif()
 
 install(TARGETS tidesdb
@@ -76,23 +77,9 @@ if(TIDESDB_BUILD_TESTS) # enable building tests and benchmarks
         add_executable(tidesdb_bench bench/tidesdb__bench.c)
 
         # Add include and link directories for test executables
-        if(APPLE AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
-                foreach(test_target err_tests block_manager_tests skip_list_tests hash_table_tests compress_tests bloom_filter_tests tidesdb_tests tidesdb_bench)
-                        target_include_directories(${test_target} PRIVATE /opt/homebrew/include)
-                        target_link_directories(${test_target} PRIVATE /opt/homebrew/lib)
-                        target_link_libraries(${test_target} tidesdb m zstd snappy lz4)
-                endforeach()
-        elseif(APPLE)
-                foreach(test_target err_tests block_manager_tests skip_list_tests hash_table_tests compress_tests bloom_filter_tests tidesdb_tests tidesdb_bench)
-                        target_include_directories(${test_target} PRIVATE /usr/local/include)
-                        target_link_directories(${test_target} PRIVATE /usr/local/lib)
-                        target_link_libraries(${test_target} tidesdb m zstd snappy lz4)
-                endforeach()
-        else()
-                foreach(test_target err_tests block_manager_tests skip_list_tests hash_table_tests compress_tests bloom_filter_tests tidesdb_tests tidesdb_bench)
-                        target_link_libraries(${test_target} tidesdb m zstd snappy lz4)
-                endforeach()
-        endif()
+        foreach(test_target err_tests block_manager_tests skip_list_tests hash_table_tests compress_tests bloom_filter_tests tidesdb_tests tidesdb_bench)
+                target_link_libraries(${test_target} PRIVATE tidesdb)
+        endforeach()
 
         add_test(NAME err_tests COMMAND err_tests)
         add_test(NAME block_manager_tests COMMAND block_manager_tests)


### PR DESCRIPTION
Sorry I mistake the scpoe of dependent libraries. 
This is now fixed.