### PR TITLE
tidesdb: on start up if we cannot get available system memory close database and throw new error TIDESDB_ERR_FAILED_TO_GET_SYSTEM_MEMORY.

### DIFF
--- a/src/err.h
+++ b/src/err.h
@@ -103,6 +103,7 @@ typedef enum
     TIDESDB_ERR_THREAD_CREATION_FAILED,
     TIDESDB_ERR_LOG_INIT_FAILED,
     TIDESDB_ERR_PUT_MEMORY_OVERFLOW,
+    TIDESDB_ERR_FAILED_TO_GET_SYSTEM_MEMORY,
 } TIDESDB_ERR_CODE;
 
 /* TidesDB error messages */
@@ -157,6 +158,7 @@ static const tidesdb_err_info_t tidesdb_err_messages[] = {
     {TIDESDB_ERR_PUT_MEMORY_OVERFLOW,
      "Memory overflow while putting key-value pair.  Attempting to write data greater than "
      "available memory.\n"},
+     {TIDESDB_ERR_FAILED_TO_GET_SYSTEM_MEMORY, "Failed to get system memory.\n"},
 };
 
 /*

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -566,6 +566,13 @@ tidesdb_err_t *tidesdb_open(const char *directory, tidesdb_t **tdb)
     (*tdb)->available_mem =
         (size_t)((double)(*tdb)->available_mem * TDB_AVAILABLE_MEMORY_THRESHOLD);
 
+    if ((*tdb)->available_mem == 0)
+    {
+        (void)log_write((*tdb)->log, "Failed to get available memory");
+        tidesdb_close(*tdb);
+        return tidesdb_err_from_code(TIDESDB_ERR_FAILED_TO_GET_SYSTEM_MEMORY);
+    }
+
     (void)log_write((*tdb)->log, "Available memory: %zu bytes", (*tdb)->available_mem);
 
     (void)log_write((*tdb)->log, "Opened TidesDB instance at %s", directory);


### PR DESCRIPTION
On tidesdb_open aka start up if we cannot get available system memory close database and throw new error TIDESDB_ERR_FAILED_TO_GET_SYSTEM_MEMORY.