### PR TITLE
- correct missing context for TIDESDB_ERR_FAILED_TO_WRITE_TO_MEMTABLE…

### DIFF
--- a/src/err.h
+++ b/src/err.h
@@ -281,7 +281,7 @@ static const tidesdb_err_info_t tidesdb_err_messages[] = {
     {TIDESDB_ERR_FAILED_TO_SERIALIZE, "Failed to serialize %s for column family %s\n",
      TIDESDB_ERR_WITH_CONTEXT},
     {TIDESDB_ERR_FAILED_TO_WRITE_TO_MEMTABLE,
-     "Failed to write key-value pair to memtable for column family %s\n"},
+     "Failed to write key-value pair to memtable for column family %s\n", TIDESDB_ERR_WITH_CONTEXT},
     {TIDESDB_ERR_PUT_TOMBSTONE, "Cannot write a tombstone\n", TIDESDB_ERR_WITHOUT_CONTEXT}};
 
 /*

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -1149,6 +1149,18 @@ extern "C"
      */
     int _tidesdb_print_keys_tree(tidesdb_t *tdb, const char *column_family_name);
 
+    /*
+     * _tidesdb_put
+     * put a key-value pair into TidesDB (mainly used for deletion.)
+     * @param tdb the TidesDB instance
+     * @param column_family_name the name of the column family
+     * @param key the key
+     * @param key_size the size of the key
+     * @param value the value
+     * @param value_size the size of the value
+     * @param ttl the time-to-live for the key-value pair
+     * @return error or NULL
+     */
     tidesdb_err_t *_tidesdb_put(tidesdb_t *tdb, const char *column_family_name, const uint8_t *key,
                                 size_t key_size, const uint8_t *value, size_t value_size,
                                 time_t ttl);

--- a/test/bloom_filter__tests.c
+++ b/test/bloom_filter__tests.c
@@ -113,7 +113,7 @@ void test_false_positive_rate()
     bloom_filter_t *bf;
     (void)bloom_filter_new(&bf, p, n);
 
-    // we write n elements
+    /* we write n elements */
     for (int i = 0; i < n; i++)
     {
         char key[20];
@@ -127,7 +127,7 @@ void test_false_positive_rate()
     for (int i = 0; i < m; i++)
     {
         char key[20];
-        sprintf(key, "test_key_%d", i + n);  // Different from inserted keys
+        sprintf(key, "test_key_%d", i + n); /** different from inserted keys */
         if (bloom_filter_contains(bf, (const uint8_t *)key, strlen(key)))
         {
             false_positives++;


### PR DESCRIPTION
- correct missing context for TIDESDB_ERR_FAILED_TO_WRITE_TO_MEMTABLE within err.h (cmake build warning fix)
- addition to bloom_filter__tests test_bloom_filter_serialize_deserialize, test_false_positive_rate, test_boundary_conditions
- further commenting _tidesdb_flush_memtable

