### PR TITLE
issue #223 implementation

### DIFF
--- a/src/block_manager.c
+++ b/src/block_manager.c
@@ -377,3 +377,11 @@ int block_manager_count_blocks(block_manager_t *bm)
     block_manager_cursor_free(cursor);
     return count;
 }
+
+int block_manager_get_size(block_manager_t *bm, uint64_t *size)
+{
+    struct stat st;
+    if (stat(bm->file_path, &st) != 0) return -1;
+    *size = st.st_size;
+    return 0;
+}

--- a/src/block_manager.h
+++ b/src/block_manager.h
@@ -229,4 +229,13 @@ int block_manager_cursor_goto_last(block_manager_cursor_t *cursor);
  */
 int block_manager_cursor_goto_first(block_manager_cursor_t *cursor);
 
+/**
+ * block_manager_get_size
+ * gets the size of a block manager
+ * @param bm the block manager to get the size of
+ * @param size the size of the block manager
+ * @return 0 if successful, -1 if not
+ */
+int block_manager_get_size(block_manager_t *bm, uint64_t *size);
+
 #endif /* __BLOCK_MANAGER_H__ */

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -41,6 +41,9 @@
 #define TDB_FLUSH_THRESHOLD               1048576    /* default flush threshold for column family */
 #define TDB_MIN_MAX_LEVEL                 5          /* minimum max level for column family */
 #define TDB_MIN_PROBABILITY               0.1        /* minimum probability for column family */
+#define TDB_MERGE_MULTIPLIER                                                                      \
+    4 /* if either pair in a merge is larger than column family configured flush threshold * this \
+      multiplier, they will not get merged but cleaned of expired keys if any */
 
 /*
  * tidesdb_compression_algo_t
@@ -837,5 +840,14 @@ int _tidesdb_is_expired(int64_t ttl);
  * @return the correct compress_type algo
  */
 compress_type _tidesdb_map_compression_algo(tidesdb_compression_algo_t algo);
+
+/*
+ * _tidesdb_scan_update_sstable
+ * scans sstable for tombstones, and expired keys, removes them, and updates the sstable
+ * @param cf the column family
+ * @param sst the sstable
+ * @return 0 if the sstable was updated, -1 if not
+ */
+int _tidesdb_scan_update_sstable(tidesdb_column_family_t *cf, tidesdb_sstable_t *sst);
 
 #endif /* __TIDESDB_H__ */


### PR DESCRIPTION
- TDB_MERGE_MULTIPLIER introduction
- only merge pairs if their both less than flush threshold * TDB_MERGE_MULTIPLIER.  We only remove expired keys and tombstoned keys if any when not merging 2 sstables.

https://github.com/tidesdb/tidesdb/issues/223