### PR TITLE
Standardized all 225+ tests across the TidesDB test suite to use cons…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.25)
 project(tidesdb C)
 
 set(CMAKE_C_STANDARD 11)
-set(PROJECT_VERSION 3.1.3)
+set(PROJECT_VERSION 3.1.4)
 
 configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/src/tidesdb_version.h.in"

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -20,7 +20,6 @@
 #define __TIDESDB_H__
 #include "block_manager.h"
 #include "bloom_filter.h"
-#include "compat.h"
 #include "compress.h"
 #include "ini.h"
 #include "lru.h"

--- a/test/block_manager__tests.c
+++ b/test/block_manager__tests.c
@@ -34,7 +34,6 @@ void test_block_manager_open()
     (void)block_manager_close(bm);
 
     remove("test.db"); /* remove created file */
-    printf(GREEN "test_block_manager_open passed\n" RESET);
 }
 
 void test_block_manager_block_create()
@@ -47,8 +46,6 @@ void test_block_manager_block_create()
 
     ASSERT_EQ(memcmp(block->data, data, size), 0);
     (void)block_manager_block_free(block);
-
-    printf(GREEN "test_block_manager_block_create passed\n" RESET);
 }
 
 void test_block_manager_block_write()
@@ -70,8 +67,6 @@ void test_block_manager_block_write()
     ASSERT_TRUE(block_manager_close(bm) == 0);
 
     (void)remove("test.db");
-
-    printf(GREEN "test_block_manager_block_write passed\n" RESET);
 }
 
 void test_block_manager_block_write_close_reopen_read()
@@ -113,8 +108,6 @@ void test_block_manager_block_write_close_reopen_read()
     ASSERT_TRUE(block_manager_close(bm) == 0);
 
     remove("test.db");
-
-    printf(GREEN "test_block_manager_block_write_close_reopen_read passed\n" RESET);
 }
 
 void test_block_manager_truncate()
@@ -154,8 +147,6 @@ void test_block_manager_truncate()
     ASSERT_TRUE(block_manager_close(bm) == 0);
 
     (void)remove("test.db");
-
-    printf(GREEN "test_block_manager_truncate passed\n" RESET);
 }
 
 void test_block_manager_cursor()
@@ -280,8 +271,6 @@ void test_block_manager_cursor()
     ASSERT_TRUE(block_manager_close(bm) == 0);
 
     (void)remove("test.db");
-
-    printf(GREEN "test_block_manager_cursor passed\n" RESET);
 }
 
 void test_block_manager_count_blocks()
@@ -307,8 +296,6 @@ void test_block_manager_count_blocks()
 
     ASSERT_TRUE(block_manager_close(bm) == 0);
     (void)remove("test.db");
-
-    printf(GREEN "test_block_manager_count_blocks passed\n" RESET);
 }
 
 void test_block_manager_cursor_goto_first()
@@ -346,8 +333,6 @@ void test_block_manager_cursor_goto_first()
     (void)block_manager_cursor_free(cursor);
     ASSERT_TRUE(block_manager_close(bm) == 0);
     (void)remove("test.db");
-
-    printf(GREEN "test_block_manager_cursor_goto_first passed\n" RESET);
 }
 
 void test_block_manager_cursor_goto_last()
@@ -386,8 +371,6 @@ void test_block_manager_cursor_goto_last()
     (void)block_manager_cursor_free(cursor);
     ASSERT_TRUE(block_manager_close(bm) == 0);
     (void)remove("test.db");
-
-    printf(GREEN "test_block_manager_cursor_goto_last passed\n" RESET);
 }
 
 void test_block_manager_cursor_has_next()
@@ -427,8 +410,6 @@ void test_block_manager_cursor_has_next()
     (void)block_manager_cursor_free(cursor);
     ASSERT_TRUE(block_manager_close(bm) == 0);
     (void)remove("test.db");
-
-    printf(GREEN "test_block_manager_cursor_has_next passed\n" RESET);
 }
 
 void test_block_manager_cursor_has_prev()
@@ -468,8 +449,6 @@ void test_block_manager_cursor_has_prev()
     (void)block_manager_cursor_free(cursor);
     ASSERT_TRUE(block_manager_close(bm) == 0);
     (void)remove("test.db");
-
-    printf(GREEN "test_block_manager_cursor_has_prev passed\n" RESET);
 }
 
 void test_block_manager_cursor_position_checks()
@@ -518,8 +497,6 @@ void test_block_manager_cursor_position_checks()
     (void)block_manager_cursor_free(cursor);
     ASSERT_TRUE(block_manager_close(bm) == 0);
     (void)remove("test.db");
-
-    printf(GREEN "test_block_manager_cursor_position_checks passed\n" RESET);
 }
 
 void test_block_manager_get_size()
@@ -558,8 +535,6 @@ void test_block_manager_get_size()
 
     ASSERT_TRUE(block_manager_close(bm) == 0);
     (void)remove("test.db");
-
-    printf(GREEN "test_block_manager_get_size passed\n" RESET);
 }
 
 void test_block_manager_seek_and_goto()
@@ -623,8 +598,6 @@ void test_block_manager_seek_and_goto()
 
     ASSERT_TRUE(block_manager_close(bm) == 0);
     (void)remove("test.db");
-
-    printf(GREEN "test_block_manager_seek_and_goto passed\n" RESET);
 }
 
 /** multithreaded tests */
@@ -825,14 +798,10 @@ void test_block_manager_concurrent_rw()
 
     ASSERT_TRUE(block_manager_close(bm) == 0);
     (void)remove("concurrent_test.db");
-
-    printf(GREEN "test_block_manager_concurrent_rw passed\n" RESET);
 }
 
 void test_block_manager_validate_last_block()
 {
-    printf("Testing block manager validation of last block...\n");
-
     /* first, create a block manager and write some valid blocks */
     block_manager_t *bm = NULL;
     ASSERT_TRUE(block_manager_open(&bm, "validate_test.db", BLOCK_MANAGER_SYNC_NONE) == 0);
@@ -921,14 +890,10 @@ void test_block_manager_validate_last_block()
     (void)block_manager_cursor_free(cursor);
     ASSERT_TRUE(block_manager_close(bm) == 0);
     remove("validate_test.db");
-
-    printf(GREEN "test_block_manager_validate_last_block passed\n" RESET);
 }
 
 void test_block_manager_validation_edge_cases()
 {
-    printf("Testing block manager validation edge cases...\n");
-
     block_manager_t *bm = NULL;
 
     /* opening a fresh empty database */
@@ -957,14 +922,10 @@ void test_block_manager_validation_edge_cases()
     }
 
     (void)remove("empty_test.db");
-
-    printf(GREEN "test_block_manager_validation_edge_cases passed\n" RESET);
 }
 
 void test_block_manager_open_safety()
 {
-    printf("Testing block manager open with very long path...\n");
-
     block_manager_t *bm = NULL;
 
     /* we create a path name that would exceed the buffer */
@@ -991,8 +952,6 @@ void test_block_manager_open_safety()
         ASSERT_TRUE(block_manager_close(bm) == 0);
         remove(long_path); /* try to remove, might fail */
     }
-
-    printf(GREEN "test_block_manager_open_safety passed\n" RESET);
 }
 
 /** benchmark tests */
@@ -1005,8 +964,6 @@ void test_block_manager_open_safety()
 
 void benchmark_block_manager()
 {
-    printf(BOLDWHITE "Running block manager benchmark...\n" RESET);
-
     block_manager_t *bm = NULL;
     ASSERT_TRUE(block_manager_open(&bm, "benchmark.db", BLOCK_MANAGER_SYNC_NONE) == 0);
 
@@ -1184,14 +1141,10 @@ void benchmark_block_manager()
 
     ASSERT_TRUE(block_manager_close(bm) == 0);
     (void)remove("benchmark.db");
-
-    printf(GREEN "benchmark_block_manager completed successfully\n" RESET);
 }
 
 void test_block_manager_lru_cache()
 {
-    printf("Testing block manager LRU cache functionality...\n");
-
     block_manager_t *bm = NULL;
 
     ASSERT_TRUE(
@@ -1316,13 +1269,10 @@ void test_block_manager_lru_cache()
     ASSERT_TRUE(block_manager_close(bm) == 0);
 
     (void)remove("cache_test.db");
-    printf(GREEN "test_block_manager_lru_cache passed\n" RESET);
 }
 
 void test_block_manager_lru_cache_edge_cases()
 {
-    printf("Testing block manager LRU cache edge cases...\n");
-
     block_manager_t *bm = NULL;
 
     /* zero  cache size (should work without caching) */
@@ -1491,14 +1441,10 @@ void test_block_manager_lru_cache_edge_cases()
     (void)block_manager_cursor_free(cursor);
     ASSERT_TRUE(block_manager_close(bm) == 0);
     (void)remove("edge_test.db");
-
-    printf(GREEN "test_block_manager_lru_cache_edge_cases passed\n" RESET);
 }
 
 void test_block_manager_cache_concurrent()
 {
-    printf("Testing block manager cache with concurrent access...\n");
-
     block_manager_t *bm = NULL;
     ASSERT_TRUE(block_manager_open_with_cache(&bm, "cache_concurrent_test.db",
                                               BLOCK_MANAGER_SYNC_NONE, 2048) == 0);
@@ -1597,14 +1543,10 @@ void test_block_manager_cache_concurrent()
 
     ASSERT_TRUE(block_manager_close(bm) == 0);
     (void)remove("cache_concurrent_test.db");
-
-    printf(GREEN "test_block_manager_cache_concurrent passed\n" RESET);
 }
 
 void benchmark_block_manager_with_cache()
 {
-    printf(BOLDWHITE "Running block manager benchmark with LRU cache...\n" RESET);
-
     block_manager_t *bm = NULL;
 
     uint32_t cache_size = 10 * 1024 * 1024;
@@ -1835,8 +1777,6 @@ void benchmark_block_manager_with_cache()
 
     ASSERT_TRUE(block_manager_close(bm) == 0);
     (void)remove("benchmark_cache.db");
-
-    printf(GREEN "benchmark_block_manager_with_cache completed successfully\n" RESET);
 }
 
 typedef struct
@@ -1876,8 +1816,6 @@ void *parallel_write_worker(void *arg)
 
 void test_block_manager_sync_modes()
 {
-    printf("testing block manager sync modes...\n");
-
     /* test SYNC_NONE */
     block_manager_t *bm_none = NULL;
     ASSERT_EQ(block_manager_open(&bm_none, "test_sync_none.db", BLOCK_MANAGER_SYNC_NONE), 0);
@@ -1903,14 +1841,10 @@ void test_block_manager_sync_modes()
     block_manager_block_free(block);
     block_manager_close(bm_full);
     remove("test_sync_full.db");
-
-    printf(GREEN "test_block_manager_sync_modes passed\n" RESET);
 }
 
 void test_block_manager_overflow_blocks()
 {
-    printf("testing block manager overflow blocks (>32KB)...\n");
-
     block_manager_t *bm = NULL;
     ASSERT_EQ(block_manager_open(&bm, "test_overflow.db", BLOCK_MANAGER_SYNC_NONE), 0);
 
@@ -1940,14 +1874,10 @@ void test_block_manager_overflow_blocks()
     block_manager_block_free(block);
     block_manager_close(bm);
     remove("test_overflow.db");
-
-    printf(GREEN "test_block_manager_overflow_blocks passed\n" RESET);
 }
 
 void test_block_manager_empty_block()
 {
-    printf("testing block manager empty block...\n");
-
     block_manager_t *bm = NULL;
     ASSERT_EQ(block_manager_open(&bm, "test_empty.db", BLOCK_MANAGER_SYNC_NONE), 0);
 
@@ -1977,14 +1907,10 @@ void test_block_manager_empty_block()
     block_manager_block_free(block);
     block_manager_close(bm);
     remove("test_empty.db");
-
-    printf(GREEN "test_block_manager_empty_block passed\n" RESET);
 }
 
 void benchmark_block_manager_parallel_write(void)
 {
-    printf("\nRunning block manager parallel write benchmark...\n");
-
     block_manager_t *bm = NULL;
     (void)remove("test_parallel.db");
     ASSERT_TRUE(block_manager_open_with_cache(&bm, "test_parallel.db", 0, 0) == 0);
@@ -2049,8 +1975,6 @@ void benchmark_block_manager_parallel_write(void)
 
     ASSERT_TRUE(block_manager_close(bm) == 0);
     (void)remove("test_parallel.db");
-
-    printf(GREEN "\nbenchmark_block_manager_parallel_write completed successfully\n" RESET);
 }
 
 int main(void)

--- a/test/bloom_filter__tests.c
+++ b/test/bloom_filter__tests.c
@@ -63,7 +63,6 @@ void test_bloom_filter_is_full()
     ASSERT_EQ(bloom_filter_is_full(bf), 0);
 
     (void)bloom_filter_free(bf);
-    printf(GREEN "test_bloom_filter_is_full passed\n" RESET);
 }
 
 void test_bloom_filter_serialize_deserialize()
