### PR TITLE
TidesDB 8 PATCH (v8.9.4)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 project(tidesdb C)
 
 set(CMAKE_C_STANDARD 11)
-set(PROJECT_VERSION 8.9.3)
+set(PROJECT_VERSION 8.9.4)
 
 configure_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/src/tidesdb_version.h.in"

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -16528,46 +16528,79 @@ int tidesdb_txn_get(tidesdb_txn_t *txn, tidesdb_column_family_t *cf, const uint8
             tidesdb_immutable_memtable_unref(umt);
         }
 
-        /* search unified immutable memtables (newest first) */
+        /* we search unified immutable memtables (newest first).
+         * we snapshot pointers under a single rwlock acquisition to avoid
+         * per-element locking overhead. */
         if (txn->db->unified_mt.immutables)
         {
             const size_t uimm_count = queue_size(txn->db->unified_mt.immutables);
-            for (size_t qi = uimm_count; qi > 0; qi--)
+            if (uimm_count > 0)
             {
-                tidesdb_memtable_t *imm_mt =
-                    (tidesdb_memtable_t *)queue_peek_at(txn->db->unified_mt.immutables, qi - 1);
-                if (!imm_mt || !imm_mt->skip_list) continue;
-                if (atomic_load_explicit(&imm_mt->flushed, memory_order_acquire)) continue;
-
-                int mr = skip_list_get_with_seq_ref(
-                    imm_mt->skip_list, prefixed_key, pk_size, &temp_val, &temp_val_size, &ttl_u,
-                    &deleted_u, &found_seq_u, snapshot_seq, visibility_check,
-                    visibility_check ? txn->db->commit_status : NULL);
-                if (mr == 0)
+                /* we snapshot immutable pointers under one lock */
+                tidesdb_memtable_t *uimm_stack[16];
+                tidesdb_memtable_t **uimm_ptrs = uimm_stack;
+                if (uimm_count > 16)
                 {
-                    if (deleted_u)
+                    uimm_ptrs = malloc(uimm_count * sizeof(tidesdb_memtable_t *));
+                    if (!uimm_ptrs) uimm_ptrs = uimm_stack;
+                }
+
+                size_t snap_count = 0;
+                queue_t *uq = txn->db->unified_mt.immutables;
+                pthread_rwlock_rdlock(&uq->read_lock);
+                {
+                    queue_node_t *cur = uq->head->next;
+                    size_t max = (uimm_ptrs == uimm_stack) ? 16 : uimm_count;
+                    for (size_t i = 0; i < max && cur != NULL; i++, cur = cur->next)
                     {
-                        unified_rc = TDB_ERR_NOT_FOUND;
-                        goto unified_memtable_done;
+                        uimm_ptrs[i] = (tidesdb_memtable_t *)cur->data;
+                        snap_count++;
                     }
-                    if (ttl_u <= 0 || ttl_u > now_u)
+                }
+                pthread_rwlock_unlock(&uq->read_lock);
+
+                /* we search snapshot lock-free (newest first) */
+                for (size_t qi = snap_count; qi > 0; qi--)
+                {
+                    tidesdb_memtable_t *imm_mt = uimm_ptrs[qi - 1];
+                    if (!imm_mt || !imm_mt->skip_list) continue;
+                    if (atomic_load_explicit(&imm_mt->flushed, memory_order_acquire)) continue;
+
+                    int mr = skip_list_get_with_seq_ref(
+                        imm_mt->skip_list, prefixed_key, pk_size, &temp_val, &temp_val_size, &ttl_u,
+                        &deleted_u, &found_seq_u, snapshot_seq, visibility_check,
+                        visibility_check ? txn->db->commit_status : NULL);
+                    if (mr == 0)
                     {
-                        *value = malloc(temp_val_size);
-                        if (!*value)
+                        if (deleted_u)
                         {
-                            unified_rc = TDB_ERR_MEMORY;
+                            unified_rc = TDB_ERR_NOT_FOUND;
+                            if (uimm_ptrs != uimm_stack) free(uimm_ptrs);
                             goto unified_memtable_done;
                         }
-                        memcpy(*value, temp_val, temp_val_size);
-                        *value_size = temp_val_size;
-                        PROFILE_INC(txn->db, immutable_hits);
-                        tidesdb_txn_add_to_read_set(txn, cf, key, key_size, found_seq_u);
-                        unified_rc = TDB_SUCCESS;
+                        if (ttl_u <= 0 || ttl_u > now_u)
+                        {
+                            *value = malloc(temp_val_size);
+                            if (!*value)
+                            {
+                                unified_rc = TDB_ERR_MEMORY;
+                                if (uimm_ptrs != uimm_stack) free(uimm_ptrs);
+                                goto unified_memtable_done;
+                            }
+                            memcpy(*value, temp_val, temp_val_size);
+                            *value_size = temp_val_size;
+                            PROFILE_INC(txn->db, immutable_hits);
+                            tidesdb_txn_add_to_read_set(txn, cf, key, key_size, found_seq_u);
+                            unified_rc = TDB_SUCCESS;
+                            if (uimm_ptrs != uimm_stack) free(uimm_ptrs);
+                            goto unified_memtable_done;
+                        }
+                        unified_rc = TDB_ERR_NOT_FOUND;
+                        if (uimm_ptrs != uimm_stack) free(uimm_ptrs);
                         goto unified_memtable_done;
                     }
-                    unified_rc = TDB_ERR_NOT_FOUND;
-                    goto unified_memtable_done;
                 }
+                if (uimm_ptrs != uimm_stack) free(uimm_ptrs);
             }
         }
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tidesdb",
-  "version-string": "8.9.3",
+  "version-string": "8.9.4",
   "description": "TidesDB is a high-performance durable, transactional embeddable storage engine designed for flash and RAM optimization.",
   "dependencies": [
     "zstd",


### PR DESCRIPTION
unified immutable memtable search lock contention fix in tidesdb_txn_get. replaced the per element queue_peek_at loop that acquired and released pthread_rwlock_rdlock on every immutable memtable, n lock round trips per point lookup, with a single rwlock acquisition that snapshots all immutable pointers into a stack local array, then searches the snapshot lock free in reverse order. uses a 16 element stack buffer to avoid heap allocation for the common case, falling back to malloc for larger queues. this eliminates the rwlock cache line bouncing across n concurrent reader threads that was consuming lots of cpu in read only workloads, improving read only workloads