### PR TITLE
TidesDB 7 PATCH (v7.0.3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.25)
 project(tidesdb C)
 
 set(CMAKE_C_STANDARD 11)
-set(PROJECT_VERSION 7.0.2)
+set(PROJECT_VERSION 7.0.3)
 
 configure_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/src/tidesdb_version.h.in"

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -9793,6 +9793,216 @@ static void test_wal_commit_shutdown_recovery(void)
     cleanup_test_dir();
 }
 
+static void test_iterator_seek_after_reopen_bloom_indexes_disabled(void)
+{
+    /* case for issue #490 */
+    cleanup_test_dir();
+
+    const char *keys[] = {"foo", "foobar", "foobaz"};
+    const char *values[] = {"value1", "value2", "value3"};
+    const int num_keys = 3;
+
+    {
+        tidesdb_config_t config = tidesdb_default_config();
+        config.db_path = TEST_DB_PATH;
+
+        tidesdb_t *db = NULL;
+        ASSERT_EQ(tidesdb_open(&config, &db), 0);
+        ASSERT_TRUE(db != NULL);
+
+        tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
+        cf_config.enable_bloom_filter = 0;
+        cf_config.enable_block_indexes = 0;
+
+        ASSERT_EQ(tidesdb_create_column_family(db, "test_cf", &cf_config), 0);
+
+        ASSERT_EQ(tidesdb_close(db), 0);
+    }
+
+    for (int i = 0; i < num_keys; i++)
+    {
+        tidesdb_config_t config = tidesdb_default_config();
+        config.db_path = TEST_DB_PATH;
+
+        tidesdb_t *db = NULL;
+        ASSERT_EQ(tidesdb_open(&config, &db), 0);
+        ASSERT_TRUE(db != NULL);
+
+        tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "test_cf");
+        ASSERT_TRUE(cf != NULL);
+
+        tidesdb_txn_t *txn = NULL;
+        ASSERT_EQ(tidesdb_txn_begin(db, &txn), 0);
+
+        ASSERT_EQ(tidesdb_txn_put(txn, cf, (uint8_t *)keys[i], strlen(keys[i]) + 1,
+                                  (uint8_t *)values[i], strlen(values[i]) + 1, 0),
+                  0);
+        ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+        tidesdb_txn_free(txn);
+
+        ASSERT_EQ(tidesdb_close(db), 0);
+    }
+
+    {
+        tidesdb_config_t config = tidesdb_default_config();
+        config.db_path = TEST_DB_PATH;
+
+        tidesdb_t *db = NULL;
+        ASSERT_EQ(tidesdb_open(&config, &db), 0);
+        ASSERT_TRUE(db != NULL);
+
+        tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "test_cf");
+        ASSERT_TRUE(cf != NULL);
+
+        tidesdb_txn_t *txn = NULL;
+        ASSERT_EQ(tidesdb_txn_begin(db, &txn), 0);
+
+        tidesdb_iter_t *iter = NULL;
+        ASSERT_EQ(tidesdb_iter_new(txn, cf, &iter), 0);
+
+        ASSERT_EQ(tidesdb_iter_seek_to_first(iter), 0);
+        ASSERT_TRUE(tidesdb_iter_valid(iter));
+
+        int total_count = 0;
+        while (tidesdb_iter_valid(iter))
+        {
+            total_count++;
+            tidesdb_iter_next(iter);
+        }
+        ASSERT_EQ(total_count, num_keys);
+
+        const char *seek_key = "foo";
+        int seek_result = tidesdb_iter_seek(iter, (uint8_t *)seek_key, strlen(seek_key) + 1);
+        ASSERT_EQ(seek_result, 0);
+        ASSERT_TRUE(tidesdb_iter_valid(iter));
+
+        int count = 0;
+        while (tidesdb_iter_valid(iter))
+        {
+            uint8_t *key = NULL;
+            size_t key_size = 0;
+            ASSERT_EQ(tidesdb_iter_key(iter, &key, &key_size), 0);
+            ASSERT_TRUE(key != NULL);
+
+            count++;
+            tidesdb_iter_next(iter);
+        }
+
+        ASSERT_EQ(count, num_keys);
+
+        tidesdb_iter_free(iter);
+        tidesdb_txn_free(txn);
+        ASSERT_EQ(tidesdb_close(db), 0);
+    }
+
+    cleanup_test_dir();
+}
+
+static void test_iterator_seek_after_reopen(void)
+{
+    /* case for issue #490 */
+    cleanup_test_dir();
+
+    const char *keys[] = {"foo", "foobar", "foobaz"};
+    const char *values[] = {"value1", "value2", "value3"};
+    const int num_keys = 3;
+
+    {
+        tidesdb_config_t config = tidesdb_default_config();
+        config.db_path = TEST_DB_PATH;
+
+        tidesdb_t *db = NULL;
+        ASSERT_EQ(tidesdb_open(&config, &db), 0);
+        ASSERT_TRUE(db != NULL);
+
+        tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
+        cf_config.enable_bloom_filter = 1;
+        cf_config.enable_block_indexes = 1;
+
+        ASSERT_EQ(tidesdb_create_column_family(db, "test_cf", &cf_config), 0);
+
+        ASSERT_EQ(tidesdb_close(db), 0);
+    }
+
+    for (int i = 0; i < num_keys; i++)
+    {
+        tidesdb_config_t config = tidesdb_default_config();
+        config.db_path = TEST_DB_PATH;
+
+        tidesdb_t *db = NULL;
+        ASSERT_EQ(tidesdb_open(&config, &db), 0);
+        ASSERT_TRUE(db != NULL);
+
+        tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "test_cf");
+        ASSERT_TRUE(cf != NULL);
+
+        tidesdb_txn_t *txn = NULL;
+        ASSERT_EQ(tidesdb_txn_begin(db, &txn), 0);
+
+        ASSERT_EQ(tidesdb_txn_put(txn, cf, (uint8_t *)keys[i], strlen(keys[i]) + 1,
+                                  (uint8_t *)values[i], strlen(values[i]) + 1, 0),
+                  0);
+        ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+        tidesdb_txn_free(txn);
+
+        ASSERT_EQ(tidesdb_close(db), 0);
+    }
+
+    {
+        tidesdb_config_t config = tidesdb_default_config();
+        config.db_path = TEST_DB_PATH;
+
+        tidesdb_t *db = NULL;
+        ASSERT_EQ(tidesdb_open(&config, &db), 0);
+        ASSERT_TRUE(db != NULL);
+
+        tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "test_cf");
+        ASSERT_TRUE(cf != NULL);
+
+        tidesdb_txn_t *txn = NULL;
+        ASSERT_EQ(tidesdb_txn_begin(db, &txn), 0);
+
+        tidesdb_iter_t *iter = NULL;
+        ASSERT_EQ(tidesdb_iter_new(txn, cf, &iter), 0);
+
+        ASSERT_EQ(tidesdb_iter_seek_to_first(iter), 0);
+        ASSERT_TRUE(tidesdb_iter_valid(iter));
+
+        int total_count = 0;
+        while (tidesdb_iter_valid(iter))
+        {
+            total_count++;
+            tidesdb_iter_next(iter);
+        }
+        ASSERT_EQ(total_count, num_keys);
+
+        const char *seek_key = "foo";
+        int seek_result = tidesdb_iter_seek(iter, (uint8_t *)seek_key, strlen(seek_key) + 1);
+        ASSERT_EQ(seek_result, 0);
+        ASSERT_TRUE(tidesdb_iter_valid(iter));
+
+        int count = 0;
+        while (tidesdb_iter_valid(iter))
+        {
+            uint8_t *key = NULL;
+            size_t key_size = 0;
+            ASSERT_EQ(tidesdb_iter_key(iter, &key, &key_size), 0);
+            ASSERT_TRUE(key != NULL);
+
+            count++;
+            tidesdb_iter_next(iter);
+        }
+
+        ASSERT_EQ(count, num_keys);
+
+        tidesdb_iter_free(iter);
+        tidesdb_txn_free(txn);
+        ASSERT_EQ(tidesdb_close(db), 0);
+    }
+
+    cleanup_test_dir();
+}
+
 int main(void)
 {
     cleanup_test_dir();
@@ -9955,6 +10165,8 @@ int main(void)
     RUN_TEST(test_basic_open_close, tests_passed);
     RUN_TEST(test_multiple_databases_concurrent_operations, tests_passed);
     RUN_TEST(test_wal_commit_shutdown_recovery, tests_passed);
+    RUN_TEST(test_iterator_seek_after_reopen_bloom_indexes_disabled, tests_passed);
+    RUN_TEST(test_iterator_seek_after_reopen, tests_passed);
 
     PRINT_TEST_RESULTS(tests_passed, tests_failed);
     return tests_failed > 0 ? 1 : 0;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tidesdb",
-  "version-string": "7.0.2",
+  "version-string": "7.0.3",
   "description": "TidesDB is a high-performance durable, transactional embeddable storage engine designed for flash and RAM optimization.",
   "dependencies": [
     "zstd",


### PR DESCRIPTION
… identified a couple issues wit the seek iteration, 1 we shouldn't be using a bloom on seek iteration, the defeats purpose, we just want to get closet to the approximate key. also the seek early exit was incorrect and has been adjusted.  with that i've also implemented 2 more cases for the edge cases identified test_iterator_seek_after_reopen_bloom_indexes_disabled,test_iterator_seek_after_reopen