@@ -98,8 +97,6 @@ void test_bloom_filter_serialize_deserialize()
     free(serialized_data);
     (void)bloom_filter_free(bf);
     (void)bloom_filter_free(deserialized_bf);
-
-    printf(GREEN "test_bloom_filter_serialize_deserialize passed\n" RESET);
 }
 
 void test_false_positive_rate()
@@ -137,7 +134,6 @@ void test_false_positive_rate()
     ASSERT_TRUE(fabs(actual_fp_rate - p) < 0.01);
 
     (void)bloom_filter_free(bf);
-    printf(GREEN "test_false_positive_rate passed\n" RESET);
 }
 
 void test_boundary_conditions()
@@ -164,8 +160,6 @@ void test_boundary_conditions()
     (void)bloom_filter_add(bf, (const uint8_t *)empty_key, strlen(empty_key));
     ASSERT_EQ(bloom_filter_contains(bf, (const uint8_t *)empty_key, strlen(empty_key)), 1);
     (void)bloom_filter_free(bf);
-
-    printf(GREEN "test_boundary_conditions passed\n" RESET);
 }
 
 void test_bloom_filter_edge_cases()
@@ -184,8 +178,6 @@ void test_bloom_filter_edge_cases()
     ASSERT_EQ(bloom_filter_contains(bf, large_key, sizeof(large_key)), 1);
 
     bloom_filter_free(bf);
-
-    printf(GREEN "test_bloom_filter_edge_cases passed\n" RESET);
 }
 
 void test_bloom_filter_boundary_values()
@@ -205,8 +197,6 @@ void test_bloom_filter_boundary_values()
     /** very low false positive rate (0.0001) */
     ASSERT_EQ(bloom_filter_new(&bf, 0.0001, 100), 0);
     bloom_filter_free(bf);
-
-    printf(GREEN "test_bloom_filter_boundary_values passed\n" RESET);
 }
 
 void test_bloom_filter_serialize_empty()
@@ -227,8 +217,6 @@ void test_bloom_filter_serialize_empty()
     free(data);
     bloom_filter_free(bf);
     bloom_filter_free(bf2);
-
-    printf(GREEN "test_bloom_filter_serialize_empty passed\n" RESET);
 }
 
 void test_bloom_filter_duplicate_keys()
@@ -245,8 +233,6 @@ void test_bloom_filter_duplicate_keys()
     ASSERT_EQ(bloom_filter_contains(bf, (uint8_t *)"duplicate", 9), 1);
 
     bloom_filter_free(bf);
-
-    printf(GREEN "test_bloom_filter_duplicate_keys passed\n" RESET);
 }
 
 void test_bloom_filter_invalid_inputs()
@@ -262,8 +248,6 @@ void test_bloom_filter_invalid_inputs()
     /* invalid n*/
     ASSERT_EQ(bloom_filter_new(&bf, 0.01, 0), -1);   /* n = 0 */
     ASSERT_EQ(bloom_filter_new(&bf, 0.01, -10), -1); /* negative n */
-
-    printf(GREEN "test_bloom_filter_invalid_inputs passed\n" RESET);
 }
 
 void test_bloom_filter_hash_distribution()
@@ -288,8 +272,6 @@ void test_bloom_filter_hash_distribution()
     }
 
     bloom_filter_free(bf);
-
-    printf(GREEN "test_bloom_filter_hash_distribution passed\n" RESET);
 }
 
 void test_bloom_filter_deserialize_corrupted()
@@ -312,8 +294,6 @@ void test_bloom_filter_deserialize_corrupted()
     free(data);
     bloom_filter_free(bf);
     if (bf2) bloom_filter_free(bf2);
-
-    printf(GREEN "test_bloom_filter_deserialize_corrupted passed\n" RESET);
 }
 
 void test_bloom_filter_binary_keys()
@@ -327,13 +307,11 @@ void test_bloom_filter_binary_keys()
     ASSERT_EQ(bloom_filter_contains(bf, binary_key, sizeof(binary_key)), 1);
 
     bloom_filter_free(bf);
-    printf(GREEN "test_bloom_filter_binary_keys passed\n" RESET);
 }
 
 void test_bloom_filter_free_null()
 {
     bloom_filter_free(NULL);
-    printf(GREEN "test_bloom_filter_free_null passed\n" RESET);
 }
 
 void benchmark_bloom_filter()

--- a/test/lru__tests.c
+++ b/test/lru__tests.c
@@ -440,8 +440,6 @@ void test_lru_cache_destroy_vs_free()
     lru_cache_put(cache2, "key2", &v2, test_evict_callback, NULL);
     lru_cache_free(cache2);
     ASSERT_EQ(eviction_count, 2);
-
-    printf(GREEN "test_lru_cache_destroy_vs_free passed\n" RESET);
 }
 
 void test_lru_cache_zero_capacity()
@@ -455,7 +453,6 @@ void test_lru_cache_zero_capacity()
         ASSERT_EQ(lru_cache_put(cache, "key", &v, NULL, NULL), -1);
         lru_cache_free(cache);
     }
-    printf(GREEN "test_lru_cache_zero_capacity passed\n" RESET);
 }
 
 void test_lru_cache_long_keys()
@@ -472,7 +469,6 @@ void test_lru_cache_long_keys()
     ASSERT_TRUE(lru_cache_get(cache, long_key) == &v);
 
     lru_cache_free(cache);
-    printf(GREEN "test_lru_cache_long_keys passed\n" RESET);
 }
 
 void test_lru_cache_empty_key()
@@ -484,7 +480,6 @@ void test_lru_cache_empty_key()
     ASSERT_TRUE(lru_cache_get(cache, "") == &v);
 
     lru_cache_free(cache);
-    printf(GREEN "test_lru_cache_empty_key passed\n" RESET);
 }
 
 void test_lru_cache_hash_collisions()
@@ -512,7 +507,6 @@ void test_lru_cache_hash_collisions()
     }
 
     lru_cache_free(cache);
-    printf(GREEN "test_lru_cache_hash_collisions passed\n" RESET);
 }
 
 void test_lru_cache_free_null()
@@ -520,7 +514,6 @@ void test_lru_cache_free_null()
     lru_cache_free(NULL);
     lru_cache_destroy(NULL);
     lru_cache_clear(NULL);
-    printf(GREEN "test_lru_cache_free_null passed\n" RESET);
 }
 
 int main(void)

--- a/test/queue__tests.c
+++ b/test/queue__tests.c
@@ -30,7 +30,6 @@ void test_queue_new(void)
     ASSERT_EQ(queue_size(queue), 0);
     ASSERT_EQ(queue_is_empty(queue), 1);
     queue_free(queue);
-    printf(GREEN "test_queue_new passed\n" RESET);
 }
 
 void test_queue_enqueue_dequeue(void)
@@ -72,7 +71,6 @@ void test_queue_enqueue_dequeue(void)
     ASSERT_TRUE(result4 == NULL);
 
     queue_free(queue);
-    printf(GREEN "test_queue_enqueue_dequeue passed\n" RESET);
 }
 
 void test_queue_peek(void)
@@ -103,7 +101,6 @@ void test_queue_peek(void)
     ASSERT_EQ(*peek3, 100);
 
     queue_free(queue);
-    printf(GREEN "test_queue_peek passed\n" RESET);
 }
 
 void test_queue_clear(void)
