### PR TITLE
- tidesdb_create_column_family logical correction to check memtable d…

### DIFF
--- a/src/err.h
+++ b/src/err.h
@@ -96,6 +96,7 @@ typedef enum
     TIDESDB_ERR_FAILED_TO_DESERIALIZE_BLOOM_FILTER,
     TIDESDB_ERR_NOT_IMPLEMENTED,
     TIDESDB_ERR_INVALID_MEMTABLE_DATA_STRUCTURE,
+    TIDESDB_ERR_COLUMN_FAMILY_ALREADY_EXISTS,
 } TIDESDB_ERR_CODE;
 
 /* TidesDB error messages */
@@ -140,6 +141,7 @@ static const tidesdb_err_info_t tidesdb_err_messages[] = {
     {TIDESDB_ERR_FAILED_TO_DESERIALIZE_BLOOM_FILTER, "Failed to deserialize bloom filter.\n"},
     {TIDESDB_ERR_NOT_IMPLEMENTED, "Not implemented.\n"},
     {TIDESDB_ERR_INVALID_MEMTABLE_DATA_STRUCTURE, "Invalid memtable data structure.\n"},
+    {TIDESDB_ERR_COLUMN_FAMILY_ALREADY_EXISTS, "Column family already exists.\n"},
 
 };
 


### PR DESCRIPTION
- tidesdb_create_column_family logical correction to check memtable ds.  Better to check early on.
- _tidesdb_add_column_family correction to lock db whilst adding column family to tdb column_families
- tidesdb_drop_column_family corrections to check name, if column family exists and acquire appropriate locks during operations
