### PR TITLE
issue #348.. more

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ It is not a full-featured database, but rather a library that can be used to bui
 - [x] **Logging** system logs debug messages to log file.  This can be disabled.  Log file is created in the database directory.
 - [x] **Block Indices** by default `TDB_BLOCK_INDICES` is set to 1.  This means TidesDB for each column family sstable there is a last block containing a sorted binary hash array.  This compact data structure gives us the ability to retrieve the specific offset for a key and seek to its containing key value pair block within an sstable without having to scan an entire sstable.  If `TDB_BLOCK_INDICES` is set to 0 then block indices aren't used nor created and reads are slower and consume more IO and CPU having to scan and compare.
 - [x] **Statistics** column family statistics, configs, information can be retrieved through public API.
-- [x] **Range queries** are supported.  You can retrieve a range of key-value pairs.
+- [x] **Range queries** are supported.  You can retrieve a range of key-value pairs.  Each sstable initial block contains a min-max key range.  This allows for fast(er) range queries.
 - [x] **Filter queries** are supported.  You can filter key-value pairs based on a filter function.
 
 ## Building
@@ -320,7 +320,7 @@ if (e != NULL)
     tidesdb_err_free(e);
 }
 
-/* you can add delete operations as well */
+/* you can add get (tidesdb_txn_get) or delete operations as well */
 e = tidesdb_txn_delete(transaction, key, sizeof(key));
 if (e != NULL)
 {

--- a/src/block_manager.h
+++ b/src/block_manager.h
@@ -25,6 +25,8 @@
 
 #include "compat.h"
 
+/* more time equals more results, but remember to take breaks to refresh your mind. */
+
 #define MAX_FILE_PATH_LENGTH 1024 /* max file path length for block manager file(s) */
 
 /**

--- a/src/err.h
+++ b/src/err.h
@@ -152,6 +152,8 @@ typedef enum
     TIDESDB_ERR_FAILED_TO_REMOVE_TEMP_FILE,
     TIDESDB_ERR_INVALID_COMPARISON_METHOD,
     TIDESDB_ERR_FAILED_TO_ESCALATE_FSYNC,
+    TIDESDB_ERR_FAILED_TO_GET_MIN_KEY_FOR_FLUSH,
+    TIDESDB_ERR_FAILED_TO_GET_MAX_KEY_FOR_FLUSH,
 } TIDESDB_ERR_CODE;
 
 /* TidesDB error messages */
@@ -315,7 +317,10 @@ static const tidesdb_err_info_t tidesdb_err_messages[] = {
      TIDESDB_ERR_WITH_CONTEXT},
     {TIDESDB_ERR_FAILED_TO_ESCALATE_FSYNC, "Failed to escalate fsync.\n",
      TIDESDB_ERR_WITHOUT_CONTEXT},
-};
+    {TIDESDB_ERR_FAILED_TO_GET_MIN_KEY_FOR_FLUSH,
+     "Failed to get minimum key for flush for column family %s.\n", TIDESDB_ERR_WITH_CONTEXT},
+    {TIDESDB_ERR_FAILED_TO_GET_MAX_KEY_FOR_FLUSH,
+     "Failed to get maximum key for flush for column family %s.\n", TIDESDB_ERR_WITH_CONTEXT}};
 
 /*
  * tidesdb_err_new

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -19,6 +19,8 @@
 #ifndef __TIDESDB_H__
 #define __TIDESDB_H__
 
+/* follow your passion, be obsessed, don't worry too much. */
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -156,7 +158,7 @@ extern "C"
     } tidesdb_column_family_config_t;
 
     /*
-     * tidesdb_sst_min_max
+     * tidesdb_sst_min_max_t
      * struct for the min and max keys in a SSTable
      * @param min_key the minimum key
      * @param min_key_size the size of the minimum key
@@ -169,7 +171,7 @@ extern "C"
         uint32_t min_key_size;
         uint8_t *max_key;
         uint32_t max_key_size;
-    } tidesdb_sst_min_max;
+    } tidesdb_sst_min_max_t;
 
     /* forward declaration of tidesdb_t */
     typedef struct tidesdb_t tidesdb_t;
