### PR TITLE
- bench 'control reaches end of non-void function' corrections..

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.25)
 project(tidesdb C)
 
-set(CMAKE_C_STANDARD 23)
+set(CMAKE_C_STANDARD 99)
 set(PROJECT_VERSION 0.8.0) # TidesDB v0.8.0b
 
 # when building for production releases, you/we want to disable all warnings and sanitizers

--- a/bench/tidesdb__bench.c
+++ b/bench/tidesdb__bench.c
@@ -68,6 +68,8 @@ void *thread_put(void *arg)
             (void)tidesdb_err_free(err);
         }
     }
+
+    return NULL;
 }
 
 void *thread_get(void *arg)
@@ -87,6 +89,8 @@ void *thread_get(void *arg)
         }
         free(value_out);
     }
+
+    return NULL;
 }
 
 void *thread_delete(void *arg)
@@ -102,6 +106,8 @@ void *thread_delete(void *arg)
             (void)tidesdb_err_free(err);
         }
     }
+
+    return NULL;
 }
 
 int main()


### PR DESCRIPTION
- bench 'control reaches end of non-void function' corrections
- set CMake to C99 default (Taking conservative approach. Thank you @rochus-keller)