### PR TITLE
tidesdb: block indices implementation using sorted binary hash array at end of each sstable to assist retrieval methods seek to blocks in rather constant times and consistent times.  issue #249.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It is not a full-featured database, but rather a library that can be used to bui
 - [x] **Multiple Memtable Data Structures** memtable can be a skip list or hash table.
 - [x] **Multiplatform** Linux, MacOS, and Windows support.
 - [x] **Logging** system logs debug messages to log file.  This can be disabled.  Log file is created in the database directory.
-- [ ] **Block Indices** more info coming soon.
+- [x] **Block Indices** by default `TDB_BLOCK_INDICES` is set to 1.  This means TidesDB for each column family sstable there is a last block containing a sorted binary hash array.  This compact data structure gives us the ability to retrieve the specific offset for a key and seek to its containing key value pair block within an sstable without having to scan an entire sstable.  If `TDB_BLOCK_INDICES` is set to 0 then block indices aren't used nor created and reads are slower and consume for IO.
 
 ## Building
 Using cmake to build the shared library.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It is not a full-featured database, but rather a library that can be used to bui
 - [x] **Multiple Memtable Data Structures** memtable can be a skip list or hash table.
 - [x] **Multiplatform** Linux, MacOS, and Windows support.
 - [x] **Logging** system logs debug messages to log file.  This can be disabled.  Log file is created in the database directory.
-- [x] **Block Indices** by default `TDB_BLOCK_INDICES` is set to 1.  This means TidesDB for each column family sstable there is a last block containing a sorted binary hash array.  This compact data structure gives us the ability to retrieve the specific offset for a key and seek to its containing key value pair block within an sstable without having to scan an entire sstable.  If `TDB_BLOCK_INDICES` is set to 0 then block indices aren't used nor created and reads are slower and consume for IO.
+- [x] **Block Indices** by default `TDB_BLOCK_INDICES` is set to 1.  This means TidesDB for each column family sstable there is a last block containing a sorted binary hash array.  This compact data structure gives us the ability to retrieve the specific offset for a key and seek to its containing key value pair block within an sstable without having to scan an entire sstable.  If `TDB_BLOCK_INDICES` is set to 0 then block indices aren't used nor created and reads are slower and consume more IO and CPU having to scan and compare.
 
 ## Building
 Using cmake to build the shared library.

--- a/src/block_manager.c
+++ b/src/block_manager.c
@@ -396,3 +396,10 @@ int block_manager_seek(block_manager_t *bm, uint64_t pos)
     if (fseek(bm->file, pos, SEEK_SET) != 0) return -1;
     return 0;
 }
+
+int block_manager_cursor_goto(block_manager_cursor_t *cursor, uint64_t pos)
+{
+    if (fseek(cursor->bm->file, pos, SEEK_SET) != 0) return -1;
+    cursor->current_pos = pos;
+    return 0;
+}

--- a/src/block_manager.h
+++ b/src/block_manager.h
@@ -222,6 +222,15 @@ int block_manager_cursor_has_prev(block_manager_cursor_t *cursor);
 int block_manager_cursor_goto_last(block_manager_cursor_t *cursor);
 
 /**
+ * block_manager_cursor_goto
+ * moves the cursor to a specific block
+ * @param cursor the cursor to move
+ * @param pos the position to move the cursor to
+ * @return 0 if successful, -1 if not
+ */
+int block_manager_cursor_goto(block_manager_cursor_t *cursor, uint64_t pos);
+
+/**
  * block_manager_cursor_goto_first
  * moves the cursor to the first block
  * @param cursor the cursor to move

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -21,6 +21,7 @@
 
 #include <stdbool.h>
 
+#include "binary_hash_array.h"
 #include "block_manager.h"
 #include "bloom_filter.h"
 #include "compat.h"
@@ -39,6 +40,9 @@
 #define TDB_TOMBSTONE                     0xDEADBEEF /* tombstone value for deleted keys */
 #define TDB_SYNC_INTERVAL                 0.24       /* interval for syncing mainly WAL */
 #define TDB_BLOOM_FILTER_P                0.01       /*  the false positive rate for bloom filter */
+#define TDB_BLOCK_INDICES                                                                          \
+    1 /* whether to store block indices in SSTable. Will cause more memory usage but reads will be \
+         faster */
 #define TDB_SSTABLE_PREFIX                "sstable_" /* prefix for SSTable files */
 #define TDB_FLUSH_THRESHOLD               1048576    /* default flush threshold for column family */
 #define TDB_MIN_MAX_LEVEL                 5          /* minimum max level for column family */

--- a/test/binary_hash_array__tests.c
+++ b/test/binary_hash_array__tests.c
@@ -85,7 +85,8 @@ void benchmark_binary_hash_array()
     binary_hash_array_free(bha);
 
     /* we print the size of the serialized sorted binary hash array */
-    printf(BOLDWHITE "Sorted binary hash array size: %f MB\n" RESET, (float)serialized_size / 1000000);
+    printf(BOLDWHITE "Sorted binary hash array size: %f MB\n" RESET,
+           (float)serialized_size / 1000000);
 
     binary_hash_array_t *deserialized_bha = binary_hash_array_deserialize(serialized_data);
     free(serialized_data);

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -1793,6 +1793,23 @@ int main(void)
     test_tidesdb_put_many_flush_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
     test_tidesdb_put_flush_compact_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_SKIP_LIST);
 
+    /* using hash table memtable */
+    test_tidesdb_put_get_memtable(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_HASH_TABLE);
+    test_tidesdb_put_close_replay_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_HASH_TABLE);
+    test_tidesdb_txn_put_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_HASH_TABLE);
+    test_tidesdb_txn_put_get_rollback_get(false, TDB_NO_COMPRESSION, false,
+                                          TDB_MEMTABLE_HASH_TABLE);
+    test_tidesdb_txn_put_put_delete_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_HASH_TABLE);
+    test_tidesdb_put_delete_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_HASH_TABLE);
+    test_tidesdb_cursor(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_HASH_TABLE);
+    test_tidesdb_cursor_memtable_sstables(false, TDB_NO_COMPRESSION, false,
+                                          TDB_MEMTABLE_HASH_TABLE);
+    test_tidesdb_put_flush_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_HASH_TABLE);
+    test_tidesdb_put_flush_close_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_HASH_TABLE);
+    test_tidesdb_put_flush_delete_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_HASH_TABLE);
+    test_tidesdb_put_many_flush_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_HASH_TABLE);
+    test_tidesdb_put_flush_compact_get(false, TDB_NO_COMPRESSION, false, TDB_MEMTABLE_HASH_TABLE);
+
     /* the next batch of tests we will run with bloom filters and compression
      * same tests just with bloom filters and compression enabled */
     test_tidesdb_serialize_deserialize_key_value_pair(true, TDB_COMPRESS_SNAPPY);


### PR DESCRIPTION
SSTable block indices implementation using sorted binary hash array at end of each sstable to assist retrieval methods seek to blocks in rather constant times and consistent times.  issue #249.