### PR TITLE
issue #379 merge cursor implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,77 @@ tidesdb_cursor_free(c);
 
 ```
 
+#### Merge Cursor
+
+You can also use `tidesdb_merge_cursor` which keeps keys sorted during iteration.
+```c
+tidesdb_merge_cursor_t *c;
+tidesdb_err_t *e = tidesdb_merge_cursor_init(tdb, "your_column_family", &c);
+if (e != NULL)
+{
+    /* handle error */
+    tidesdb_err_free(e);
+    return;
+}
+
+uint8_t *retrieved_key = NULL;
+size_t key_size;
+uint8_t *retrieved_value = NULL;
+size_t value_size;
+
+/* iterate forward */
+do
+{
+    e = tidesdb_merge_cursor_get(c, &retrieved_key, &key_size, &retrieved_value, &value_size);
+    if (e != NULL)
+    {
+        /* handle error */
+        tidesdb_err_free(e);
+        break;
+    }
+
+    /* use retrieved_key and retrieved_value
+     * .. */
+
+    /* free the key and value */
+    free(retrieved_key);
+    free(retrieved_value);
+} while ((e = tidesdb_merge_cursor_next(c)) == NULL);
+
+if (e != NULL && e->code != TIDESDB_ERR_AT_END_OF_CURSOR)
+{
+    /* handle error */
+    tidesdb_err_free(e);
+}
+
+/* iterate backward */
+do
+{
+    e = tidesdb_merge_cursor_get(c, &retrieved_key, &key_size, &retrieved_value, &value_size);
+    if (e != NULL)
+    {
+        /* handle error */
+        tidesdb_err_free(e);
+        break;
+    }
+
+    /* use retrieved_key and retrieved_value
+     * .. */
+
+    /* free the key and value */
+    free(retrieved_key);
+    free(retrieved_value);
+} while ((e = tidesdb_merge_cursor_prev(c)) == NULL);
+
+if (e != NULL && e->code != TIDESDB_ERR_AT_START_OF_CURSOR)
+{
+    /* handle error */
+    tidesdb_err_free(e);
+}
+
+tidesdb_merge_cursor_free(c);
+```
+
 ## Deleting multiple key-value pairs
 
 ### Deleting by range

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -6842,14 +6842,14 @@ int _tidesdb_print_keys_tree(tidesdb_t *tdb, const char *column_family_name)
     return 0;
 }
 
-void min_heap_swap(int *heap, int idx1, int idx2)
+void _min_heap_swap(int *heap, int idx1, int idx2)
 {
     int temp = heap[idx1];
     heap[idx1] = heap[idx2];
     heap[idx2] = temp;
 }
 
-void min_heap_sift_down(tidesdb_merge_cursor_t *cursor, int start, int end)
+void _min_heap_sift_down(tidesdb_merge_cursor_t *cursor, int start, int end)
 {
     int root = start;
 
@@ -6905,21 +6905,21 @@ void min_heap_sift_down(tidesdb_merge_cursor_t *cursor, int start, int end)
             return;
         }
 
-        (void)min_heap_swap(cursor->min_heap, root, swap_idx);
+        (void)_min_heap_swap(cursor->min_heap, root, swap_idx);
         root = swap_idx;
     }
 }
 
-void min_heap_heapify(tidesdb_merge_cursor_t *cursor)
+void _min_heap_heapify(tidesdb_merge_cursor_t *cursor)
 {
     int count = cursor->min_heap_size;
     for (int i = (count - 2) / 2; i >= 0; i--)
     {
-        (void)min_heap_sift_down(cursor, i, count - 1);
+        (void)_min_heap_sift_down(cursor, i, count - 1);
     }
 }
 
-void max_heap_sift_down(tidesdb_merge_cursor_t *cursor, int start, int end)
+void _max_heap_sift_down(tidesdb_merge_cursor_t *cursor, int start, int end)
 {
     int root = start;
 
@@ -6985,19 +6985,19 @@ void max_heap_sift_down(tidesdb_merge_cursor_t *cursor, int start, int end)
             return;
         }
 
-        (void)min_heap_swap(cursor->min_heap, root, swap_idx);
+        (void)_min_heap_swap(cursor->min_heap, root, swap_idx);
         root = swap_idx;
     }
 }
 
-void max_heap_heapify(tidesdb_merge_cursor_t *cursor)
+void _max_heap_heapify(tidesdb_merge_cursor_t *cursor)
 {
     int count = cursor->min_heap_size;
 
     /* we build the max heap from the bottom up */
     for (int i = (count - 2) / 2; i >= 0; i--)
     {
-        (void)max_heap_sift_down(cursor, i, count - 1);
+        (void)_max_heap_sift_down(cursor, i, count - 1);
     }
 }
 
@@ -7148,11 +7148,11 @@ tidesdb_err_t *_tidesdb_merge_cursor_init_entries(tidesdb_merge_cursor_t *cursor
     /* we build the heap */
     if (cursor->direction == TIDESDB_CURSOR_FORWARD)
     {
-        (void)min_heap_heapify(cursor);
+        (void)_min_heap_heapify(cursor);
     }
     else
     {
-        (void)max_heap_heapify(cursor);
+        (void)_max_heap_heapify(cursor);
     }
 
     return NULL;
@@ -7645,7 +7645,7 @@ tidesdb_err_t *tidesdb_merge_cursor_prev(tidesdb_merge_cursor_t *cursor)
         {
             cursor->min_heap[i] = i;
         }
-        (void)max_heap_heapify(cursor);
+        (void)_max_heap_heapify(cursor);
 
         /* when we're switching directions, we don't need to advance.. just return the current entry
          * which should be at the end */
@@ -8089,11 +8089,11 @@ tidesdb_err_t *_tidesdb_merge_cursor_advance(tidesdb_merge_cursor_t *cursor, int
 
     if (cursor->direction == TIDESDB_CURSOR_FORWARD)
     {
-        (void)min_heap_heapify(cursor);
+        (void)_min_heap_heapify(cursor);
     }
     else
     {
-        (void)max_heap_heapify(cursor);
+        (void)_max_heap_heapify(cursor);
     }
 
     return NULL;

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -6841,3 +6841,1495 @@ int _tidesdb_print_keys_tree(tidesdb_t *tdb, const char *column_family_name)
 
     return 0;
 }
+
+void min_heap_swap(int *heap, int idx1, int idx2)
+{
+    int temp = heap[idx1];
+    heap[idx1] = heap[idx2];
+    heap[idx2] = temp;
+}
+
+void min_heap_sift_down(tidesdb_merge_cursor_t *cursor, int start, int end)
+{
+    int root = start;
+
+    while (root * 2 + 1 <= end)
+    {
+        int child = root * 2 + 1;
+        int swap_idx = root;
+
+        /* we compare with left child */
+        if (cursor->current_entries[cursor->min_heap[swap_idx]].valid &&
+            cursor->current_entries[cursor->min_heap[child]].valid)
+        {
+            if (_tidesdb_compare_keys(
+                    cursor->current_entries[cursor->min_heap[swap_idx]].kv.key,
+                    cursor->current_entries[cursor->min_heap[swap_idx]].kv.key_size,
+                    cursor->current_entries[cursor->min_heap[child]].kv.key,
+                    cursor->current_entries[cursor->min_heap[child]].kv.key_size) > 0)
+            {
+                swap_idx = child;
+            }
+        }
+        else if (!cursor->current_entries[cursor->min_heap[swap_idx]].valid &&
+                 cursor->current_entries[cursor->min_heap[child]].valid)
+        {
+            swap_idx = child;
+        }
+
+        /* we compare with right child */
+        if (child + 1 <= end)
+        {
+            if (cursor->current_entries[cursor->min_heap[swap_idx]].valid &&
+                cursor->current_entries[cursor->min_heap[child + 1]].valid)
+            {
+                if (_tidesdb_compare_keys(
+                        cursor->current_entries[cursor->min_heap[swap_idx]].kv.key,
+                        cursor->current_entries[cursor->min_heap[swap_idx]].kv.key_size,
+                        cursor->current_entries[cursor->min_heap[child + 1]].kv.key,
+                        cursor->current_entries[cursor->min_heap[child + 1]].kv.key_size) > 0)
+                {
+                    swap_idx = child + 1;
+                }
+            }
+            else if (!cursor->current_entries[cursor->min_heap[swap_idx]].valid &&
+                     cursor->current_entries[cursor->min_heap[child + 1]].valid)
+            {
+                swap_idx = child + 1;
+            }
+        }
+
+        if (swap_idx == root)
+        {
+            /* root is already at the minimum */
+            return;
+        }
+
+        (void)min_heap_swap(cursor->min_heap, root, swap_idx);
+        root = swap_idx;
+    }
+}
+
+void min_heap_heapify(tidesdb_merge_cursor_t *cursor)
+{
+    int count = cursor->min_heap_size;
+    for (int i = (count - 2) / 2; i >= 0; i--)
+    {
+        (void)min_heap_sift_down(cursor, i, count - 1);
+    }
+}
+
+void max_heap_sift_down(tidesdb_merge_cursor_t *cursor, int start, int end)
+{
+    int root = start;
+
+    while (root * 2 + 1 <= end)
+    {
+        int child = root * 2 + 1;
+        int swap_idx = root;
+
+        /* we compare with left child
+         ** in reverse direction larger keys have priority */
+        if (child <= end)
+        {
+            /* if both entries are valid, compare keys */
+            if (cursor->current_entries[cursor->min_heap[swap_idx]].valid &&
+                cursor->current_entries[cursor->min_heap[child]].valid)
+            {
+                /* for max heap we want larger keys at the root */
+                if (_tidesdb_compare_keys(
+                        cursor->current_entries[cursor->min_heap[swap_idx]].kv.key,
+                        cursor->current_entries[cursor->min_heap[swap_idx]].kv.key_size,
+                        cursor->current_entries[cursor->min_heap[child]].kv.key,
+                        cursor->current_entries[cursor->min_heap[child]].kv.key_size) < 0)
+                {
+                    swap_idx = child;
+                }
+            }
+            /* only child is valid, do swap */
+            else if (!cursor->current_entries[cursor->min_heap[swap_idx]].valid &&
+                     cursor->current_entries[cursor->min_heap[child]].valid)
+            {
+                swap_idx = child;
+            }
+        }
+
+        /* compare with right child */
+        if (child + 1 <= end)
+        {
+            /* both entries are valid - compare keys */
+            if (cursor->current_entries[cursor->min_heap[swap_idx]].valid &&
+                cursor->current_entries[cursor->min_heap[child + 1]].valid)
+            {
+                /* for max heap, we want larger keys at the root */
+                if (_tidesdb_compare_keys(
+                        cursor->current_entries[cursor->min_heap[swap_idx]].kv.key,
+                        cursor->current_entries[cursor->min_heap[swap_idx]].kv.key_size,
+                        cursor->current_entries[cursor->min_heap[child + 1]].kv.key,
+                        cursor->current_entries[cursor->min_heap[child + 1]].kv.key_size) < 0)
+                {
+                    swap_idx = child + 1;
+                }
+            }
+            /* only right child is valid, do swap */
+            else if (!cursor->current_entries[cursor->min_heap[swap_idx]].valid &&
+                     cursor->current_entries[cursor->min_heap[child + 1]].valid)
+            {
+                swap_idx = child + 1;
+            }
+        }
+
+        if (swap_idx == root)
+        {
+            /* root is already the maximum */
+            return;
+        }
+
+        (void)min_heap_swap(cursor->min_heap, root, swap_idx);
+        root = swap_idx;
+    }
+}
+
+void max_heap_heapify(tidesdb_merge_cursor_t *cursor)
+{
+    int count = cursor->min_heap_size;
+
+    /* we build the max heap from the bottom up */
+    for (int i = (count - 2) / 2; i >= 0; i--)
+    {
+        (void)max_heap_sift_down(cursor, i, count - 1);
+    }
+}
+
+bool _tidesdb_merge_cursor_has_valid_entries(tidesdb_merge_cursor_t *cursor)
+{
+    for (int i = 0; i < cursor->min_heap_size; i++)
+    {
+        if (cursor->current_entries[i].valid)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+tidesdb_err_t *_tidesdb_merge_cursor_init_entries(tidesdb_merge_cursor_t *cursor)
+{
+    if (cursor->initialized)
+    {
+        return NULL;
+    }
+
+    /* we init a memtable entry if available */
+    if (cursor->memtable_cursor != NULL)
+    {
+        uint8_t *key, *value;
+        size_t key_size, value_size;
+        time_t ttl;
+
+        if (skip_list_cursor_get(cursor->memtable_cursor, &key, &key_size, &value, &value_size,
+                                 &ttl) == 0)
+        {
+            /* alloc memory and copy key/value */
+            cursor->current_entries[0].kv.key = malloc(key_size);
+            if (cursor->current_entries[0].kv.key == NULL)
+            {
+                return tidesdb_err_from_code(TIDESDB_ERR_MEMORY_ALLOC, "key in merge cursor");
+            }
+
+            memcpy(cursor->current_entries[0].kv.key, key, key_size);
+            cursor->current_entries[0].kv.key_size = key_size;
+
+            cursor->current_entries[0].kv.value = malloc(value_size);
+            if (cursor->current_entries[0].kv.value == NULL)
+            {
+                free(cursor->current_entries[0].kv.key);
+                return tidesdb_err_from_code(TIDESDB_ERR_MEMORY_ALLOC, "value in merge cursor");
+            }
+
+            memcpy(cursor->current_entries[0].kv.value, value, value_size);
+            cursor->current_entries[0].kv.value_size = value_size;
+            cursor->current_entries[0].kv.ttl = ttl;
+            cursor->current_entries[0].source_index = 0;
+            cursor->current_entries[0].valid = true;
+
+            /* we check if it's a tombstone or expired */
+            if (_tidesdb_is_tombstone(value, value_size) || _tidesdb_is_expired(ttl))
+            {
+                cursor->current_entries[0].valid = false;
+            }
+        }
+        else
+        {
+            cursor->current_entries[0].valid = false;
+        }
+    }
+    else
+    {
+        cursor->current_entries[0].valid = false;
+    }
+
+    /* we init entries from each sst */
+    for (int i = 0; i < cursor->num_sstables; i++)
+    {
+        if (cursor->sstable_cursors[i] != NULL)
+        {
+            block_manager_block_t *block = block_manager_cursor_read(cursor->sstable_cursors[i]);
+            if (block != NULL)
+            {
+                tidesdb_key_value_pair_t *kv = _tidesdb_deserialize_key_value_pair(
+                    block->data, block->size, cursor->cf->config.compressed,
+                    cursor->cf->config.compress_algo);
+
+                (void)block_manager_block_free(block);
+
+                if (kv != NULL)
+                {
+                    /* we need our own copies of the key and value */
+                    cursor->current_entries[i + 1].kv.key = malloc(kv->key_size);
+                    if (cursor->current_entries[i + 1].kv.key == NULL)
+                    {
+                        (void)_tidesdb_free_key_value_pair(kv);
+                        return tidesdb_err_from_code(TIDESDB_ERR_MEMORY_ALLOC,
+                                                     "key in merge cursor");
+                    }
+
+                    memcpy(cursor->current_entries[i + 1].kv.key, kv->key, kv->key_size);
+                    cursor->current_entries[i + 1].kv.key_size = kv->key_size;
+
+                    cursor->current_entries[i + 1].kv.value = malloc(kv->value_size);
+                    if (cursor->current_entries[i + 1].kv.value == NULL)
+                    {
+                        free(cursor->current_entries[i + 1].kv.key);
+                        (void)_tidesdb_free_key_value_pair(kv);
+                        return tidesdb_err_from_code(TIDESDB_ERR_MEMORY_ALLOC,
+                                                     "value in merge cursor");
+                    }
+
+                    memcpy(cursor->current_entries[i + 1].kv.value, kv->value, kv->value_size);
+                    cursor->current_entries[i + 1].kv.value_size = kv->value_size;
+                    cursor->current_entries[i + 1].kv.ttl = kv->ttl;
+                    cursor->current_entries[i + 1].source_index = i + 1;
+                    cursor->current_entries[i + 1].valid = true;
+
+                    /* we check if it's a tombstone or expired */
+                    if (_tidesdb_is_tombstone(kv->value, kv->value_size) ||
+                        _tidesdb_is_expired(kv->ttl))
+                    {
+                        cursor->current_entries[i + 1].valid = false;
+                    }
+
+                    (void)_tidesdb_free_key_value_pair(kv);
+                }
+                else
+                {
+                    cursor->current_entries[i + 1].valid = false;
+                }
+            }
+            else
+            {
+                cursor->current_entries[i + 1].valid = false;
+            }
+        }
+        else
+        {
+            cursor->current_entries[i + 1].valid = false;
+        }
+    }
+
+    cursor->initialized = true;
+
+    /* we init the min heap for merging */
+    for (int i = 0; i < cursor->min_heap_size; i++)
+    {
+        cursor->min_heap[i] = i;
+    }
+
+    /* we build the heap */
+    if (cursor->direction == TIDESDB_CURSOR_FORWARD)
+    {
+        (void)min_heap_heapify(cursor);
+    }
+    else
+    {
+        (void)max_heap_heapify(cursor);
+    }
+
+    return NULL;
+}
+
+tidesdb_err_t *tidesdb_merge_cursor_seek(tidesdb_merge_cursor_t *cursor, const uint8_t *key,
+                                         size_t key_size)
+{
+    if (cursor == NULL)
+    {
+        return tidesdb_err_from_code(TIDESDB_ERR_INVALID_CURSOR);
+    }
+
+    if (key == NULL)
+    {
+        return tidesdb_err_from_code(TIDESDB_ERR_INVALID_KEY);
+    }
+
+    /* we lock the column family for reading */
+    if (pthread_rwlock_rdlock(&cursor->cf->rwlock) != 0)
+    {
+        return tidesdb_err_from_code(TIDESDB_ERR_FAILED_TO_ACQUIRE_LOCK, "column family");
+    }
+
+    /* we reset the cursor */
+    for (int i = 0; i < cursor->min_heap_size; i++)
+    {
+        if (cursor->current_entries[i].valid)
+        {
+            free(cursor->current_entries[i].kv.key);
+            free(cursor->current_entries[i].kv.value);
+            cursor->current_entries[i].valid = false;
+        }
+    }
+
+    /* we clean up up existing cursors */
+    if (cursor->memtable_cursor != NULL)
+    {
+        (void)skip_list_cursor_free(cursor->memtable_cursor);
+    }
+
+    for (int i = 0; i < cursor->num_sstables; i++)
+    {
+        if (cursor->sstable_cursors[i] != NULL)
+        {
+            (void)block_manager_cursor_free(cursor->sstable_cursors[i]);
+        }
+    }
+
+    /* we set direction to forward for seeking */
+    cursor->direction = TIDESDB_CURSOR_FORWARD;
+
+    /* we init new cursors at the appropriate positions */
+
+    /* for memtable, we need to create a cursor and position it */
+    cursor->memtable_cursor = skip_list_cursor_init(cursor->cf->memtable);
+    if (cursor->memtable_cursor != NULL)
+    {
+        /* pos at first element greater than or equal to key */
+        skip_list_node_t *x = cursor->cf->memtable->header;
+
+        /* start from the highest level and work down */
+        for (int i = cursor->cf->memtable->level - 1; i >= 0; i--)
+        {
+            while (x->forward[i] &&
+                   skip_list_compare_keys(x->forward[i]->key, x->forward[i]->key_size, key,
+                                          key_size) < 0)
+            {
+                x = x->forward[i];
+            }
+        }
+
+        /* move to the node */
+        x = x->forward[0];
+
+        /* if x is NULL, we're at the end, so position at the start */
+        if (x == NULL)
+        {
+            (void)skip_list_cursor_goto_first(cursor->memtable_cursor);
+        }
+        else
+        {
+            /* we gotta iterate until we find the node */
+            (void)skip_list_cursor_goto_first(cursor->memtable_cursor);
+
+            uint8_t *current_key;
+            size_t current_key_size;
+            uint8_t *value;
+            size_t value_size;
+            time_t ttl;
+
+            while (skip_list_cursor_get(cursor->memtable_cursor, &current_key, &current_key_size,
+                                        &value, &value_size, &ttl) == 0)
+            {
+                /* we check if this is the node we want */
+                if (_tidesdb_compare_keys(current_key, current_key_size, x->key, x->key_size) == 0)
+                {
+                    break;
+                }
+
+                /** not the right node, try next */
+                if (skip_list_cursor_next(cursor->memtable_cursor) != 0)
+                {
+                    /* we hit the end, reset to start */
+                    (void)skip_list_cursor_goto_first(cursor->memtable_cursor);
+                    break;
+                }
+            }
+        }
+    }
+
+    for (int i = 0; i < cursor->num_sstables; i++)
+    {
+        if (block_manager_cursor_init(&cursor->sstable_cursors[i],
+                                      cursor->cf->sstables[i]->block_manager) == -1)
+        {
+            cursor->sstable_cursors[i] = NULL;
+            continue;
+        }
+
+        /* skip min-max block */
+        if (block_manager_cursor_next(cursor->sstable_cursors[i]) == -1)
+        {
+            (void)block_manager_cursor_free(cursor->sstable_cursors[i]);
+            cursor->sstable_cursors[i] = NULL;
+            continue;
+        }
+
+        /* skip bloom filter block if configured */
+        if (cursor->cf->config.bloom_filter)
+        {
+            if (block_manager_cursor_next(cursor->sstable_cursors[i]) == -1)
+            {
+                (void)block_manager_cursor_free(cursor->sstable_cursors[i]);
+                cursor->sstable_cursors[i] = NULL;
+                continue;
+            }
+        }
+
+        /*** for block indices, we could potentially do a binary search here for sst data blocks
+           to find the one containing our key.. for now, linear scan works fine... */
+
+        /* we scan for the first key >= the seek key */
+        block_manager_block_t *block;
+        while ((block = block_manager_cursor_read(cursor->sstable_cursors[i])) != NULL)
+        {
+            tidesdb_key_value_pair_t *kv = _tidesdb_deserialize_key_value_pair(
+                block->data, block->size, cursor->cf->config.compressed,
+                cursor->cf->config.compress_algo);
+
+            (void)block_manager_block_free(block);
+
+            if (kv != NULL)
+            {
+                int cmp = _tidesdb_compare_keys(kv->key, kv->key_size, key, key_size);
+
+                if (cmp >= 0)
+                {
+                    /* we found a key >= seek key, we're positioned correctly */
+                    (void)_tidesdb_free_key_value_pair(kv);
+                    break;
+                }
+
+                (void)_tidesdb_free_key_value_pair(kv);
+            }
+
+            /* next block */
+            if (block_manager_cursor_next(cursor->sstable_cursors[i]) != 0)
+            {
+                /* if we reached the end, position at the first data block */
+                (void)block_manager_cursor_free(cursor->sstable_cursors[i]);
+
+                if (block_manager_cursor_init(&cursor->sstable_cursors[i],
+                                              cursor->cf->sstables[i]->block_manager) == -1)
+                {
+                    cursor->sstable_cursors[i] = NULL;
+                    break;
+                }
+
+                /* skip min-max block */
+                if (block_manager_cursor_next(cursor->sstable_cursors[i]) == -1)
+                {
+                    (void)block_manager_cursor_free(cursor->sstable_cursors[i]);
+                    cursor->sstable_cursors[i] = NULL;
+                    break;
+                }
+
+                /* skip bloom filter block if configured */
+                if (cursor->cf->config.bloom_filter)
+                {
+                    if (block_manager_cursor_next(cursor->sstable_cursors[i]) == -1)
+                    {
+                        (void)block_manager_cursor_free(cursor->sstable_cursors[i]);
+                        cursor->sstable_cursors[i] = NULL;
+                        break;
+                    }
+                }
+
+                break;
+            }
+        }
+    }
+
+    /* reinit entries */
+    cursor->initialized = false;
+    tidesdb_err_t *err = _tidesdb_merge_cursor_init_entries(cursor);
+
+    (void)pthread_rwlock_unlock(&cursor->cf->rwlock);
+
+    if (err != NULL)
+    {
+        return err;
+    }
+
+    if (!_tidesdb_merge_cursor_has_valid_entries(cursor))
+    {
+        return tidesdb_err_from_code(TIDESDB_ERR_AT_END_OF_CURSOR);
+    }
+
+    /* find the closest next key */
+    int idx = cursor->min_heap[0];
+    while (!cursor->current_entries[idx].valid)
+    {
+        /* advance thhis current source */
+        err = _tidesdb_merge_cursor_advance(cursor, idx);
+        if (err != NULL)
+        {
+            return err;
+        }
+
+        /* we check if we're out of valid entries */
+        if (!_tidesdb_merge_cursor_has_valid_entries(cursor))
+        {
+            return tidesdb_err_from_code(TIDESDB_ERR_AT_END_OF_CURSOR);
+        }
+
+        /* get the new index */
+        idx = cursor->min_heap[0];
+    }
+
+    return NULL;
+}
+
+tidesdb_err_t *tidesdb_merge_cursor_next(tidesdb_merge_cursor_t *cursor)
+{
+    if (cursor == NULL)
+    {
+        return tidesdb_err_from_code(TIDESDB_ERR_INVALID_CURSOR);
+    }
+
+    if (!cursor->initialized)
+    {
+        return tidesdb_err_from_code(TIDESDB_ERR_INVALID_CURSOR);
+    }
+
+    /* we set direction for forward traversal */
+    if (cursor->direction != TIDESDB_CURSOR_FORWARD)
+    {
+        cursor->direction = TIDESDB_CURSOR_FORWARD;
+
+        /* reinit entries in the correct direction */
+        for (int i = 0; i < cursor->min_heap_size; i++)
+        {
+            if (cursor->current_entries[i].valid)
+            {
+                free(cursor->current_entries[i].kv.key);
+                free(cursor->current_entries[i].kv.value);
+                cursor->current_entries[i].valid = false;
+            }
+        }
+
+        /* we close all cursors */
+        if (cursor->memtable_cursor != NULL)
+        {
+            (void)skip_list_cursor_free(cursor->memtable_cursor);
+            cursor->memtable_cursor = skip_list_cursor_init(cursor->cf->memtable);
+        }
+
+        for (int i = 0; i < cursor->num_sstables; i++)
+        {
+            if (cursor->sstable_cursors[i] != NULL)
+            {
+                (void)block_manager_cursor_free(cursor->sstable_cursors[i]);
+
+                if (block_manager_cursor_init(&cursor->sstable_cursors[i],
+                                              cursor->cf->sstables[i]->block_manager) == -1)
+                {
+                    return tidesdb_err_from_code(TIDESDB_ERR_FAILED_TO_INIT_CURSOR);
+                }
+
+                /* we skip min-max block */
+                if (block_manager_cursor_next(cursor->sstable_cursors[i]) == -1)
+                {
+                    return tidesdb_err_from_code(TIDESDB_ERR_FAILED_TO_INIT_CURSOR);
+                }
+
+                /* we skip bloom filter block if configured */
+                if (cursor->cf->config.bloom_filter)
+                {
+                    if (block_manager_cursor_next(cursor->sstable_cursors[i]) == -1)
+                    {
+                        return tidesdb_err_from_code(TIDESDB_ERR_FAILED_TO_INIT_CURSOR);
+                    }
+                }
+            }
+        }
+
+        /* reinit entries */
+        cursor->initialized = false;
+        tidesdb_err_t *err = _tidesdb_merge_cursor_init_entries(cursor);
+        if (err != NULL)
+        {
+            return err;
+        }
+    }
+
+    /* we check if there are any valid entries */
+    if (!_tidesdb_merge_cursor_has_valid_entries(cursor))
+    {
+        return tidesdb_err_from_code(TIDESDB_ERR_AT_END_OF_CURSOR);
+    }
+
+    /* we get the index of the current smallest entry from the min heap */
+    int smallest_idx = cursor->min_heap[0];
+
+    /* skip until we find a valid entry if the current smallest isn't valid */
+    while (!cursor->current_entries[smallest_idx].valid)
+    {
+        /* we advance this source */
+        tidesdb_err_t *err = _tidesdb_merge_cursor_advance(cursor, smallest_idx);
+        if (err != NULL)
+        {
+            return err;
+        }
+
+        /* we check if we're out of valid entries */
+        if (!_tidesdb_merge_cursor_has_valid_entries(cursor))
+        {
+            return tidesdb_err_from_code(TIDESDB_ERR_AT_END_OF_CURSOR);
+        }
+
+        /* we get the new smallest index */
+        smallest_idx = cursor->min_heap[0];
+    }
+
+    /* advance the source that had the smallest key */
+    tidesdb_err_t *err = _tidesdb_merge_cursor_advance(cursor, smallest_idx);
+    if (err != NULL)
+    {
+        return err;
+    }
+
+    /* we check if we're out of valid entries */
+    if (!_tidesdb_merge_cursor_has_valid_entries(cursor))
+    {
+        return tidesdb_err_from_code(TIDESDB_ERR_AT_END_OF_CURSOR);
+    }
+
+    return NULL;
+}
+
+tidesdb_err_t *tidesdb_merge_cursor_prev(tidesdb_merge_cursor_t *cursor)
+{
+    if (cursor == NULL)
+    {
+        return tidesdb_err_from_code(TIDESDB_ERR_INVALID_CURSOR);
+    }
+
+    if (!cursor->initialized)
+    {
+        return tidesdb_err_from_code(TIDESDB_ERR_INVALID_CURSOR);
+    }
+
+    /* we set direction for reverse traversal */
+    if (cursor->direction != TIDESDB_CURSOR_REVERSE)
+    {
+        cursor->direction = TIDESDB_CURSOR_REVERSE;
+
+        /* we get the column family read lock before we change cursor state */
+        if (pthread_rwlock_rdlock(&cursor->cf->rwlock) != 0)
+        {
+            return tidesdb_err_from_code(TIDESDB_ERR_FAILED_TO_ACQUIRE_LOCK, "column family");
+        }
+
+        /* reinit entries in the correct direction */
+        for (int i = 0; i < cursor->min_heap_size; i++)
+        {
+            if (cursor->current_entries[i].valid)
+            {
+                free(cursor->current_entries[i].kv.key);
+                free(cursor->current_entries[i].kv.value);
+                cursor->current_entries[i].valid = false;
+            }
+        }
+
+        /* re reset all cursors to start from the end */
+        if (cursor->memtable_cursor != NULL)
+        {
+            (void)skip_list_cursor_free(cursor->memtable_cursor);
+            cursor->memtable_cursor = skip_list_cursor_init(cursor->cf->memtable);
+
+            /* we pos at the last element */
+            if (cursor->memtable_cursor != NULL)
+            {
+                if (skip_list_cursor_goto_last(cursor->memtable_cursor) == -1)
+                {
+                    (void)skip_list_cursor_free(cursor->memtable_cursor);
+                    cursor->memtable_cursor = NULL;
+                }
+            }
+        }
+
+        for (int i = 0; i < cursor->num_sstables; i++)
+        {
+            if (cursor->sstable_cursors[i] != NULL)
+            {
+                (void)block_manager_cursor_free(cursor->sstable_cursors[i]);
+                cursor->sstable_cursors[i] = NULL;
+            }
+
+            /* we try to reinitialize cursors for all ssts when switching direction */
+            if (block_manager_cursor_init(&cursor->sstable_cursors[i],
+                                          cursor->cf->sstables[i]->block_manager) == -1)
+            {
+                continue;
+            }
+
+            /* go to the last block */
+            if (block_manager_cursor_goto_last(cursor->sstable_cursors[i]) == -1)
+            {
+                (void)block_manager_cursor_free(cursor->sstable_cursors[i]);
+                cursor->sstable_cursors[i] = NULL;
+                continue;
+            }
+
+            /* we skip binary hash array block if using block indices */
+            if (TDB_BLOCK_INDICES)
+            {
+                /* we check if this is actually the last block and not just metadata */
+                block_manager_block_t *block =
+                    block_manager_cursor_read(cursor->sstable_cursors[i]);
+                if (block != NULL)
+                {
+                    /* try to deserialize as a key-value pair to identify if it's data or metadata
+                     */
+                    tidesdb_key_value_pair_t *kv = _tidesdb_deserialize_key_value_pair(
+                        block->data, block->size, cursor->cf->config.compressed,
+                        cursor->cf->config.compress_algo);
+
+                    (void)block_manager_block_free(block);
+
+                    if (kv == NULL)
+                    {
+                        /* this is likely a metadata block, go back to the last data block */
+                        if (block_manager_cursor_prev(cursor->sstable_cursors[i]) == -1)
+                        {
+                            (void)block_manager_cursor_free(cursor->sstable_cursors[i]);
+                            cursor->sstable_cursors[i] = NULL;
+                        }
+                    }
+                    else
+                    {
+                        /*  was a valid KV block, free the kv */
+                        (void)_tidesdb_free_key_value_pair(kv);
+                    }
+                }
+                else
+                {
+                    /* cannot read the block, free the cursor */
+                    (void)block_manager_cursor_free(cursor->sstable_cursors[i]);
+                    cursor->sstable_cursors[i] = NULL;
+                }
+            }
+        }
+
+        /* reinit entries */
+        cursor->initialized = false;
+        tidesdb_err_t *err = _tidesdb_merge_cursor_init_entries(cursor);
+
+        /* release the lock before checking for errors */
+        (void)pthread_rwlock_unlock(&cursor->cf->rwlock);
+
+        if (err != NULL)
+        {
+            return err;
+        }
+
+        /* reheapify with max heap ordering */
+        for (int i = 0; i < cursor->min_heap_size; i++)
+        {
+            cursor->min_heap[i] = i;
+        }
+        (void)max_heap_heapify(cursor);
+
+        /* when we're switching directions, we don't need to advance.. just return the current entry
+         * which should be at the end */
+        return NULL;
+    }
+
+    /* check if there are any valid entries */
+    if (!_tidesdb_merge_cursor_has_valid_entries(cursor))
+    {
+        return tidesdb_err_from_code(TIDESDB_ERR_AT_START_OF_CURSOR);
+    }
+
+    /* we get the index of the current largest entry from the max heap */
+    int largest_idx = cursor->min_heap[0];
+
+    /* we skip until we find a valid entry if the current largest isn't valid */
+    while (!cursor->current_entries[largest_idx].valid)
+    {
+        /* adv (prev) this source */
+        tidesdb_err_t *err = _tidesdb_merge_cursor_advance(cursor, largest_idx);
+        if (err != NULL)
+        {
+            return err;
+        }
+
+        /* we check if we're out of valid entries */
+        if (!_tidesdb_merge_cursor_has_valid_entries(cursor))
+        {
+            return tidesdb_err_from_code(TIDESDB_ERR_AT_START_OF_CURSOR);
+        }
+
+        /* we get the new largest index */
+        largest_idx = cursor->min_heap[0];
+    }
+
+    /* we make a copy of the current key for duplicate checking */
+    uint8_t *current_key = NULL;
+    size_t current_key_size = 0;
+
+    if (cursor->current_entries[largest_idx].valid)
+    {
+        current_key_size = cursor->current_entries[largest_idx].kv.key_size;
+        current_key = malloc(current_key_size);
+        if (current_key == NULL)
+        {
+            return tidesdb_err_from_code(TIDESDB_ERR_MEMORY_ALLOC, "duplicate key buffer");
+        }
+        memcpy(current_key, cursor->current_entries[largest_idx].kv.key, current_key_size);
+    }
+
+    /* adv (prev) the source that had the largest key */
+    tidesdb_err_t *err = _tidesdb_merge_cursor_advance(cursor, largest_idx);
+    if (err != NULL)
+    {
+        if (current_key != NULL)
+        {
+            free(current_key);
+        }
+        return err;
+    }
+
+    /* we check if we're out of valid entries */
+    if (!_tidesdb_merge_cursor_has_valid_entries(cursor))
+    {
+        if (current_key != NULL)
+        {
+            free(current_key);
+        }
+        return tidesdb_err_from_code(TIDESDB_ERR_AT_START_OF_CURSOR);
+    }
+
+    /* after advancing, we need to ensure we don't produce duplicate keys */
+    largest_idx = cursor->min_heap[0];
+
+    /* we skip any keys that are the same as the one we just processed */
+    if (current_key != NULL)
+    {
+        while (cursor->current_entries[largest_idx].valid &&
+               _tidesdb_compare_keys(cursor->current_entries[largest_idx].kv.key,
+                                     cursor->current_entries[largest_idx].kv.key_size, current_key,
+                                     current_key_size) == 0)
+        {
+            /* adv this source */
+            err = _tidesdb_merge_cursor_advance(cursor, largest_idx);
+            if (err != NULL)
+            {
+                free(current_key);
+                return err;
+            }
+
+            /* we check if we're out of valid entries */
+            if (!_tidesdb_merge_cursor_has_valid_entries(cursor))
+            {
+                free(current_key);
+                return tidesdb_err_from_code(TIDESDB_ERR_AT_START_OF_CURSOR);
+            }
+
+            largest_idx = cursor->min_heap[0];
+        }
+        free(current_key);
+    }
+
+    return NULL;
+}
+
+tidesdb_err_t *tidesdb_merge_cursor_get(tidesdb_merge_cursor_t *cursor, uint8_t **key,
+                                        size_t *key_size, uint8_t **value, size_t *value_size)
+{
+    if (cursor == NULL)
+    {
+        return tidesdb_err_from_code(TIDESDB_ERR_INVALID_CURSOR);
+    }
+
+    if (!cursor->initialized)
+    {
+        return tidesdb_err_from_code(TIDESDB_ERR_INVALID_CURSOR);
+    }
+
+    /* we check if there are any valid entries */
+    if (!_tidesdb_merge_cursor_has_valid_entries(cursor))
+    {
+        return tidesdb_err_from_code(TIDESDB_ERR_KEY_NOT_FOUND);
+    }
+
+    /* we get the index of the min/max entry from the heap */
+    int idx = cursor->min_heap[0];
+
+    /* we skip any invalid entries */
+    while (!cursor->current_entries[idx].valid)
+    {
+        /* adv this source */
+        tidesdb_err_t *err = _tidesdb_merge_cursor_advance(cursor, idx);
+        if (err != NULL)
+        {
+            return err;
+        }
+
+        /* we check if we're out of valid entries */
+        if (!_tidesdb_merge_cursor_has_valid_entries(cursor))
+        {
+            return tidesdb_err_from_code(TIDESDB_ERR_KEY_NOT_FOUND);
+        }
+
+        /* get the new index */
+        idx = cursor->min_heap[0];
+    }
+
+    /* root of the heap is our next entry to return */
+    tidesdb_merge_cursor_entry_t *entry = &cursor->current_entries[idx];
+
+    /* alloc memory and copy key/value */
+    *key = malloc(entry->kv.key_size);
+    if (*key == NULL)
+    {
+        return tidesdb_err_from_code(TIDESDB_ERR_MEMORY_ALLOC, "key in merge cursor get");
+    }
+
+    memcpy(*key, entry->kv.key, entry->kv.key_size);
+    *key_size = entry->kv.key_size;
+
+    *value = malloc(entry->kv.value_size);
+    if (*value == NULL)
+    {
+        free(*key);
+        return tidesdb_err_from_code(TIDESDB_ERR_MEMORY_ALLOC, "value in merge cursor get");
+    }
+
+    memcpy(*value, entry->kv.value, entry->kv.value_size);
+    *value_size = entry->kv.value_size;
+
+    return NULL;
+}
+
+tidesdb_err_t *tidesdb_merge_cursor_free(tidesdb_merge_cursor_t *cursor)
+{
+    if (cursor == NULL)
+    {
+        return tidesdb_err_from_code(TIDESDB_ERR_INVALID_CURSOR);
+    }
+
+    /* we free all entries */
+    if (cursor->current_entries != NULL)
+    {
+        for (int i = 0; i < cursor->min_heap_size; i++)
+        {
+            if (cursor->current_entries[i].valid)
+            {
+                free(cursor->current_entries[i].kv.key);
+                free(cursor->current_entries[i].kv.value);
+            }
+        }
+
+        free(cursor->current_entries);
+    }
+
+    /* we free the min heap */
+    if (cursor->min_heap != NULL)
+    {
+        free(cursor->min_heap);
+    }
+
+    /* we free all cursors */
+    if (cursor->memtable_cursor != NULL)
+    {
+        (void)skip_list_cursor_free(cursor->memtable_cursor);
+    }
+
+    if (cursor->sstable_cursors != NULL)
+    {
+        for (int i = 0; i < cursor->num_sstables; i++)
+        {
+            if (cursor->sstable_cursors[i] != NULL)
+            {
+                (void)block_manager_cursor_free(cursor->sstable_cursors[i]);
+            }
+        }
+
+        free(cursor->sstable_cursors);
+    }
+
+    free(cursor);
+    cursor = NULL;
+
+    return NULL;
+}
+
+tidesdb_err_t *_tidesdb_merge_cursor_advance(tidesdb_merge_cursor_t *cursor, int source_idx)
+{
+    /* we get column family read lock */
+    if (pthread_rwlock_rdlock(&cursor->cf->rwlock) != 0)
+    {
+        return tidesdb_err_from_code(TIDESDB_ERR_FAILED_TO_ACQUIRE_LOCK, "column family");
+    }
+
+    /* we free existing key/value in the entry */
+    if (cursor->current_entries[source_idx].valid)
+    {
+        free(cursor->current_entries[source_idx].kv.key);
+        free(cursor->current_entries[source_idx].kv.value);
+        cursor->current_entries[source_idx].valid = false;
+    }
+
+    /* we get the next element
+     * from the source */
+    if (source_idx == 0)
+    {
+        /* memtable source */
+        if (cursor->memtable_cursor != NULL)
+        {
+            int result;
+
+            if (cursor->direction == TIDESDB_CURSOR_FORWARD)
+            {
+                result = skip_list_cursor_next(cursor->memtable_cursor);
+            }
+            else
+            {
+                result = skip_list_cursor_prev(cursor->memtable_cursor);
+            }
+
+            if (result == 0)
+            {
+                uint8_t *key, *value;
+                size_t key_size, value_size;
+                time_t ttl;
+
+                if (skip_list_cursor_get(cursor->memtable_cursor, &key, &key_size, &value,
+                                         &value_size, &ttl) == 0)
+                {
+                    /* we alloc memory and copy key/value */
+                    cursor->current_entries[source_idx].kv.key = malloc(key_size);
+                    if (cursor->current_entries[source_idx].kv.key == NULL)
+                    {
+                        cursor->current_entries[source_idx].valid = false;
+                        (void)pthread_rwlock_unlock(&cursor->cf->rwlock);
+                        return tidesdb_err_from_code(TIDESDB_ERR_MEMORY_ALLOC,
+                                                     "key in merge cursor");
+                    }
+
+                    memcpy(cursor->current_entries[source_idx].kv.key, key, key_size);
+                    cursor->current_entries[source_idx].kv.key_size = key_size;
+
+                    cursor->current_entries[source_idx].kv.value = malloc(value_size);
+                    if (cursor->current_entries[source_idx].kv.value == NULL)
+                    {
+                        free(cursor->current_entries[source_idx].kv.key);
+                        cursor->current_entries[source_idx].valid = false;
+                        (void)pthread_rwlock_unlock(&cursor->cf->rwlock);
+                        return tidesdb_err_from_code(TIDESDB_ERR_MEMORY_ALLOC,
+                                                     "value in merge cursor");
+                    }
+
+                    memcpy(cursor->current_entries[source_idx].kv.value, value, value_size);
+                    cursor->current_entries[source_idx].kv.value_size = value_size;
+                    cursor->current_entries[source_idx].kv.ttl = ttl;
+                    cursor->current_entries[source_idx].source_index = source_idx;
+
+                    /* we check if it's a tombstone or expired */
+                    if (_tidesdb_is_tombstone(value, value_size) || _tidesdb_is_expired(ttl))
+                    {
+                        cursor->current_entries[source_idx].valid = false;
+                    }
+                    else
+                    {
+                        cursor->current_entries[source_idx].valid = true;
+                    }
+                }
+                else
+                {
+                    cursor->current_entries[source_idx].valid = false;
+                }
+            }
+            else
+            {
+                cursor->current_entries[source_idx].valid = false;
+            }
+        }
+        else
+        {
+            cursor->current_entries[source_idx].valid = false;
+        }
+    }
+    else
+    {
+        /* sst source */
+        int sstable_idx = source_idx - 1;
+
+        if (cursor->sstable_cursors[sstable_idx] != NULL)
+        {
+            int result;
+
+            if (cursor->direction == TIDESDB_CURSOR_FORWARD)
+            {
+                result = block_manager_cursor_next(cursor->sstable_cursors[sstable_idx]);
+            }
+            else
+            {
+                result = block_manager_cursor_prev(cursor->sstable_cursors[sstable_idx]);
+            }
+
+            if (result == 0)
+            {
+                block_manager_block_t *block =
+                    block_manager_cursor_read(cursor->sstable_cursors[sstable_idx]);
+                if (block != NULL)
+                {
+                    /* we check if this is a valid data block,
+                     * not a metadata block */
+                    tidesdb_key_value_pair_t *kv = _tidesdb_deserialize_key_value_pair(
+                        block->data, block->size, cursor->cf->config.compressed,
+                        cursor->cf->config.compress_algo);
+
+                    /* we free the block as we've read its data */
+                    (void)block_manager_block_free(block);
+
+                    if (kv != NULL)
+                    {
+                        /* we need our own copies of the key and value */
+                        cursor->current_entries[source_idx].kv.key = malloc(kv->key_size);
+                        if (cursor->current_entries[source_idx].kv.key == NULL)
+                        {
+                            (void)_tidesdb_free_key_value_pair(kv);
+                            cursor->current_entries[source_idx].valid = false;
+                            (void)pthread_rwlock_unlock(&cursor->cf->rwlock);
+                            return tidesdb_err_from_code(TIDESDB_ERR_MEMORY_ALLOC,
+                                                         "key in merge cursor");
+                        }
+
+                        memcpy(cursor->current_entries[source_idx].kv.key, kv->key, kv->key_size);
+                        cursor->current_entries[source_idx].kv.key_size = kv->key_size;
+
+                        cursor->current_entries[source_idx].kv.value = malloc(kv->value_size);
+                        if (cursor->current_entries[source_idx].kv.value == NULL)
+                        {
+                            free(cursor->current_entries[source_idx].kv.key);
+                            (void)_tidesdb_free_key_value_pair(kv);
+                            cursor->current_entries[source_idx].valid = false;
+                            (void)pthread_rwlock_unlock(&cursor->cf->rwlock);
+                            return tidesdb_err_from_code(TIDESDB_ERR_MEMORY_ALLOC,
+                                                         "value in merge cursor");
+                        }
+
+                        memcpy(cursor->current_entries[source_idx].kv.value, kv->value,
+                               kv->value_size);
+                        cursor->current_entries[source_idx].kv.value_size = kv->value_size;
+                        cursor->current_entries[source_idx].kv.ttl = kv->ttl;
+                        cursor->current_entries[source_idx].source_index = source_idx;
+
+                        /* we check if it's a tombstone or expired */
+                        if (_tidesdb_is_tombstone(kv->value, kv->value_size) ||
+                            _tidesdb_is_expired(kv->ttl))
+                        {
+                            cursor->current_entries[source_idx].valid = false;
+                        }
+                        else
+                        {
+                            cursor->current_entries[source_idx].valid = true;
+                        }
+
+                        (void)_tidesdb_free_key_value_pair(kv);
+                    }
+                    else
+                    {
+                        /* cannot deserialize
+                         * could be a metadata block or corrupted */
+                        cursor->current_entries[source_idx].valid = false;
+
+                        /* we skip this block in reverse direction
+                         * it might be a metadata block */
+                        if (cursor->direction == TIDESDB_CURSOR_REVERSE)
+                        {
+                            if (block_manager_cursor_prev(cursor->sstable_cursors[sstable_idx]) ==
+                                0)
+                            {
+                                /* we try the next block
+                                 * recursive call with same source_idx */
+                                (void)pthread_rwlock_unlock(&cursor->cf->rwlock);
+                                return _tidesdb_merge_cursor_advance(cursor, source_idx);
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    cursor->current_entries[source_idx].valid = false;
+                }
+            }
+            else
+            {
+                cursor->current_entries[source_idx].valid = false;
+            }
+        }
+        else
+        {
+            cursor->current_entries[source_idx].valid = false;
+        }
+    }
+
+    /* we release the column family lock */
+    (void)pthread_rwlock_unlock(&cursor->cf->rwlock);
+
+    if (cursor->direction == TIDESDB_CURSOR_FORWARD)
+    {
+        (void)min_heap_heapify(cursor);
+    }
+    else
+    {
+        (void)max_heap_heapify(cursor);
+    }
+
+    return NULL;
+}
+
+tidesdb_err_t *tidesdb_merge_cursor_init(tidesdb_t *tdb, const char *column_family_name,
+                                         tidesdb_merge_cursor_t **cursor)
+{
+    if (tdb == NULL)
+    {
+        return tidesdb_err_from_code(TIDESDB_ERR_INVALID_DB);
+    }
+
+    if (column_family_name == NULL)
+    {
+        return tidesdb_err_from_code(TIDESDB_ERR_INVALID_COLUMN_FAMILY);
+    }
+
+    /* we validate column family name length */
+    if (strlen(column_family_name) < 2)
+    {
+        return tidesdb_err_from_code(TIDESDB_ERR_INVALID_NAME, "column family");
+    }
+
+    if (strlen(column_family_name) > TDB_MAX_COLUMN_FAMILY_NAME_LEN)
+    {
+        return tidesdb_err_from_code(TIDESDB_ERR_INVALID_NAME_LENGTH, "column family");
+    }
+
+    /* we get the column family */
+    if (pthread_rwlock_rdlock(&tdb->rwlock) != 0)
+    {
+        return tidesdb_err_from_code(TIDESDB_ERR_FAILED_TO_ACQUIRE_LOCK, "db");
+    }
+
+    tidesdb_column_family_t *cf = NULL;
+    if (_tidesdb_get_column_family(tdb, column_family_name, &cf) == -1)
+    {
+        (void)pthread_rwlock_unlock(&tdb->rwlock);
+        return tidesdb_err_from_code(TIDESDB_ERR_COLUMN_FAMILY_NOT_FOUND);
+    }
+
+    (void)pthread_rwlock_unlock(&tdb->rwlock);
+
+    /* we lock the column family for reading */
+    if (pthread_rwlock_rdlock(&cf->rwlock) != 0)
+    {
+        return tidesdb_err_from_code(TIDESDB_ERR_FAILED_TO_ACQUIRE_LOCK, "column family");
+    }
+
+    /* we alloc memory for the merge cursor */
+    *cursor = malloc(sizeof(tidesdb_merge_cursor_t));
+    if (*cursor == NULL)
+    {
+        (void)pthread_rwlock_unlock(&cf->rwlock);
+        return tidesdb_err_from_code(TIDESDB_ERR_MEMORY_ALLOC, "merge cursor");
+    }
+
+    /* we init the cursor */
+    (*cursor)->tdb = tdb;
+    (*cursor)->cf = cf;
+    (*cursor)->direction = TIDESDB_CURSOR_FORWARD;
+    (*cursor)->initialized = false;
+    (*cursor)->num_sstables = cf->num_sstables;
+
+    /* we init the memtable cursor */
+    (*cursor)->memtable_cursor = skip_list_cursor_init(cf->memtable);
+
+    /* we alloc memory for sstable cursors */
+    (*cursor)->sstable_cursors = NULL;
+    if (cf->num_sstables > 0)
+    {
+        (*cursor)->sstable_cursors = malloc(cf->num_sstables * sizeof(block_manager_cursor_t *));
+        if ((*cursor)->sstable_cursors == NULL)
+        {
+            (void)skip_list_cursor_free((*cursor)->memtable_cursor);
+            free(*cursor);
+            (void)pthread_rwlock_unlock(&cf->rwlock);
+            return tidesdb_err_from_code(TIDESDB_ERR_MEMORY_ALLOC, "sstable cursors");
+        }
+
+        /* calc size for current entries and min heap */
+        (*cursor)->min_heap_size = cf->num_sstables + 1; /* +1 for the memtable */
+
+        /* we init each sst cursor */
+        for (int i = 0; i < cf->num_sstables; i++)
+        {
+            if (block_manager_cursor_init(&(*cursor)->sstable_cursors[i],
+                                          cf->sstables[i]->block_manager) == -1)
+            {
+                /* we free previously allocated cursors */
+                for (int j = 0; j < i; j++)
+                {
+                    (void)block_manager_cursor_free((*cursor)->sstable_cursors[j]);
+                }
+
+                free((*cursor)->sstable_cursors);
+                (void)skip_list_cursor_free((*cursor)->memtable_cursor);
+                free(*cursor);
+                (void)pthread_rwlock_unlock(&cf->rwlock);
+                return tidesdb_err_from_code(TIDESDB_ERR_FAILED_TO_INIT_CURSOR);
+            }
+
+            /* we skip min-max block */
+            if (block_manager_cursor_next((*cursor)->sstable_cursors[i]) == -1)
+            {
+                /* we free previously allocated cursors */
+                for (int j = 0; j < i; j++)
+                {
+                    (void)block_manager_cursor_free((*cursor)->sstable_cursors[j]);
+                }
+
+                free((*cursor)->sstable_cursors);
+                (void)skip_list_cursor_free((*cursor)->memtable_cursor);
+                free(*cursor);
+                (void)pthread_rwlock_unlock(&cf->rwlock);
+                return tidesdb_err_from_code(TIDESDB_ERR_FAILED_TO_INIT_CURSOR);
+            }
+
+            /* we skip bloom filter block if configured */
+            if (cf->config.bloom_filter)
+            {
+                if (block_manager_cursor_next((*cursor)->sstable_cursors[i]) == -1)
+                {
+                    /* we free previously allocated cursors */
+                    for (int j = 0; j <= i; j++)
+                    {
+                        (void)block_manager_cursor_free((*cursor)->sstable_cursors[j]);
+                    }
+
+                    free((*cursor)->sstable_cursors);
+                    (void)skip_list_cursor_free((*cursor)->memtable_cursor);
+                    free(*cursor);
+                    (void)pthread_rwlock_unlock(&cf->rwlock);
+                    return tidesdb_err_from_code(TIDESDB_ERR_FAILED_TO_INIT_CURSOR);
+                }
+            }
+
+            /* if using block indices, ensure we're reading the data blocks, not the SBHA at the
+             * end..
+             */
+            if (TDB_BLOCK_INDICES)
+            {
+                /* we check if this is the SBHA block at the end to avoid it */
+                if (block_manager_cursor_at_last((*cursor)->sstable_cursors[i]))
+                {
+                    (void)block_manager_cursor_prev((*cursor)->sstable_cursors[i]);
+                }
+            }
+        }
+    }
+
+    /* we alloc memory for current entries
+     * one for memtable and one for each sstable */
+    (*cursor)->current_entries =
+        malloc((cf->num_sstables + 1) * sizeof(tidesdb_merge_cursor_entry_t));
+    if ((*cursor)->current_entries == NULL)
+    {
+        /* we free all cursors */
+        for (int i = 0; i < cf->num_sstables; i++)
+        {
+            if ((*cursor)->sstable_cursors[i] != NULL)
+            {
+                (void)block_manager_cursor_free((*cursor)->sstable_cursors[i]);
+            }
+        }
+
+        free((*cursor)->sstable_cursors);
+        if ((*cursor)->memtable_cursor != NULL)
+        {
+            (void)skip_list_cursor_free((*cursor)->memtable_cursor);
+        }
+
+        free(*cursor);
+        (void)pthread_rwlock_unlock(&cf->rwlock);
+        return tidesdb_err_from_code(TIDESDB_ERR_MEMORY_ALLOC, "merge cursor entries");
+    }
+
+    /* we init entries to invalid */
+    for (int i = 0; i < cf->num_sstables + 1; i++)
+    {
+        (*cursor)->current_entries[i].valid = false;
+    }
+
+    /* we alloc memory for min heap */
+    (*cursor)->min_heap = malloc((*cursor)->min_heap_size * sizeof(int));
+    if ((*cursor)->min_heap == NULL)
+    {
+        /* we free all cursors and entries */
+        for (int i = 0; i < cf->num_sstables; i++)
+        {
+            if ((*cursor)->sstable_cursors[i] != NULL)
+            {
+                (void)block_manager_cursor_free((*cursor)->sstable_cursors[i]);
+            }
+        }
+
+        free((*cursor)->sstable_cursors);
+        if ((*cursor)->memtable_cursor != NULL)
+        {
+            (void)skip_list_cursor_free((*cursor)->memtable_cursor);
+        }
+
+        free((*cursor)->current_entries);
+        free(*cursor);
+        (void)pthread_rwlock_unlock(&cf->rwlock);
+        return tidesdb_err_from_code(TIDESDB_ERR_MEMORY_ALLOC, "merge cursor min heap");
+    }
+
+    /* we init the entries */
+    tidesdb_err_t *err = _tidesdb_merge_cursor_init_entries(*cursor);
+    if (err != NULL)
+    {
+        /* we free all cursors and entries */
+        for (int i = 0; i < cf->num_sstables; i++)
+        {
+            if ((*cursor)->sstable_cursors[i] != NULL)
+            {
+                (void)block_manager_cursor_free((*cursor)->sstable_cursors[i]);
+            }
+        }
+
+        free((*cursor)->sstable_cursors);
+        if ((*cursor)->memtable_cursor != NULL)
+        {
+            (void)skip_list_cursor_free((*cursor)->memtable_cursor);
+        }
+
+        free((*cursor)->current_entries);
+        free((*cursor)->min_heap);
+        free(*cursor);
+        (void)pthread_rwlock_unlock(&cf->rwlock);
+        return err;
+    }
+
+    (void)pthread_rwlock_unlock(&cf->rwlock);
+
+    return NULL;
+}

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -1296,7 +1296,7 @@ extern "C"
     /* min-heap methods in-which assist us with merge iteration */
 
     /**
-     * min_heap_swap
+     * _min_heap_swap
      *
      * swaps two elements in the heap array.
      * used by both min-heap and max-heap operations.
@@ -1305,13 +1305,15 @@ extern "C"
      * @param idx1 index of first element to swap
      * @param idx2 index of second element to swap
      */
-    void min_heap_swap(int *heap, int idx1, int idx2);
+    void _min_heap_swap(int *heap, int idx1, int idx2);
 
     /**
-     * min_heap_sift_down
+     * _min_heap_sift_down
      *
      * restores min-heap property by moving the element at the root position down
-     * to its correct position. Used after extraction or when building a heap.
+     * to its correct position.
+     *
+     * used after extraction or when building a heap.
      *
      * the min-heap ensures the smallest element is always at the root, which supports
      * forward iteration through merge sources.
@@ -1320,10 +1322,10 @@ extern "C"
      * @param start the index of the root element to sift down
      * @param end the last valid index in the heap
      */
-    void min_heap_sift_down(tidesdb_merge_cursor_t *cursor, int start, int end);
+    void _min_heap_sift_down(tidesdb_merge_cursor_t *cursor, int start, int end);
 
     /**
-     * min_heap_heapify
+     * _min_heap_heapify
      *
      * builds a min-heap from an unordered array by repeatedly applying sift_down
      * from the bottom up.
@@ -1333,25 +1335,25 @@ extern "C"
      *
      * @param cursor the merge cursor containing the array to heapify
      */
-    void min_heap_heapify(tidesdb_merge_cursor_t *cursor);
+    void _min_heap_heapify(tidesdb_merge_cursor_t *cursor);
 
     /**
-     * max_heap_sift_down
+     * _max_heap_sift_down
      *
      * restores max-heap property by moving the element at the root position down
      * to its correct position.
      *
-     * similar to min_heap_sift_down but ensures largest
+     * similar to _min_heap_sift_down but ensures largest
      * elements are at the root, which supports backward iteration through merge sources.
      *
      * @param cursor the merge cursor containing the heap
      * @param start the index of the root element to sift down
      * @param end the last valid index in the heap
      */
-    void max_heap_sift_down(tidesdb_merge_cursor_t *cursor, int start, int end);
+    void _max_heap_sift_down(tidesdb_merge_cursor_t *cursor, int start, int end);
 
     /**
-     * max_heap_heapify
+     * _max_heap_heapify
      *
      * builds a max-heap from an unordered array.
      *
@@ -1360,7 +1362,7 @@ extern "C"
      *
      * @param cursor the merge cursor containing the array to heapify
      */
-    void max_heap_heapify(tidesdb_merge_cursor_t *cursor);
+    void _max_heap_heapify(tidesdb_merge_cursor_t *cursor);
 
 #ifdef __cplusplus
 }

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -2155,6 +2155,202 @@ void test_tidesdb_cursor_memtable_sstables(bool compress, tidesdb_compression_al
            compress ? " with compression" : "", bloom_filter ? " with bloom filter" : "");
 }
 
+void test_tidesdb_merge_cursor_memtable_sstables(bool compress, tidesdb_compression_algo_t algo,
+                                                 bool bloom_filter)
+{
+    tidesdb_t *db = NULL;
+
+    tidesdb_err_t *err = tidesdb_open("test_db", &db);
+    if (err != NULL)
+    {
+        printf(RED "%s" RESET, err->message);
+    }
+    assert(err == NULL);
+
+    (void)tidesdb_err_free(err);
+
+    err = tidesdb_create_column_family(db, "test_cf", 1024 * 1024, 12, 0.24f, compress, algo,
+                                       bloom_filter);
+    if (err != NULL)
+    {
+        printf(RED "%s" RESET, err->message);
+    }
+    assert(err == NULL);
+
+    uint8_t key[20];
+    uint8_t value[1024 * 1024];
+    uint8_t smaller_value[20];
+
+    cursor_test_entry_t entries[24];
+
+    /* fill the value with random data */
+    for (size_t i = 0; i < sizeof(value); i++)
+    {
+        value[i] = (uint8_t)(rand() % 256);
+    }
+
+    /* fill the smaller value with random data */
+    for (size_t i = 0; i < sizeof(smaller_value); i++)
+    {
+        smaller_value[i] = (uint8_t)(rand() % 256);
+    }
+
+    for (int i = 0; i < 12; i++)
+    {
+        snprintf((char *)key, sizeof(key), "key_%03d", i);
+        err = tidesdb_put(db, "test_cf", key, strlen((char *)key) + 1, value, sizeof(value), -1);
+        if (err != NULL)
+        {
+            printf(RED "%s" RESET, err->message);
+        }
+        assert(err == NULL);
+
+        /* add the key to the entries */
+        memcpy(entries[i].key, key, sizeof(key));
+        entries[i].found = false;
+    }
+
+    /* put 12 more keys with smaller values */
+    for (int i = 0; i < 12; i++)
+    {
+        snprintf((char *)key, sizeof(key), "key_%03d", i + 12);
+        err = tidesdb_put(db, "test_cf", key, strlen((char *)key) + 1, smaller_value,
+                          sizeof(smaller_value), -1);
+        if (err != NULL)
+        {
+            printf(RED "%s" RESET, err->message);
+        }
+        assert(err == NULL);
+
+        /* add the key to the entries */
+        memcpy(entries[i + 12].key, key, sizeof(key));
+        entries[i + 12].found = false;
+    }
+
+    /** _tidesdb_print_keys_tree(db, "test_cf"); */
+
+    tidesdb_merge_cursor_t *c;
+    tidesdb_err_t *e = tidesdb_merge_cursor_init(db, "test_cf", &c);
+    if (e != NULL)
+    {
+        printf(RED "%s" RESET, err->message);
+        tidesdb_err_free(e);
+        return;
+    }
+
+    uint8_t *retrieved_key = NULL;
+    size_t key_size;
+    uint8_t *retrieved_value = NULL;
+    size_t value_size;
+
+    /* iterate forward */
+    do
+    {
+        e = tidesdb_merge_cursor_get(c, &retrieved_key, &key_size, &retrieved_value, &value_size);
+        if (e != NULL)
+        {
+            printf(RED "%s" RESET, err->message);
+            tidesdb_err_free(e);
+            break;
+        }
+
+        printf("key: %s\n", retrieved_key);
+
+        /* check if the key is in the entries */
+        for (int i = 0; i < 24; i++)
+        {
+            if (memcmp(entries[i].key, retrieved_key, key_size) == 0)
+            {
+                entries[i].found = true;
+                break;
+            }
+        }
+
+        free(retrieved_key);
+        free(retrieved_value);
+
+    } while ((e = tidesdb_merge_cursor_next(c)) == NULL);
+
+    if (e != NULL && e->code != TIDESDB_ERR_AT_END_OF_CURSOR)
+    {
+        printf(RED "%s" RESET, e->message);
+    }
+    tidesdb_err_free(e);
+
+    /* check if all keys are found */
+    for (int i = 0; i < 24; i++)
+    {
+        if (!entries[i].found)
+        {
+            printf(RED "key %s not found\n" RESET, entries[i].key);
+            assert(entries[i].found);
+        }
+    }
+
+    /* reset the found flags */
+    for (int i = 0; i < 24; i++)
+    {
+        entries[i].found = false;
+    }
+
+    /* iterate backward */
+    while ((e = tidesdb_merge_cursor_prev(c)) == NULL)
+    {
+        e = tidesdb_merge_cursor_get(c, &retrieved_key, &key_size, &retrieved_value, &value_size);
+        if (e != NULL)
+        {
+            printf(RED "%s" RESET, err->message);
+            tidesdb_err_free(e);
+            break;
+        }
+
+        printf("key: %s\n", retrieved_key);
+
+        /* check if the key is in the entries */
+        for (int i = 0; i < 24; i++)
+        {
+            if (memcmp(entries[i].key, retrieved_key, key_size) == 0)
+            {
+                entries[i].found = true;
+                break;
+            }
+        }
+
+        free(retrieved_key);
+        free(retrieved_value);
+    }
+
+    if (e != NULL && e->code != TIDESDB_ERR_AT_START_OF_CURSOR)
+    {
+        printf(RED "%s" RESET, e->message);
+    }
+
+    /* check if all keys are found */
+    for (int i = 0; i < 24; i++)
+    {
+        if (!entries[i].found)
+        {
+            printf(RED "key %s not found\n" RESET, entries[i].key);
+            assert(entries[i].found);
+        }
+    }
+
+    tidesdb_err_free(e);
+
+    tidesdb_merge_cursor_free(c);
+
+    err = tidesdb_close(db);
+    if (err != NULL)
+    {
+        printf(RED "%s" RESET, err->message);
+    }
+    assert(err == NULL);
+
+    (void)_tidesdb_remove_directory("test_db");
+    printf(GREEN "test_tidesdb_merge_cursor_memtable_sstables%s%s passed\n" RESET,
+           compress ? " with compression" : "", bloom_filter ? " with bloom filter" : "");
+}
+
 void test_tidesdb_cursor_background_compaction_shift(bool compress, tidesdb_compression_algo_t algo,
                                                      bool bloom_filter)
 {
@@ -3499,6 +3695,8 @@ int main(void)
 
     test_tidesdb_cursor_memtable_sstables(false, TDB_NO_COMPRESSION, false);
 
+    test_tidesdb_merge_cursor_memtable_sstables(false, TDB_NO_COMPRESSION, false);
+
     test_tidesdb_put_flush_compact_get(false, TDB_NO_COMPRESSION, false);
 
     test_tidesdb_put_flush_shutdown_compact_get(false, TDB_NO_COMPRESSION, false);
@@ -3550,6 +3748,8 @@ int main(void)
     test_tidesdb_cursor_sstables_only(true, TDB_COMPRESS_ZSTD, true);
 
     test_tidesdb_cursor_memtable_sstables(true, TDB_COMPRESS_ZSTD, true);
+
+    test_tidesdb_merge_cursor_memtable_sstables(true, TDB_COMPRESS_ZSTD, true);
 
     test_tidesdb_put_flush_get(true, TDB_COMPRESS_ZSTD, true);
 


### PR DESCRIPTION
Implementation of merge cursor which allows for users to iterate over keeps in order regardless of source(memtable,sstables) using heap.

**New methods**
- `tidesdb_merge_cursor_init`
- `tidesdb_merge_cursor_next`
- `tidesdb_merge_cursor_prev`
- `tidesdb_merge_cursor_get`
- `tidesdb_merge_cursor_free`
- `tidesdb_merge_cursor_seek`
- `_tidesdb_merge_cursor_advance`
- `_tidesdb_merge_cursor_init_entries`
- `_tidesdb_merge_cursor_has_valid_entries`
- `_min_heap_swap`
- `_min_heap_sift_down`
- `_max_heap_heapify`