### PR TITLE
- remove _tidesdb_merge_sstables_w_bloom_filter.. more

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.25)
 project(tidesdb C)
 
 set(CMAKE_C_STANDARD 99)
-set(PROJECT_VERSION 0.8.0) # TidesDB v0.8.0b
+set(PROJECT_VERSION 0.9.0) # TidesDB v0.9.0b
 
 # when building for production releases, you/we want to disable all warnings and sanitizers
 option(TIDESDB_WITH_SANITIZER "build with sanitizer in tidesdb" ON)

--- a/src/err.h
+++ b/src/err.h
@@ -154,6 +154,14 @@ typedef enum
     TIDESDB_ERR_FAILED_TO_ESCALATE_FSYNC,
     TIDESDB_ERR_FAILED_TO_GET_MIN_KEY_FOR_FLUSH,
     TIDESDB_ERR_FAILED_TO_GET_MAX_KEY_FOR_FLUSH,
+    TIDESDB_ERR_FAILED_TO_COUNT_BLOCKS,
+    TIDESDB_ERR_FAILED_TO_READ_BLOCK,
+    TIDESDB_ERR_FAILED_TO_DESERIALIZE_SST_MIN_MAX,
+    TIDESDB_ERR_FAILED_TO_MERGE_MIN_MAX,
+    TIDESDB_ERR_FAILED_TO_SERIALIZE_MIN_MAX,
+    TIDESDB_ERR_FAILED_TO_CREATE_BLOCK,
+    TIDESDB_ERR_CURSOR_NAVIGATION_FAILED,
+    TIDESDB_ERR_FAILED_TO_WRITE_BLOCK,
 } TIDESDB_ERR_CODE;
 
 /* TidesDB error messages */
@@ -320,7 +328,31 @@ static const tidesdb_err_info_t tidesdb_err_messages[] = {
     {TIDESDB_ERR_FAILED_TO_GET_MIN_KEY_FOR_FLUSH,
      "Failed to get minimum key for flush for column family %s.\n", TIDESDB_ERR_WITH_CONTEXT},
     {TIDESDB_ERR_FAILED_TO_GET_MAX_KEY_FOR_FLUSH,
-     "Failed to get maximum key for flush for column family %s.\n", TIDESDB_ERR_WITH_CONTEXT}};
+     "Failed to get maximum key for flush for column family %s.\n", TIDESDB_ERR_WITH_CONTEXT},
+    {TIDESDB_ERR_FAILED_TO_COUNT_BLOCKS, "Failed to count blocks for %s.\n",
+     TIDESDB_ERR_WITH_CONTEXT},
+    {TIDESDB_ERR_FAILED_TO_READ_BLOCK, "Failed to read block for %s.\n", TIDESDB_ERR_WITH_CONTEXT},
+    {TIDESDB_ERR_FAILED_TO_DESERIALIZE_SST_MIN_MAX,
+     "Failed to deserialize SSTable min max for %s.\n", TIDESDB_ERR_WITH_CONTEXT},
+    {TIDESDB_ERR_FAILED_TO_MERGE_MIN_MAX, "Failed to merge SSTable min max for %s.\n",
+     TIDESDB_ERR_WITH_CONTEXT},
+    {TIDESDB_ERR_FAILED_TO_SERIALIZE_MIN_MAX, "Failed to serialize SSTable min max for %s.\n",
+     TIDESDB_ERR_WITH_CONTEXT},
+
+    {TIDESDB_ERR_FAILED_TO_CREATE_BLOCK, "Failed to create block for %s.\n",
+     TIDESDB_ERR_WITH_CONTEXT},
+
+    {TIDESDB_ERR_CURSOR_NAVIGATION_FAILED, "Failed to navigate cursor for %s.\n",
+     TIDESDB_ERR_WITH_CONTEXT},
+    {TIDESDB_ERR_FAILED_TO_WRITE_BLOCK, "Failed to write block for %s.\n",
+     TIDESDB_ERR_WITH_CONTEXT},
+    {TIDESDB_ERR_FAILED_TO_SERIALIZE_BLOOM_FILTER, "Failed to serialize bloom filter for %s.\n",
+     TIDESDB_ERR_WITH_CONTEXT},
+    {TIDESDB_ERR_FAILED_TO_CREATE_BLOOM_FILTER, "Failed to create bloom filter for %s.\n",
+     TIDESDB_ERR_WITH_CONTEXT},
+    {TIDESDB_ERR_FAILED_TO_SERIALIZE_BLOOM, "Failed to serialize bloom filter for %s.\n",
+     TIDESDB_ERR_WITH_CONTEXT},
+};
 
 /*
  * tidesdb_err_new

--- a/src/err.h
+++ b/src/err.h
@@ -154,14 +154,6 @@ typedef enum
     TIDESDB_ERR_FAILED_TO_ESCALATE_FSYNC,
     TIDESDB_ERR_FAILED_TO_GET_MIN_KEY_FOR_FLUSH,
     TIDESDB_ERR_FAILED_TO_GET_MAX_KEY_FOR_FLUSH,
-    TIDESDB_ERR_FAILED_TO_COUNT_BLOCKS,
-    TIDESDB_ERR_FAILED_TO_READ_BLOCK,
-    TIDESDB_ERR_FAILED_TO_DESERIALIZE_SST_MIN_MAX,
-    TIDESDB_ERR_FAILED_TO_MERGE_MIN_MAX,
-    TIDESDB_ERR_FAILED_TO_SERIALIZE_MIN_MAX,
-    TIDESDB_ERR_FAILED_TO_CREATE_BLOCK,
-    TIDESDB_ERR_CURSOR_NAVIGATION_FAILED,
-    TIDESDB_ERR_FAILED_TO_WRITE_BLOCK,
 } TIDESDB_ERR_CODE;
 
 /* TidesDB error messages */
