### PR TITLE
tidesdb: TDB_MAX_COLUMN_FAMILY_NAME_LEN introduction. tidesdb_create_…

### DIFF
--- a/src/err.c
+++ b/src/err.c
@@ -354,6 +354,12 @@ tidesdb_err_t* tidesdb_err_from_code(TIDESDB_ERR_CODE code, ...)
             snprintf(buffer, sizeof(buffer), tidesdb_err_messages[code].message, obj);
             break;
         }
+        case TIDESDB_ERR_INVALID_NAME_LENGTH:
+        {
+            const char* obj = va_arg(args, const char*);
+            snprintf(buffer, sizeof(buffer), tidesdb_err_messages[code].message, obj);
+            break;
+        }
         default:
             snprintf(buffer, sizeof(buffer), "%s", tidesdb_err_messages[code].message);
     }

--- a/src/err.h
+++ b/src/err.h
@@ -141,6 +141,7 @@ typedef enum
     TIDESDB_ERR_FAILED_TO_SERIALIZE_BLOOM_FILTER,
     TIDESDB_ERR_FAILED_TO_GET_SSTABLE_SIZE,
     TIDESDB_ERR_INVALID_STAT,
+    TIDESDB_ERR_INVALID_NAME_LENGTH,
 } TIDESDB_ERR_CODE;
 
 /* TidesDB error messages */
@@ -256,6 +257,7 @@ static const tidesdb_err_info_t tidesdb_err_messages[] = {
     {TIDESDB_ERR_FAILED_TO_GET_SSTABLE_SIZE,
      "Failed to get SSTable size from block manager for column family %s.\n"},
     {TIDESDB_ERR_INVALID_STAT, "Invalid stat for column family %s.\n"},
+    {TIDESDB_ERR_INVALID_NAME_LENGTH, "Invalid name length for %s.\n"},
 };
 
 /*

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -1290,9 +1290,17 @@ tidesdb_err_t *tidesdb_create_column_family(tidesdb_t *tdb, const char *name, in
     /* we check if the column family name is greater than 2 */
     if (strlen(name) < 2) return tidesdb_err_from_code(TIDESDB_ERR_INVALID_NAME, "column family");
 
+    /* we check if column name length exceeds TDB_MAX_COLUMN_FAMILY_NAME_LEN */
+    if (strlen(name) > TDB_MAX_COLUMN_FAMILY_NAME_LEN)
+        return tidesdb_err_from_code(TIDESDB_ERR_INVALID_NAME_LENGTH, "column family");
+
     /* we check flush threshold
      * the system expects at least TDB_FLUSH_THRESHOLD threshold */
     if (flush_threshold < TDB_FLUSH_THRESHOLD)
+        return tidesdb_err_from_code(TIDESDB_ERR_INVALID_FLUSH_THRESHOLD);
+
+    /* don't allow flush threshold greater than available memory */
+    if (flush_threshold > tdb->available_mem)
         return tidesdb_err_from_code(TIDESDB_ERR_INVALID_FLUSH_THRESHOLD);
 
     /* only if the memtable data structure is skip list

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -43,6 +43,7 @@ extern "C"
 #define TDB_COLUMN_FAMILY_CONFIG_FILE_EXT ".cfc"     /* configuration file for the column family */
 #define TDB_TEMP_EXT                      ".tmp"     /* extension for temporary files, names */
 #define TDB_TOMBSTONE                     0xDEADBEEF /* tombstone value for deleted keys */
+#define TDB_MAX_COLUMN_FAMILY_NAME_LEN    256        /* max length for column family name */
 #define TDB_SYNC_INTERVAL                 0.24       /* interval for syncing mainly WAL */
 #define TDB_BLOOM_FILTER_P                0.01       /*  the false positive rate for bloom filter */
 #define TDB_BLOCK_INDICES                                                                          \


### PR DESCRIPTION
`TDB_MAX_COLUMN_FAMILY_NAME_LEN` introduction. `tidesdb_create_column_family` logical additions to check column family name length against TDB_MAX_COLUMN_FAMILY_NAME_LEN and if provided flush threshold exceeds set available_mem.

**New error(s)**
- TIDESDB_ERR_INVALID_NAME_LENGTH