### PR TITLE
Fix Memory Leak in queue_free_with_data

### DIFF
--- a/src/queue.c
+++ b/src/queue.c
@@ -383,6 +383,14 @@ void queue_free_with_data(queue_t *queue, void (*free_fn)(void *))
         current = next;
     }
 
+    current = queue->node_pool;
+    while (current != NULL)
+    {
+        queue_node_t *next = current->next;
+        free(current);
+        current = next;
+    }
+
     queue->head = NULL;
     queue->tail = NULL;
     queue->size = 0;

--- a/test/queue__tests.c
+++ b/test/queue__tests.c
@@ -162,6 +162,9 @@ void test_queue_free_with_data(void)
     queue_enqueue(queue, str2);
     queue_enqueue(queue, str3);
 
+    char *item1 = (char *)queue_dequeue(queue);
+    free(item1);
+
     queue_free_with_data(queue, free);
 }
 


### PR DESCRIPTION
The `queue_free_with_data` function was leaking memory from the node pool.

In this case, I have dequeued an element. This allows the node to be returned to the node pool, and when `queue_free_with_data` is called, the node pool is not freed.
<img width="1360" height="680" alt="Screenshot from 2025-11-20 14-19-49" src="https://github.com/user-attachments/assets/de252706-4c01-487e-a9d4-7c9f7859771e" />

And here is the fix.
<img width="1360" height="680" alt="Screenshot from 2025-11-20 14-20-59" src="https://github.com/user-attachments/assets/9a1da587-2705-44cd-9a5f-8d1cb810b8d1" />

