### PR TITLE
cmake,sbha: correct xxhash inclusion.  Modified cmake and sorted bina…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ install(TARGETS tidesdb
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib)
 
-install(FILES src/tidesdb.h src/err.h src/block_manager.h src/skip_list.h src/hash_table.h src/compress.h src/bloom_filter.h src/compat.h src/log.h src/binary_hash_array.h DESTINATION include)
+install(FILES src/tidesdb.h src/err.h src/block_manager.h src/skip_list.h src/hash_table.h src/compress.h src/bloom_filter.h src/compat.h src/log.h src/binary_hash_array.h external/xxhash.h DESTINATION include)
 
 if(TIDESDB_BUILD_TESTS) # enable building tests and benchmarks
         enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,9 +25,11 @@ if(TIDESDB_WITH_SANITIZER)
         endif()
 endif()
 
+include_directories(external) # for external libraries linking internally
+
 add_library(tidesdb SHARED src/tidesdb.c src/err.c src/block_manager.c src/skip_list.c src/compress.c src/bloom_filter.c src/hash_table.c src/binary_hash_array.c src/log.c external/xxhash.c)
 
-target_include_directories(tidesdb PRIVATE src external)
+target_include_directories(tidesdb PRIVATE src)
 
 if(APPLE AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
         # for apple silicon macs, homebrew installs packages in /opt/homebrew
@@ -65,7 +67,7 @@ install(TARGETS tidesdb
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib)
 
-install(FILES src/tidesdb.h src/err.h src/block_manager.h src/skip_list.h src/hash_table.h src/compress.h src/bloom_filter.h src/compat.h src/log.h src/binary_hash_array.h external/xxhash.h DESTINATION include)
+install(FILES src/tidesdb.h src/err.h src/block_manager.h src/skip_list.h src/hash_table.h src/compress.h src/bloom_filter.h src/compat.h src/log.h src/binary_hash_array.h DESTINATION include)
 
 if(TIDESDB_BUILD_TESTS) # enable building tests and benchmarks
         enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,8 @@ install(TARGETS tidesdb
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib)
 
-install(FILES src/tidesdb.h src/err.h src/block_manager.h src/skip_list.h src/hash_table.h src/compress.h src/bloom_filter.h src/compat.h src/log.h src/binary_hash_array.h external/xxhash.h DESTINATION include)
+install(DIRECTORY src/ DESTINATION include/tidesdb FILES_MATCHING PATTERN "*.h")
+install(FILES external/xxhash.h DESTINATION include/tidesdb)
 
 if(TIDESDB_BUILD_TESTS) # enable building tests and benchmarks
         enable_testing()

--- a/src/binary_hash_array.h
+++ b/src/binary_hash_array.h
@@ -21,7 +21,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-#include <xxhash.h>
+#include "../external/xxhash.h"
 
 /* sorted* binary hash array
  * on serialization, the entries are sorted by hashed key.

--- a/src/binary_hash_array.h
+++ b/src/binary_hash_array.h
@@ -21,7 +21,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-#include "../external/xxhash.h"
+
+#include "xxhash.h" /* use install location based on cmake */
 
 /* sorted* binary hash array
  * on serialization, the entries are sorted by hashed key.


### PR DESCRIPTION
Correct xxhash inclusion.  Modified cmake and sorted binary hash array to use internal to package xxhash implementation.  Thank you for pointer @toge.