### PR TITLE
use xxhash.h in c source files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ install(TARGETS tidesdb
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib)
 
-install(FILES src/tidesdb.h src/err.h src/block_manager.h src/skip_list.h src/hash_table.h src/compress.h src/bloom_filter.h src/compat.h src/log.h src/binary_hash_array.h external/xxhash.h DESTINATION include)
+install(FILES src/tidesdb.h src/err.h src/block_manager.h src/skip_list.h src/hash_table.h src/compress.h src/bloom_filter.h src/compat.h src/log.h src/binary_hash_array.h DESTINATION include)
 
 if(TIDESDB_BUILD_TESTS) # enable building tests and benchmarks
         enable_testing()

--- a/src/binary_hash_array.c
+++ b/src/binary_hash_array.c
@@ -16,6 +16,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <xxhash.h>
+
 #include "binary_hash_array.h"
 
 int binary_hash_array_compare(const void *a, const void *b)

--- a/src/binary_hash_array.h
+++ b/src/binary_hash_array.h
@@ -21,7 +21,6 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-#include <xxhash.h>
 
 /* sorted* binary hash array
  * on serialization, the entries are sorted by hashed key.


### PR DESCRIPTION
Try to fix missing xxhash.h issues. 
https://github.com/tidesdb/tidesdb/issues/286