### PR TITLE
compat.h: fix for 10.5 ppc64

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -1439,10 +1439,10 @@ static inline size_t get_available_memory(void)
 
     mach_port = mach_host_self();
 
-    /* use 32-bit vm statistics on PPC 32-bit regardless of OS version
-     * host_statistics64 is not available on PPC 32-bit even on 10.6+ */
-#if defined(__ppc__) || defined(__ppc)
-    /* PPC 32-bit always uses 32-bit vm statistics */
+    /* use 32-bit vm statistics on PPC regardless of OS version.
+     * host_statistics64 is not available on 10.5 and for PPC 32-bit even on 10.6 */
+#if defined(__ppc__) || (MAC_OS_X_VERSION_MIN_REQUIRED < 1060)
+    /* PPC always uses 32-bit vm statistics */
     vm_statistics_data_t vm_stats;
     count = HOST_VM_INFO_COUNT;
     if (host_page_size(mach_port, &page_size) == KERN_SUCCESS &&


### PR DESCRIPTION
Fixes the build error on ppc64:
```
[  3%] Building C object CMakeFiles/tidesdb.dir/src/block_manager.c.o
/opt/local/bin/gcc-mp-14 -Dtidesdb_EXPORTS -I/opt/local/var/macports/build/tidesdb-96d82b06/work/tidesdb-6.0.0/external -I/opt/local/var/macports/build/tidesdb-96d82b06/work/tidesdb-6.0.0/src -I/opt/local/include -pipe -Os -DNDEBUG -isystem/opt/local/include/LegacySupport -I/opt/local/include -std=gnu11 -arch ppc64 -mmacosx-version-min=10.5 -fPIC -Wno-psabi -MD -MT CMakeFiles/tidesdb.dir/src/block_manager.c.o -MF CMakeFiles/tidesdb.dir/src/block_manager.c.o.d -o CMakeFiles/tidesdb.dir/src/block_manager.c.o -c /opt/local/var/macports/build/tidesdb-96d82b06/work/tidesdb-6.0.0/src/block_manager.c
[  6%] Building C object CMakeFiles/tidesdb.dir/src/tidesdb.c.o
/opt/local/bin/gcc-mp-14 -Dtidesdb_EXPORTS -I/opt/local/var/macports/build/tidesdb-96d82b06/work/tidesdb-6.0.0/external -I/opt/local/var/macports/build/tidesdb-96d82b06/work/tidesdb-6.0.0/src -I/opt/local/include -pipe -Os -DNDEBUG -isystem/opt/local/include/LegacySupport -I/opt/local/include -std=gnu11 -arch ppc64 -mmacosx-version-min=10.5 -fPIC -Wno-psabi -MD -MT CMakeFiles/tidesdb.dir/src/tidesdb.c.o -MF CMakeFiles/tidesdb.dir/src/tidesdb.c.o.d -o CMakeFiles/tidesdb.dir/src/tidesdb.c.o -c /opt/local/var/macports/build/tidesdb-96d82b06/work/tidesdb-6.0.0/src/tidesdb.c
In file included from /opt/local/var/macports/build/tidesdb-96d82b06/work/tidesdb-6.0.0/src/block_manager.h:21,
                 from /opt/local/var/macports/build/tidesdb-96d82b06/work/tidesdb-6.0.0/src/tidesdb.h:22,
                 from /opt/local/var/macports/build/tidesdb-96d82b06/work/tidesdb-6.0.0/src/tidesdb.c:19:
/opt/local/var/macports/build/tidesdb-96d82b06/work/tidesdb-6.0.0/src/compat.h: In function 'get_available_memory':
In file included from /opt/local/var/macports/build/tidesdb-96d82b06/work/tidesdb-6.0.0/src/block_manager.h:21,
                 from /opt/local/var/macports/build/tidesdb-96d82b06/work/tidesdb-6.0.0/src/block_manager.c:19:
/opt/local/var/macports/build/tidesdb-96d82b06/work/tidesdb-6.0.0/src/compat.h: In function 'get_available_memory':
/opt/local/var/macports/build/tidesdb-96d82b06/work/tidesdb-6.0.0/src/compat.h:1316:5: error: unknown type name 'vm_statistics64_data_t'; did you mean 'vm_statistics_data_t'?
 1316 |     vm_statistics64_data_t vm_stats64;
      |     ^~~~~~~~~~~~~~~~~~~~~~
      |     vm_statistics_data_t
/opt/local/var/macports/build/tidesdb-96d82b06/work/tidesdb-6.0.0/src/compat.h:1316:5: error: unknown type name 'vm_statistics64_data_t'; did you mean 'vm_statistics_data_t'?
 1316 |     vm_statistics64_data_t vm_stats64;
      |     ^~~~~~~~~~~~~~~~~~~~~~
      |     vm_statistics_data_t
/opt/local/var/macports/build/tidesdb-96d82b06/work/tidesdb-6.0.0/src/compat.h:1319:9: error: implicit declaration of function 'host_statistics64'; did you mean 'host_statistics'? [-Wimplicit-function-declaration]
 1319 |         host_statistics64(mach_port, HOST_VM_INFO, (host_info64_t)&vm_stats64, &count) ==
      |         ^~~~~~~~~~~~~~~~~
      |         host_statistics
/opt/local/var/macports/build/tidesdb-96d82b06/work/tidesdb-6.0.0/src/compat.h:1319:9: error: implicit declaration of function 'host_statistics64'; did you mean 'host_statistics'? [-Wimplicit-function-declaration]
 1319 |         host_statistics64(mach_port, HOST_VM_INFO, (host_info64_t)&vm_stats64, &count) ==
      |         ^~~~~~~~~~~~~~~~~
      |         host_statistics
/opt/local/var/macports/build/tidesdb-96d82b06/work/tidesdb-6.0.0/src/compat.h:1319:53: error: 'host_info64_t' undeclared (first use in this function); did you mean 'host_info_t'?
 1319 |         host_statistics64(mach_port, HOST_VM_INFO, (host_info64_t)&vm_stats64, &count) ==
      |                                                     ^~~~~~~~~~~~~
      |                                                     host_info_t
/opt/local/var/macports/build/tidesdb-96d82b06/work/tidesdb-6.0.0/src/compat.h:1319:53: note: each undeclared identifier is reported only once for each function it appears in
/opt/local/var/macports/build/tidesdb-96d82b06/work/tidesdb-6.0.0/src/compat.h:1319:53: error: 'host_info64_t' undeclared (first use in this function); did you mean 'host_info_t'?
 1319 |         host_statistics64(mach_port, HOST_VM_INFO, (host_info64_t)&vm_stats64, &count) ==
      |                                                     ^~~~~~~~~~~~~
      |                                                     host_info_t
/opt/local/var/macports/build/tidesdb-96d82b06/work/tidesdb-6.0.0/src/compat.h:1319:53: note: each undeclared identifier is reported only once for each function it appears in
/opt/local/var/macports/build/tidesdb-96d82b06/work/tidesdb-6.0.0/src/compat.h:1322:35: error: request for member 'free_count' in something not a structure or union
 1322 |         return (size_t)(vm_stats64.free_count * page_size);
      |                                   ^
/opt/local/var/macports/build/tidesdb-96d82b06/work/tidesdb-6.0.0/src/compat.h:1322:35: error: request for member 'free_count' in something not a structure or union
 1322 |         return (size_t)(vm_stats64.free_count * page_size);
      |                                   ^
make[2]: *** [CMakeFiles/tidesdb.dir/src/block_manager.c.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: *** [CMakeFiles/tidesdb.dir/src/tidesdb.c.o] Error 1
make[2]: Leaving directory `/opt/local/var/macports/build/tidesdb-96d82b06/work/build'
make[1]: *** [CMakeFiles/tidesdb.dir/all] Error 2
make[1]: Leaving directory `/opt/local/var/macports/build/tidesdb-96d82b06/work/build'
make: *** [all] Error 2
```
Adjust comments accordingly and drop `__ppc` which is not used on Apple (this is inside macOS-specific block, we do not care about other systems here).