### PR TITLE
Minor touch ups to cursor to keep current direction state for get method redundancy when shift occurs.

### DIFF
--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -348,6 +348,13 @@ extern "C"
         pthread_mutex_t lock;
     } tidesdb_txn_t;
 
+    /* tidesdb_cursor_direction_t */
+    typedef enum
+    {
+        TIDESDB_CURSOR_FORWARD,
+        TIDESDB_CURSOR_REVERSE
+    } tidesdb_cursor_direction_t;
+
     /*
      * tidesdb_cursor_t
      * struct for a TidesDB cursor
@@ -356,6 +363,7 @@ extern "C"
      * @param memtable_cursor the cursor for the memtable
      * @param sstable_index the current index of the sstable the cursor is on
      * @param sstable_cursor the cursor for the sstable
+     * @param direction the direction of the cursor
      */
     typedef struct
     {
@@ -364,6 +372,7 @@ extern "C"
         skip_list_cursor_t *memtable_cursor;
         int sstable_index;
         block_manager_cursor_t *sstable_cursor;
+        tidesdb_cursor_direction_t direction;
     } tidesdb_cursor_t;
 
     /*

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -3453,7 +3453,6 @@ void test_tidesdb_delete_by_filter(bool compress, tidesdb_compression_algo_t alg
 
 int main(void)
 {
-
     test_tidesdb_serialize_deserialize_key_value_pair(false, TDB_NO_COMPRESSION);
 
     test_tidesdb_serialize_deserialize_column_family_config();
@@ -3573,7 +3572,6 @@ int main(void)
     test_tidesdb_start_incremental_merge(true, TDB_COMPRESS_ZSTD, true);
 
     test_tidesdb_cursor_background_compaction_shift(true, TDB_COMPRESS_ZSTD, true);
-
 
     return 0;
 }


### PR DESCRIPTION
Minor touch ups to cursor to keep current direction state for get method redundancy when shift occurs.