### PR TITLE
corrected windows rename issue by adding a cross-platform atomic_rena…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 project(tidesdb C)
 
 set(CMAKE_C_STANDARD 11)
-set(PROJECT_VERSION 8.1.1)
+set(PROJECT_VERSION 8.1.2)
 
 configure_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/src/tidesdb_version.h.in"

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tidesdb",
-  "version-string": "8.1.1",
+  "version-string": "8.1.2",
   "description": "TidesDB is a high-performance durable, transactional embeddable storage engine designed for flash and RAM optimization.",
   "dependencies": [
     "zstd",


### PR DESCRIPTION
…me_dir helper that uses movefileex on windows, updating column family rename logic to detect existing destination directories before renaming, and replacing all rename and rollback rename calls with the atomic helper to prevent failures when the target directory already exists