### PR TITLE
tidesdb: added system capability to get available system threads on s…

### DIFF
--- a/src/err.h
+++ b/src/err.h
@@ -143,6 +143,7 @@ typedef enum
     TIDESDB_ERR_INVALID_STAT,
     TIDESDB_ERR_INVALID_NAME_LENGTH,
     TIDESDB_ERR_PATH_TOO_LONG,
+    TIDESDB_ERR_FAILED_TO_GET_SYSTEM_THREADS,
 } TIDESDB_ERR_CODE;
 
 /* TidesDB error messages */
@@ -260,6 +261,7 @@ static const tidesdb_err_info_t tidesdb_err_messages[] = {
     {TIDESDB_ERR_INVALID_STAT, "Invalid stat for column family %s.\n"},
     {TIDESDB_ERR_INVALID_NAME_LENGTH, "Invalid name length for %s.\n"},
     {TIDESDB_ERR_PATH_TOO_LONG, "Path too long for %s.\n"},
+    {TIDESDB_ERR_FAILED_TO_GET_SYSTEM_THREADS, "Failed to get system threads.\n"},
 };
 
 /*

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -2879,7 +2879,7 @@ tidesdb_err_t *tidesdb_compact_sstables(tidesdb_t *tdb, const char *column_famil
     }
 
     /* we check if provided max_threads exceeds system available threads */
-    if (tdb->avail_threads > max_threads)
+    if (max_threads > tdb->avail_threads)
     {
         (void)pthread_rwlock_unlock(&tdb->rwlock); /* release db read lock */
         return tidesdb_err_from_code(TIDESDB_ERR_INVALID_MAX_THREADS);

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -585,8 +585,21 @@ tidesdb_err_t *tidesdb_open(const char *directory, tidesdb_t **tdb)
         return tidesdb_err_from_code(TIDESDB_ERR_FAILED_TO_GET_SYSTEM_MEMORY);
     }
 
+    /* we get available system threads */
+    (*tdb)->avail_threads = _tidesdb_get_max_sys_threads();
+    if ((*tdb)->avail_threads == 0 || (*tdb)->avail_threads == -1)
+    {
+        (void)log_write((*tdb)->log,
+                        tidesdb_err_from_code(TIDESDB_ERR_FAILED_TO_GET_SYSTEM_THREADS)->message);
+        tidesdb_close(*tdb);
+        return tidesdb_err_from_code(TIDESDB_ERR_FAILED_TO_GET_SYSTEM_THREADS);
+    }
+
     (void)log_write((*tdb)->log, _tidesdb_get_debug_log_format(TIDESDB_DEBUG_AVAIL_MEMORY),
                     (*tdb)->available_mem);
+
+    (void)log_write((*tdb)->log, _tidesdb_get_debug_log_format(TIDESDB_DEBUG_AVAIL_THREADS),
+                    (*tdb)->avail_threads);
 
     (void)log_write((*tdb)->log, _tidesdb_get_debug_log_format(TIDESDB_DEBUG_OPENED_SUCCESS),
                     directory);
@@ -2863,6 +2876,13 @@ tidesdb_err_t *tidesdb_compact_sstables(tidesdb_t *tdb, const char *column_famil
     if (pthread_rwlock_rdlock(&tdb->rwlock) != 0)
     {
         return tidesdb_err_from_code(TIDESDB_ERR_FAILED_TO_ACQUIRE_LOCK, "db");
+    }
+
+    /* we check if provided max_threads exceeds system available threads */
+    if (tdb->avail_threads > max_threads)
+    {
+        (void)pthread_rwlock_unlock(&tdb->rwlock); /* release db read lock */
+        return tidesdb_err_from_code(TIDESDB_ERR_INVALID_MAX_THREADS);
     }
 
     /* get column family */
@@ -6391,6 +6411,8 @@ char *_tidesdb_get_debug_log_format(tidesdb_debug_log_t log_type)
             return "Reopening TidesDB instance at %s";
         case TIDESDB_DEBUG_AVAIL_MEMORY:
             return "Available memory: %zu bytes";
+        case TIDESDB_DEBUG_AVAIL_THREADS:
+            return "Available threads: %d";
         case TIDESDB_DEBUG_OPENED_SUCCESS:
             return "Opened TidesDB instance at %s";
         case TIDESDB_DEBUG_COLUMN_FAMILY_SETTING_UP:
@@ -6613,4 +6635,30 @@ tidesdb_err_t *tidesdb_free_column_family_stat(tidesdb_column_family_stat_t *sta
     stat = NULL;
 
     return NULL;
+}
+
+int _tidesdb_get_max_sys_threads()
+{
+    int max_threads = 0;
+
+#if defined(_WIN32) || defined(_WIN64)
+    SYSTEM_INFO sysInfo;
+    GetSystemInfo(&sysInfo);
+    max_threads = sysInfo.dwNumberOfProcessors;
+
+#elif defined(__linux__) || defined(__APPLE__) || defined(__unix__)
+#if defined(__APPLE__) /* macOS specific */
+    int mib[2] = {CTL_HW, HW_NCPU};
+    size_t len = sizeof(max_threads);
+    if (sysctl(mib, 2, &max_threads, &len, NULL, 0) != 0)
+    {
+        return -1; /* ret -1 on error, tidesdb_open will catch this */
+    }
+#else                  /* unix-posix specific */
+    max_threads = sysconf(_SC_NPROCESSORS_ONLN);
+#endif
+
+#endif
+
+    return max_threads;
 }

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -125,6 +125,7 @@ extern "C"
         TIDESDB_DEBUG_BLOCK_INDICES_ENABLED,
         TIDESDB_DEBUG_REOPEN_DATABASE,
         TIDESDB_DEBUG_AVAIL_MEMORY,
+        TIDESDB_DEBUG_AVAIL_THREADS,
         TIDESDB_DEBUG_OPENED_SUCCESS,
         TIDESDB_DEBUG_COLUMN_FAMILY_SETTING_UP,
         TIDESDB_DEBUG_COLUMN_FAMILY_USING_DATA_STRUCTURE,
@@ -311,6 +312,7 @@ extern "C"
      * @param available_mem the available memory for the system.  TidesDB gets
      * TDB_AVAILABLE_MEMORY_THRESHOLD % of available memory on start up and will not allow kvp to be
      * added if exceeds available memory.
+     * @param avail_threads the available threads for the system
      */
     struct tidesdb_t
     {
@@ -320,6 +322,7 @@ extern "C"
         pthread_rwlock_t rwlock;
         log_t *log;
         size_t available_mem;
+        int avail_threads;
     };
 
     /*
@@ -1036,6 +1039,13 @@ extern "C"
      * @return error or NULL
      */
     tidesdb_err_t *tidesdb_free_column_family_stat(tidesdb_column_family_stat_t *stat);
+
+    /*
+     * _tidesdb_get_max_sys_threads
+     * get the maximum number of available system threads
+     * @return the maximum number of available system threads
+     */
+    int _tidesdb_get_max_sys_threads();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Added system capability to get available system threads on start up and on say manual compaction we check if the provided threads to use for manual compaction exceeds available system threads.  I've introduced error `TIDESDB_ERR_FAILED_TO_GET_SYSTEM_THREADS` and new method `_tidesdb_get_max_sys_threads`.  I've also added a new debug log `TIDESDB_DEBUG_AVAIL_THREADS` which prints avail threads on start up.