### PR TITLE
removed unused functions, introduced partial merge compaction (automatic as opposed to manual and is optional)..

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ It is not a full-featured database, but rather a library that can be used to bui
 - [x] **Cursor** iterate over key-value pairs forward and backward.
 - [x] **WAL** write-ahead logging for durability. Column families replay WAL on startup.  This reconstructs memtable if the column family did not reach threshold prior to shutdown.
 - [x] **Multithreaded Compaction** manual multi-threaded paired and merged compaction of sstables.  When run for example 10 sstables compacts into 5 as their paired and merged.  Each thread is responsible for one pair - you can set the number of threads to use for compaction.
+- [x] **Background Partial Merge Compaction** background merge compaction can be started.  If started the system will incrementally merge sstables in the background from oldest to newest.  Merges are done every n seconds. Merges are not done in parallel but incrementally.
 - [x] **Bloom Filters** reduce disk reads by reading initial blocks of sstables to check key existence.
 - [x] **Compression** compression is achieved with Snappy, or LZ4, or ZSTD.  SStable entries can be compressed as well as WAL entries.
 - [x] **TTL** time-to-live for key-value pairs.
@@ -411,6 +412,8 @@ tidesdb_cursor_free(c);
 ```
 
 ### Compaction
+
+#### Manual
 You can manually compact sstables.  This method pairs and merges column family sstables.
 Say you have 100, after compaction you will have 50; Always half the amount you had prior.  You can set the number of threads to use for compaction.
 
@@ -421,6 +424,18 @@ if (e != NULL)
     /* handle error */
     tidesdb_err_free(e);
 }
+```
+
+#### Automatic / Background Partial Merge Compaction
+You can start a background partial merge compaction.  This will incrementally merge sstables in the background from oldest to newest.  Merges are done every n seconds.  Merges are not done in parallel but incrementally.  Less blocking than manual compaction.
+
+You pass
+- the database you want to start the background partial merge compaction in.  Must be open
+- the column family name
+- the number of seconds to wait before going to next pair and merging
+- the minimum number of sstables to trigger a merge
+```c
+tidesdb_err_t *e = tidesdb_start_partial_merge(tdb, "your_column_family", 10, 10); /* merge a pair every 10 seconds and if there are a minimum 10 sstables */
 ```
 
 ## License

--- a/src/compat.h
+++ b/src/compat.h
@@ -135,8 +135,8 @@ int sem_init(sem_t *sem, int pshared, unsigned int value)
 #include <dirent.h>
 #include <pthread.h>
 #include <semaphore.h>
-#include <unistd.h>
 #include <sys/stat.h>
+#include <unistd.h>
 
 typedef pthread_t thread_t;
 typedef pthread_mutex_t mutex_t;

--- a/src/err.c
+++ b/src/err.c
@@ -125,6 +125,12 @@ tidesdb_err_t* tidesdb_err_from_code(TIDESDB_ERR_CODE code, ...)
             snprintf(buffer, sizeof(buffer), tidesdb_err_messages[code].message, obj);
             break;
         }
+        case TIDESDB_ERR_PARTIAL_MERGE_ALREADY_STARTED:
+        {
+            const char* obj = va_arg(args, const char*);
+            snprintf(buffer, sizeof(buffer), tidesdb_err_messages[code].message, obj);
+            break;
+        }
         default:
             snprintf(buffer, sizeof(buffer), "%s", tidesdb_err_messages[code].message);
     }

--- a/src/err.h
+++ b/src/err.h
@@ -97,6 +97,9 @@ typedef enum
     TIDESDB_ERR_NOT_IMPLEMENTED,
     TIDESDB_ERR_INVALID_MEMTABLE_DATA_STRUCTURE,
     TIDESDB_ERR_COLUMN_FAMILY_ALREADY_EXISTS,
+    TIDESDB_ERR_INVALID_PARTIAL_MERGE_INTERVAL,
+    TIDESDB_ERR_INVALID_PARTIAL_MERGE_MIN_SST,
+    TIDESDB_ERR_PARTIAL_MERGE_ALREADY_STARTED
 } TIDESDB_ERR_CODE;
 
 /* TidesDB error messages */