@@ -541,6 +543,19 @@ extern "C"
                                      const char *column_family_name);
 
     /*
+     * tidesdb_txn_get
+     * get a value from a transaction
+     * @param txn the transaction
+     * @param key the key
+     * @param key_size the size of the key
+     * @param value the value
+     * @param value_size the size of the value
+     * @return error or NULL
+     */
+    tidesdb_err_t *tidesdb_txn_get(tidesdb_txn_t *txn, const uint8_t *key, size_t key_size,
+                                   uint8_t **value, size_t *value_size);
+
+    /*
      * tidesdb_txn_put
      * put a key-value pair into a transaction
      * @param txn the transaction
@@ -806,15 +821,6 @@ extern "C"
     int _tidesdb_flush_memtable(tidesdb_column_family_t *cf);
 
     /*
-     * _tidesdb_flush_memtable_w_bloom_filter
-     * flushes a memtable to disk in an SSTable with a bloom filter at initial block from a skip
-     * list memtable
-     * @param cf the column family
-     * @return 0 if the memtable was flushed, -1 if not
-     */
-    int _tidesdb_flush_memtable_w_bloom_filter(tidesdb_column_family_t *cf);
-
-    /*
      * _tidesdb_is_tombstone
      * checks if value is a tombstone TDB_TOMBSTONE
      * @param value the value to check
@@ -933,7 +939,7 @@ extern "C"
      * @param data the serialized data
      * @return the deserialized sst min max struct
      */
-    tidesdb_sst_min_max *_tidesdb_deserialize_sst_min_max(const uint8_t *data);
+    tidesdb_sst_min_max_t *_tidesdb_deserialize_sst_min_max(const uint8_t *data);
 
     /*
      * _tidesdb_serialize_key_value_pair
@@ -1088,6 +1094,23 @@ extern "C"
      */
     int _tidesdb_key_exists(const uint8_t *key, size_t key_size, tidesdb_key_value_pair_t **result,
                             size_t result_size);
+
+    /*
+     * _tidesdb_merge_min_max
+     * merge two min max keys
+     * @param a the first min max key
+     * @param b the second min max key
+     * @return the merged min max key
+     */
+    tidesdb_sst_min_max_t *_tidesdb_merge_min_max(const tidesdb_sst_min_max_t *a,
+                                                  const tidesdb_sst_min_max_t *b);
+
+    /*
+     * _tidesdb_free_sst_min_max
+     *  free the memory for a sst min max key
+     * @param min_max the sst min max key
+     */
+    void _tidesdb_free_sst_min_max(tidesdb_sst_min_max_t *min_max);
 
 #ifdef __cplusplus
 }

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -99,7 +99,7 @@ void test_tidesdb_serialize_deserialize_sst_min_max()
     size_t expected_size = sizeof(size_t) + min_key_size + sizeof(size_t) + max_key_size;
     assert(serialized_size == expected_size);
 
-    tidesdb_sst_min_max *deserialized = _tidesdb_deserialize_sst_min_max(serialized);
+    tidesdb_sst_min_max_t *deserialized = _tidesdb_deserialize_sst_min_max(serialized);
     assert(deserialized != NULL);
 
     assert(deserialized->min_key_size == min_key_size);


### PR DESCRIPTION
issue #348
- Remove redunant _tidesdb_flush_memtable_w_bloom_filter
- Min-Max initial block implementation and optimization for tidesdb_range
- More commenting core engine
- tidesdb_txn_get addition for atomic transactions
- New error codes TIDESDB_ERR_FAILED_TO_GET_MIN_KEY_FOR_FLUSH, TIDESDB_ERR_FAILED_TO_GET_MAX_KEY_FOR_FLUSH