### PR TITLE
win: windows compatibility adjustments based on #241 thank you @mrfearless

### DIFF
--- a/src/bloom_filter.h
+++ b/src/bloom_filter.h
@@ -19,9 +19,9 @@
 #ifndef __BLOOM_FILTER_H__
 #define __BLOOM_FILTER_H__
 #include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
 #include <tgmath.h>
+
+#include "compat.h"
 
 /**
  * bloom_filter_t

--- a/src/compat.h
+++ b/src/compat.h
@@ -23,6 +23,7 @@
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #ifdef _WIN32
 #include <direct.h>
@@ -33,6 +34,10 @@
 #pragma warning(disable : 4996) /* disable deprecated warning for Windows */
 
 #include "pthread.h" /* pthreads-win32 library (https://github.com/tidesdb/tidesdb/issues/241) */
+
+#define truncate                                                                                                                                            \
+    _chsize /* https://github.com/tidesdb/tidesdb/issues/241#:~:text=back%20and%20added%3A-,%23define%20truncate%20%20%20%20%20%20%20_chsize,-to%20compat.h \
+             */
 
 /* Access flags are normally defined in unistd.h, which unavailable under
  * Windows. Instead, define the flags as documented at

--- a/src/hash_table.h
+++ b/src/hash_table.h
@@ -18,12 +18,8 @@
  */
 #ifndef __HASH_TABLE_H__
 #define __HASH_TABLE_H__
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <time.h> /* should be fine for windows, linux, and mac */
-
 #include "bloom_filter.h" /* for bloom_filter_hash */
+#include "compat.h"
 
 #define TOMBSTONE                                                                                 \
     0xDEADBEEF /* on expiration of a bucket if time to live is set we set the key's value to this \

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -24,7 +24,7 @@
 #include "binary_hash_array.h"
 #include "block_manager.h"
 #include "bloom_filter.h"
-#include "compat.h"
+/* we include compat.h in above headers already */
 #include "compress.h"
 #include "err.h"
 #include "hash_table.h"

--- a/test/bloom_filter__tests.c
+++ b/test/bloom_filter__tests.c
@@ -18,9 +18,6 @@
  */
 
 #include <assert.h>
-#include <stdio.h>
-#include <string.h>
-#include <time.h>
 
 #include "../src/bloom_filter.h"
 #include "test_macros.h"

--- a/test/hash_table__tests.c
+++ b/test/hash_table__tests.c
@@ -18,9 +18,6 @@
  */
 
 #include <assert.h>
-#include <stdio.h>
-#include <string.h>
-#include <time.h>
 
 #include "../src/hash_table.h"
 #include "test_macros.h"


### PR DESCRIPTION
Some minor adjustments with includes and additions to compat.h regarding truncate method.   It seems Windows is complaining regarding the multiple inclusions of compat.h.  This adjustment should assist.  I will further test and research.  The thing is because we include compat.h within say bloom_filter.h and hash_table.h then we include them in tidesdb.h we need not include compat.h in tidesdb.h. 