@@ -122,7 +119,6 @@ void test_queue_clear(void)
     ASSERT_EQ(queue_is_empty(queue), 1);
 
     queue_free(queue);
-    printf(GREEN "test_queue_clear passed\n" RESET);
 }
 
 void test_queue_with_strings(void)
@@ -151,7 +147,6 @@ void test_queue_with_strings(void)
     free(result3);
 
     queue_free(queue);
-    printf(GREEN "test_queue_with_strings passed\n" RESET);
 }
 
 void test_queue_free_with_data(void)
@@ -168,7 +163,6 @@ void test_queue_free_with_data(void)
     queue_enqueue(queue, str3);
 
     queue_free_with_data(queue, free);
-    printf(GREEN "test_queue_free_with_data passed\n" RESET);
 }
 
 typedef struct
@@ -281,7 +275,6 @@ void test_queue_threaded(void)
 
     pthread_mutex_destroy(&count_lock);
     queue_free(queue);
-    printf(GREEN "test_queue_threaded passed\n" RESET);
 }
 
 static void *blocking_consumer_thread(void *arg)
@@ -313,7 +306,6 @@ void test_queue_dequeue_wait(void)
     pthread_join(consumer, NULL);
 
     queue_free(queue);
-    printf(GREEN "test_queue_dequeue_wait passed\n" RESET);
 }
 
 void test_queue_large_volume(void)
@@ -342,7 +334,6 @@ void test_queue_large_volume(void)
 
     ASSERT_EQ(queue_is_empty(queue), 1);
     queue_free(queue);
-    printf(GREEN "test_queue_large_volume passed\n" RESET);
 }
 
 typedef struct
@@ -394,7 +385,6 @@ void test_queue_foreach(void)
     ASSERT_EQ(queue_foreach(NULL, sum_callback, &ctx), -1);
 
     queue_free(queue);
-    printf(GREEN "test_queue_foreach passed\n" RESET);
 }
 
 typedef struct cleanup_item_t
@@ -438,7 +428,6 @@ void test_queue_foreach_cleanup(void)
     /* clear the queue (items already freed by foreach) */
     queue_clear(queue);
     queue_free(queue);
-    printf(GREEN "test_queue_foreach_cleanup passed\n" RESET);
 }
 
 void test_queue_null_handling(void)
@@ -449,7 +438,6 @@ void test_queue_null_handling(void)
     ASSERT_EQ(queue_dequeue(NULL), NULL);
     queue_clear(NULL); /* should not crash */
     queue_free(NULL);  /* should not crash */
-    printf(GREEN "test_queue_null_handling passed\n" RESET);
 }
 
 void test_queue_peek_at(void)
@@ -484,7 +472,6 @@ void test_queue_peek_at(void)
     ASSERT_EQ(queue_peek_at(NULL, 0), NULL);
 
     queue_free(queue);
-    printf(GREEN "test_queue_peek_at passed\n" RESET);
 }
 
 typedef struct
@@ -544,7 +531,6 @@ void test_queue_free_with_waiting_threads(void)
     pthread_join(waiter, NULL);
 
     pthread_mutex_destroy(&start_lock);
-    printf(GREEN "test_queue_free_with_waiting_threads passed\n" RESET);
 }
 
 void test_queue_node_pool()
@@ -581,7 +567,6 @@ void test_queue_node_pool()
     ASSERT_EQ(queue_size(queue), 50);
 
     queue_free_with_data(queue, free);
-    printf(GREEN "test_queue_node_pool passed\n" RESET);
 }
 
 void *multi_waiter_thread(void *arg)
@@ -622,7 +607,6 @@ void test_queue_multiple_waiters()
 
     ASSERT_EQ(queue_size(queue), 0);
     queue_free(queue);
-    printf(GREEN "test_queue_multiple_waiters passed\n" RESET);
 }
 
 void test_queue_enqueue_null_data()
@@ -637,7 +621,6 @@ void test_queue_enqueue_null_data()
     ASSERT_EQ(data, NULL); /* NULL is valid data */
 
     queue_free(queue);
-    printf(GREEN "test_queue_enqueue_null_data passed\n" RESET);
 }
 
 void test_queue_is_empty()
@@ -654,7 +637,6 @@ void test_queue_is_empty()
     ASSERT_EQ(queue_is_empty(queue), 1);
 
     queue_free(queue);
-    printf(GREEN "test_queue_is_empty passed\n" RESET);
 }
 
 void test_queue_peek_at_boundary()
@@ -675,7 +657,6 @@ void test_queue_peek_at_boundary()
     ASSERT_EQ(queue_peek_at(queue, 100), NULL);     /* way out of bounds */
 
     queue_free(queue);
-    printf(GREEN "test_queue_peek_at_boundary passed\n" RESET);
 }
 
 void test_queue_foreach_empty()
@@ -689,7 +670,6 @@ void test_queue_foreach_empty()
     ASSERT_EQ(ctx.sum, 0);
 
     queue_free(queue);
-    printf(GREEN "test_queue_foreach_empty passed\n" RESET);
 }
 
 int main(void)

--- a/test/skip_list__tests.c
+++ b/test/skip_list__tests.c
@@ -41,7 +41,6 @@ void test_skip_list_create_node()
     ASSERT_TRUE(memcmp(NODE_VALUE(node), value, sizeof(value)) == 0);
     ASSERT_EQ(node->deleted, 0);
     skip_list_release_node(node);
-    printf(GREEN "test_skip_list_create_node passed\n" RESET);
 }
 
 void test_skip_list_put_get()
@@ -66,7 +65,6 @@ void test_skip_list_put_get()
 
     free(retrieved_value);
     skip_list_free(list);
-    printf(GREEN "test_skip_list_put_get passed\n" RESET);
 }
 
 void test_skip_list_destroy()
@@ -79,7 +77,6 @@ void test_skip_list_destroy()
     }
     int result = skip_list_free(list);
     ASSERT_EQ(result, 0);
-    printf(GREEN "test_skip_list_destroy passed\n" RESET);
 }
 
 void test_skip_list_clear()
@@ -97,7 +94,6 @@ void test_skip_list_clear()
     ASSERT_EQ(result, 0);
     ASSERT_TRUE(skip_list_count_entries(list) == 0);
     (void)skip_list_free(list);
-    printf(GREEN "test_skip_list_clear passed\n" RESET);
 }
 
 void test_skip_list_count_entries()
@@ -116,7 +112,6 @@ void test_skip_list_count_entries()
     ASSERT_TRUE(skip_list_count_entries(list) == 1);
 
     (void)skip_list_free(list);
-    printf(GREEN "test_skip_list_count_entries passed\n" RESET);
 }
 
 void test_skip_list_get_size()
@@ -135,7 +130,6 @@ void test_skip_list_get_size()
     ASSERT_TRUE(skip_list_get_size(list) > 0);
 
     (void)skip_list_free(list);
-    printf(GREEN "test_skip_list_get_size passed\n" RESET);
 }
 
 void test_skip_list_copy()
@@ -166,7 +160,6 @@ void test_skip_list_copy()
     free(retrieved_value);
     (void)skip_list_free(copy);
     (void)skip_list_free(list);
-    printf(GREEN "test_skip_list_copy passed\n" RESET);
 }
 
 void test_skip_list_cursor_init()
@@ -184,7 +177,6 @@ void test_skip_list_cursor_init()
 
     (void)skip_list_cursor_free(cursor);
     ASSERT_TRUE(skip_list_free(list) == 0);
-    printf(GREEN "test_skip_list_cursor_init passed\n" RESET);
 }
 
 void test_skip_list_cursor_next()
@@ -213,7 +205,6 @@ void test_skip_list_cursor_next()
 
     (void)skip_list_cursor_free(cursor);
     (void)skip_list_free(list);
-    printf(GREEN "test_skip_list_cursor_next passed\n" RESET);
 }
 
 void test_skip_list_cursor_prev()
@@ -243,7 +234,6 @@ void test_skip_list_cursor_prev()
 
     (void)skip_list_cursor_free(cursor);
     (void)skip_list_free(list);
-    printf(GREEN "test_skip_list_cursor_prev passed\n" RESET);
 }
 
 void benchmark_skip_list()
@@ -423,7 +413,6 @@ void test_skip_list_ttl()
 
     free(retrieved_value);
     (void)skip_list_free(list);
-    printf(GREEN "test_skip_list_ttl passed\n" RESET);
 }
 
 void test_skip_list_cursor_functions()
@@ -569,7 +558,6 @@ void test_skip_list_min_max_key()
     free(min_key);
 
     ASSERT_TRUE(skip_list_free(list) == 0);
-    printf(GREEN "test_skip_list_min_max_key passed\n" RESET);
 }
 
 void test_skip_list_cursor_seek()
@@ -632,7 +620,6 @@ void test_skip_list_cursor_seek()
 
     skip_list_cursor_free(cursor);
     ASSERT_TRUE(skip_list_free(list) == 0);
-    printf(GREEN "test_skip_list_cursor_seek passed\n" RESET);
 }
 
 void test_skip_list_cursor_seek_for_prev()
@@ -685,12 +672,10 @@ void test_skip_list_cursor_seek_for_prev()
 
     skip_list_cursor_free(cursor);
     ASSERT_TRUE(skip_list_free(list) == 0);
-    printf(GREEN "test_skip_list_cursor_seek_for_prev passed\n" RESET);
 }
 
 void test_skip_list_cow_updates()
 {
-    printf("Testing COW updates...\n");
     skip_list_t *list = NULL;
     ASSERT_EQ(skip_list_new(&list, 12, 0.25f), 0);
     ASSERT_TRUE(list != NULL);
@@ -717,7 +702,6 @@ void test_skip_list_cow_updates()
     }
 
     skip_list_free(list);
-    printf(GREEN "test_skip_list_cow_updates passed\n" RESET);
 }
 
 typedef struct
