### PR TITLE
_tidesdb_load_sstables: on unexpected shutdown during compaction operations there may be stray sstables...

### DIFF
--- a/src/err.c
+++ b/src/err.c
@@ -366,6 +366,12 @@ tidesdb_err_t* tidesdb_err_from_code(TIDESDB_ERR_CODE code, ...)
             snprintf(buffer, sizeof(buffer), tidesdb_err_messages[code].message, obj);
             break;
         }
+        case TIDESDB_ERR_FAILED_TO_REMOVE_TEMP_FILE:
+        {
+            const char* obj = va_arg(args, const char*);
+            snprintf(buffer, sizeof(buffer), tidesdb_err_messages[code].message, obj);
+            break;
+        }
         default:
             snprintf(buffer, sizeof(buffer), "%s", tidesdb_err_messages[code].message);
     }

--- a/src/err.h
+++ b/src/err.h
@@ -144,6 +144,7 @@ typedef enum
     TIDESDB_ERR_INVALID_NAME_LENGTH,
     TIDESDB_ERR_PATH_TOO_LONG,
     TIDESDB_ERR_FAILED_TO_GET_SYSTEM_THREADS,
+    TIDESDB_ERR_FAILED_TO_REMOVE_TEMP_FILE,
 } TIDESDB_ERR_CODE;
 
 /* TidesDB error messages */
@@ -262,6 +263,7 @@ static const tidesdb_err_info_t tidesdb_err_messages[] = {
     {TIDESDB_ERR_INVALID_NAME_LENGTH, "Invalid name length for %s.\n"},
     {TIDESDB_ERR_PATH_TOO_LONG, "Path too long for %s.\n"},
     {TIDESDB_ERR_FAILED_TO_GET_SYSTEM_THREADS, "Failed to get system threads.\n"},
+    {TIDESDB_ERR_FAILED_TO_REMOVE_TEMP_FILE, "Failed to remove temporary file %s.\n"},
 };
 
 /*


### PR DESCRIPTION
On unexpected shutdown during compaction operations there may be stray temporary sstables.  We want to clean those up on start up, if there are any as it could cause conflicts with functionality.  issue #311 