### PR TITLE
tidesdb_iter_seek_for_prev bug correction, the seek iterators do not …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.25)
 project(tidesdb C)
 
 set(CMAKE_C_STANDARD 11)
-set(PROJECT_VERSION 7.0.4)
+set(PROJECT_VERSION 7.0.5)
 
 configure_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/src/tidesdb_version.h.in"

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -13700,15 +13700,6 @@ int tidesdb_iter_seek_for_prev(tidesdb_iter_t *iter, const uint8_t *key, size_t 
             tidesdb_sstable_t *sst = source->source.sstable.sst;
             block_manager_cursor_t *cursor = source->source.sstable.klog_cursor;
 
-            if (sst->bloom_filter)
-            {
-                if (!bloom_filter_contains(sst->bloom_filter, key, key_size))
-                {
-                    /* key definitely not in this sst, skip it */
-                    continue;
-                }
-            }
-
             /* clean up previous state */
             if (source->source.sstable.current_rc_block)
             {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tidesdb",
-  "version-string": "7.0.4",
+  "version-string": "7.0.5",
   "description": "TidesDB is a high-performance durable, transactional embeddable storage engine designed for flash and RAM optimization.",
   "dependencies": [
     "zstd",


### PR DESCRIPTION
…need to utilize bloom filters, this was flawed logic with that i've written 2 more tests to assure this logic is now correct, these tests helped me trace the issue in the first place, good thing.  new core tests test_iterator_seek_for_prev_after_reopen,test_iterator_seek_for_prev_after_reopen_indexes