@@ -778,7 +762,6 @@ void *concurrent_writer(void *arg)
 
 void test_skip_list_concurrent_read_write()
 {
-    printf("Testing concurrent reads and writes (non-blocking)...\n");
     skip_list_t *list = NULL;
     ASSERT_EQ(skip_list_new(&list, 12, 0.25f), 0);
     ASSERT_TRUE(list != NULL);
@@ -846,13 +829,10 @@ void test_skip_list_concurrent_read_write()
     free(writer_ctx);
 
     skip_list_free(list);
-    printf(GREEN "test_skip_list_concurrent_read_write passed - readers never blocked!\n" RESET);
 }
 
 void test_skip_list_null_validation()
 {
-    printf("testing skip list null validation...\n");
-
     skip_list_t *list = NULL;
     ASSERT_EQ(skip_list_new(&list, 12, 0.25f), 0);
 
@@ -878,13 +858,10 @@ void test_skip_list_null_validation()
     ASSERT_EQ(skip_list_get(list, key, sizeof(key), &out_value, NULL, &deleted), -1);
 
     skip_list_free(list);
-    printf(GREEN "test_skip_list_null_validation passed\n" RESET);
 }
 
 void test_skip_list_zero_size_key()
 {
-    printf("testing skip list zero-size key...\n");
-
     skip_list_t *list = NULL;
     ASSERT_EQ(skip_list_new(&list, 12, 0.25f), 0);
 
@@ -895,13 +872,10 @@ void test_skip_list_zero_size_key()
     ASSERT_EQ(skip_list_put(list, key, 0, value, sizeof(value), -1), -1);
 
     skip_list_free(list);
-    printf(GREEN "test_skip_list_zero_size_key passed\n" RESET);
 }
 
 void test_skip_list_large_keys_values()
 {
-    printf("testing skip list large keys and values...\n");
-
     skip_list_t *list = NULL;
     ASSERT_EQ(skip_list_new(&list, 12, 0.25f), 0);
 
@@ -928,13 +902,10 @@ void test_skip_list_large_keys_values()
 
     free(retrieved_value);
     skip_list_free(list);
-    printf(GREEN "test_skip_list_large_keys_values passed\n" RESET);
 }
 
 void test_skip_list_duplicate_key_update()
 {
-    printf("testing skip list duplicate key update...\n");
-
     skip_list_t *list = NULL;
     ASSERT_EQ(skip_list_new(&list, 12, 0.25f), 0);
 
@@ -964,13 +935,10 @@ void test_skip_list_duplicate_key_update()
 
     free(retrieved_value);
     skip_list_free(list);
-    printf(GREEN "test_skip_list_duplicate_key_update passed\n" RESET);
 }
 
 void test_skip_list_delete_operations()
 {
-    printf("testing skip list delete operations...\n");
-
     skip_list_t *list = NULL;
     ASSERT_EQ(skip_list_new(&list, 12, 0.25f), 0);
 
@@ -1001,7 +969,6 @@ void test_skip_list_delete_operations()
     ASSERT_EQ(result, -1);
 
     skip_list_free(list);
-    printf(GREEN "test_skip_list_delete_operations passed\n" RESET);
 }
 
 int main(void)

--- a/test/succinct_trie__tests.c
+++ b/test/succinct_trie__tests.c
@@ -56,7 +56,6 @@ void test_disk_streaming_basic()
     ASSERT_EQ(succinct_trie_prefix_get(trie, (uint8_t *)"fig", 3, &value), -1);
 
     succinct_trie_free(trie);
-    printf(GREEN "test_disk_streaming_basic passed\n" RESET);
 }
 
 void test_disk_streaming_prefix_queries()
@@ -87,7 +86,6 @@ void test_disk_streaming_prefix_queries()
     ASSERT_EQ(value, 4); /* should find "toast" */
 
     succinct_trie_free(trie);
-    printf(GREEN "test_disk_streaming_prefix_queries passed\n" RESET);
 }
 
 void test_disk_streaming_sorted_order_validation()
@@ -103,7 +101,6 @@ void test_disk_streaming_sorted_order_validation()
     ASSERT_EQ(succinct_trie_builder_add(builder, (uint8_t *)"banana", 6, 2), -1);
 
     succinct_trie_builder_free(builder);
-    printf(GREEN "test_disk_streaming_sorted_order_validation passed\n" RESET);
 }
 
 void test_disk_streaming_large_dataset()
@@ -146,7 +143,6 @@ void test_disk_streaming_large_dataset()
     printf(YELLOW "Disk-streaming trie size: %.2f KB\n" RESET, trie_size / 1024.0);
 
     succinct_trie_free(trie);
-    printf(GREEN "test_disk_streaming_large_dataset passed\n" RESET);
 }
 
 void test_disk_streaming_common_prefix()
@@ -174,7 +170,6 @@ void test_disk_streaming_common_prefix()
     ASSERT_EQ(value, 1); /* should find first entry */
 
     succinct_trie_free(trie);
-    printf(GREEN "test_disk_streaming_common_prefix passed\n" RESET);
 }
 
 void test_disk_streaming_single_entry()
@@ -193,7 +188,6 @@ void test_disk_streaming_single_entry()
     ASSERT_EQ(value, 42);
 
     succinct_trie_free(trie);
-    printf(GREEN "test_disk_streaming_single_entry passed\n" RESET);
 }
 
 void test_disk_streaming_serialization()
@@ -229,7 +223,6 @@ void test_disk_streaming_serialization()
     free(serialized);
     succinct_trie_free(trie);
     succinct_trie_free(trie2);
-    printf(GREEN "test_disk_streaming_serialization passed\n" RESET);
 }
 
 void benchmark_succinct_trie()
@@ -281,8 +274,6 @@ void benchmark_succinct_trie()
     succinct_trie_free(trie);
     for (int i = 0; i < N; i++) free(keys[i]);
     free(keys);
-
-    printf(GREEN "benchmark_succinct_trie passed\n" RESET);
 }
 
 void test_succinct_trie_invalid_inputs()
@@ -311,8 +302,6 @@ void test_succinct_trie_invalid_inputs()
 
     /* succinct_trie_free with NULL */
     succinct_trie_free(NULL);
-
-    printf(GREEN "test_succinct_trie_invalid_inputs passed\n" RESET);
 }
 
 void test_succinct_trie_empty()
@@ -338,7 +327,6 @@ void test_succinct_trie_empty()
     free(data);
     succinct_trie_free(trie);
     succinct_trie_free(trie2);
-    printf(GREEN "test_succinct_trie_empty passed\n" RESET);
 }
 
 void test_succinct_trie_binary_keys()
@@ -362,7 +350,6 @@ void test_succinct_trie_binary_keys()
     ASSERT_EQ(val, 200);
 
     succinct_trie_free(trie);
-    printf(GREEN "test_succinct_trie_binary_keys passed\n" RESET);
 }
 
 void test_succinct_trie_duplicate_keys()
@@ -382,7 +369,6 @@ void test_succinct_trie_duplicate_keys()
     ASSERT_EQ(val, 100);
 
     succinct_trie_free(trie);
-    printf(GREEN "test_succinct_trie_duplicate_keys passed\n" RESET);
 }
 
 void test_succinct_trie_long_keys()
@@ -403,7 +389,6 @@ void test_succinct_trie_long_keys()
     ASSERT_EQ(val, 999);
 
     succinct_trie_free(trie);
-    printf(GREEN "test_succinct_trie_long_keys passed\n" RESET);
 }
 
 void test_succinct_trie_prefix_edge_cases()
@@ -428,7 +413,6 @@ void test_succinct_trie_prefix_edge_cases()
     ASSERT_EQ(val, 3);
 
     succinct_trie_free(trie);
-    printf(GREEN "test_succinct_trie_prefix_edge_cases passed\n" RESET);
 }
 
 void test_succinct_trie_deserialize_corrupted()
@@ -457,7 +441,6 @@ void test_succinct_trie_deserialize_corrupted()
     free(data);
     succinct_trie_free(trie);
     if (trie2) succinct_trie_free(trie2);
-    printf(GREEN "test_succinct_trie_deserialize_corrupted passed\n" RESET);
 }
 
 void benchmark_disk_streaming_vs_memory()
@@ -504,7 +487,7 @@ void benchmark_disk_streaming_vs_memory()
     end = clock();
     double mem_time = (double)(end - start) / CLOCKS_PER_SEC;
 
-    printf(CYAN "\n=== Performance Comparison (%d entries) ===\n" RESET, N);
+    printf(CYAN "\n*=== Performance Comparison (%d entries) ===*\n" RESET, N);
     printf(YELLOW "Disk streaming: %.3f seconds\n" RESET, disk_time);
     printf(YELLOW "Memory streaming: %.3f seconds\n" RESET, mem_time);
     printf(YELLOW "Disk/Memory ratio: %.2fx\n" RESET, disk_time / mem_time);
@@ -527,8 +510,6 @@ void benchmark_disk_streaming_vs_memory()
     succinct_trie_free(mem_trie);
     for (int i = 0; i < N; i++) free(keys[i]);
     free(keys);
-
-    printf(GREEN "benchmark_disk_streaming_vs_memory passed\n" RESET);
 }
 
 int main(void)

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -24,6 +24,12 @@
 #include "../src/compat.h" /* for PATH_SEPARATOR and platform compatibility */
 #include "test_macros.h"
 
+/* disable format-truncation warnings for test utilities. all path buffers use 1024 bytes */
+#ifndef _MSC_VER
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#endif
+
 #define TEST_DB_PATH "./test_tidesdb"
 
 /* ensure assertions work in both Debug and Release builds */
@@ -173,5 +179,9 @@ static inline void generate_random_key_value(uint8_t *key, size_t key_size, uint
         value[i] = (uint8_t)charset[rand() % (int)charset_size];
     }
 }
+
+#ifndef _MSC_VER
+#pragma GCC diagnostic pop
+#endif
 
 #endif /* TEST_UTILS_H */

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -817,9 +817,6 @@ static void test_many_sstables(void)
 
     tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "many_sst");
 
-    printf("\n  [Verification] Creating many SSTables... ");
-    fflush(stdout);
-
     int total_keys = 0;
     for (int batch = 0; batch < 10; batch++)
     {
@@ -900,9 +897,6 @@ static void test_backward_iteration(void)
 
     tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "backward_test");
 
-    printf("\n  [Verification] Testing backward iteration... ");
-    fflush(stdout);
-
     /* insert data in batches */
     int total_keys = 0;
     for (int batch = 0; batch < 10; batch++)