@@ -142,6 +145,10 @@ static const tidesdb_err_info_t tidesdb_err_messages[] = {
     {TIDESDB_ERR_NOT_IMPLEMENTED, "Not implemented.\n"},
     {TIDESDB_ERR_INVALID_MEMTABLE_DATA_STRUCTURE, "Invalid memtable data structure.\n"},
     {TIDESDB_ERR_COLUMN_FAMILY_ALREADY_EXISTS, "Column family already exists.\n"},
+    {TIDESDB_ERR_INVALID_PARTIAL_MERGE_INTERVAL, "Invalid partial merge interval.\n"},
+    {TIDESDB_ERR_INVALID_PARTIAL_MERGE_MIN_SST, "Invalid partial merge min SSTables.\n"},
+    {TIDESDB_ERR_PARTIAL_MERGE_ALREADY_STARTED,
+     "Partial merge already started for column family %s.\n"}
 
 };
 

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -1773,69 +1773,65 @@ void test_tidesdb_start_partial_merge(bool compress, tidesdb_compression_algo_t 
 
 int main(void)
 {
-    // test_tidesdb_serialize_deserialize_key_value_pair(false, TDB_NO_COMPRESSION);
-    // test_tidesdb_serialize_deserialize_column_family_config();
-    // test_tidesdb_serialize_deserialize_operation(false, TDB_NO_COMPRESSION);
-    // test_tidesdb_tidesdb_open_close();
-    // test_tidesdb_create_drop_column_family(false, TDB_NO_COMPRESSION, false,
-    //                                        TDB_MEMTABLE_SKIP_LIST);
-    // test_tidesdb_put_get_memtable(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
-    // test_tidesdb_put_close_replay_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
-    // test_tidesdb_txn_put_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
-    // test_tidesdb_txn_put_get_rollback_get(false, TDB_NO_COMPRESSION, false,
-    // TDB_MEMTABLE_SKIP_LIST); test_tidesdb_txn_put_put_delete_get(false, TDB_NO_COMPRESSION,
-    // false, TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_delete_get(false, TDB_NO_COMPRESSION, false,
-    // TDB_MEMTABLE_SKIP_LIST); test_tidesdb_cursor(false, TDB_NO_COMPRESSION, false,
-    // TDB_MEMTABLE_SKIP_LIST); test_tidesdb_cursor_memtable_sstables(false, TDB_NO_COMPRESSION,
-    // false, TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_flush_get(false, TDB_NO_COMPRESSION, false,
-    // TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_flush_close_get(false, TDB_NO_COMPRESSION, false,
-    // TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_flush_delete_get(false, TDB_NO_COMPRESSION, false,
-    // TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_many_flush_get(false, TDB_NO_COMPRESSION, false,
-    // TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_flush_compact_get(false, TDB_NO_COMPRESSION, false,
-    // TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_serialize_deserialize_key_value_pair(false, TDB_NO_COMPRESSION);
+    test_tidesdb_serialize_deserialize_column_family_config();
+    test_tidesdb_serialize_deserialize_operation(false, TDB_NO_COMPRESSION);
+    test_tidesdb_tidesdb_open_close();
+    test_tidesdb_create_drop_column_family(false, TDB_NO_COMPRESSION, false,
+                                           TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_put_get_memtable(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_put_close_replay_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_txn_put_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_txn_put_get_rollback_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_txn_put_put_delete_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_put_delete_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_cursor(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_cursor_memtable_sstables(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_put_flush_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_put_flush_close_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_put_flush_delete_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_put_many_flush_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_put_flush_compact_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
+
+    /* the next batch of tests we will run with bloom filters and compression
+     * same tests just with bloom filters and compression enabled */
+    test_tidesdb_serialize_deserialize_key_value_pair(true, TDB_COMPRESS_SNAPPY);
+    test_tidesdb_serialize_deserialize_operation(true, TDB_COMPRESS_SNAPPY);
+    test_tidesdb_serialize_deserialize_key_value_pair(true, TDB_COMPRESS_LZ4);
+    test_tidesdb_serialize_deserialize_operation(true, TDB_COMPRESS_LZ4);
+    test_tidesdb_serialize_deserialize_key_value_pair(true, TDB_COMPRESS_ZSTD);
+    test_tidesdb_serialize_deserialize_operation(true, TDB_COMPRESS_ZSTD);
+    test_tidesdb_create_drop_column_family(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_put_get_memtable(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_put_close_replay_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_txn_put_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_txn_put_get_rollback_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_txn_put_put_delete_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_put_delete_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_put_flush_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_put_flush_close_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_put_flush_delete_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_cursor(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_cursor_memtable_sstables(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_put_many_flush_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
+    test_tidesdb_put_flush_compact_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
+
+    /* same tests as above but using a hash table as the memtable data structure */
+    test_tidesdb_put_get_memtable(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
+    test_tidesdb_put_close_replay_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
+    test_tidesdb_txn_put_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
+    test_tidesdb_txn_put_get_rollback_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
+    test_tidesdb_txn_put_put_delete_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
+    test_tidesdb_put_delete_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
+    test_tidesdb_put_flush_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
+    test_tidesdb_put_flush_close_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
+    test_tidesdb_put_flush_delete_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
+    test_tidesdb_cursor(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
+    test_tidesdb_cursor_memtable_sstables(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
+    test_tidesdb_put_many_flush_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
+    test_tidesdb_put_flush_compact_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
+
     test_tidesdb_start_partial_merge(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
-    //
-    // /* the next batch of tests we will run with bloom filters and compression
-    //  * same tests just with bloom filters and compression enabled */
-    // test_tidesdb_serialize_deserialize_key_value_pair(true, TDB_COMPRESS_SNAPPY);
-    // test_tidesdb_serialize_deserialize_operation(true, TDB_COMPRESS_SNAPPY);
-    // test_tidesdb_serialize_deserialize_key_value_pair(true, TDB_COMPRESS_LZ4);
-    // test_tidesdb_serialize_deserialize_operation(true, TDB_COMPRESS_LZ4);
-    // test_tidesdb_serialize_deserialize_key_value_pair(true, TDB_COMPRESS_ZSTD);
-    // test_tidesdb_serialize_deserialize_operation(true, TDB_COMPRESS_ZSTD);
-    // test_tidesdb_create_drop_column_family(true, TDB_COMPRESS_SNAPPY, true,
-    // TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_get_memtable(true, TDB_COMPRESS_SNAPPY, true,
-    // TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_close_replay_get(true, TDB_COMPRESS_SNAPPY, true,
-    // TDB_MEMTABLE_SKIP_LIST); test_tidesdb_txn_put_get(true, TDB_COMPRESS_SNAPPY, true,
-    // TDB_MEMTABLE_SKIP_LIST); test_tidesdb_txn_put_get_rollback_get(true, TDB_COMPRESS_SNAPPY,
-    // true, TDB_MEMTABLE_SKIP_LIST); test_tidesdb_txn_put_put_delete_get(true, TDB_COMPRESS_SNAPPY,
-    // true, TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_delete_get(true, TDB_COMPRESS_SNAPPY, true,
-    // TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_flush_get(true, TDB_COMPRESS_SNAPPY, true,
-    // TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_flush_close_get(true, TDB_COMPRESS_SNAPPY, true,
-    // TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_flush_delete_get(true, TDB_COMPRESS_SNAPPY, true,
-    // TDB_MEMTABLE_SKIP_LIST); test_tidesdb_cursor(true, TDB_COMPRESS_SNAPPY, true,
-    // TDB_MEMTABLE_SKIP_LIST); test_tidesdb_cursor_memtable_sstables(true, TDB_COMPRESS_SNAPPY,
-    // true, TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_many_flush_get(true, TDB_COMPRESS_SNAPPY,
-    // true, TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_flush_compact_get(true, TDB_COMPRESS_SNAPPY,
-    // true, TDB_MEMTABLE_SKIP_LIST); test_tidesdb_start_partial_merge(true, TDB_COMPRESS_SNAPPY,
-    // true, TDB_MEMTABLE_SKIP_LIST);
-    //
-    // /* same tests as above but using a hash table as the memtable data structure */
-    // test_tidesdb_put_get_memtable(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
-    // test_tidesdb_put_close_replay_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
-    // test_tidesdb_txn_put_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
-    // test_tidesdb_txn_put_get_rollback_get(true, TDB_COMPRESS_SNAPPY, true,
-    // TDB_MEMTABLE_HASH_TABLE); test_tidesdb_txn_put_put_delete_get(true, TDB_COMPRESS_SNAPPY,
-    // true, TDB_MEMTABLE_HASH_TABLE); test_tidesdb_put_delete_get(true, TDB_COMPRESS_SNAPPY, true,
-    // TDB_MEMTABLE_HASH_TABLE); test_tidesdb_put_flush_get(true, TDB_COMPRESS_SNAPPY, true,
-    // TDB_MEMTABLE_HASH_TABLE); test_tidesdb_put_flush_close_get(true, TDB_COMPRESS_SNAPPY, true,
-    // TDB_MEMTABLE_HASH_TABLE); test_tidesdb_put_flush_delete_get(true, TDB_COMPRESS_SNAPPY, true,
-    // TDB_MEMTABLE_HASH_TABLE); test_tidesdb_cursor(true, TDB_COMPRESS_SNAPPY, true,
-    // TDB_MEMTABLE_HASH_TABLE); test_tidesdb_cursor_memtable_sstables(true, TDB_COMPRESS_SNAPPY,
-    // true, TDB_MEMTABLE_HASH_TABLE); test_tidesdb_put_many_flush_get(true, TDB_COMPRESS_SNAPPY,
-    // true, TDB_MEMTABLE_HASH_TABLE); test_tidesdb_put_flush_compact_get(true, TDB_COMPRESS_SNAPPY,
-    // true, TDB_MEMTABLE_HASH_TABLE); test_tidesdb_start_partial_merge(true, TDB_COMPRESS_SNAPPY,
-    // true, TDB_MEMTABLE_HASH_TABLE);
 
     return 0;
 }

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -1742,8 +1742,7 @@ void test_tidesdb_start_partial_merge(bool compress, tidesdb_compression_algo_t 
         tidesdb_err_free(err);
     }
 
-
-    sleep(5);
+    sleep(10);
 
     for (int i = 0; i < 12; i++)
     {
@@ -1766,71 +1765,77 @@ void test_tidesdb_start_partial_merge(bool compress, tidesdb_compression_algo_t 
     tidesdb_err_free(err);
 
     _tidesdb_remove_directory("test_db");
-    printf(GREEN "test_tidesdb_start_partial_merge passed\n" RESET);
+    printf(GREEN "test_tidesdb_start_partial_merge%s%s%s passed\n" RESET,
+           compress ? " with compression" : "", bloom_filter ? " with bloom filter" : "",
+           memtable_ds == TDB_MEMTABLE_SKIP_LIST ? " with skip list memtable"
+                                                 : " with hash table memtable");
 }
 
 int main(void)
 {
-    test_tidesdb_serialize_deserialize_key_value_pair(false, TDB_NO_COMPRESSION);
-    test_tidesdb_serialize_deserialize_column_family_config();
-    test_tidesdb_serialize_deserialize_operation(false, TDB_NO_COMPRESSION);
-    test_tidesdb_tidesdb_open_close();
-    test_tidesdb_create_drop_column_family(false, TDB_NO_COMPRESSION, false,
-                                           TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_put_get_memtable(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_put_close_replay_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_txn_put_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_txn_put_get_rollback_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_txn_put_put_delete_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_put_delete_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_cursor(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_cursor_memtable_sstables(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_put_flush_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_put_flush_close_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_put_flush_delete_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_put_many_flush_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_put_flush_compact_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
+    // test_tidesdb_serialize_deserialize_key_value_pair(false, TDB_NO_COMPRESSION);
+    // test_tidesdb_serialize_deserialize_column_family_config();
+    // test_tidesdb_serialize_deserialize_operation(false, TDB_NO_COMPRESSION);
+    // test_tidesdb_tidesdb_open_close();
+    // test_tidesdb_create_drop_column_family(false, TDB_NO_COMPRESSION, false,
+    //                                        TDB_MEMTABLE_SKIP_LIST);
+    // test_tidesdb_put_get_memtable(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
+    // test_tidesdb_put_close_replay_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
+    // test_tidesdb_txn_put_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
+    // test_tidesdb_txn_put_get_rollback_get(false, TDB_NO_COMPRESSION, false,
+    // TDB_MEMTABLE_SKIP_LIST); test_tidesdb_txn_put_put_delete_get(false, TDB_NO_COMPRESSION,
+    // false, TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_delete_get(false, TDB_NO_COMPRESSION, false,
+    // TDB_MEMTABLE_SKIP_LIST); test_tidesdb_cursor(false, TDB_NO_COMPRESSION, false,
+    // TDB_MEMTABLE_SKIP_LIST); test_tidesdb_cursor_memtable_sstables(false, TDB_NO_COMPRESSION,
+    // false, TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_flush_get(false, TDB_NO_COMPRESSION, false,
+    // TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_flush_close_get(false, TDB_NO_COMPRESSION, false,
+    // TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_flush_delete_get(false, TDB_NO_COMPRESSION, false,
+    // TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_many_flush_get(false, TDB_NO_COMPRESSION, false,
+    // TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_flush_compact_get(false, TDB_NO_COMPRESSION, false,
+    // TDB_MEMTABLE_SKIP_LIST);
     test_tidesdb_start_partial_merge(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
-
-    /* the next batch of tests we will run with bloom filters and compression
-     * same tests just with bloom filters and compression enabled */
-    test_tidesdb_serialize_deserialize_key_value_pair(true, TDB_COMPRESS_SNAPPY);
-    test_tidesdb_serialize_deserialize_operation(true, TDB_COMPRESS_SNAPPY);
-    test_tidesdb_serialize_deserialize_key_value_pair(true, TDB_COMPRESS_LZ4);
-    test_tidesdb_serialize_deserialize_operation(true, TDB_COMPRESS_LZ4);
-    test_tidesdb_serialize_deserialize_key_value_pair(true, TDB_COMPRESS_ZSTD);
-    test_tidesdb_serialize_deserialize_operation(true, TDB_COMPRESS_ZSTD);
-    test_tidesdb_create_drop_column_family(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_put_get_memtable(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_put_close_replay_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_txn_put_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_txn_put_get_rollback_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_txn_put_put_delete_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_put_delete_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_put_flush_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_put_flush_close_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_put_flush_delete_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_cursor(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_cursor_memtable_sstables(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_put_many_flush_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_put_flush_compact_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
-    test_tidesdb_start_partial_merge(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_SKIP_LIST);
-
-    /* same tests as above but using a hash table as the memtable data structure */
-    test_tidesdb_put_get_memtable(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
-    test_tidesdb_put_close_replay_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
-    test_tidesdb_txn_put_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
-    test_tidesdb_txn_put_get_rollback_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
-    test_tidesdb_txn_put_put_delete_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
-    test_tidesdb_put_delete_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
-    test_tidesdb_put_flush_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
-    test_tidesdb_put_flush_close_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
-    test_tidesdb_put_flush_delete_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
-    test_tidesdb_cursor(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
-    test_tidesdb_cursor_memtable_sstables(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
-    test_tidesdb_put_many_flush_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
-    test_tidesdb_put_flush_compact_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
-    test_tidesdb_start_partial_merge(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
+    //
+    // /* the next batch of tests we will run with bloom filters and compression
+    //  * same tests just with bloom filters and compression enabled */
+    // test_tidesdb_serialize_deserialize_key_value_pair(true, TDB_COMPRESS_SNAPPY);
+    // test_tidesdb_serialize_deserialize_operation(true, TDB_COMPRESS_SNAPPY);
+    // test_tidesdb_serialize_deserialize_key_value_pair(true, TDB_COMPRESS_LZ4);
+    // test_tidesdb_serialize_deserialize_operation(true, TDB_COMPRESS_LZ4);
+    // test_tidesdb_serialize_deserialize_key_value_pair(true, TDB_COMPRESS_ZSTD);
+    // test_tidesdb_serialize_deserialize_operation(true, TDB_COMPRESS_ZSTD);
+    // test_tidesdb_create_drop_column_family(true, TDB_COMPRESS_SNAPPY, true,
+    // TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_get_memtable(true, TDB_COMPRESS_SNAPPY, true,
+    // TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_close_replay_get(true, TDB_COMPRESS_SNAPPY, true,
+    // TDB_MEMTABLE_SKIP_LIST); test_tidesdb_txn_put_get(true, TDB_COMPRESS_SNAPPY, true,
+    // TDB_MEMTABLE_SKIP_LIST); test_tidesdb_txn_put_get_rollback_get(true, TDB_COMPRESS_SNAPPY,
+    // true, TDB_MEMTABLE_SKIP_LIST); test_tidesdb_txn_put_put_delete_get(true, TDB_COMPRESS_SNAPPY,
+    // true, TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_delete_get(true, TDB_COMPRESS_SNAPPY, true,
+    // TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_flush_get(true, TDB_COMPRESS_SNAPPY, true,
+    // TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_flush_close_get(true, TDB_COMPRESS_SNAPPY, true,
+    // TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_flush_delete_get(true, TDB_COMPRESS_SNAPPY, true,
+    // TDB_MEMTABLE_SKIP_LIST); test_tidesdb_cursor(true, TDB_COMPRESS_SNAPPY, true,
+    // TDB_MEMTABLE_SKIP_LIST); test_tidesdb_cursor_memtable_sstables(true, TDB_COMPRESS_SNAPPY,
+    // true, TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_many_flush_get(true, TDB_COMPRESS_SNAPPY,
+    // true, TDB_MEMTABLE_SKIP_LIST); test_tidesdb_put_flush_compact_get(true, TDB_COMPRESS_SNAPPY,
+    // true, TDB_MEMTABLE_SKIP_LIST); test_tidesdb_start_partial_merge(true, TDB_COMPRESS_SNAPPY,
+    // true, TDB_MEMTABLE_SKIP_LIST);
+    //
+    // /* same tests as above but using a hash table as the memtable data structure */
+    // test_tidesdb_put_get_memtable(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
+    // test_tidesdb_put_close_replay_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
+    // test_tidesdb_txn_put_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
+    // test_tidesdb_txn_put_get_rollback_get(true, TDB_COMPRESS_SNAPPY, true,
+    // TDB_MEMTABLE_HASH_TABLE); test_tidesdb_txn_put_put_delete_get(true, TDB_COMPRESS_SNAPPY,
+    // true, TDB_MEMTABLE_HASH_TABLE); test_tidesdb_put_delete_get(true, TDB_COMPRESS_SNAPPY, true,
+    // TDB_MEMTABLE_HASH_TABLE); test_tidesdb_put_flush_get(true, TDB_COMPRESS_SNAPPY, true,
+    // TDB_MEMTABLE_HASH_TABLE); test_tidesdb_put_flush_close_get(true, TDB_COMPRESS_SNAPPY, true,
+    // TDB_MEMTABLE_HASH_TABLE); test_tidesdb_put_flush_delete_get(true, TDB_COMPRESS_SNAPPY, true,
+    // TDB_MEMTABLE_HASH_TABLE); test_tidesdb_cursor(true, TDB_COMPRESS_SNAPPY, true,
+    // TDB_MEMTABLE_HASH_TABLE); test_tidesdb_cursor_memtable_sstables(true, TDB_COMPRESS_SNAPPY,
+    // true, TDB_MEMTABLE_HASH_TABLE); test_tidesdb_put_many_flush_get(true, TDB_COMPRESS_SNAPPY,
+    // true, TDB_MEMTABLE_HASH_TABLE); test_tidesdb_put_flush_compact_get(true, TDB_COMPRESS_SNAPPY,
+    // true, TDB_MEMTABLE_HASH_TABLE); test_tidesdb_start_partial_merge(true, TDB_COMPRESS_SNAPPY,
+    // true, TDB_MEMTABLE_HASH_TABLE);
 
     return 0;
 }

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -1721,6 +1721,11 @@ void test_tidesdb_start_partial_merge(bool compress, tidesdb_compression_algo_t 
     assert(err == NULL);
     tidesdb_err_free(err);
 
+    /* start partial merging in background */
+    err = tidesdb_start_partial_merge(db, "test_cf", 1, 2);
+    assert(err == NULL);
+    tidesdb_err_free(err);
+
     uint8_t key[20];
     uint8_t value[1024 * 1024];
 
@@ -1737,11 +1742,8 @@ void test_tidesdb_start_partial_merge(bool compress, tidesdb_compression_algo_t 
         tidesdb_err_free(err);
     }
 
-    err = tidesdb_start_partial_merge(db, "test_cf", 1, 2);
-    assert(err == NULL);
-    tidesdb_err_free(err);
 
-    sleep(2);
+    sleep(5);
 
     for (int i = 0; i < 12; i++)
     {


### PR DESCRIPTION
- removed unused functions
- introduced partial merge compaction (automatic as opposed to manual and is optional)
- new errors TIDESDB_ERR_INVALID_PARTIAL_MERGE_INTERVAL, TIDESDB_ERR_INVALID_PARTIAL_MERGE_MIN_SST, 
- new definitions TDB_TEMP_EXT
- i have optimized and corrected merge method to use name of first sst1 so no new ids are required thus less cf locking
- new public method `tidesdb_start_partial_merge`
- new internal method `_tidesdb_partial_merge_thread`
- new structure `tidesdb_partial_merge_thread_args_t`
- i have also introduce few new members to column family struct to assist with flow of partial merge, configs, start, and closeure.
- updated read me