### PR TITLE
fix compilation error on macOS (due to missing sysinfo.h)

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -148,6 +148,15 @@ int fsync(int fd)
     return FlushFileBuffers(h) ? 0 : -1;
 }
 
+#elif defined (__APPLE__)
+#include <dirent.h>
+#include <pthread.h>
+#include <semaphore.h>
+#include <sys/stat.h>
+#include <sys/sysctl.h>
+#include <mach/mach.h>
+#include <unistd.h>
+
 #else /* posix systems */
 #include <dirent.h>
 #include <pthread.h>

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -5515,6 +5515,23 @@ size_t _tidesdb_get_available_mem()
     }
 
     return 0;
+#elif defined(__APPLE__)
+    mach_port_t host_port = mach_host_self();
+    vm_size_t page_size;
+    kern_return_t kr;
+    kr = host_page_size(host_port, &page_size);
+    if (kr != KERN_SUCCESS) 
+    {
+        return 0;
+    }
+    vm_statistics64_data_t vm_stat;
+    mach_msg_type_number_t host_size = sizeof(vm_statistics64_data_t) / sizeof(integer_t);
+    kr = host_statistics64(host_port, HOST_VM_INFO64, (host_info_t)&vm_stat, &host_size);
+    if (kr != KERN_SUCCESS) 
+    {
+        return 0;
+    }
+    return (vm_stat.free_count + vm_stat.inactive_count) * page_size;
 #else
     struct sysinfo info;
     if (sysinfo(&info) == 0)


### PR DESCRIPTION
Try to close https://github.com/tidesdb/tidesdb/issues/290.

There seem to be various ideas on how to calculate available memory in macOS.
I will follow [the psutil's approach](https://github.com/giampaolo/psutil/issues/1277#issuecomment-431356787).
Of course there are other ways of thinking abount it, but I would like to give priority to solving the compilation errors on macOS.