@@ -973,9 +967,6 @@ static void test_backward_iteration(void)
 
 static void test_crash_recovery(void)
 {
-    printf("\n  [Reliability] Testing crash recovery... ");
-    fflush(stdout);
-
     /* write data and close normally */
     {
         tidesdb_t *db = create_test_db();
@@ -1069,9 +1060,6 @@ static void test_background_compaction(void)
 
     tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "bg_compact");
 
-    printf("\n  [Background] Testing background compaction... ");
-    fflush(stdout);
-
     for (int i = 0; i < 100; i++)
     {
         tidesdb_txn_t *txn = NULL;
@@ -1121,9 +1109,6 @@ static void test_update_patterns(void)
     ASSERT_EQ(tidesdb_create_column_family(db, "updates", &cf_config), 0);
 
     tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "updates");
-
-    printf("\n  [Reliability] Testing update patterns... ");
-    fflush(stdout);
 
     /* write initial data */
     tidesdb_txn_t *txn1 = NULL;
@@ -1195,9 +1180,6 @@ static void test_delete_patterns(void)
 
     ASSERT_EQ(tidesdb_create_column_family(db, "deletes", &cf_config), 0);
     tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "deletes");
-
-    printf("\n  [Reliability] Testing delete patterns... ");
-    fflush(stdout);
 
     tidesdb_txn_t *txn1 = NULL;
     ASSERT_EQ(tidesdb_txn_begin(db, cf, &txn1), 0);
@@ -1355,9 +1337,6 @@ static void test_mixed_workload(void)
     ASSERT_EQ(tidesdb_create_column_family(db, "mixed", &cf_config), 0);
     tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "mixed");
 
-    printf("\n  [Verification] Testing mixed workload (put/get/delete/iterate)... ");
-    fflush(stdout);
-
     for (int round = 0; round < 10; round++)
     {
         tidesdb_txn_t *txn = NULL;
@@ -1443,9 +1422,6 @@ static void test_overflow_blocks(void)
 
     tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "overflow_cf");
 
-    printf("\n  [Edge Case] Testing overflow blocks for large values... ");
-    fflush(stdout);
-
     /* create value larger than MAX_INLINE_BLOCK_SIZE (32KB) */
     size_t large_size = 128 * 1024; /* 128KB */
     uint8_t *large_value = malloc(large_size);
@@ -1489,9 +1465,6 @@ static void test_empty_key_value(void)
 
     tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "empty_cf");
 
-    printf("\n  [Edge Case] Testing empty key and value handling... ");
-    fflush(stdout);
-
     tidesdb_txn_t *txn1 = NULL;
     ASSERT_EQ(tidesdb_txn_begin(db, cf, &txn1), 0);
     ASSERT_EQ(tidesdb_txn_put(txn1, (uint8_t *)"key_with_empty_val", 18, (uint8_t *)"", 0, -1), 0);
@@ -1525,9 +1498,6 @@ static void test_read_your_own_writes(void)
     ASSERT_EQ(tidesdb_create_column_family(db, "ryow_cf", &cf_config), 0);
 
     tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "ryow_cf");
-
-    printf("\n  [Transaction] Testing read-your-own-writes... ");
-    fflush(stdout);
 
     tidesdb_txn_t *txn = NULL;
     ASSERT_EQ(tidesdb_txn_begin(db, cf, &txn), 0);
@@ -1578,9 +1548,6 @@ static void test_compaction_tombstones(void)
     cf_config.enable_background_compaction = 0;
 
     ASSERT_EQ(tidesdb_create_column_family(db, "tombstone_cf", &cf_config), 0);
-
-    printf("\n  [Compaction] Testing compaction with tombstones... ");
-    fflush(stdout);
 
     tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "tombstone_cf");
     ASSERT_TRUE(cf != NULL);
@@ -1675,9 +1642,6 @@ static void test_iterator_expired_ttl(void)
 
     tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "ttl_iter_cf");
 
-    printf("\n  [Iterator] Testing iterator skips expired TTL entries... ");
-    fflush(stdout);
-
     tidesdb_txn_t *txn = NULL;
     ASSERT_EQ(tidesdb_txn_begin(db, cf, &txn), 0);
 
@@ -1753,9 +1717,6 @@ static void test_iterator_expired_ttl(void)
 
 static void test_wal_uncommitted_recovery(void)
 {
-    printf("\n  [WAL Recovery] Testing recovery with uncommitted data... ");
-    fflush(stdout);
-
     /* 1 write committed and uncommitted data */
     {
         tidesdb_t *db = create_test_db();
@@ -1826,9 +1787,6 @@ static void test_parallel_compaction(void)
 
     cf_config.compaction_threads = 4; /* enable parallel compaction with 4 threads */
     ASSERT_EQ(tidesdb_create_column_family(db, "parallel_cf", &cf_config), 0);
-
-    printf("\n  [Parallel Compaction] Testing parallel compaction with 4 threads... ");
-    fflush(stdout);
 
     /* get column family */
     tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "parallel_cf");
@@ -1920,9 +1878,6 @@ static void test_compaction_deduplication(void)
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     cf_config.compaction_threads = 0; /* single-threaded for deterministic behavior */
     ASSERT_EQ(tidesdb_create_column_family(db, "dedup_cf", &cf_config), 0);
-
-    printf("\n  [Compaction] Testing deduplication with overlapping keys... ");
-    fflush(stdout);
 
     tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "dedup_cf");
     ASSERT_TRUE(cf != NULL);
@@ -2054,9 +2009,6 @@ static void test_max_key_size(void)
 
     tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "maxkey_cf");
 
-    printf("\n  [Edge Case] Testing large key sizes... ");
-    fflush(stdout);
-
     size_t key_sizes[] = {100, 1024, 4096, 16384};
     int successful = 0;
 
@@ -2183,9 +2135,6 @@ static void test_true_concurrency(void)
 
     tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "concurrent_cf");
 
-    printf("\n  [Concurrency] Testing multi-threaded concurrent operations... ");
-    fflush(stdout);
-
     _Atomic(int) errors = 0;
 #define NUM_WRITER_THREADS 4
 #define NUM_READER_THREADS 4
