### PR TITLE
- minor SBHA comments and binary_hash_array_contains warning correcti…

### DIFF
--- a/src/binary_hash_array.h
+++ b/src/binary_hash_array.h
@@ -72,7 +72,7 @@ void binary_hash_array_hash_key(const uint8_t *key, size_t key_len, uint8_t *has
  * binary_hash_array_new
  * creates a new binary hash array
  * @param size the size of the array
- * @return the new binary hash array
+ * @return the new binary hash array or NULL if failed
  */
 binary_hash_array_t *binary_hash_array_new(size_t size);
 

--- a/src/bloom_filter.c
+++ b/src/bloom_filter.c
@@ -120,6 +120,10 @@ unsigned int bloom_filter_hash(const uint8_t *entry, size_t size, int seed)
             h *= m;                 /* multiply the hash by the large prime */
             h ^= (h >> r);          /* xor the hash with its right-shifted value */
             break;
+        default:
+            /* no real action required here, break is just to avoid
+             * compiler warnings */
+            break;
     }
 
     return h;

--- a/src/compress.c
+++ b/src/compress.c
@@ -20,53 +20,49 @@
 
 uint8_t *compress_data(uint8_t *data, size_t data_size, size_t *compressed_size, compress_type type)
 {
-    uint8_t *compressed_data = NULL; /* the final compressed data */
-    size_t total_size;               /* the total size of the compressed data */
+    uint8_t *compressed_data = NULL;
 
     switch (type)
     {
         case COMPRESS_SNAPPY:
+        {
             *compressed_size = snappy_max_compressed_length(data_size);
             compressed_data = malloc(*compressed_size);
-            if (!compressed_data)
-            {
-                return NULL;
-            }
-            (void)snappy_compress((const char *)data, data_size, (char *)compressed_data,
-                                  compressed_size);
+            if (!compressed_data) return NULL;
+
+            snappy_compress((const char *)data, data_size, (char *)compressed_data,
+                            compressed_size);
             break;
+        }
 
         case COMPRESS_LZ4:
         case COMPRESS_ZSTD:
-            /* because lz4 and zstd require the original size to decompress, we need to prepend it
-             * to the compressed data */
+        {
             *compressed_size = (type == COMPRESS_LZ4) ? (size_t)LZ4_compressBound((int)data_size)
                                                       : ZSTD_compressBound(data_size);
-            total_size = *compressed_size + sizeof(size_t);
+            size_t total_size = *compressed_size + sizeof(size_t);
             compressed_data = malloc(total_size);
-            if (!compressed_data)
-            {
-                return NULL;
-            }
+            if (!compressed_data) return NULL;
 
             memcpy(compressed_data, &data_size, sizeof(size_t));
-            int actual_compressed_size =
+
+            size_t actual_size =
                 (type == COMPRESS_LZ4)
                     ? (size_t)LZ4_compress_default((const char *)data,
                                                    (char *)(compressed_data + sizeof(size_t)),
-                                                   (int)data_size, *compressed_size)
+                                                   (int)data_size, (int)*compressed_size)
                     : ZSTD_compress(compressed_data + sizeof(size_t), *compressed_size, data,
                                     data_size, 1);
 
-            if (actual_compressed_size <= 0 ||
-                (type == COMPRESS_ZSTD && ZSTD_isError(actual_compressed_size)))
+            if (actual_size <= 0 || (type == COMPRESS_ZSTD && ZSTD_isError(actual_size)))
             {
                 free(compressed_data);
                 return NULL;
             }
 
-            *compressed_size = actual_compressed_size + sizeof(size_t);
+            *compressed_size = actual_size + sizeof(size_t);
             break;
+        }
 
         default:
             return NULL;
@@ -78,21 +74,19 @@ uint8_t *compress_data(uint8_t *data, size_t data_size, size_t *compressed_size,
 uint8_t *decompress_data(uint8_t *data, size_t data_size, size_t *decompressed_size,
                          compress_type type)
 {
-    uint8_t *decompressed_data = NULL; /* the final decompressed data */
+    uint8_t *decompressed_data = NULL;
 
     switch (type)
     {
         case COMPRESS_SNAPPY:
+        {
             if (snappy_uncompressed_length((const char *)data, data_size, decompressed_size) !=
                 SNAPPY_OK)
-            {
                 return NULL;
-            }
+
             decompressed_data = malloc(*decompressed_size);
-            if (!decompressed_data)
-            {
-                return NULL;
-            }
+            if (!decompressed_data) return NULL;
+
             if (snappy_uncompress((const char *)data, data_size, (char *)decompressed_data,
                                   decompressed_size) != SNAPPY_OK)
             {
@@ -100,29 +94,32 @@ uint8_t *decompress_data(uint8_t *data, size_t data_size, size_t *decompressed_s
                 return NULL;
             }
             break;
+        }
 
         case COMPRESS_LZ4:
         case COMPRESS_ZSTD:
+        {
             memcpy(decompressed_size, data, sizeof(size_t));
+
             decompressed_data = malloc(*decompressed_size);
-            if (!decompressed_data)
-            {
-                return NULL;
-            }
-            int decompressed =
+            if (!decompressed_data) return NULL;
+
+            size_t actual_size =
                 (type == COMPRESS_LZ4)
                     ? (size_t)LZ4_decompress_safe(
                           (const char *)(data + sizeof(size_t)), (char *)decompressed_data,
-                          (int)data_size - sizeof(size_t), *decompressed_size)
+                          (int)(data_size - sizeof(size_t)), (int)*decompressed_size)
                     : ZSTD_decompress(decompressed_data, *decompressed_size, data + sizeof(size_t),
                                       data_size - sizeof(size_t));
 
-            if (decompressed < 0 || (type == COMPRESS_ZSTD && ZSTD_isError(decompressed)))
+            if ((type == COMPRESS_ZSTD && ZSTD_isError(actual_size)) ||
+                (type == COMPRESS_LZ4 && actual_size <= 0))
             {
                 free(decompressed_data);
                 return NULL;
             }
             break;
+        }
 
         default:
             return NULL;

--- a/src/err.c
+++ b/src/err.c
@@ -18,14 +18,15 @@
  */
 #include "err.h"
 
-tidesdb_err_t* tidesdb_err_new(int code, char* message)
+tidesdb_err_t *tidesdb_err_new(int code, char *message)
 {
     /* we allocate memory for the error struct */
-    tidesdb_err_t* e = malloc(sizeof(tidesdb_err_t));
+    tidesdb_err_t *e = malloc(sizeof(tidesdb_err_t));
     if (e == NULL) return NULL;
 
-    /* We set the code and message */
+    /* we set the code and message */
     e->code = code;
+
     /* we check if the message is NULL */
     if (message == NULL)
     {
@@ -43,11 +44,11 @@ tidesdb_err_t* tidesdb_err_new(int code, char* message)
         }
     }
 
-    /* We return the error */
+    /* we return the error */
     return e;
 }
 
-void tidesdb_err_free(tidesdb_err_t* e)
+void tidesdb_err_free(tidesdb_err_t *e)
 {
     /* check if err is NULL */
     if (e == NULL) return;
@@ -63,7 +64,7 @@ void tidesdb_err_free(tidesdb_err_t* e)
     e = NULL;
 }
 
-tidesdb_err_t* tidesdb_err_from_code(TIDESDB_ERR_CODE code, ...)
+tidesdb_err_t *tidesdb_err_from_code(TIDESDB_ERR_CODE code, ...)
 {
     char buffer[TDB_ERR_MAX_MESSAGE_SIZE];
     va_list args;
@@ -71,7 +72,7 @@ tidesdb_err_t* tidesdb_err_from_code(TIDESDB_ERR_CODE code, ...)
 
     if (tidesdb_err_messages[code].has_context)
     {
-        const char* obj = va_arg(args, const char*);
+        const char *obj = va_arg(args, const char *);
         snprintf(buffer, sizeof(buffer), tidesdb_err_messages[code].message, obj);
     }
     else
@@ -81,6 +82,6 @@ tidesdb_err_t* tidesdb_err_from_code(TIDESDB_ERR_CODE code, ...)
 
     va_end(args);
 
-    tidesdb_err_t* err = tidesdb_err_new(tidesdb_err_messages[code].code, buffer);
+    tidesdb_err_t *err = tidesdb_err_new(tidesdb_err_messages[code].code, buffer);
     return err;
 }

--- a/test/binary_hash_array__tests.c
+++ b/test/binary_hash_array__tests.c
@@ -199,7 +199,7 @@ void benchmark_binary_hash_array()
     }
     end = clock();
     cpu_time_used = ((double)(end - start)) / CLOCKS_PER_SEC;
-    printf(CYAN "Time taken to add entries: %f seconds\n" RESET, cpu_time_used);
+    printf(CYAN "Time taken to add %d entries: %f seconds\n" RESET, 1000000, cpu_time_used);
 
     size_t serialized_size;
     uint8_t *serialized_data = binary_hash_array_serialize(bha, &serialized_size);
@@ -225,7 +225,7 @@ void benchmark_binary_hash_array()
     }
     end = clock();
     cpu_time_used = ((double)(end - start)) / CLOCKS_PER_SEC;
-    printf(CYAN "Time taken to check entries: %f seconds\n" RESET, cpu_time_used);
+    printf(CYAN "Time taken to check %d entries: %f seconds\n" RESET, 1000000, cpu_time_used);
 
     (void)binary_hash_array_free(deserialized_bha);
     printf(GREEN "benchmark_binary_hash_array passed\n" RESET);


### PR DESCRIPTION
- minor SBHA comments and binary_hash_array_contains warning corrections;  We should use size_t instead of int in binary_hash_array_contains.
- block manager narrowing conversion warning corrections also minor refactor joining declaration and assignments in few areas.
- break on default case within bloom_filter_hash to avoid compiler warnings.
- compress: less casting refactor
- tidesdb err consistency corrections(minor code style)

