### PR TITLE
- tidesdb: rename tidesdb_start_partial_merge to tidesdb_start_backgr…

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ if (e != NULL)
 ```
 
 #### Automatic / Background Partial Merge Compaction
-You can start a background partial merge compaction.  This will incrementally merge sstables in the background from oldest to newest.  Merges are done every n seconds.  Merges are not done in parallel but incrementally.  Less blocking than manual compaction.
+You can start a background partial merge compaction.  This will incrementally merge sstables in the background from oldest to newest when minimum sstables are reached.  Merges are done every n seconds.  Merges are not done in parallel but incrementally.  Less blocking than manual compaction.
 
 You pass
 - the database you want to start the background partial merge compaction in.  Must be open
@@ -434,7 +434,7 @@ You pass
 - the number of seconds to wait before going to next pair and merging
 - the minimum number of sstables to trigger a merge
 ```c
-tidesdb_err_t *e = tidesdb_start_partial_merge(tdb, "your_column_family", 10, 10); /* merge a pair every 10 seconds and if there are a minimum 10 sstables */
+tidesdb_err_t *e = tidesdb_start_background_partial_merge(tdb, "your_column_family", 10, 10); /* merge a pair every 10 seconds and if there are a minimum 10 sstables */
 ```
 
 ## License

--- a/src/err.h
+++ b/src/err.h
@@ -99,7 +99,8 @@ typedef enum
     TIDESDB_ERR_COLUMN_FAMILY_ALREADY_EXISTS,
     TIDESDB_ERR_INVALID_PARTIAL_MERGE_INTERVAL,
     TIDESDB_ERR_INVALID_PARTIAL_MERGE_MIN_SST,
-    TIDESDB_ERR_PARTIAL_MERGE_ALREADY_STARTED
+    TIDESDB_ERR_PARTIAL_MERGE_ALREADY_STARTED,
+    TIDESDB_ERR_THREAD_CREATION_FAILED
 } TIDESDB_ERR_CODE;
 
 /* TidesDB error messages */
@@ -148,7 +149,8 @@ static const tidesdb_err_info_t tidesdb_err_messages[] = {
     {TIDESDB_ERR_INVALID_PARTIAL_MERGE_INTERVAL, "Invalid partial merge interval.\n"},
     {TIDESDB_ERR_INVALID_PARTIAL_MERGE_MIN_SST, "Invalid partial merge min SSTables.\n"},
     {TIDESDB_ERR_PARTIAL_MERGE_ALREADY_STARTED,
-     "Partial merge already started for column family %s.\n"}
+     "Partial merge already started for column family %s.\n"},
+    {TIDESDB_ERR_THREAD_CREATION_FAILED, "Failed to create thread.\n"}
 
 };
 

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -512,9 +512,10 @@ tidesdb_err_t *tidesdb_cursor_free(tidesdb_cursor_t *cursor);
 tidesdb_err_t *tidesdb_list_column_families(tidesdb_t *tdb, char **list);
 
 /*
- * tidesdb_start_partial_merge
- * starts background partial merge for column family. Blocks less than full compaction as sstables
- * are copied and merged in the background then replaced
+ * tidesdb_start_background_partial_merge
+ * starts background partial merge for column family. Will incrementally when minimum is reached
+ * pair and merge sstables. Blocks less than full compaction as sstables are copied and merged in
+ * the background then replaced.
  * @param tdb the TidesDB instance
  * @param column_family_name the name of the column family
  * @param seconds the interval in seconds for the partial merges, each provided seconds a partial
@@ -522,8 +523,9 @@ tidesdb_err_t *tidesdb_list_column_families(tidesdb_t *tdb, char **list);
  * @param min_sstables the minimum number of sstables to trigger a partial merge
  * @return error or NULL if thread was started
  */
-tidesdb_err_t *tidesdb_start_partial_merge(tidesdb_t *tdb, const char *column_family_name,
-                                           int seconds, int min_sstables);
+tidesdb_err_t *tidesdb_start_background_partial_merge(tidesdb_t *tdb,
+                                                      const char *column_family_name, int seconds,
+                                                      int min_sstables);
 
 /* internal functions */
 

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -1722,7 +1722,7 @@ void test_tidesdb_start_partial_merge(bool compress, tidesdb_compression_algo_t 
     tidesdb_err_free(err);
 
     /* start partial merging in background */
-    err = tidesdb_start_partial_merge(db, "test_cf", 1, 2);
+    err = tidesdb_start_background_partial_merge(db, "test_cf", 1, 2);
     assert(err == NULL);
     tidesdb_err_free(err);
 
@@ -1831,8 +1831,7 @@ int main(void)
     test_tidesdb_put_many_flush_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
     test_tidesdb_put_flush_compact_get(true, TDB_COMPRESS_SNAPPY, true, TDB_MEMTABLE_HASH_TABLE);
 
-    /* test_tidesdb_start_partial_merge(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
-     * bit flaky */
+    test_tidesdb_start_partial_merge(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
 
     return 0;
 }


### PR DESCRIPTION
- tidesdb: rename tidesdb_start_partial_merge to tidesdb_start_background_partial_merge
- tidesdb: _tidesdb_flush_memtableminor memory handling on error 
- tidesdb_start_background_partial_merge reformat.  Correct incorrect read lock handling, memory handling pthread_create, incorrect use of pthread_mutex_destroy
- Introduction of error TIDESDB_ERR_THREAD_CREATION_FAILED
- _tidesdb_partial_merge_thread rewrite 
- run code_formatter
- pass all tidesdb__tests