### PR TITLE
_tidesdb_get_available_mem on system start up we get available memory for system.  On write operations like tidesdb_put we check the size of the key and value combined if exceeds available memory.

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -141,6 +141,7 @@ int fsync(int fd)
 #include <pthread.h>
 #include <semaphore.h>
 #include <sys/stat.h>
+#include <sys/sysinfo.h>
 #include <unistd.h>
 
 typedef pthread_t thread_t;

--- a/src/err.h
+++ b/src/err.h
@@ -102,6 +102,7 @@ typedef enum
     TIDESDB_ERR_PARTIAL_MERGE_ALREADY_STARTED,
     TIDESDB_ERR_THREAD_CREATION_FAILED,
     TIDESDB_ERR_LOG_INIT_FAILED,
+    TIDESDB_ERR_PUT_MEMORY_OVERFLOW,
 } TIDESDB_ERR_CODE;
 
 /* TidesDB error messages */
@@ -153,7 +154,9 @@ static const tidesdb_err_info_t tidesdb_err_messages[] = {
      "Partial merge already started for column family %s.\n"},
     {TIDESDB_ERR_THREAD_CREATION_FAILED, "Failed to create thread.\n"},
     {TIDESDB_ERR_LOG_INIT_FAILED, "Failed to initialize db debug log.\n"},
-
+    {TIDESDB_ERR_PUT_MEMORY_OVERFLOW,
+     "Memory overflow while putting key-value pair.  Attempting to write data greater than "
+     "available memory.\n"},
 };
 
 /*

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -226,6 +226,10 @@ typedef struct
  * @param column_families the column families currently
  * @param num_column_families the number of column families
  * @param rwlock read-write lock for the database
+ * @param log the log for the database
+ * @param available_mem the available memory for the system.  TidesDB gets available memory on start
+ * up and will not allow a value and key pair to be inserted if the value is larger than the
+ * available memory.
  */
 struct tidesdb_t
 {
@@ -234,6 +238,7 @@ struct tidesdb_t
     int num_column_families;
     pthread_rwlock_t rwlock;
     log_t *log;
+    size_t available_mem;
 };
 
 /*
@@ -901,5 +906,12 @@ compress_type _tidesdb_map_compression_algo(tidesdb_compression_algo_t algo);
  * @param arg the arguments for the thread in this case a partial_merge_thread_args struct
  */
 void *_tidesdb_partial_merge_thread(void *arg);
+
+/*
+ * _tidesdb_get_available_mem
+ * get the available memory for the system
+ * @return the available memory
+ */
+size_t _tidesdb_get_available_mem();
 
 #endif /* __TIDESDB_H__ */


### PR DESCRIPTION
_tidesdb_get_available_mem on system start up we get available memory for system.  On write operations like tidesdb_put we check the size of the key and value combined if exceeds available memory.  I've also introduced a new error code `TIDESDB_ERR_PUT_MEMORY_OVERFLOW`.