@@ -329,23 +321,6 @@ static const tidesdb_err_info_t tidesdb_err_messages[] = {
      "Failed to get minimum key for flush for column family %s.\n", TIDESDB_ERR_WITH_CONTEXT},
     {TIDESDB_ERR_FAILED_TO_GET_MAX_KEY_FOR_FLUSH,
      "Failed to get maximum key for flush for column family %s.\n", TIDESDB_ERR_WITH_CONTEXT},
-    {TIDESDB_ERR_FAILED_TO_COUNT_BLOCKS, "Failed to count blocks for %s.\n",
-     TIDESDB_ERR_WITH_CONTEXT},
-    {TIDESDB_ERR_FAILED_TO_READ_BLOCK, "Failed to read block for %s.\n", TIDESDB_ERR_WITH_CONTEXT},
-    {TIDESDB_ERR_FAILED_TO_DESERIALIZE_SST_MIN_MAX,
-     "Failed to deserialize SSTable min max for %s.\n", TIDESDB_ERR_WITH_CONTEXT},
-    {TIDESDB_ERR_FAILED_TO_MERGE_MIN_MAX, "Failed to merge SSTable min max for %s.\n",
-     TIDESDB_ERR_WITH_CONTEXT},
-    {TIDESDB_ERR_FAILED_TO_SERIALIZE_MIN_MAX, "Failed to serialize SSTable min max for %s.\n",
-     TIDESDB_ERR_WITH_CONTEXT},
-
-    {TIDESDB_ERR_FAILED_TO_CREATE_BLOCK, "Failed to create block for %s.\n",
-     TIDESDB_ERR_WITH_CONTEXT},
-
-    {TIDESDB_ERR_CURSOR_NAVIGATION_FAILED, "Failed to navigate cursor for %s.\n",
-     TIDESDB_ERR_WITH_CONTEXT},
-    {TIDESDB_ERR_FAILED_TO_WRITE_BLOCK, "Failed to write block for %s.\n",
-     TIDESDB_ERR_WITH_CONTEXT},
     {TIDESDB_ERR_FAILED_TO_SERIALIZE_BLOOM_FILTER, "Failed to serialize bloom filter for %s.\n",
      TIDESDB_ERR_WITH_CONTEXT},
     {TIDESDB_ERR_FAILED_TO_CREATE_BLOOM_FILTER, "Failed to create bloom filter for %s.\n",

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -875,20 +875,6 @@ extern "C"
                                                pthread_mutex_t *shared_lock);
 
     /*
-     * _tidesdb_merge_sstables_w_bloom_filter
-     * merges two sstables into a new sstable and adds a bloom filter to initial block
-     * @param sst1 the first sstable
-     * @param sst2 the second sstable
-     * @param cf the column family
-     * @param shared_lock the lock for the path creation on parallel compaction
-     * @return the new merged sstable
-     */
-    tidesdb_sstable_t *_tidesdb_merge_sstables_w_bloom_filter(tidesdb_sstable_t *sst1,
-                                                              tidesdb_sstable_t *sst2,
-                                                              tidesdb_column_family_t *cf,
-                                                              pthread_mutex_t *shared_lock);
-
-    /*
      * _tidesdb_free_column_families
      * free's and closes column families
      * @param tdb the TidesDB instance

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -1991,7 +1991,7 @@ void test_tidesdb_start_incremental_merge(bool compress, tidesdb_compression_alg
     (void)tidesdb_err_free(err);
 
     /* start incremental merging in background */
