### PR TITLE
Minor to v0.6.0b, so update cmake and vcpkg.json, rid all cmake build warnings.  Correction for _tidesdb_partial_merge_…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.25)
 project(tidesdb C)
 
 set(CMAKE_C_STANDARD 23)
-set(PROJECT_VERSION 0.5.0) # TidesDB v0.5.0b
+set(PROJECT_VERSION 0.6.0) # TidesDB v0.6.0b
 
 # when building for production releases, you/we want to disable all warnings and sanitizers
 option(TIDESDB_WITH_SANITIZER "build with sanitizer in tidesdb" ON)

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -5322,8 +5322,8 @@ void *_tidesdb_partial_merge_thread(void *arg)
                                                cf->sstables[i]->block_manager->file_path,
                                                TDB_SYNC_INTERVAL) == -1)
                         {
-                            free(args);
                             (void)pthread_mutex_destroy(args->lock);
+                            free(args);
                             free(merged_sstable);
                             (void)pthread_rwlock_unlock(&cf->rwlock);
                             return NULL;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tidesdb",
-  "version-string": "0.5.0b",
+  "version-string": "0.6.0b",
   "description": "TidesDB is a high-performance log structured storage engine for fast key-value storage and time series data.",
   "dependencies": [
     "zstd",


### PR DESCRIPTION
rid all cmake build warnings.  Correction for _tidesdb_partial_merge_thread, minor just placement of when we were destroying mutex for partial merge args