### PR TITLE
tidesdb_column_family_t to not use void pointer for memtable as causi…

### DIFF
--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -283,12 +283,7 @@ int hash_table_cursor_prev(hash_table_cursor_t *cursor)
 int hash_table_cursor_get(hash_table_cursor_t *cursor, uint8_t **key, size_t *key_size,
                           uint8_t **value, size_t *value_size, time_t *ttl)
 {
-    if (cursor->current_bucket_index >= cursor->ht->bucket_count)
-    {
-        return -1; /* we are at the end */
-    }
-
-    while (cursor->current_bucket_index < cursor->ht->bucket_count)
+    while (cursor->current_bucket_index <= cursor->last_bucket_index)
     {
         hash_table_bucket_t *bucket = cursor->ht->buckets[cursor->current_bucket_index];
         /* we check if the bucket is not null and not a tombstone */

--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -23,35 +23,35 @@
 #include <string.h>
 #include <time.h>
 
-int hash_table_new(hash_table_t **ht)
+hash_table_t *hash_table_new()
 {
     /* we alloc the hash table */
-    *ht = malloc(sizeof(hash_table_t));
-    if (*ht == NULL)
+    hash_table_t *ht = malloc(sizeof(hash_table_t));
+    if (ht == NULL)
     {
-        return -1;
+        return NULL;
     }
 
     /* we set the buckets to INITIAL_BUCKETS */
-    (*ht)->buckets = malloc(INITIAL_BUCKETS * sizeof(hash_table_bucket_t *));
-    if ((*ht)->buckets == NULL)
+    ht->buckets = malloc(INITIAL_BUCKETS * sizeof(hash_table_bucket_t *));
+    if (ht->buckets == NULL)
     {
-        free(*ht);
-        return -1;
+        free(ht);
+        return NULL;
     }
 
     /* we set the buckets to 0 */
-    memset((*ht)->buckets, 0, INITIAL_BUCKETS * sizeof(hash_table_bucket_t *));
+    memset(ht->buckets, 0, INITIAL_BUCKETS * sizeof(hash_table_bucket_t *));
 
     /* we set the bucket count */
-    (*ht)->bucket_count = INITIAL_BUCKETS;
+    ht->bucket_count = INITIAL_BUCKETS;
 
     /* we set the count to 0 */
-    (*ht)->count = 0;
+    ht->count = 0;
 
     /* we set the total size to 0 */
-    (*ht)->total_size = 0;
-    return 0;
+    ht->total_size = 0;
+    return ht;
 }
 
 int hash_table_put(hash_table_t **ht, const uint8_t *key, size_t key_size, const uint8_t *value,
@@ -61,32 +61,46 @@ int hash_table_put(hash_table_t **ht, const uint8_t *key, size_t key_size, const
     size_t index = original_index;
     size_t i = 1;
 
-    /* Find the next available slot using quadratic probing */
-    while ((*ht)->buckets[index] != NULL && (*ht)->buckets[index]->key != NULL)
+    /* find the correct slot using quadratic probing */
+    while ((*ht)->buckets[index] != NULL)
     {
+        hash_table_bucket_t *bucket = (*ht)->buckets[index];
+        if (bucket->key_size == key_size && memcmp(bucket->key, key, key_size) == 0)
+        {
+            /* key already exists, update the value */
+            free(bucket->value);
+            bucket->value = malloc(value_size);
+            if (bucket->value == NULL)
+            {
+                return -1;
+            }
+            memcpy(bucket->value, value, value_size);
+            bucket->value_size = value_size;
+            bucket->ttl = ttl;
+            return 0;
+        }
         index = (original_index + i * i) % (*ht)->bucket_count;
         i++;
     }
 
-    /* we initialize the bucket */
+    /* key does not exist, create a new bucket */
     hash_table_bucket_t *bucket = malloc(sizeof(hash_table_bucket_t));
     if (bucket == NULL)
     {
         return -1;
     }
 
-    /* we set the key */
+    /* set the key */
     bucket->key = malloc(key_size);
     if (bucket->key == NULL)
     {
         free(bucket);
         return -1;
     }
-
     memcpy(bucket->key, key, key_size);
     bucket->key_size = key_size;
 
-    /* we set the value */
+    /* set the value */
     bucket->value = malloc(value_size);
     if (bucket->value == NULL)
     {
@@ -94,12 +108,11 @@ int hash_table_put(hash_table_t **ht, const uint8_t *key, size_t key_size, const
         free(bucket);
         return -1;
     }
-
     memcpy(bucket->value, value, value_size);
     bucket->value_size = value_size;
     bucket->ttl = ttl;
 
-    /* we free the old bucket if it exists */
+    /* free the old bucket if it exists */
     if ((*ht)->buckets[index] != NULL)
     {
         free((*ht)->buckets[index]->key);
@@ -111,10 +124,10 @@ int hash_table_put(hash_table_t **ht, const uint8_t *key, size_t key_size, const
         (*ht)->count++;
     }
 
-    (*ht)->buckets[index] = bucket; /* we set the bucket */
+    (*ht)->buckets[index] = bucket; /* set the bucket */
     (*ht)->total_size += key_size + value_size;
 
-    /* we check if we should resize */
+    /* check if we should resize */
     if (hash_table_should_resize(*ht))
     {
         if (hash_table_resize(ht, (*ht)->bucket_count * 2) == -1)
@@ -187,7 +200,7 @@ int hash_table_get(hash_table_t *ht, const uint8_t *key, size_t key_size, uint8_
     size_t index = original_index;
     size_t i = 1;
 
-    /* Find the correct slot using quadratic probing */
+    /* find the correct slot using quadratic probing */
     while (ht->buckets[index] != NULL)
     {
         hash_table_bucket_t *bucket = ht->buckets[index];
@@ -196,8 +209,12 @@ int hash_table_get(hash_table_t *ht, const uint8_t *key, size_t key_size, uint8_
             /* check if ttl is set and if the key has expired */
             if (bucket->ttl != -1 && time(NULL) > bucket->ttl)
             {
+                ht->total_size -= bucket->value_size;
+                free(bucket->value);
+                bucket->value = malloc(4);
                 *(uint32_t *)bucket->value = TOMBSTONE;
-                return -1;
+                bucket->value_size = 4;
+                ht->total_size += 4;
             }
 
             *value = malloc(bucket->value_size);
@@ -235,7 +252,7 @@ void hash_table_cursor_reset(hash_table_cursor_t *cursor)
 
 int hash_table_cursor_next(hash_table_cursor_t *cursor)
 {
-    while (cursor->current_bucket_index < cursor->ht->bucket_count)
+    while (cursor->current_bucket_index < cursor->last_bucket_index)
     {
         cursor->current_bucket_index++;
         if (cursor->current_bucket_index >= cursor->ht->bucket_count)
@@ -252,7 +269,7 @@ int hash_table_cursor_next(hash_table_cursor_t *cursor)
 
 int hash_table_cursor_prev(hash_table_cursor_t *cursor)
 {
-    while (cursor->current_bucket_index > 0)
+    while (cursor->last_bucket_index > -1)
     {
         --cursor->current_bucket_index;
         if (cursor->ht->buckets[cursor->current_bucket_index] != NULL)
@@ -271,23 +288,37 @@ int hash_table_cursor_get(hash_table_cursor_t *cursor, uint8_t **key, size_t *ke
         return -1; /* we are at the end */
     }
 
-    hash_table_bucket_t *bucket = cursor->ht->buckets[cursor->current_bucket_index];
-    /* we check if the bucket is not null and not a tombstone */
-    if (bucket != NULL)
+    while (cursor->current_bucket_index < cursor->ht->bucket_count)
     {
-        if (bucket->ttl != -1 && time(NULL) > bucket->ttl)
+        hash_table_bucket_t *bucket = cursor->ht->buckets[cursor->current_bucket_index];
+        /* we check if the bucket is not null and not a tombstone */
+        if (bucket != NULL)
         {
-            *(uint32_t *)bucket->value = TOMBSTONE;
-            return -1;
-        }
+            if (bucket->ttl != -1 && time(NULL) > bucket->ttl)
+            {
+                cursor->ht->total_size -= bucket->value_size;
+                free(bucket->value);
+                bucket->value = malloc(4);
+                if (bucket->value == NULL)
+                {
+                    return -1; /* malloc failed */
+                }
+                *(uint32_t *)bucket->value = TOMBSTONE;
+                bucket->value_size = 4;
+                cursor->ht->total_size += 4;
+            }
 
-        *key = bucket->key;
-        *key_size = bucket->key_size;
-        *value = bucket->value;
-        *value_size = bucket->value_size;
-        *ttl = bucket->ttl;
-        return 0;
+            *key = bucket->key;
+            *key_size = bucket->key_size;
+            *value = bucket->value;
+            *value_size = bucket->value_size;
+            *ttl = bucket->ttl;
+            return 0;
+        }
+        /* skip and go to the next bucket */
+        cursor->current_bucket_index++;
     }
+
     return -1;
 }
 

--- a/src/hash_table.h
+++ b/src/hash_table.h
@@ -87,10 +87,9 @@ typedef struct
 /**
  * hash_table_new
  * creates a new hash table
- * @param ht the hash table to create
- * @return 0 if successful, -1 if not
+ * @return the new hash table
  */
-int hash_table_new(hash_table_t **ht);
+hash_table_t *hash_table_new();
 
 /**
  * hash_table_put

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -634,10 +634,11 @@ int _tidesdb_load_column_families(tidesdb_t *tdb)
                 switch (cf->config.memtable_ds)
                 {
                     case TDB_MEMTABLE_SKIP_LIST:
-                        cf->memtable = skip_list_new(cf->config.max_level, cf->config.probability);
+                        cf->memtable_sl =
+                            skip_list_new(cf->config.max_level, cf->config.probability);
                         break; /* create a skip list */
                     case TDB_MEMTABLE_HASH_TABLE:
-                        (void)hash_table_new(cf->memtable);
+                        cf->memtable_ht = hash_table_new();
                         break;
                 }
 
@@ -737,21 +738,23 @@ void _tidesdb_free_column_families(tidesdb_t *tdb)
 
             if (tdb->column_families[i]->path != NULL) free(tdb->column_families[i]->path);
 
-            if (tdb->column_families[i]->memtable != NULL)
+            if (tdb->column_families[i]->memtable_ht != NULL ||
+                tdb->column_families[i]->memtable_sl != NULL)
             {
                 switch (tdb->column_families[i]->config.memtable_ds)
                 {
                     case TDB_MEMTABLE_SKIP_LIST:
-                        (void)skip_list_free(tdb->column_families[i]->memtable);
+                        (void)skip_list_free(tdb->column_families[i]->memtable_sl);
                         break;
                     case TDB_MEMTABLE_HASH_TABLE:
-                        (void)hash_table_free(tdb->column_families[i]->memtable);
+                        (void)hash_table_free(tdb->column_families[i]->memtable_ht);
                         break;
                     default:
                         break;
                 }
 
-                tdb->column_families[i]->memtable = NULL;
+                tdb->column_families[i]->memtable_ht = NULL;
+                tdb->column_families[i]->memtable_sl = NULL;
             }
 
             /* we free the sstables, closing them as well */
@@ -1033,12 +1036,12 @@ int _tidesdb_replay_from_wal(tidesdb_column_family_t *cf)
                 {
                     case TDB_MEMTABLE_SKIP_LIST:
                     {
-                        (void)skip_list_put(cf->memtable, op->kv->key, op->kv->key_size,
+                        (void)skip_list_put(cf->memtable_sl, op->kv->key, op->kv->key_size,
                                             op->kv->value, op->kv->value_size, op->kv->ttl);
                     }
                     break;
                     case TDB_MEMTABLE_HASH_TABLE:
-                        (void)hash_table_put(cf->memtable, op->kv->key, op->kv->key_size,
+                        (void)hash_table_put(&cf->memtable_ht, op->kv->key, op->kv->key_size,
                                              op->kv->value, op->kv->value_size, op->kv->ttl);
                         break;
                     default:
@@ -1058,13 +1061,13 @@ int _tidesdb_replay_from_wal(tidesdb_column_family_t *cf)
                 {
                     case TDB_MEMTABLE_SKIP_LIST:
                     {
-                        (void)skip_list_put(cf->memtable, op->kv->key, op->kv->key_size, tombstone,
-                                            4, op->kv->ttl);
+                        (void)skip_list_put(cf->memtable_sl, op->kv->key, op->kv->key_size,
+                                            tombstone, 4, op->kv->ttl);
                     }
                     break;
                     case TDB_MEMTABLE_HASH_TABLE:
-                        (void)hash_table_put(cf->memtable, op->kv->key, op->kv->key_size, tombstone,
-                                             4, op->kv->ttl);
+                        (void)hash_table_put(&cf->memtable_ht, op->kv->key, op->kv->key_size,
+                                             tombstone, 4, op->kv->ttl);
                         break;
                     default:
                         break;
@@ -1192,7 +1195,17 @@ tidesdb_err_t *tidesdb_drop_column_family(tidesdb_t *tdb, const char *name)
 
     (void)remove(wal_path); /*incase */
 
-    (void)skip_list_free(tdb->column_families[index]->memtable);
+    switch (tdb->column_families[index]->config.memtable_ds)
+    {
+        case TDB_MEMTABLE_SKIP_LIST:
+            (void)skip_list_free(tdb->column_families[index]->memtable_sl);
+            break;
+        case TDB_MEMTABLE_HASH_TABLE:
+            (void)hash_table_free(tdb->column_families[index]->memtable_ht);
+            break;
+        default:
+            break;
+    }
 
     /* remove all files in the column family directory */
     (void)_tidesdb_remove_directory(tdb->column_families[index]->path);
@@ -1416,15 +1429,15 @@ int _tidesdb_new_column_family(const char *db_path, const char *name, int flush_
     switch ((*cf)->config.memtable_ds)
     {
         case TDB_MEMTABLE_SKIP_LIST:
-            (*cf)->memtable = skip_list_new((*cf)->config.max_level, (*cf)->config.probability);
+            (*cf)->memtable_sl = skip_list_new((*cf)->config.max_level, (*cf)->config.probability);
             break;
         case TDB_MEMTABLE_HASH_TABLE:
-            (void)hash_table_new((*cf)->memtable);
+            (*cf)->memtable_ht = hash_table_new();
             break;
     }
 
     /* we check if the memtable was created */
-    if ((*cf)->memtable == NULL)
+    if ((*cf)->memtable_sl == NULL || (*cf)->memtable_ht == NULL)
     {
         free((*cf)->config.name);
         free((*cf)->path);
@@ -1572,14 +1585,14 @@ tidesdb_err_t *tidesdb_put(tidesdb_t *tdb, const char *column_family_name, const
     {
         case TDB_MEMTABLE_SKIP_LIST:
             /* put in memtable */
-            if (skip_list_put(cf->memtable, key, key_size, value, value_size, ttl) == -1)
+            if (skip_list_put(cf->memtable_sl, key, key_size, value, value_size, ttl) == -1)
             {
                 (void)pthread_rwlock_unlock(&cf->rwlock);
                 return tidesdb_err_from_code(TIDESDB_ERR_FAILED_TO_PUT_TO_MEMTABLE);
             }
 
             /* we check if the memtable has reached the flush threshold */
-            if ((int)((skip_list_t *)cf->memtable)->total_size >= cf->config.flush_threshold)
+            if ((int)((skip_list_t *)cf->memtable_sl)->total_size >= cf->config.flush_threshold)
             {
                 if (cf->config.bloom_filter)
                 {
@@ -1623,14 +1636,14 @@ tidesdb_err_t *tidesdb_put(tidesdb_t *tdb, const char *column_family_name, const
             break;
         case TDB_MEMTABLE_HASH_TABLE:
             /* put in memtable */
-            if (hash_table_put(cf->memtable, key, key_size, value, value_size, ttl) == -1)
+            if (hash_table_put(&cf->memtable_ht, key, key_size, value, value_size, ttl) == -1)
             {
                 (void)pthread_rwlock_unlock(&cf->rwlock);
                 return tidesdb_err_from_code(TIDESDB_ERR_FAILED_TO_PUT_TO_MEMTABLE);
             }
 
             /* we check if the memtable has reached the flush threshold */
-            if ((int)((hash_table_t *)cf->memtable)->total_size >= cf->config.flush_threshold)
+            if ((int)((hash_table_t *)cf->memtable_ht)->total_size >= cf->config.flush_threshold)
             {
                 if (cf->config.bloom_filter)
                 {
@@ -1733,7 +1746,7 @@ tidesdb_err_t *tidesdb_get(tidesdb_t *tdb, const char *column_family_name, const
     switch (cf->config.memtable_ds)
     {
         case TDB_MEMTABLE_SKIP_LIST:
-            if (skip_list_get(cf->memtable, key, key_size, value, value_size) != -1)
+            if (skip_list_get(cf->memtable_sl, key, key_size, value, value_size) != -1)
             {
                 /* we found the key in the memtable
                  * we check if the value is a tombstone */
@@ -1750,7 +1763,8 @@ tidesdb_err_t *tidesdb_get(tidesdb_t *tdb, const char *column_family_name, const
             }
             break;
         case TDB_MEMTABLE_HASH_TABLE:
-            if (hash_table_get(cf->memtable, key, key_size, value, value_size) != -1)
+            if (hash_table_get((hash_table_t *)cf->memtable_ht, key, key_size, value, value_size) !=
+                -1)
             {
                 /* we found the key in the memtable
                  * we check if the value is a tombstone */
@@ -1766,6 +1780,7 @@ tidesdb_err_t *tidesdb_get(tidesdb_t *tdb, const char *column_family_name, const
                 return NULL;
             }
             break;
+
         default:
             return tidesdb_err_from_code(TIDESDB_ERR_INVALID_MEMTABLE_DATA_STRUCTURE);
     }
@@ -1969,11 +1984,28 @@ tidesdb_err_t *tidesdb_delete(tidesdb_t *tdb, const char *column_family_name, co
         return tidesdb_err_from_code(TIDESDB_ERR_FAILED_TO_APPEND_TO_WAL);
     }
     /* add to memtable */
-    if (skip_list_put(cf->memtable, key, key_size, tombstone, 4, -1) == -1)
+    switch (cf->config.memtable_ds)
     {
-        free(tombstone);
-        (void)pthread_rwlock_unlock(&cf->rwlock);
-        return tidesdb_err_from_code(TIDESDB_ERR_FAILED_TO_PUT_TO_MEMTABLE);
+        case TDB_MEMTABLE_SKIP_LIST:
+            if (skip_list_put(cf->memtable_sl, key, key_size, tombstone, 4, 0) == -1)
+            {
+                free(tombstone);
+                (void)pthread_rwlock_unlock(&cf->rwlock);
+                return tidesdb_err_from_code(TIDESDB_ERR_FAILED_TO_PUT_TO_MEMTABLE);
+            }
+            break;
+        case TDB_MEMTABLE_HASH_TABLE:
+            if (hash_table_put(&cf->memtable_ht, key, key_size, tombstone, 4, 0) == -1)
+            {
+                free(tombstone);
+                (void)pthread_rwlock_unlock(&cf->rwlock);
+                return tidesdb_err_from_code(TIDESDB_ERR_FAILED_TO_PUT_TO_MEMTABLE);
+            }
+            break;
+        default:
+            free(tombstone);
+            (void)pthread_rwlock_unlock(&cf->rwlock);
+            return tidesdb_err_from_code(TIDESDB_ERR_INVALID_MEMTABLE_DATA_STRUCTURE);
     }
 
     free(tombstone);
@@ -1982,7 +2014,7 @@ tidesdb_err_t *tidesdb_delete(tidesdb_t *tdb, const char *column_family_name, co
     switch (cf->config.memtable_ds)
     {
         case TDB_MEMTABLE_SKIP_LIST:
-            if ((int)((skip_list_t *)cf->memtable)->total_size >= cf->config.flush_threshold)
+            if ((int)((skip_list_t *)cf->memtable_sl)->total_size >= cf->config.flush_threshold)
             {
                 if (cf->config.bloom_filter)
                 {
@@ -2025,7 +2057,7 @@ tidesdb_err_t *tidesdb_delete(tidesdb_t *tdb, const char *column_family_name, co
             }
             break;
         case TDB_MEMTABLE_HASH_TABLE:
-            if ((int)((hash_table_t *)cf->memtable)->total_size >= cf->config.flush_threshold)
+            if ((int)((hash_table_t *)cf->memtable_ht)->total_size >= cf->config.flush_threshold)
             {
                 if (cf->config.bloom_filter)
                 {
@@ -2195,7 +2227,7 @@ int _tidesdb_flush_memtable(tidesdb_column_family_t *cf)
     /* we create a new skip list cursor and populate the memtable
      * with serialized key value pairs */
 
-    skip_list_cursor_t *cursor = skip_list_cursor_init(cf->memtable);
+    skip_list_cursor_t *cursor = skip_list_cursor_init(cf->memtable_sl);
     if (cursor == NULL)
     {
         free(sst);
@@ -2337,7 +2369,7 @@ int _tidesdb_flush_memtable(tidesdb_column_family_t *cf)
     cf->num_sstables++;
 
     /* clear memtable */
-    if (skip_list_clear(cf->memtable) == -1)
+    if (skip_list_clear(cf->memtable_sl) == -1)
     {
         free(sst);
         (void)remove(sstable_path);
@@ -3208,7 +3240,7 @@ tidesdb_err_t *tidesdb_txn_commit(tidesdb_txn_t *txn)
                 switch (txn->cf->config.memtable_ds)
                 {
                     case TDB_MEMTABLE_SKIP_LIST:
-                        if (skip_list_put(txn->cf->memtable, op.kv->key, op.kv->key_size,
+                        if (skip_list_put(txn->cf->memtable_sl, op.kv->key, op.kv->key_size,
                                           op.kv->value, op.kv->value_size, op.kv->ttl) == -1)
                         {
                             /* unlock the column family */
@@ -3222,7 +3254,7 @@ tidesdb_err_t *tidesdb_txn_commit(tidesdb_txn_t *txn)
                         }
                         break;
                     case TDB_MEMTABLE_HASH_TABLE:
-                        if (hash_table_put(txn->cf->memtable, op.kv->key, op.kv->key_size,
+                        if (hash_table_put(&txn->cf->memtable_ht, op.kv->key, op.kv->key_size,
                                            op.kv->value, op.kv->value_size, op.kv->ttl) == -1)
                         {
                             /* unlock the column family */
@@ -3257,7 +3289,7 @@ tidesdb_err_t *tidesdb_txn_commit(tidesdb_txn_t *txn)
                 switch (txn->cf->config.memtable_ds)
                 {
                     case TDB_MEMTABLE_SKIP_LIST:
-                        if (skip_list_put(txn->cf->memtable, op.kv->key, op.kv->key_size,
+                        if (skip_list_put(txn->cf->memtable_sl, op.kv->key, op.kv->key_size,
                                           op.kv->value, 4, 0) == -1)
                         {
                             /* unlock the column family */
@@ -3271,7 +3303,7 @@ tidesdb_err_t *tidesdb_txn_commit(tidesdb_txn_t *txn)
                         }
                         break;
                     case TDB_MEMTABLE_HASH_TABLE:
-                        if (hash_table_put(txn->cf->memtable, op.kv->key, op.kv->key_size,
+                        if (hash_table_put(&txn->cf->memtable_ht, op.kv->key, op.kv->key_size,
                                            op.kv->value, 4, 0) == -1)
                         {
                             /* unlock the column family */
@@ -3303,7 +3335,7 @@ tidesdb_err_t *tidesdb_txn_commit(tidesdb_txn_t *txn)
     {
         case TDB_MEMTABLE_SKIP_LIST:
 
-            if (((int)((skip_list_t *)txn->cf->memtable)->total_size >=
+            if (((int)((skip_list_t *)txn->cf->memtable_sl)->total_size >=
                  txn->cf->config.flush_threshold))
             {
                 if (txn->cf->config.bloom_filter)
@@ -3347,7 +3379,7 @@ tidesdb_err_t *tidesdb_txn_commit(tidesdb_txn_t *txn)
             }
             break;
         case TDB_MEMTABLE_HASH_TABLE:
-            if (((int)((hash_table_t *)txn->cf->memtable)->total_size >=
+            if (((int)((hash_table_t *)txn->cf->memtable_ht)->total_size >=
                  txn->cf->config.flush_threshold))
             {
                 if (txn->cf->config.bloom_filter)
@@ -3440,11 +3472,11 @@ tidesdb_err_t *tidesdb_txn_rollback(tidesdb_txn_t *txn)
             switch (txn->cf->config.memtable_ds)
             {
                 case TDB_MEMTABLE_SKIP_LIST:
-                    (void)skip_list_put(txn->cf->memtable, op.kv->key, op.kv->key_size,
+                    (void)skip_list_put(txn->cf->memtable_sl, op.kv->key, op.kv->key_size,
                                         op.kv->value, op.kv->value_size, op.kv->ttl);
                     break;
                 case TDB_MEMTABLE_HASH_TABLE:
-                    (void)hash_table_put(txn->cf->memtable, op.kv->key, op.kv->key_size,
+                    (void)hash_table_put(&txn->cf->memtable_ht, op.kv->key, op.kv->key_size,
                                          op.kv->value, op.kv->value_size, op.kv->ttl);
                     break;
                 default:
@@ -3461,7 +3493,7 @@ tidesdb_err_t *tidesdb_txn_rollback(tidesdb_txn_t *txn)
     switch (txn->cf->config.memtable_ds)
     {
         case TDB_MEMTABLE_SKIP_LIST:
-            if (((int)((skip_list_t *)txn->cf->memtable)->total_size >=
+            if (((int)((skip_list_t *)txn->cf->memtable_sl)->total_size >=
                  txn->cf->config.flush_threshold))
             {
                 if (txn->cf->config.bloom_filter)
@@ -3505,7 +3537,7 @@ tidesdb_err_t *tidesdb_txn_rollback(tidesdb_txn_t *txn)
             }
             break;
         case TDB_MEMTABLE_HASH_TABLE:
-            if (((int)((hash_table_t *)txn->cf->memtable)->total_size >=
+            if (((int)((hash_table_t *)txn->cf->memtable_ht)->total_size >=
                  txn->cf->config.flush_threshold))
             {
                 if (txn->cf->config.bloom_filter)
@@ -3638,7 +3670,7 @@ tidesdb_err_t *tidesdb_cursor_init(tidesdb_t *tdb, const char *column_family_nam
     switch ((*cursor)->cf->config.memtable_ds)
     {
         case TDB_MEMTABLE_SKIP_LIST:
-            (*cursor)->memtable_cursor = skip_list_cursor_init(cf->memtable);
+            (*cursor)->memtable_cursor = skip_list_cursor_init(cf->memtable_sl);
             if ((*cursor)->memtable_cursor == NULL)
             {
                 /* unlock column family */
@@ -3648,7 +3680,7 @@ tidesdb_err_t *tidesdb_cursor_init(tidesdb_t *tdb, const char *column_family_nam
             }
             break;
         case TDB_MEMTABLE_HASH_TABLE:
-            (*cursor)->memtable_cursor = hash_table_cursor_init(cf->memtable);
+            (*cursor)->memtable_cursor = hash_table_cursor_init(cf->memtable_ht);
             break;
         default:
             free(cursor);
@@ -3759,6 +3791,8 @@ tidesdb_err_t *tidesdb_cursor_next(tidesdb_cursor_t *cursor)
                 (void)pthread_rwlock_unlock(&cursor->cf->rwlock);
                 return tidesdb_err_from_code(TIDESDB_ERR_INVALID_MEMTABLE_DATA_STRUCTURE);
         }
+
+        break;
     }
 
     /* if memtable is exhausted we check sstables
@@ -4462,7 +4496,7 @@ int _tidesdb_flush_memtable_w_bloomfilter(tidesdb_column_family_t *cf)
     sst->block_manager = sstable_block_manager;
 
     /* we figure out how large the bloom filter should be by getting amount of nodes in memtable */
-    int bloom_filter_size = skip_list_count_entries(cf->memtable);
+    int bloom_filter_size = skip_list_count_entries(cf->memtable_sl);
 
     /* we initialize the bloom filter */
     bloom_filter_t *bf = NULL;
@@ -4474,7 +4508,7 @@ int _tidesdb_flush_memtable_w_bloomfilter(tidesdb_column_family_t *cf)
     }
 
     /* we iterate over memtable and populate the bloom filter */
-    skip_list_cursor_t *cursor = skip_list_cursor_init(cf->memtable);
+    skip_list_cursor_t *cursor = skip_list_cursor_init(cf->memtable_sl);
     if (cursor == NULL)
     {
         free(sst);
@@ -4544,7 +4578,7 @@ int _tidesdb_flush_memtable_w_bloomfilter(tidesdb_column_family_t *cf)
     (void)block_manager_block_free(bf_block);
 
     /* we reinitialize the cursor to populate the sstable with keyvalue pairs after bloomfilter */
-    cursor = skip_list_cursor_init(cf->memtable);
+    cursor = skip_list_cursor_init(cf->memtable_sl);
     if (cursor == NULL)
     {
         free(sst);
@@ -4652,7 +4686,7 @@ int _tidesdb_flush_memtable_w_bloomfilter(tidesdb_column_family_t *cf)
     cf->num_sstables++;
 
     /* clear memtable */
-    if (skip_list_clear(cf->memtable) == -1)
+    if (skip_list_clear(cf->memtable_sl) == -1)
     {
         free(sst);
         (void)remove(sstable_path);
@@ -4710,7 +4744,7 @@ int _tidesdb_flush_memtable_w_bloomfilter_f_hash_table(tidesdb_column_family_t *
     sst->block_manager = sstable_block_manager;
 
     /* we figure out how large the bloom filter should be by getting amount of nodes in memtable */
-    int bloom_filter_size = (int)((hash_table_t *)cf->memtable)->count;
+    int bloom_filter_size = (int)((hash_table_t *)cf->memtable_ht->count);
 
     /* we initialize the bloom filter */
     bloom_filter_t *bf = NULL;
@@ -4722,13 +4756,15 @@ int _tidesdb_flush_memtable_w_bloomfilter_f_hash_table(tidesdb_column_family_t *
     }
 
     /* we iterate over memtable and populate the bloom filter */
-    hash_table_cursor_t *cursor = hash_table_cursor_init(cf->memtable);
+    hash_table_cursor_t *cursor = hash_table_cursor_init(cf->memtable_ht);
     if (cursor == NULL)
     {
         free(sst);
         (void)remove(sstable_path);
         return -1;
     }
+
+    printf("here\n");
 
     do
     {
@@ -4744,6 +4780,7 @@ int _tidesdb_flush_memtable_w_bloomfilter_f_hash_table(tidesdb_column_family_t *
             free(retrieved_value);
             free(sst);
             (void)remove(sstable_path);
+            printf("here 2\n");
             return -1;
         }
 
@@ -4792,7 +4829,7 @@ int _tidesdb_flush_memtable_w_bloomfilter_f_hash_table(tidesdb_column_family_t *
     (void)block_manager_block_free(bf_block);
 
     /* we reinitialize the cursor to populate the sstable with keyvalue pairs after bloomfilter */
-    cursor = hash_table_cursor_init(cf->memtable);
+    cursor = hash_table_cursor_init(cf->memtable_ht);
     if (cursor == NULL)
     {
         free(sst);
@@ -4900,7 +4937,7 @@ int _tidesdb_flush_memtable_w_bloomfilter_f_hash_table(tidesdb_column_family_t *
     cf->num_sstables++;
 
     /* clear memtable */
-    (void)hash_table_clear(cf->memtable);
+    (void)hash_table_clear(cf->memtable_ht);
 
     /* truncate the wal */
     if (block_manager_truncate(cf->wal->block_manager) == -1)
@@ -4938,7 +4975,7 @@ int _tidesdb_flush_memtable_f_hash_table(tidesdb_column_family_t *cf)
     /* we create a new hash table cursor and populate the memtable
      * with serialized key value pairs */
 
-    hash_table_cursor_t *cursor = hash_table_cursor_init(cf->memtable);
+    hash_table_cursor_t *cursor = hash_table_cursor_init(cf->memtable_ht);
     if (cursor == NULL)
     {
         free(sst);
@@ -5080,7 +5117,7 @@ int _tidesdb_flush_memtable_f_hash_table(tidesdb_column_family_t *cf)
     cf->num_sstables++;
 
     /* clear memtable */
-    (void)hash_table_clear(cf->memtable);
+    (void)hash_table_clear(cf->memtable_ht);
 
     /* truncate the wal */
     if (block_manager_truncate(cf->wal->block_manager) == -1)

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -4847,7 +4847,6 @@ int _tidesdb_flush_memtable_w_bloomfilter_f_hash_table(tidesdb_column_family_t *
         }
 
         /* we get the key */
-
         if (hash_table_cursor_get(cursor, &kv->key, (size_t *)&kv->key_size, &kv->value,
                                   (size_t *)&kv->value_size, &kv->ttl) == -1)
         {

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -4764,8 +4764,6 @@ int _tidesdb_flush_memtable_w_bloomfilter_f_hash_table(tidesdb_column_family_t *
         return -1;
     }
 
-    printf("here\n");
-
     do
     {
         uint8_t *retrieved_key;
@@ -4780,7 +4778,6 @@ int _tidesdb_flush_memtable_w_bloomfilter_f_hash_table(tidesdb_column_family_t *
             free(retrieved_value);
             free(sst);
             (void)remove(sstable_path);
-            printf("here 2\n");
             return -1;
         }
 

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -131,7 +131,8 @@ typedef struct
     tidesdb_sstable_t **sstables;
     int num_sstables;
     pthread_rwlock_t rwlock;
-    void *memtable; /* can be a skip list or hash table */
+    skip_list_t *memtable_sl;
+    hash_table_t *memtable_ht;
     tidesdb_wal_t *wal;
 } tidesdb_column_family_t;
 

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -121,7 +121,8 @@ typedef struct
  * @param sstables the sstables for the column family
  * @param num_sstables the number of sstables for the column family
  * @param rwlock read-write lock for column family
- * @param memtable the memtable for the column family
+ * @param memtable_sl the skip list memtable for the column family. Can be NULL
+ * @param memtable_ht the hash table memtable for the column family. Can be NULL
  * @param wal the write-ahead log for column family
  */
 typedef struct

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -1658,13 +1658,11 @@ int main(void)
     test_tidesdb_put_get_memtable(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
     test_tidesdb_put_close_replay_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
     test_tidesdb_txn_put_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_txn_put_get_rollback_get(false, TDB_NO_COMPRESSION, false,
-    TDB_MEMTABLE_SKIP_LIST); test_tidesdb_txn_put_put_delete_get(false, TDB_NO_COMPRESSION,
-    false, TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_delete_get(false, TDB_NO_COMPRESSION, false,
-    TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_txn_put_get_rollback_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_txn_put_put_delete_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_put_delete_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
     test_tidesdb_cursor(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_cursor_memtable_sstables(false, TDB_NO_COMPRESSION, false,
-    TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_cursor_memtable_sstables(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
     test_tidesdb_put_flush_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
     test_tidesdb_put_flush_close_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
     test_tidesdb_put_flush_delete_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
@@ -1681,19 +1679,18 @@ int main(void)
     test_tidesdb_serialize_deserialize_operation(true, TDB_COMPRESS_LZ4);
     test_tidesdb_serialize_deserialize_key_value_pair(true, TDB_COMPRESS_ZSTD);
     test_tidesdb_serialize_deserialize_operation(true, TDB_COMPRESS_ZSTD);
-    test_tidesdb_create_drop_column_family(true, TDB_COMPRESS_SNAPPY, true,
-    TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_get_memtable(true, TDB_COMPRESS_SNAPPY, true,
-    TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_close_replay_get(true, TDB_COMPRESS_SNAPPY, true,
-    TDB_MEMTABLE_SKIP_LIST); test_tidesdb_txn_put_get(true, TDB_COMPRESS_SNAPPY, true,
-    TDB_MEMTABLE_SKIP_LIST); test_tidesdb_txn_put_get_rollback_get(true, TDB_COMPRESS_SNAPPY,
-    true, TDB_MEMTABLE_SKIP_LIST); test_tidesdb_txn_put_put_delete_get(true, TDB_COMPRESS_SNAPPY,
-    true, TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_delete_get(true, TDB_COMPRESS_SNAPPY, true,
-    TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_flush_get(true, TDB_COMPRESS_SNAPPY, true,
-    TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_flush_close_get(true, TDB_COMPRESS_SNAPPY, true,
-    TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_flush_delete_get(true, TDB_COMPRESS_SNAPPY, true,
-    TDB_MEMTABLE_SKIP_LIST); test_tidesdb_cursor(true, TDB_COMPRESS_SNAPPY, true,
-    TDB_MEMTABLE_SKIP_LIST); test_tidesdb_cursor_memtable_sstables(true, TDB_COMPRESS_SNAPPY,
-    true, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_create_drop_column_family(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_put_get_memtable(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_put_close_replay_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_txn_put_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_txn_put_get_rollback_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_txn_put_put_delete_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_put_delete_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_put_flush_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_put_flush_close_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_put_flush_delete_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_cursor(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_cursor_memtable_sstables(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
 
     /* these tests take a while to run */
     test_tidesdb_put_many_flush_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
@@ -1711,6 +1708,8 @@ int main(void)
     test_tidesdb_put_flush_delete_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
     test_tidesdb_cursor(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
     test_tidesdb_cursor_memtable_sstables(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
+
+    /* these tests take a while to run */
     test_tidesdb_put_many_flush_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
     test_tidesdb_put_flush_compact_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
 

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -1463,6 +1463,8 @@ void test_tidesdb_cursor(bool compress, tidesdb_compression_algo_t algo, bool bl
         assert(found[i]);
     }
 
+    printf("ddd\n");
+
     err = tidesdb_cursor_free(cursor);
     assert(err == NULL);
 
@@ -1656,11 +1658,13 @@ int main(void)
     test_tidesdb_put_get_memtable(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
     test_tidesdb_put_close_replay_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
     test_tidesdb_txn_put_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_txn_put_get_rollback_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_txn_put_put_delete_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_put_delete_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_txn_put_get_rollback_get(false, TDB_NO_COMPRESSION, false,
+    TDB_MEMTABLE_SKIP_LIST); test_tidesdb_txn_put_put_delete_get(false, TDB_NO_COMPRESSION,
+    false, TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_delete_get(false, TDB_NO_COMPRESSION, false,
+    TDB_MEMTABLE_SKIP_LIST);
     test_tidesdb_cursor(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_cursor_memtable_sstables(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_cursor_memtable_sstables(false, TDB_NO_COMPRESSION, false,
+    TDB_MEMTABLE_SKIP_LIST);
     test_tidesdb_put_flush_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
     test_tidesdb_put_flush_close_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
     test_tidesdb_put_flush_delete_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
@@ -1677,18 +1681,19 @@ int main(void)
     test_tidesdb_serialize_deserialize_operation(true, TDB_COMPRESS_LZ4);
     test_tidesdb_serialize_deserialize_key_value_pair(true, TDB_COMPRESS_ZSTD);
     test_tidesdb_serialize_deserialize_operation(true, TDB_COMPRESS_ZSTD);
-    test_tidesdb_create_drop_column_family(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_put_get_memtable(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_put_close_replay_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_txn_put_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_txn_put_get_rollback_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_txn_put_put_delete_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_put_delete_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_put_flush_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_put_flush_close_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_put_flush_delete_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_cursor(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_cursor_memtable_sstables(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_create_drop_column_family(true, TDB_COMPRESS_SNAPPY, true,
+    TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_get_memtable(true, TDB_COMPRESS_SNAPPY, true,
+    TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_close_replay_get(true, TDB_COMPRESS_SNAPPY, true,
+    TDB_MEMTABLE_SKIP_LIST); test_tidesdb_txn_put_get(true, TDB_COMPRESS_SNAPPY, true,
+    TDB_MEMTABLE_SKIP_LIST); test_tidesdb_txn_put_get_rollback_get(true, TDB_COMPRESS_SNAPPY,
+    true, TDB_MEMTABLE_SKIP_LIST); test_tidesdb_txn_put_put_delete_get(true, TDB_COMPRESS_SNAPPY,
+    true, TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_delete_get(true, TDB_COMPRESS_SNAPPY, true,
+    TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_flush_get(true, TDB_COMPRESS_SNAPPY, true,
+    TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_flush_close_get(true, TDB_COMPRESS_SNAPPY, true,
+    TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_flush_delete_get(true, TDB_COMPRESS_SNAPPY, true,
+    TDB_MEMTABLE_SKIP_LIST); test_tidesdb_cursor(true, TDB_COMPRESS_SNAPPY, true,
+    TDB_MEMTABLE_SKIP_LIST); test_tidesdb_cursor_memtable_sstables(true, TDB_COMPRESS_SNAPPY,
+    true, TDB_MEMTABLE_SKIP_LIST);
 
     /* these tests take a while to run */
     test_tidesdb_put_many_flush_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);


### PR DESCRIPTION
tidesdb_column_family_t to not use void pointer for memtable as causing misalignment issues we don't want.  This corrected lots of underlaying lower level issues when using a hash table.  Majority of all tests except for some reason when a column family is configured with hash table and you use cursor going backwards, the hash table has a bit different logic on cursor get I am trying to align but every other test now passes, all test pass except for the as stated cursor prev when set as hash table, I am looking into this.  Lots of simple changes to align data structures.  I've also fixed a bug on cursor next where we don't return a proper error code thus causing a stall.