-    err = tidesdb_start_incremental_merge(db, "test_cf", 1, 10);
+    err = tidesdb_start_incremental_merge(db, "test_cf", 1, 4);
     assert(err == NULL);
     (void)tidesdb_err_free(err);
 
@@ -2011,7 +2011,7 @@ void test_tidesdb_start_incremental_merge(bool compress, tidesdb_compression_alg
         (void)tidesdb_err_free(err);
     }
 
-    sleep(10);
+    sleep(16);
 
     for (int i = 0; i < 12; i++)
     {
@@ -2033,7 +2033,7 @@ void test_tidesdb_start_incremental_merge(bool compress, tidesdb_compression_alg
     assert(err == NULL);
     (void)tidesdb_err_free(err);
 
-    (void)_tidesdb_remove_directory("test_db");
+    //(void)_tidesdb_remove_directory("test_db");
     printf(GREEN "test_tidesdb_start_incremental_merge%s%s passed\n" RESET,
            compress ? " with compression" : "", bloom_filter ? " with bloom filter" : "");
 }
@@ -3004,55 +3004,61 @@ int main(void)
 
     test_tidesdb_delete_by_range(false, TDB_NO_COMPRESSION, false);
 
-    test_tidesdb_delete_by_range(true, TDB_COMPRESS_ZSTD, true);
-
     test_tidesdb_delete_by_filter(false, TDB_NO_COMPRESSION, false);
 
-    test_tidesdb_delete_by_filter(true, TDB_COMPRESS_ZSTD, true);
-
-    test_tidesdb_serialize_deserialize_key_value_pair(true, TDB_COMPRESS_SNAPPY);
-
-    test_tidesdb_serialize_deserialize_operation(true, TDB_COMPRESS_SNAPPY);
-
-    test_tidesdb_serialize_deserialize_key_value_pair(true, TDB_COMPRESS_LZ4);
-
-    test_tidesdb_serialize_deserialize_operation(true, TDB_COMPRESS_LZ4);
+    test_tidesdb_start_incremental_merge(false, TDB_NO_COMPRESSION, false);
 
     test_tidesdb_serialize_deserialize_key_value_pair(true, TDB_COMPRESS_ZSTD);
 
     test_tidesdb_serialize_deserialize_operation(true, TDB_COMPRESS_ZSTD);
 
-    test_tidesdb_create_drop_column_family(true, TDB_COMPRESS_SNAPPY, true);
+    test_tidesdb_serialize_deserialize_key_value_pair(true, TDB_COMPRESS_LZ4);
 
-    test_tidesdb_put_get_memtable(true, TDB_COMPRESS_SNAPPY, true);
+    test_tidesdb_serialize_deserialize_operation(true, TDB_COMPRESS_LZ4);
 
-    test_tidesdb_put_close_replay_get(true, TDB_COMPRESS_SNAPPY, true);
+    test_tidesdb_tidesdb_open_close();
 
-    test_tidesdb_txn_put_get(true, TDB_COMPRESS_SNAPPY, true);
+    test_tidesdb_create_drop_column_family(true, TDB_COMPRESS_ZSTD, true);
 
-    test_tidesdb_txn_put_get_rollback_get(true, TDB_COMPRESS_SNAPPY, true);
+    test_tidesdb_put_get_memtable(true, TDB_COMPRESS_ZSTD, true);
 
-    test_tidesdb_txn_put_put_delete_get(true, TDB_COMPRESS_SNAPPY, true);
+    test_tidesdb_put_close_replay_get(true, TDB_COMPRESS_ZSTD, true);
 
-    test_tidesdb_put_delete_get(true, TDB_COMPRESS_SNAPPY, true);
+    test_tidesdb_txn_put_get(true, TDB_COMPRESS_ZSTD, true);
 
-    test_tidesdb_put_flush_get(true, TDB_COMPRESS_SNAPPY, true);
+    test_tidesdb_txn_put_get_rollback_get(true, TDB_COMPRESS_ZSTD, true);
 
-    test_tidesdb_put_flush_close_get(true, TDB_COMPRESS_SNAPPY, true);
+    test_tidesdb_txn_put_put_delete_get(true, TDB_COMPRESS_ZSTD, true);
 
-    test_tidesdb_put_flush_delete_get(true, TDB_COMPRESS_SNAPPY, true);
+    test_tidesdb_put_delete_get(true, TDB_COMPRESS_ZSTD, true);
 
-    test_tidesdb_cursor(true, TDB_COMPRESS_SNAPPY, true);
+    test_tidesdb_put_flush_stat(true, TDB_COMPRESS_ZSTD, true);
 
-    test_tidesdb_cursor_memtable_sstables(true, TDB_COMPRESS_SNAPPY, true);
+    test_tidesdb_cursor(true, TDB_COMPRESS_ZSTD, true);
 
-    test_tidesdb_put_many_flush_get(true, TDB_COMPRESS_SNAPPY, true);
+    test_tidesdb_cursor_memtable_sstables(true, TDB_COMPRESS_ZSTD, true);
 
-    test_tidesdb_put_flush_compact_get(true, TDB_COMPRESS_SNAPPY, true);
+    test_tidesdb_put_flush_get(true, TDB_COMPRESS_ZSTD, true);
 
-    test_tidesdb_put_get_concurrent(true, TDB_COMPRESS_SNAPPY, true);
+    test_tidesdb_put_flush_close_get(true, TDB_COMPRESS_ZSTD, true);
 
-    test_tidesdb_start_incremental_merge(false, TDB_NO_COMPRESSION, false);
+    test_tidesdb_put_flush_delete_get(true, TDB_COMPRESS_ZSTD, true);
+
+    test_tidesdb_put_many_flush_get(true, TDB_COMPRESS_ZSTD, true);
+
+    test_tidesdb_put_flush_compact_get(true, TDB_COMPRESS_ZSTD, true);
+
+    test_tidesdb_put_flush_shutdown_compact_get(true, TDB_COMPRESS_ZSTD, true);
+
+    test_tidesdb_put_get_concurrent(true, TDB_COMPRESS_ZSTD, true);
+
+    test_tidesdb_delete_range(true, TDB_COMPRESS_ZSTD, true);
+
+    test_tidesdb_delete_by_range(true, TDB_COMPRESS_ZSTD, true);
+
+    test_tidesdb_delete_by_filter(true, TDB_COMPRESS_ZSTD, true);
+
+    test_tidesdb_start_incremental_merge(true, TDB_COMPRESS_ZSTD, true);
 
     return 0;
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tidesdb",
-  "version-string": "0.8.0b",
+  "version-string": "0.9.0b",
   "description": "TidesDB is a high-performance log structured storage engine for fast key-value storage and time series data.",
   "dependencies": [
     "zstd",


### PR DESCRIPTION
- remove _tidesdb_merge_sstables_w_bloom_filter
- refactor _tidesdb_merge_sstables to support bloom filter, this also fixes the merge with bloom filter bug
- _tidesdb_incremental_merge_thread correction, we check for null sstables, as they can be null in thread process 
- tidesdb__tests.c additions