### PR TITLE
bloom_filter__tests.c and binary_hash_array__tests.c to print seriali…

### DIFF
--- a/test/binary_hash_array__tests.c
+++ b/test/binary_hash_array__tests.c
@@ -84,6 +84,9 @@ void benchmark_binary_hash_array()
 
     binary_hash_array_free(bha);
 
+    /* we print the size of the serialized sorted binary hash array */
+    printf(BOLDWHITE "Bloom filter size: %f MB\n" RESET, (float)serialized_size / 1000000);
+
     binary_hash_array_t *deserialized_bha = binary_hash_array_deserialize(serialized_data);
     free(serialized_data);
     assert(deserialized_bha != NULL);

--- a/test/binary_hash_array__tests.c
+++ b/test/binary_hash_array__tests.c
@@ -85,7 +85,7 @@ void benchmark_binary_hash_array()
     binary_hash_array_free(bha);
 
     /* we print the size of the serialized sorted binary hash array */
-    printf(BOLDWHITE "Bloom filter size: %f MB\n" RESET, (float)serialized_size / 1000000);
+    printf(BOLDWHITE "Sorted binary hash array size: %f MB\n" RESET, (float)serialized_size / 1000000);
 
     binary_hash_array_t *deserialized_bha = binary_hash_array_deserialize(serialized_data);
     free(serialized_data);

--- a/test/bloom_filter__tests.c
+++ b/test/bloom_filter__tests.c
@@ -86,6 +86,15 @@ void benchmark_bloom_filter()
     double time_spent_add = (double)(end_add - start_add) / CLOCKS_PER_SEC;
     printf(CYAN "Adding 1,000,000 elements took %f seconds\n" RESET, time_spent_add);
 
+    /* serializing and deserializing the bloom filter */
+    size_t serialized_bf_size = 0;
+    uint8_t *serialized_bf = bloom_filter_serialize(bf, &serialized_bf_size);
+    assert(serialized_bf != NULL);
+    free(serialized_bf);
+
+    /* we print the size of the serialized bloom filter */
+    printf(BOLDWHITE "Bloom filter size: %f MB\n" RESET, (float)serialized_bf_size / 1000000);
+
     clock_t start_check = clock();
     for (int i = 0; i < 1000000; i++)
     {


### PR DESCRIPTION
bloom_filter__tests.c and binary_hash_array__tests.c to print serialized size in megabytes during benchmark.  Helps us get an idea of the memory usage per sstable retrieval operation, say tidesdb_get if bloom enabled we check initial block, this gives us a general idea how much memory these data structures will take.