### PR TITLE
bug: handle memtable pointers properly

### DIFF
--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -1513,6 +1513,11 @@ int _tidesdb_new_column_family(tidesdb_t *tdb, const char *name, int flush_thres
 
     (*cf)->tdb = tdb;
 
+    (*cf)->memtable_sl = NULL;
+
+    (*cf)->memtable_ht = NULL;
+
+
     if (pthread_rwlock_init(&(*cf)->rwlock, NULL) != 0)
     {
         free((*cf)->config.name);
@@ -1611,7 +1616,7 @@ int _tidesdb_new_column_family(tidesdb_t *tdb, const char *name, int flush_thres
     }
 
     /* we check if the memtable was created */
-    if ((*cf)->memtable_sl == NULL || (*cf)->memtable_ht == NULL)
+    if ((*cf)->memtable_sl == NULL && (*cf)->memtable_ht == NULL)
     {
         free((*cf)->config.name);
         free((*cf)->path);


### PR DESCRIPTION
The random failure of _tidesdb_new_column_family is happen to be due to memtable pointers wasn't zeroed that lead to containing random garbage for them

Next: memtable check for NULL pointer is failing for any of the configuration (i.e. TDB_MEMTABLE_SKIP_LIST or TDB_MEMTABLE_HASH_TABLE) however we actually want ONE of them to contain a valid pointer instead.