@@ -2264,9 +2213,6 @@ static void test_true_concurrency(void)
 
 static void test_iterator_metadata_boundary(void)
 {
-    printf("\n  [Regression] Testing iterator metadata boundary... ");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     cf_config.memtable_flush_size = 2048; /* small to force flush */
@@ -2355,9 +2301,6 @@ static void test_iterator_metadata_boundary(void)
 
 static void test_sstable_num_entries_accuracy(void)
 {
-    printf("\n  [Regression] Testing SSTable num_entries accuracy... ");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     cf_config.memtable_flush_size = 1024;
@@ -2939,8 +2882,6 @@ static int test_linear_scan_fallback(void)
 
 static int test_column_family_config_persistence(void)
 {
-    printf("Testing column family config persistence and updates...\n");
-
     cleanup_test_dir();
 
     tidesdb_config_t db_config = {.db_path = TEST_DB_PATH};
@@ -3082,9 +3023,6 @@ static int test_column_family_config_persistence(void)
 
 static void test_iterator_seek(void)
 {
-    printf("Testing iterator seek functionality...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
 
@@ -3153,9 +3091,6 @@ static void test_iterator_seek(void)
 
 static void test_iterator_seek_range(void)
 {
-    printf("Testing iterator seek with range queries...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
 
@@ -3215,9 +3150,6 @@ static void test_iterator_seek_range(void)
 
 static void test_iterator_seek_prefix(void)
 {
-    printf("Testing iterator seek with prefix scan...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
 
@@ -3281,9 +3213,6 @@ static void test_iterator_seek_prefix(void)
 
 static void test_iterator_seek_large_sstable(void)
 {
-    printf("Testing iterator seek on large SSTable...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     cf_config.memtable_flush_size = 4096;
@@ -3353,9 +3282,6 @@ static void test_iterator_seek_large_sstable(void)
 
 static void test_iterator_seek_multi_source(void)
 {
-    printf("Testing iterator seek across multiple sources...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     cf_config.memtable_flush_size = 2048;
@@ -3526,9 +3452,6 @@ static void test_memory_safety(void)
 
 static void test_txn_write_write_serialization(void)
 {
-    printf("Testing transaction write-write serialization...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     ASSERT_EQ(tidesdb_create_column_family(db, "conflict_cf", &cf_config), 0);
@@ -3562,9 +3485,6 @@ static void test_txn_write_write_serialization(void)
 
 static void test_txn_read_your_own_deletes(void)
 {
-    printf("Testing transaction read-your-own-deletes...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     ASSERT_EQ(tidesdb_create_column_family(db, "delete_cf", &cf_config), 0);
@@ -3594,9 +3514,6 @@ static void test_txn_read_your_own_deletes(void)
 
 static void test_txn_rollback_no_side_effects(void)
 {
-    printf("Testing transaction rollback has no side effects...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     ASSERT_EQ(tidesdb_create_column_family(db, "rollback_cf", &cf_config), 0);
@@ -3633,9 +3550,6 @@ static void test_txn_rollback_no_side_effects(void)
 
 static void test_iterator_empty_column_family(void)
 {
-    printf("Testing iterator on empty column family...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     ASSERT_EQ(tidesdb_create_column_family(db, "empty_cf", &cf_config), 0);
@@ -3666,9 +3580,6 @@ static void test_iterator_empty_column_family(void)
 
 static void test_iterator_single_entry(void)
 {
-    printf("Testing iterator with single entry...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     ASSERT_EQ(tidesdb_create_column_family(db, "single_cf", &cf_config), 0);
@@ -3712,9 +3623,6 @@ static void test_iterator_single_entry(void)
 
 static void test_iterator_all_expired_ttl(void)
 {
-    printf("Testing iterator with all expired TTL entries...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     ASSERT_EQ(tidesdb_create_column_family(db, "expired_cf", &cf_config), 0);
@@ -3757,9 +3665,6 @@ static void test_iterator_all_expired_ttl(void)
 
 static void test_iterator_all_tombstones(void)
 {
-    printf("Testing iterator with all tombstones...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     ASSERT_EQ(tidesdb_create_column_family(db, "tombstone_cf", &cf_config), 0);
@@ -3808,9 +3713,6 @@ static void test_iterator_all_tombstones(void)
 
 static void test_iterator_seek_to_deleted_key(void)
 {
-    printf("Testing iterator seek to deleted key...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     ASSERT_EQ(tidesdb_create_column_family(db, "seek_del_cf", &cf_config), 0);
@@ -3855,9 +3757,6 @@ static void test_iterator_seek_to_deleted_key(void)
 
 static void test_iterator_direction_changes(void)
 {
-    printf("Testing iterator direction changes...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     ASSERT_EQ(tidesdb_create_column_family(db, "direction_cf", &cf_config), 0);
@@ -3911,9 +3810,6 @@ static void test_iterator_direction_changes(void)
 
 static void test_compaction_single_sstable(void)
 {
-    printf("Testing compaction with single SSTable...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     cf_config.memtable_flush_size = 2048;
@@ -3951,9 +3847,6 @@ static void test_compaction_single_sstable(void)
 
 static void test_compaction_all_expired(void)
 {
-    printf("Testing compaction with all expired entries...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     cf_config.memtable_flush_size = 2048;
@@ -4007,9 +3900,6 @@ static void test_compaction_all_expired(void)
 
 static void test_compaction_duplicate_keys(void)
 {
-    printf("Testing compaction with duplicate keys...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     cf_config.memtable_flush_size = 2048;
@@ -4066,9 +3956,6 @@ static void test_compaction_duplicate_keys(void)
 
 static void test_cf_independent_operations(void)
 {
-    printf("Testing column family independent operations...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     ASSERT_EQ(tidesdb_create_column_family(db, "cf1", &cf_config), 0);
@@ -4113,9 +4000,6 @@ static void test_cf_independent_operations(void)
 
 static void test_cf_name_limits(void)
 {
-    printf("Testing column family name limits...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
 
@@ -4137,9 +4021,6 @@ static void test_cf_name_limits(void)
 
 static void test_bloom_filter_disabled(void)
 {
-    printf("Testing with very high bloom filter FP rate...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     /* use very high FP rate (0.99) which effectively disables bloom filter usefulness */
@@ -4181,9 +4062,6 @@ static void test_bloom_filter_disabled(void)
 
 static void test_block_indexes_disabled(void)
 {
-    printf("Testing with block indexes disabled...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     cf_config.enable_block_indexes = 0;
@@ -4224,9 +4102,6 @@ static void test_block_indexes_disabled(void)
 
 static void test_compression_snappy(void)
 {
-    printf("Testing Snappy compression...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     cf_config.enable_compression = 1;
@@ -4273,9 +4148,6 @@ static void test_compression_snappy(void)
 
 static void test_compression_zstd(void)
 {
-    printf("Testing ZSTD compression...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     cf_config.enable_compression = 1;
@@ -4322,9 +4194,6 @@ static void test_compression_zstd(void)
 
 static void test_compression_none(void)
 {
-    printf("Testing no compression...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     cf_config.enable_compression = 0;
@@ -4365,9 +4234,6 @@ static void test_compression_none(void)
 
 static void test_comparator_string(void)
 {
-    printf("Testing string comparator...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     strncpy(cf_config.comparator_name, "string", TDB_MAX_COMPARATOR_NAME - 1);
@@ -4403,9 +4269,6 @@ static void test_comparator_string(void)
 
 static void test_comparator_numeric(void)
 {
-    printf("Testing numeric comparator...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     strncpy(cf_config.comparator_name, "numeric", TDB_MAX_COMPARATOR_NAME - 1);
@@ -4448,9 +4311,6 @@ static void test_comparator_numeric(void)
 
 static void test_wal_recovery_after_reopen(void)
 {
-    printf("Testing WAL recovery after database reopen...");
-    fflush(stdout);
-
     {
         tidesdb_t *db = create_test_db();
         tidesdb_column_family_config_t cf_config = get_test_cf_config();
@@ -4507,9 +4367,6 @@ static void test_wal_recovery_after_reopen(void)
 
 static void test_wal_with_multiple_memtables(void)
 {
-    printf("Testing WAL with multiple memtable rotations...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     cf_config.memtable_flush_size = 2048;
@@ -4633,9 +4490,6 @@ static void *concurrent_reader_thread(void *arg)
 
 static void test_concurrent_readers_writers(void)
 {
-    printf("Testing concurrent readers and writers...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     ASSERT_EQ(tidesdb_create_column_family(db, "concurrent_cf", &cf_config), 0);
@@ -4683,11 +4537,10 @@ static void test_concurrent_readers_writers(void)
     }
 
     int total_errors = atomic_load(&error_count);
-    ASSERT_TRUE(total_errors < 10);
+    ASSERT_TRUE(total_errors == 0);
 
     tidesdb_close(db);
     cleanup_test_dir();
-    printf("OK (errors: %d)\n", total_errors);
 
 #undef NUM_WRITERS
 #undef NUM_READERS
@@ -4696,9 +4549,6 @@ static void test_concurrent_readers_writers(void)
 
 static void test_concurrent_flush_and_read(void)
 {
-    printf("Testing concurrent flush and read operations...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     cf_config.memtable_flush_size = 4096;
@@ -4744,9 +4594,6 @@ static void test_concurrent_flush_and_read(void)
 
 static void test_no_deadlock_multiple_cfs(void)
 {
-    printf("Testing no deadlock with multiple column families...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     ASSERT_EQ(tidesdb_create_column_family(db, "cf_a", &cf_config), 0);
@@ -4805,9 +4652,6 @@ static void test_no_deadlock_multiple_cfs(void)
 
 static void test_invalid_column_family_operations(void)
 {
-    printf("Testing column family operations validation...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     ASSERT_EQ(tidesdb_create_column_family(db, "valid_cf", &cf_config), 0);
@@ -4839,9 +4683,6 @@ static void test_invalid_column_family_operations(void)
 
 static void test_null_pointer_handling(void)
 {
-    printf("Testing null pointer handling...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     ASSERT_EQ(tidesdb_create_column_family(db, "null_test_cf", &cf_config), 0);
@@ -4860,9 +4701,6 @@ static void test_null_pointer_handling(void)
 
 static void test_zero_length_keys_values(void)
 {
-    printf("Testing zero-length keys and values...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     ASSERT_EQ(tidesdb_create_column_family(db, "zero_len_cf", &cf_config), 0);
@@ -4895,9 +4733,6 @@ static void test_zero_length_keys_values(void)
 
 static void test_invalid_ttl_values(void)
 {
-    printf("Testing invalid TTL values...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     ASSERT_EQ(tidesdb_create_column_family(db, "ttl_test_cf", &cf_config), 0);
@@ -4929,9 +4764,6 @@ static void test_invalid_ttl_values(void)
 
 static void test_transaction_after_close(void)
 {
-    printf("Testing transaction operations after close...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     ASSERT_EQ(tidesdb_create_column_family(db, "close_test_cf", &cf_config), 0);
@@ -4949,9 +4781,6 @@ static void test_transaction_after_close(void)
 
 static void test_iterator_invalid_operations(void)
 {
-    printf("Testing iterator invalid operations...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     ASSERT_EQ(tidesdb_create_column_family(db, "iter_invalid_cf", &cf_config), 0);
@@ -4984,9 +4813,6 @@ static void test_iterator_invalid_operations(void)
 
 static void test_config_validation(void)
 {
-    printf("Testing column family config validation...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
 
@@ -5025,9 +4851,6 @@ static void test_config_validation(void)
 
 static void test_large_batch_operations(void)
 {
-    printf("Testing large batch operations...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     ASSERT_EQ(tidesdb_create_column_family(db, "batch_cf", &cf_config), 0);
@@ -5066,9 +4889,6 @@ static void test_large_batch_operations(void)
 
 static void test_special_characters_in_keys(void)
 {
-    printf("Testing special characters in keys...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     ASSERT_EQ(tidesdb_create_column_family(db, "special_cf", &cf_config), 0);
@@ -5108,10 +4928,6 @@ static void test_special_characters_in_keys(void)
 
 static void test_read_committed_isolation(void)
 {
-    /* we test READ COMMITTED isolation -- read transactions see latest committed data */
-    printf("\n  [Isolation] Testing READ COMMITTED isolation... ");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
     tidesdb_create_column_family(db, "data", &cf_config);
@@ -5159,8 +4975,6 @@ static void test_read_committed_isolation(void)
     ASSERT_EQ(tidesdb_txn_get(read_txn, (uint8_t *)key, strlen(key), &value, &value_size), 0);
     ASSERT_TRUE(strncmp((char *)value, "v2_", 3) == 0);
     free(value);
-
-    printf("OK (read transaction sees latest committed data)\n");
 
     tidesdb_txn_free(read_txn);
     tidesdb_close(db);
@@ -5291,10 +5105,6 @@ static void test_block_cache_eviction_under_pressure(void)
 
 static void test_wal_corruption_detection(void)
 {
-    /* test that corrupted WAL is detected and handled */
-    printf("\n  [Reliability] Testing WAL corruption detection... ");
-    fflush(stdout);
-
     {
         tidesdb_t *db = create_test_db();
         tidesdb_column_family_config_t cf_config = get_test_cf_config();
@@ -5445,16 +5255,12 @@ static void test_parallel_compaction_race(void)
 
     pthread_join(compact_thread, NULL);
 
-    printf("OK (no races during parallel compaction)\n");
     tidesdb_close(db);
     cleanup_test_dir();
 }
 
 static void test_memtable_flush_size_enforcement(void)
 {
-    printf("Testing memtable_flush_size enforcement with multiple WAL files...");
-    fflush(stdout);
-
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = get_test_cf_config();
 
@@ -5529,17 +5335,12 @@ static void test_memtable_flush_size_enforcement(void)
     /* we should have at least 2 sstables if memtable_flush_size is working */
     ASSERT_TRUE(num_sstables >= 2);
 
-    printf("OK (memtable_flush_size properly enforced)\n");
-
     tidesdb_close(db);
     cleanup_test_dir();
 }
 
 static void test_iterator_all_sources(void)
 {
-    printf("Running: test_iterator_all_sources... ");
-    fflush(stdout);
-
     const char *db_path = "./test_tidesdb";
     remove_directory(db_path);
 
@@ -5650,15 +5451,10 @@ static void test_iterator_all_sources(void)
 
     tidesdb_close(db);
     remove_directory(db_path);
-
-    printf("OK\n");
 }
 
 static void test_default_comparator_persistence(void)
 {
-    printf("Testing default comparator name persistence...");
-    fflush(stdout);
-
     /* create CF without specifying comparator (should default to memcmp) */
     {
         tidesdb_t *db = create_test_db();
@@ -5733,6 +5529,420 @@ static void test_default_comparator_persistence(void)
         tidesdb_close(db);
     }
 
+    cleanup_test_dir();
+}
+
+static void test_comparator_registry_edge_cases(void)
+{
+    ASSERT_EQ(tidesdb_register_comparator("test_comp", skip_list_comparator_memcmp), 0);
+    ASSERT_EQ(tidesdb_register_comparator("test_comp", skip_list_comparator_string), 0);
+
+    /* verify it was overwritten */
+    skip_list_comparator_fn fn = tidesdb_get_comparator("test_comp");
+    ASSERT_TRUE(fn == skip_list_comparator_string);
+
+    /* test NULL name */
+    ASSERT_NE(tidesdb_register_comparator(NULL, skip_list_comparator_memcmp), 0);
+
+    /* test NULL function */
+    ASSERT_NE(tidesdb_register_comparator("null_fn", NULL), 0);
+
+    /* test get non-existent comparator */
+    fn = tidesdb_get_comparator("nonexistent_comparator_xyz");
+    ASSERT_TRUE(fn == NULL);
+
+    /* test built-in comparators exist */
+    ASSERT_TRUE(tidesdb_get_comparator("memcmp") != NULL);
+    ASSERT_TRUE(tidesdb_get_comparator("string") != NULL);
+    ASSERT_TRUE(tidesdb_get_comparator("numeric") != NULL);
+}
+
+static void test_iterator_boundary_seeks(void)
+{
+    tidesdb_t *db = create_test_db();
+    tidesdb_column_family_config_t cf_config = get_test_cf_config();
+    ASSERT_EQ(tidesdb_create_column_family(db, "seek_boundary_cf", &cf_config), 0);
+    tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "seek_boundary_cf");
+
+    tidesdb_txn_t *txn = NULL;
+    ASSERT_EQ(tidesdb_txn_begin(db, cf, &txn), 0);
+    ASSERT_EQ(tidesdb_txn_put(txn, (uint8_t *)"key1", 4, (uint8_t *)"val1", 4, -1), 0);
+    ASSERT_EQ(tidesdb_txn_put(txn, (uint8_t *)"key3", 4, (uint8_t *)"val3", 4, -1), 0);
+    ASSERT_EQ(tidesdb_txn_put(txn, (uint8_t *)"key5", 4, (uint8_t *)"val5", 4, -1), 0);
+    ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+    tidesdb_txn_free(txn);
+
+    tidesdb_txn_t *read_txn = NULL;
+    ASSERT_EQ(tidesdb_txn_begin_read(db, cf, &read_txn), 0);
+    tidesdb_iter_t *iter = NULL;
+    ASSERT_EQ(tidesdb_iter_new(read_txn, &iter), 0);
+
+    /* seek to key between existing keys (should land on next key) */
+    ASSERT_EQ(tidesdb_iter_seek(iter, (uint8_t *)"key2", 4), 0);
+    ASSERT_EQ(tidesdb_iter_valid(iter), 1);
+
+    /* verify we're at key3 by checking via next operation */
+    ASSERT_EQ(tidesdb_iter_next(iter), 0);
+    ASSERT_EQ(tidesdb_iter_valid(iter), 1); /* should now be at key5 */
+
+    /* seek_for_prev to key between existing keys (should land on prev key) */
+    ASSERT_EQ(tidesdb_iter_seek_for_prev(iter, (uint8_t *)"key4", 4), 0);
+    ASSERT_EQ(tidesdb_iter_valid(iter), 1);
+
+    /* verify we're at key3 by checking via prev operation */
+    ASSERT_EQ(tidesdb_iter_prev(iter), 0);
+    ASSERT_EQ(tidesdb_iter_valid(iter), 1); /* should now be at key1 */
+
+    /* multiple seeks without next/prev */
+    ASSERT_EQ(tidesdb_iter_seek(iter, (uint8_t *)"key1", 4), 0);
+    ASSERT_EQ(tidesdb_iter_seek(iter, (uint8_t *)"key5", 4), 0);
+    ASSERT_EQ(tidesdb_iter_seek(iter, (uint8_t *)"key3", 4), 0);
+    ASSERT_EQ(tidesdb_iter_valid(iter), 1);
+
+    tidesdb_iter_free(iter);
+    tidesdb_txn_free(read_txn);
+    tidesdb_close(db);
+    cleanup_test_dir();
+}
+
+static void test_transaction_state_validation(void)
+{
+    tidesdb_t *db = create_test_db();
+    tidesdb_column_family_config_t cf_config = get_test_cf_config();
+    ASSERT_EQ(tidesdb_create_column_family(db, "txn_state_cf", &cf_config), 0);
+    tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "txn_state_cf");
+
+    tidesdb_txn_t *txn = NULL;
+    ASSERT_EQ(tidesdb_txn_begin(db, cf, &txn), 0);
+    ASSERT_EQ(tidesdb_txn_put(txn, (uint8_t *)"key1", 4, (uint8_t *)"val1", 4, -1), 0);
+
+    ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+
+    /* operations after commit should fail */
+    int result = tidesdb_txn_put(txn, (uint8_t *)"key2", 4, (uint8_t *)"val2", 4, -1);
+    ASSERT_NE(result, 0); /* should fail */
+
+    result = tidesdb_txn_commit(txn);
+    ASSERT_NE(result, 0); /* double commit should fail */
+
+    tidesdb_txn_free(txn);
+
+    /* test rollback then commit */
+    ASSERT_EQ(tidesdb_txn_begin(db, cf, &txn), 0);
+    ASSERT_EQ(tidesdb_txn_put(txn, (uint8_t *)"key3", 4, (uint8_t *)"val3", 4, -1), 0);
+    ASSERT_EQ(tidesdb_txn_rollback(txn), 0);
+
+    result = tidesdb_txn_commit(txn);
+    ASSERT_NE(result, 0); /* commit after rollback should fail */
+
+    tidesdb_txn_free(txn);
+
+    /* test multiple rollbacks */
+    ASSERT_EQ(tidesdb_txn_begin(db, cf, &txn), 0);
+    ASSERT_EQ(tidesdb_txn_put(txn, (uint8_t *)"key4", 4, (uint8_t *)"val4", 4, -1), 0);
+    ASSERT_EQ(tidesdb_txn_rollback(txn), 0);
+
+    result = tidesdb_txn_rollback(txn);
+    ASSERT_NE(result, 0); /* double rollback should fail */
+
+    tidesdb_txn_free(txn);
+
+    tidesdb_close(db);
+    cleanup_test_dir();
+}
+
+static void test_memtable_flush_threshold_boundary(void)
+{
+    tidesdb_t *db = create_test_db();
+    tidesdb_column_family_config_t cf_config = get_test_cf_config();
+    cf_config.memtable_flush_size = 1024;
+    ASSERT_EQ(tidesdb_create_column_family(db, "flush_threshold_cf", &cf_config), 0);
+    tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "flush_threshold_cf");
+
+    tidesdb_txn_t *txn = NULL;
+    ASSERT_EQ(tidesdb_txn_begin(db, cf, &txn), 0);
+
+    /* insert data to approach threshold */
+    size_t total_size = 0;
+    int key_num = 0;
+    while (total_size < 900) /* approach but don't exceed */
+    {
+        char key[32];
+        char value[64];
+        snprintf(key, sizeof(key), "key_%d", key_num);
+        snprintf(value, sizeof(value), "value_%d", key_num);
+        ASSERT_EQ(
+            tidesdb_txn_put(txn, (uint8_t *)key, strlen(key), (uint8_t *)value, strlen(value), -1),
+            0);
+        total_size += strlen(key) + strlen(value) + TDB_KV_HEADER_SIZE;
+        key_num++;
+    }
+
+    ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+    tidesdb_txn_free(txn);
+
+    /* record initial sst count */
+    int num_ssts_before = atomic_load(&cf->num_sstables);
+
+    /* now push over the threshold with a large value */
+    ASSERT_EQ(tidesdb_txn_begin(db, cf, &txn), 0);
+    char large_value[256];
+    memset(large_value, 'X', sizeof(large_value));
+    ASSERT_EQ(tidesdb_txn_put(txn, (uint8_t *)"trigger_key", 11, (uint8_t *)large_value,
+                              sizeof(large_value), -1),
+              0);
+    ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+    tidesdb_txn_free(txn);
+
+    /* wait for flush to complete */
+    usleep(500000);
+
+    /* verify flush occurred, sstable count should have increased */
+    int num_ssts_after = atomic_load(&cf->num_sstables);
+    ASSERT_TRUE(num_ssts_after > num_ssts_before);
+
+    tidesdb_close(db);
+    cleanup_test_dir();
+}
+
+static void test_prefix_seek_multi_source(void)
+{
+    tidesdb_t *db = create_test_db();
+    tidesdb_column_family_config_t cf_config = get_test_cf_config();
+    cf_config.memtable_flush_size = 512; /* small threshold to create multiple SSTables */
+    ASSERT_EQ(tidesdb_create_column_family(db, "prefix_seek_cf", &cf_config), 0);
+    tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "prefix_seek_cf");
+
+    /* insert keys with different prefixes across multiple batches to create SSTables */
+    /* batch 1 user_* keys (will become sst 0) */
+    tidesdb_txn_t *txn = NULL;
+    ASSERT_EQ(tidesdb_txn_begin(db, cf, &txn), 0);
+    for (int i = 0; i < 10; i++)
+    {
+        char key[32];
+        char value[32];
+        snprintf(key, sizeof(key), "user_%03d", i);
+        snprintf(value, sizeof(value), "user_value_%d", i);
+        ASSERT_EQ(
+            tidesdb_txn_put(txn, (uint8_t *)key, strlen(key), (uint8_t *)value, strlen(value), -1),
+            0);
+    }
+    ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+    tidesdb_txn_free(txn);
+    ASSERT_EQ(tidesdb_flush_memtable(cf), 0);
+
+    /* batch 2 product_* keys (will become sst 1) */
+    ASSERT_EQ(tidesdb_txn_begin(db, cf, &txn), 0);
+    for (int i = 0; i < 10; i++)
+    {
+        char key[32];
+        char value[32];
+        snprintf(key, sizeof(key), "product_%03d", i);
+        snprintf(value, sizeof(value), "product_value_%d", i);
+        ASSERT_EQ(
+            tidesdb_txn_put(txn, (uint8_t *)key, strlen(key), (uint8_t *)value, strlen(value), -1),
+            0);
+    }
+    ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+    tidesdb_txn_free(txn);
+    ASSERT_EQ(tidesdb_flush_memtable(cf), 0);
+
+    /* batch 3 order_* keys (will become sst 2) */
+    ASSERT_EQ(tidesdb_txn_begin(db, cf, &txn), 0);
+    for (int i = 0; i < 10; i++)
+    {
+        char key[32];
+        char value[32];
+        snprintf(key, sizeof(key), "order_%03d", i);
+        snprintf(value, sizeof(value), "order_value_%d", i);
+        ASSERT_EQ(
+            tidesdb_txn_put(txn, (uint8_t *)key, strlen(key), (uint8_t *)value, strlen(value), -1),
+            0);
+    }
+    ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+    tidesdb_txn_free(txn);
+    ASSERT_EQ(tidesdb_flush_memtable(cf), 0);
+
+    /* batch 4 session_* keys (will be in immutable memtable,trigger flush but dont wait) */
+    ASSERT_EQ(tidesdb_txn_begin(db, cf, &txn), 0);
+    for (int i = 0; i < 8; i++)
+    {
+        char key[32];
+        char value[32];
+        snprintf(key, sizeof(key), "session_%03d", i);
+        snprintf(value, sizeof(value), "session_value_%d", i);
+        ASSERT_EQ(
+            tidesdb_txn_put(txn, (uint8_t *)key, strlen(key), (uint8_t *)value, strlen(value), -1),
+            0);
+    }
+    ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+    tidesdb_txn_free(txn);
+    ASSERT_EQ(tidesdb_flush_memtable(cf), 0);
+
+    /* batch 5 cache_* keys (will be in active memtable) */
+    ASSERT_EQ(tidesdb_txn_begin(db, cf, &txn), 0);
+    for (int i = 0; i < 5; i++)
+    {
+        char key[32];
+        char value[32];
+        snprintf(key, sizeof(key), "cache_%03d", i);
+        snprintf(value, sizeof(value), "cache_value_%d", i);
+        ASSERT_EQ(
+            tidesdb_txn_put(txn, (uint8_t *)key, strlen(key), (uint8_t *)value, strlen(value), -1),
+            0);
+    }
+    ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+    tidesdb_txn_free(txn);
+
+    usleep(1000000);
+
+    /* verify we have multiple sstables */
+    int num_ssts = atomic_load(&cf->num_sstables);
+    ASSERT_TRUE(num_ssts >= 3);
+
+    /* now perform prefix seeks across all sources */
+    tidesdb_txn_t *read_txn = NULL;
+    ASSERT_EQ(tidesdb_txn_begin_read(db, cf, &read_txn), 0);
+    tidesdb_iter_t *iter = NULL;
+    ASSERT_EQ(tidesdb_iter_new(read_txn, &iter), 0);
+
+    /* seek to "user_" prefix (in sst 0) */
+    ASSERT_EQ(tidesdb_iter_seek(iter, (uint8_t *)"user_", 5), 0);
+    int user_count = 0;
+    while (tidesdb_iter_valid(iter))
+    {
+        uint8_t *key = NULL;
+        size_t key_size = 0;
+        ASSERT_EQ(tidesdb_iter_key(iter, &key, &key_size), 0);
+
+        if (key_size >= 5 && memcmp(key, "user_", 5) == 0)
+        {
+            user_count++;
+            if (tidesdb_iter_next(iter) != 0) break;
+        }
+        else
+        {
+            break;
+        }
+    }
+    ASSERT_EQ(user_count, 10);
+
+    /* seek to "product_" prefix (in sst 1) */
+    ASSERT_EQ(tidesdb_iter_seek(iter, (uint8_t *)"product_", 8), 0);
+    int product_count = 0;
+    while (tidesdb_iter_valid(iter))
+    {
+        uint8_t *key = NULL;
+        size_t key_size = 0;
+        ASSERT_EQ(tidesdb_iter_key(iter, &key, &key_size), 0);
+
+        if (key_size >= 8 && memcmp(key, "product_", 8) == 0)
+        {
+            product_count++;
+            if (tidesdb_iter_next(iter) != 0) break;
+        }
+        else
+        {
+            break;
+        }
+    }
+    ASSERT_EQ(product_count, 10);
+
+    /* seek to "session_" prefix (in immutable memtable) */
+    ASSERT_EQ(tidesdb_iter_seek(iter, (uint8_t *)"session_", 8), 0);
+    int session_count = 0;
+    while (tidesdb_iter_valid(iter))
+    {
+        uint8_t *key = NULL;
+        size_t key_size = 0;
+        ASSERT_EQ(tidesdb_iter_key(iter, &key, &key_size), 0);
+
+        if (key_size >= 8 && memcmp(key, "session_", 8) == 0)
+        {
+            session_count++;
+            if (tidesdb_iter_next(iter) != 0) break;
+        }
+        else
+        {
+            break;
+        }
+    }
+    ASSERT_EQ(session_count, 8);
+
+    /* seek to "cache_" prefix (in active memtable) */
+    ASSERT_EQ(tidesdb_iter_seek(iter, (uint8_t *)"cache_", 6), 0);
+    int cache_count = 0;
+    while (tidesdb_iter_valid(iter))
+    {
+        uint8_t *key = NULL;
+        size_t key_size = 0;
+        ASSERT_EQ(tidesdb_iter_key(iter, &key, &key_size), 0);
+
+        if (key_size >= 6 && memcmp(key, "cache_", 6) == 0)
+        {
+            cache_count++;
+            if (tidesdb_iter_next(iter) != 0) break;
+        }
+        else
+        {
+            break;
+        }
+    }
+    ASSERT_EQ(cache_count, 5);
+
+    /*  seek to non-existent prefix (beyond all keys) */
+    int seek_result = tidesdb_iter_seek(iter, (uint8_t *)"zzz_", 4);
+    /* seek may return 0 (positioned at end) or error.**/
+    if (seek_result == 0)
+    {
+        ASSERT_EQ(tidesdb_iter_valid(iter), 0);
+    }
+
+    tidesdb_iter_free(iter);
+    tidesdb_txn_free(read_txn);
+    tidesdb_close(db);
+    cleanup_test_dir();
+}
+
+static void test_compact_single_sstable(void)
+{
+    tidesdb_t *db = create_test_db();
+    tidesdb_column_family_config_t cf_config = get_test_cf_config();
+    ASSERT_EQ(tidesdb_create_column_family(db, "single_sst_cf", &cf_config), 0);
+    tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "single_sst_cf");
+
+    /* create single sstable **/
+    tidesdb_txn_t *txn = NULL;
+    ASSERT_EQ(tidesdb_txn_begin(db, cf, &txn), 0);
+    for (int i = 0; i < 10; i++)
+    {
+        char key[32];
+        char value[32];
+        snprintf(key, sizeof(key), "key%d", i);
+        snprintf(value, sizeof(value), "value%d", i);
+        ASSERT_EQ(
+            tidesdb_txn_put(txn, (uint8_t *)key, strlen(key), (uint8_t *)value, strlen(value), -1),
+            0);
+    }
+    ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+    tidesdb_txn_free(txn);
+
+    ASSERT_EQ(tidesdb_flush_memtable(cf), 0);
+    usleep(200000);
+
+    int num_ssts_before = atomic_load(&cf->num_sstables);
+    ASSERT_EQ(num_ssts_before, 1);
+
+    /* compaction with single sst should succeed but do nothing */
+    int result = tidesdb_compact(cf);
+    /* implementation may return 0 (success/noop) or error */
+    (void)result;
+
+    int num_ssts_after = atomic_load(&cf->num_sstables);
+    /* should still have 1 sst (no merge possible) */
+    ASSERT_EQ(num_ssts_after, 1);
+
+    tidesdb_close(db);
     cleanup_test_dir();
 }
 
@@ -5837,6 +6047,12 @@ int main(void)
     RUN_TEST(test_memtable_flush_size_enforcement, tests_passed);
     RUN_TEST(test_default_comparator_persistence, tests_passed);
     RUN_TEST(test_iterator_all_sources, tests_passed);
+    RUN_TEST(test_comparator_registry_edge_cases, tests_passed);
+    RUN_TEST(test_iterator_boundary_seeks, tests_passed);
+    RUN_TEST(test_transaction_state_validation, tests_passed);
+    RUN_TEST(test_memtable_flush_threshold_boundary, tests_passed);
+    RUN_TEST(test_compact_single_sstable, tests_passed);
+    RUN_TEST(test_prefix_seek_multi_source, tests_passed);
 
     PRINT_TEST_RESULTS(tests_passed, tests_failed);
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tidesdb",
-  "version-string": "3.1.3",
+  "version-string": "3.1.4",
   "description": "TidesDB is a high-performance durable, transactional embeddable storage engine designed for flash and RAM optimization.",
   "dependencies": [
     "zstd",


### PR DESCRIPTION
…istent RUN_TEST and PRINT_TEST_RESULTS macros, bringing the testing framework in line with modern practices introduced post-beta.  Added edge case coverage for parallel compaction scenarios and multi-source prefix seeking operations, ensuring correct behavior when iterating across active memtables, immutable memtables, and sstables simultaneously.  Suppressed format-truncation warnings in test_utils.h by applying file-level pragma directives, as all path buffers use safe 1024-byte fixed allocations that are sufficient for typical filesystem paths.  Removed unused compat.h include from tidesdb.h and cleaned up minor formatting inconsistencies. Version bumped to 3.1.4.