### PR TITLE
TidesDB 8 PATCH (v8.6.2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 project(tidesdb C)
 
 set(CMAKE_C_STANDARD 11)
-set(PROJECT_VERSION 8.6.1)
+set(PROJECT_VERSION 8.6.2)
 
 configure_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/src/tidesdb_version.h.in"

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tidesdb",
-  "version-string": "8.6.1",
+  "version-string": "8.6.2",
   "description": "TidesDB is a high-performance durable, transactional embeddable storage engine designed for flash and RAM optimization.",
   "dependencies": [
     "zstd",


### PR DESCRIPTION
patch correction get_available_memory to report actual reclaimable memory on macos and linux

on macos, only vm free_count pages were counted which is typically 1-5% of total ram because macos aggressively moves pages to inactive/purgeable for file cache. this caused the os memory safety net to falsely trigger critical pressure on any loaded system, permanently blocking writes in the backpressure stall loop. now includes inactive_count and purgeable_count alongside free_count in all three macos code paths (ppc 32-bit, 64-bit, and 32-bit fallback).

on linux, sysinfo.freeram was used which only reports truly free pages, not reclaimable buffers/cache/slab. replaced with /proc/meminfo memavailable which is the kernel's own estimate of memory available without swapping. falls back to sysinfo.freeram if /proc/meminfo is unavailable.

this patches a bug where users loading large datasets would hit os memory critically low errors and the system would never recover because the os never raises free page count above 5% of total under load.