### PR TITLE
Introduction of new structure tidesdb_sst_min_max with serialization …

### DIFF
--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -282,7 +282,6 @@ tidesdb_sst_min_max *_tidesdb_deserialize_sst_min_max(const uint8_t *data)
     min_max->max_key = max_key;
     min_max->max_key_size = max_key_size;
 
-    /* return the sst min max struct */
     return min_max;
 }
 

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -210,8 +210,8 @@ void _tidesdb_free_key_value_pair(tidesdb_key_value_pair_t *kv)
 }
 
 uint8_t *_tidesdb_serialize_sst_min_max(const uint8_t *min_key, size_t min_key_size,
-                                            const uint8_t *max_key, size_t max_key_size,
-                                            size_t *out_size)
+                                        const uint8_t *max_key, size_t max_key_size,
+                                        size_t *out_size)
 {
     /* calculate the size of the serialized data */
     *out_size = sizeof(size_t) + min_key_size + sizeof(size_t) + max_key_size;
@@ -259,7 +259,8 @@ tidesdb_sst_min_max *_tidesdb_deserialize_sst_min_max(const uint8_t *data)
 
     /* deserialize max_key */
     uint8_t *max_key = malloc(max_key_size);
-    if (max_key == NULL) {
+    if (max_key == NULL)
+    {
         free(min_key);
         return NULL;
     }
@@ -268,7 +269,8 @@ tidesdb_sst_min_max *_tidesdb_deserialize_sst_min_max(const uint8_t *data)
 
     /* create the sst min max struct */
     tidesdb_sst_min_max *min_max = malloc(sizeof(tidesdb_sst_min_max));
-    if (min_max == NULL) {
+    if (min_max == NULL)
+    {
         free(min_key);
         free(max_key);
         return NULL;

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -209,6 +209,81 @@ void _tidesdb_free_key_value_pair(tidesdb_key_value_pair_t *kv)
     kv = NULL;
 }
 
+uint8_t *_tidesdb_serialize_sst_min_max(const uint8_t *min_key, size_t min_key_size,
+                                            const uint8_t *max_key, size_t max_key_size,
+                                            size_t *out_size)
+{
+    /* calculate the size of the serialized data */
+    *out_size = sizeof(size_t) + min_key_size + sizeof(size_t) + max_key_size;
+
+    /* allocate memory for the serialized data */
+    uint8_t *serialized_data = malloc(*out_size);
+    if (serialized_data == NULL) return NULL;
+
+    uint8_t *ptr = serialized_data;
+
+    /* serialize min_key_size and min_key */
+    memcpy(ptr, &min_key_size, sizeof(size_t));
+    ptr += sizeof(size_t);
+    memcpy(ptr, min_key, min_key_size);
+    ptr += min_key_size;
+
+    /* serialize max_key_size and max_key */
+    memcpy(ptr, &max_key_size, sizeof(size_t));
+    ptr += sizeof(size_t);
+    memcpy(ptr, max_key, max_key_size);
+    ptr += max_key_size;
+
+    return serialized_data;
+}
+
+tidesdb_sst_min_max *_tidesdb_deserialize_sst_min_max(const uint8_t *data)
+{
+    const uint8_t *ptr = data;
+
+    /* deserialize min_key_size */
+    size_t min_key_size;
+    memcpy(&min_key_size, ptr, sizeof(size_t));
+    ptr += sizeof(size_t);
+
+    /* deserialize min_key */
+    uint8_t *min_key = malloc(min_key_size);
+    if (min_key == NULL) return NULL;
+    memcpy(min_key, ptr, min_key_size);
+    ptr += min_key_size;
+
+    /* deserialize max_key_size */
+    size_t max_key_size;
+    memcpy(&max_key_size, ptr, sizeof(size_t));
+    ptr += sizeof(size_t);
+
+    /* deserialize max_key */
+    uint8_t *max_key = malloc(max_key_size);
+    if (max_key == NULL) {
+        free(min_key);
+        return NULL;
+    }
+    memcpy(max_key, ptr, max_key_size);
+    ptr += max_key_size;
+
+    /* create the sst min max struct */
+    tidesdb_sst_min_max *min_max = malloc(sizeof(tidesdb_sst_min_max));
+    if (min_max == NULL) {
+        free(min_key);
+        free(max_key);
+        return NULL;
+    }
+
+    /* set the values */
+    min_max->min_key = min_key;
+    min_max->min_key_size = min_key_size;
+    min_max->max_key = max_key;
+    min_max->max_key_size = max_key_size;
+
+    /* return the sst min max struct */
+    return min_max;
+}
+
 uint8_t *_tidesdb_serialize_column_family_config(tidesdb_column_family_config_t *config,
                                                  size_t *out_size)
 {

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -155,6 +155,22 @@ extern "C"
         bool bloom_filter;
     } tidesdb_column_family_config_t;
 
+    /*
+     * tidesdb_sst_min_max
+     * struct for the min and max keys in a SSTable
+     * @param min_key the minimum key
+     * @param min_key_size the size of the minimum key
+     * @param max_key the maximum key
+     * @param max_key_size the size of the maximum key
+     */
+    typedef struct
+    {
+        uint8_t *min_key;
+        uint32_t min_key_size;
+        uint8_t *max_key;
+        uint32_t max_key_size;
+    } tidesdb_sst_min_max;
+
     /* forward declaration of tidesdb_t */
     typedef struct tidesdb_t tidesdb_t;
 
@@ -898,7 +914,26 @@ extern "C"
     int _tidesdb_compare_keys(const uint8_t *key1, size_t key1_size, const uint8_t *key2,
                               size_t key2_size);
 
-    /* serialization is used for tidesdb_key_value_pair_t and tidesdb_operation_t */
+    /*
+     * _tidesdb_serialize_sst_min_max
+     * serialize a sst min max key
+     * @param min_key the min key
+     * @param min_key_size the size of the min key
+     * @param max_key the max key
+     * @param max_key_size the size of the max key
+     * @param out_size the size of the serialized data
+     * @return the serialized data
+     */
+    uint8_t *_tidesdb_serialize_sst_min_max(const uint8_t *min_key, size_t min_key_size,
+                                            const uint8_t *max_key, size_t max_key_size,
+                                            size_t *out_size);
+
+    /*
+     * _tidesdb_deserialize_sst_min_max
+     * @param data the serialized data
+     * @return the deserialized sst min max struct
+     */
+    tidesdb_sst_min_max *_tidesdb_deserialize_sst_min_max(const uint8_t *data);
 
     /*
      * _tidesdb_serialize_key_value_pair

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -107,7 +107,6 @@ void test_tidesdb_serialize_deserialize_sst_min_max()
     assert(memcmp(deserialized->min_key, min_key, min_key_size) == 0);
     assert(memcmp(deserialized->max_key, max_key, max_key_size) == 0);
 
-    // Free allocated memory
     free(deserialized->min_key);
     free(deserialized->max_key);
     free(deserialized);

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -92,9 +92,8 @@ void test_tidesdb_serialize_deserialize_sst_min_max()
     size_t max_key_size = sizeof(max_key);
 
     size_t serialized_size;
-    uint8_t *serialized = _tidesdb_serialize_sst_min_max(min_key, min_key_size,
-                                                        max_key, max_key_size,
-                                                        &serialized_size);
+    uint8_t *serialized = _tidesdb_serialize_sst_min_max(min_key, min_key_size, max_key,
+                                                         max_key_size, &serialized_size);
     assert(serialized != NULL);
 
     size_t expected_size = sizeof(size_t) + min_key_size + sizeof(size_t) + max_key_size;


### PR DESCRIPTION
Introduction of new structure tidesdb_sst_min_max with serialization methods to be used as first block within each sstable letting us know the min and max keys of the specific sstable.  Mainly to assist with range query optimization.