### PR TITLE
TidesDB 9 PATCH (v9.0.5)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 project(tidesdb C)
 
 set(CMAKE_C_STANDARD 11)
-set(PROJECT_VERSION 9.0.4)
+set(PROJECT_VERSION 9.0.5)
 
 configure_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/src/tidesdb_version.h.in"

--- a/src/btree.c
+++ b/src/btree.c
@@ -179,6 +179,42 @@ btree_arena_t *btree_arena_create(void)
     return arena;
 }
 
+btree_arena_t *btree_arena_create_sized(size_t initial_capacity)
+{
+    if (initial_capacity < BTREE_ARENA_MIN_BLOCK_SIZE)
+        initial_capacity = BTREE_ARENA_MIN_BLOCK_SIZE;
+
+    initial_capacity = (initial_capacity + 7) & ~(size_t)7;
+
+    btree_arena_t *arena = malloc(sizeof(btree_arena_t));
+    if (!arena) return NULL;
+
+    btree_arena_block_t *block = malloc(sizeof(btree_arena_block_t));
+    if (!block)
+    {
+        free(arena);
+        return NULL;
+    }
+
+    block->data = malloc(initial_capacity);
+    if (!block->data)
+    {
+        free(block);
+        free(arena);
+        return NULL;
+    }
+
+    block->size = initial_capacity;
+    block->used = 0;
+    block->next = NULL;
+
+    arena->current = block;
+    arena->blocks = block;
+    arena->total_allocated = initial_capacity;
+
+    return arena;
+}
+
 /**
  * btree_arena_alloc
  * allocates memory from the arena with 8-byte alignment
@@ -734,22 +770,38 @@ static int btree_node_deserialize_arena(const uint8_t *data, const size_t data_s
 
         if (n->num_entries > 0)
         {
-            n->entries = btree_arena_alloc(arena, n->num_entries * sizeof(btree_entry_t));
-            n->keys = btree_arena_alloc(arena, n->num_entries * sizeof(uint8_t *));
-            n->key_sizes = btree_arena_alloc(arena, n->num_entries * sizeof(size_t));
-            n->values = btree_arena_alloc(arena, n->num_entries * sizeof(uint8_t *));
+            const uint32_t ne = n->num_entries;
 
-            if (!n->entries || !n->keys || !n->key_sizes || !n->values) return -1;
+            /* single arena alloc for all 4 metadata arrays */
+            const size_t entries_sz = ne * sizeof(btree_entry_t);
+            const size_t keys_ptr_sz = ne * sizeof(uint8_t *);
+            const size_t key_sizes_sz = ne * sizeof(size_t);
+            const size_t values_ptr_sz = ne * sizeof(uint8_t *);
+            const size_t meta_total = entries_sz + keys_ptr_sz + key_sizes_sz + values_ptr_sz;
+            uint8_t *meta_buf = btree_arena_alloc(arena, meta_total);
+            if (!meta_buf) return -1;
 
-            memset(n->entries, 0, n->num_entries * sizeof(btree_entry_t));
-            memset(n->keys, 0, n->num_entries * sizeof(uint8_t *));
-            memset(n->key_sizes, 0, n->num_entries * sizeof(size_t));
-            memset(n->values, 0, n->num_entries * sizeof(uint8_t *));
+            n->entries = (btree_entry_t *)meta_buf;
+            n->keys = (uint8_t **)(meta_buf + entries_sz);
+            n->key_sizes = (size_t *)(meta_buf + entries_sz + keys_ptr_sz);
+            n->values = (uint8_t **)(meta_buf + entries_sz + keys_ptr_sz + key_sizes_sz);
+
+            /* only values needs zeroing (sparse -- vlog entries have no inline value) */
+            memset(n->values, 0, values_ptr_sz);
+
+            /* single arena alloc for all 3 temp arrays */
+            const size_t offsets_sz = ne * sizeof(uint16_t);
+            const size_t lens_sz = ne * sizeof(size_t);
+            const size_t temp_total = offsets_sz + lens_sz + lens_sz;
+            uint8_t *temp_buf = btree_arena_alloc(arena, temp_total);
+            if (!temp_buf) return -1;
+
+            uint16_t *key_offsets = (uint16_t *)temp_buf;
+            size_t *prefix_lens = (size_t *)(temp_buf + offsets_sz);
+            size_t *suffix_lens = (size_t *)(temp_buf + offsets_sz + lens_sz);
 
             /* we read key indirection table (stored as little-endian uint16) */
-            uint16_t *key_offsets = btree_arena_alloc(arena, n->num_entries * sizeof(uint16_t));
-            if (!key_offsets) return -1;
-            for (uint32_t i = 0; i < n->num_entries; i++)
+            for (uint32_t i = 0; i < ne; i++)
             {
                 key_offsets[i] = (uint16_t)(data[off] | (data[off + 1] << 8));
                 off += 2;
@@ -759,13 +811,8 @@ static int btree_node_deserialize_arena(const uint8_t *data, const size_t data_s
             uint64_t base_seq;
             off += btree_varint_decode(data + off, &base_seq);
 
-            /* we temporary arrays for prefix/suffix lengths (arena allocated) */
-            size_t *prefix_lens = btree_arena_alloc(arena, n->num_entries * sizeof(size_t));
-            size_t *suffix_lens = btree_arena_alloc(arena, n->num_entries * sizeof(size_t));
-            if (!prefix_lens || !suffix_lens) return -1;
-
             /* we read entry metadata */
-            for (uint32_t i = 0; i < n->num_entries; i++)
+            for (uint32_t i = 0; i < ne; i++)
             {
                 uint64_t prefix_len, suffix_len, value_size, vlog_offset;
                 int64_t seq_delta, ttl;
@@ -788,12 +835,22 @@ static int btree_node_deserialize_arena(const uint8_t *data, const size_t data_s
                 n->key_sizes[i] = n->entries[i].key_size;
             }
 
+            /* single arena alloc for all key data, then carve up with pointers */
+            size_t total_key_bytes = 0;
+            for (uint32_t i = 0; i < ne; i++)
+            {
+                total_key_bytes += ((size_t)n->entries[i].key_size + 7) & ~(size_t)7;
+            }
+
+            uint8_t *key_buf = btree_arena_alloc(arena, total_key_bytes);
+            if (!key_buf) return -1;
+
             /* we reconstruct keys from prefix-compressed format */
             const size_t keys_start = off;
-            for (uint32_t i = 0; i < n->num_entries; i++)
+            size_t key_buf_off = 0;
+            for (uint32_t i = 0; i < ne; i++)
             {
-                n->keys[i] = btree_arena_alloc(arena, n->entries[i].key_size);
-                if (!n->keys[i]) return -1;
+                n->keys[i] = key_buf + key_buf_off;
 
                 /* we copy prefix from previous key */
                 if (i > 0 && prefix_lens[i] > 0)
@@ -804,25 +861,41 @@ static int btree_node_deserialize_arena(const uint8_t *data, const size_t data_s
                 /* we copy suffix from serialized data */
                 const size_t suffix_pos = keys_start + key_offsets[i];
                 memcpy(n->keys[i] + prefix_lens[i], data + suffix_pos, suffix_lens[i]);
+
+                key_buf_off += ((size_t)n->entries[i].key_size + 7) & ~(size_t)7;
             }
 
             /* we advance past all key data */
-            for (uint32_t i = 0; i < n->num_entries; i++)
+            for (uint32_t i = 0; i < ne; i++)
             {
                 off += suffix_lens[i];
             }
 
-            /* we read inline values */
-            for (uint32_t i = 0; i < n->num_entries; i++)
+            /* single arena alloc for all inline values, then point each into it */
+            size_t total_inline_bytes = 0;
+            for (uint32_t i = 0; i < ne; i++)
             {
                 if (n->entries[i].vlog_offset == 0 && n->entries[i].value_size > 0)
+                    total_inline_bytes += n->entries[i].value_size;
+            }
+
+            if (total_inline_bytes > 0)
+            {
+                uint8_t *val_buf = btree_arena_alloc(arena, total_inline_bytes);
+                if (!val_buf) return -1;
+                memcpy(val_buf, data + off, total_inline_bytes);
+
+                size_t val_off = 0;
+                for (uint32_t i = 0; i < ne; i++)
                 {
-                    n->values[i] = btree_arena_alloc(arena, n->entries[i].value_size);
-                    if (!n->values[i]) return -1;
-                    memcpy(n->values[i], data + off, n->entries[i].value_size);
-                    off += n->entries[i].value_size;
+                    if (n->entries[i].vlog_offset == 0 && n->entries[i].value_size > 0)
+                    {
+                        n->values[i] = val_buf + val_off;
+                        val_off += n->entries[i].value_size;
+                    }
                 }
             }
+            off += total_inline_bytes;
         }
     }
     else if (n->type == BTREE_NODE_INTERNAL)
@@ -830,18 +903,17 @@ static int btree_node_deserialize_arena(const uint8_t *data, const size_t data_s
         const uint32_t num_keys = n->num_entries;
         const uint32_t num_children = num_keys + 1;
 
-        n->child_offsets = btree_arena_alloc(arena, num_children * sizeof(int64_t));
-        n->keys = btree_arena_alloc(arena, num_keys * sizeof(uint8_t *));
-        n->key_sizes = btree_arena_alloc(arena, num_keys * sizeof(size_t));
+        /* single arena alloc for child_offsets + keys ptrs + key_sizes */
+        const size_t child_sz = num_children * sizeof(int64_t);
+        const size_t ikeys_ptr_sz = num_keys * sizeof(uint8_t *);
+        const size_t ikey_sizes_sz = num_keys * sizeof(size_t);
+        const size_t internal_total = child_sz + ikeys_ptr_sz + ikey_sizes_sz;
+        uint8_t *ibuf = btree_arena_alloc(arena, internal_total);
+        if (!ibuf) return -1;
 
-        if (!n->child_offsets || (num_keys > 0 && (!n->keys || !n->key_sizes))) return -1;
-
-        memset(n->child_offsets, 0, num_children * sizeof(int64_t));
-        if (num_keys > 0)
-        {
-            memset(n->keys, 0, num_keys * sizeof(uint8_t *));
-            memset(n->key_sizes, 0, num_keys * sizeof(size_t));
-        }
+        n->child_offsets = (int64_t *)ibuf;
+        n->keys = (num_keys > 0) ? (uint8_t **)(ibuf + child_sz) : NULL;
+        n->key_sizes = (num_keys > 0) ? (size_t *)(ibuf + child_sz + ikeys_ptr_sz) : NULL;
 
         int64_t base_offset = decode_int64_le_compat(data + off);
         off += 8;
@@ -864,12 +936,26 @@ static int btree_node_deserialize_arena(const uint8_t *data, const size_t data_s
             n->key_sizes[i] = (size_t)key_size;
         }
 
+        /* single arena alloc for all separator key data */
+        size_t total_ikey_bytes = 0;
         for (uint32_t i = 0; i < num_keys; i++)
         {
-            n->keys[i] = btree_arena_alloc(arena, n->key_sizes[i]);
-            if (!n->keys[i]) return -1;
-            memcpy(n->keys[i], data + off, n->key_sizes[i]);
-            off += n->key_sizes[i];
+            total_ikey_bytes += (n->key_sizes[i] + 7) & ~(size_t)7;
+        }
+
+        if (total_ikey_bytes > 0)
+        {
+            uint8_t *ikey_buf = btree_arena_alloc(arena, total_ikey_bytes);
+            if (!ikey_buf) return -1;
+
+            size_t ikey_off = 0;
+            for (uint32_t i = 0; i < num_keys; i++)
+            {
+                n->keys[i] = ikey_buf + ikey_off;
+                memcpy(n->keys[i], data + off, n->key_sizes[i]);
+                off += n->key_sizes[i];
+                ikey_off += (n->key_sizes[i] + 7) & ~(size_t)7;
+            }
         }
     }
 
@@ -1027,8 +1113,10 @@ int btree_node_read_with_compression(block_manager_t *bm, const int64_t offset, 
     }
 
     /* we use arena allocation to eliminate N+7 individual malloc/free per node read
-     * btree_node_free will destroy the arena via O(1) bulk deallocation */
-    btree_arena_t *arena = btree_arena_create();
+     * btree_node_free will destroy the arena via O(1) bulk deallocation.
+     * we size the arena to data_size * 2 since deserialized form (pointers, arrays)
+     * is typically 1-2x the serialized size. avoids 64KB default for small nodes. */
+    btree_arena_t *arena = btree_arena_create_sized(data_size * 2);
     if (!arena)
     {
         free(decompressed);
@@ -1183,7 +1271,7 @@ static int btree_node_read_cached(btree_t *tree, const int64_t offset, btree_nod
     }
 
     btree_node_t *new_node = NULL;
-    btree_arena_t *node_arena = btree_arena_create();
+    btree_arena_t *node_arena = btree_arena_create_sized(data_size * 2);
     if (!node_arena)
     {
         free(decompressed);
@@ -1207,7 +1295,7 @@ static int btree_node_read_cached(btree_t *tree, const int64_t offset, btree_nod
     /* rc_count = 2, 1 for cache ownership + 1 for caller */
     atomic_store_explicit(&new_node->rc_count, 2, memory_order_relaxed);
 
-    /* we account for actual memory cost: node struct + arena allocations.
+    /* we account for actual memory cost i.e node struct + arena allocations.
      * without this the cache treats every node as 0 bytes and never evicts,
      * causing unbounded memory growth under btree workloads. */
     const size_t node_cost = sizeof(btree_node_t) + node_arena->total_allocated;

--- a/src/btree.c
+++ b/src/btree.c
@@ -1202,12 +1202,17 @@ static int btree_node_read_cached(btree_t *tree, const int64_t offset, btree_nod
     }
 
     new_node->block_offset = offset;
+    new_node->arena = node_arena;
 
     /* rc_count = 2, 1 for cache ownership + 1 for caller */
     atomic_store_explicit(&new_node->rc_count, 2, memory_order_relaxed);
 
+    /* we account for actual memory cost: node struct + arena allocations.
+     * without this the cache treats every node as 0 bytes and never evicts,
+     * causing unbounded memory growth under btree workloads. */
+    const size_t node_cost = sizeof(btree_node_t) + node_arena->total_allocated;
     clock_cache_put(tree->node_cache, cache_key, (size_t)key_len, &new_node, sizeof(btree_node_t *),
-                    0);
+                    node_cost);
 
     *node = new_node;
     return 0;

--- a/src/btree.h
+++ b/src/btree.h
@@ -262,7 +262,7 @@ struct btree_t
 
 /**
  * btree_stats_t
- * statistics for a single B+tree (per-SSTable)
+ * statistics for a single B+tree (per-sstable)
  * @param entry_count total number of entries
  * @param node_count total number of nodes
  * @param height tree height (1 = single leaf, 2+ = has internal nodes)

--- a/src/btree.h
+++ b/src/btree.h
@@ -68,7 +68,8 @@ typedef struct btree_arena_t btree_arena_t;
  * simple arena allocator for btree nodes to reduce malloc/free overhead
  * allocations are bump-pointer style, freed all at once when arena is destroyed
  */
-#define BTREE_ARENA_BLOCK_SIZE (64 * 1024) /* 64KB blocks */
+#define BTREE_ARENA_BLOCK_SIZE     (64 * 1024) /* 64KB blocks */
+#define BTREE_ARENA_MIN_BLOCK_SIZE 256         /* minimum arena block size */
 
 typedef struct btree_arena_block_t
 {
@@ -95,10 +96,19 @@ struct btree_arena_t
 
 /**
  * btree_arena_create
- * creates a new arena allocator
+ * creates a new arena allocator with default block size (64KB)
  * @return new arena or NULL on failure
  */
 btree_arena_t *btree_arena_create(void);
+
+/**
+ * btree_arena_create_sized
+ * creates a new arena allocator with a specific initial capacity
+ * used to right-size arenas for deserialized nodes to reduce memory waste
+ * @param initial_capacity initial block size in bytes (clamped to minimum 256)
+ * @return new arena or NULL on failure
+ */
+btree_arena_t *btree_arena_create_sized(size_t initial_capacity);
 
 /**
  * btree_arena_alloc

--- a/src/clock_cache.c
+++ b/src/clock_cache.c
@@ -656,6 +656,33 @@ static int ensure_space(clock_cache_t *cache, clock_cache_partition_t *partition
             cur_global = clock_cache_sum_bytes(cache);
             evict_rounds++;
         }
+
+        /* if local partition eviction wasn't enough, try other partitions.
+         * this handles the case where entries are spread across many partitions
+         * and a single partition can't free enough to meet the global byte budget
+         * (common with large external_bytes like btree nodes). */
+        if (cur_global + required_bytes > cache->max_bytes)
+        {
+            const size_t local_idx = (size_t)(partition - cache->partitions);
+            for (size_t p = 1; p < cache->num_partitions; p++)
+            {
+                const size_t other_idx = (local_idx + p) & (cache->num_partitions - 1);
+                clock_cache_partition_t *other = &cache->partitions[other_idx];
+                const size_t other_occ =
+                    atomic_load_explicit(&other->occupied_count, memory_order_relaxed);
+                if (other_occ == 0) continue;
+
+                size_t rounds = 0;
+                while (rounds < other_occ)
+                {
+                    if (!evict_for_space(cache, other)) break;
+                    rounds++;
+                    const size_t now = clock_cache_sum_bytes(cache);
+                    if (now + required_bytes <= cache->max_bytes) goto eviction_done;
+                }
+            }
+        eviction_done:;
+        }
     }
 
     /* slot-count-based eviction -- prevent hash table overload */
@@ -683,10 +710,11 @@ void clock_cache_compute_config(const size_t max_bytes, cache_config_t *config)
     num_partitions = p;
 
     /* slot count is sized for hash table efficiency (low load factor), not for byte budget.
-     * eviction is driven by bytes_used, not slot count. use a small avg_entry_size to
-     * ensure enough slots exist for the hash table to probe efficiently even when the
-     * actual entries are large (64KB+ blocks). */
-    const size_t avg_entry_size = CLOCK_CACHE_AVG_ENTRY_SIZE;
+     * when caller specifies avg_entry_size (e.g., btree 64KB nodes), use it to avoid
+     * creating vastly more slots than entries that will fit in the byte budget.
+     * otherwise use a small default so that many small entries probe efficiently. */
+    const size_t avg_entry_size =
+        (config->avg_entry_size > 0) ? config->avg_entry_size : CLOCK_CACHE_AVG_ENTRY_SIZE;
     size_t total_entries = max_bytes / avg_entry_size;
     if (total_entries < num_partitions) total_entries = num_partitions;
 

--- a/src/compat.h
+++ b/src/compat.h
@@ -2416,8 +2416,8 @@ static inline uint8_t *serialize_kv_varint(uint8_t *ptr, const uint8_t *key, uin
 
 /*
  * serialize_kv_varint_ex
- * serialize key-value pair with flags and varint length prefixes (for SSTables)
- * format: flags(1) + varint(key_size) + key + varint(value_size) + value + varint(ttl)
+ * serialize key-value pair with flags and varint length prefixes (for sstables)
+ * format is flags(1) + varint(key_size) + key + varint(value_size) + value + varint(ttl)
  * @param ptr output buffer (must have enough space)
  * @param flags flags byte (e.g., tombstone marker)
  * @param key key data
@@ -2534,7 +2534,7 @@ static inline const uint8_t *deserialize_kv_varint(const uint8_t *ptr, const uin
 
 /*
  * deserialize_kv_varint_ex
- * deserialize key-value pair with flags and varint length prefixes (for SSTables)
+ * deserialize key-value pair with flags and varint length prefixes (for sstables)
  * @param ptr input buffer
  * @param end end of input buffer (for bounds checking)
  * @param flags output flags byte

--- a/src/db.h
+++ b/src/db.h
@@ -65,7 +65,7 @@ typedef struct tidesdb_objstore_t tidesdb_objstore_t;
 /**
  * tidesdb_objstore_config_t
  * configuration for object store mode behavior
- * @param local_cache_path local directory for cached SSTable files (NULL = use db_path)
+ * @param local_cache_path local directory for cached sstable files (NULL = use db_path)
  * @param local_cache_max_bytes max local cache size in bytes (0 = unlimited)
  * @param cache_on_read cache downloaded files locally (default 1)
  * @param cache_on_write keep local copy after upload (default 1)

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -396,6 +396,24 @@ int tidesdb_manifest_commit(tidesdb_manifest_t *manifest, const char *path)
         return -1;
     }
 
+    /* we sync the parent directory to ensure the rename is durable.
+     * without this, a crash after rename could lose the directory entry
+     * on POSIX systems that don't flush directory metadata automatically. */
+    {
+        char dir_buf[1024];
+        strncpy(dir_buf, path, sizeof(dir_buf) - 1);
+        dir_buf[sizeof(dir_buf) - 1] = '\0';
+        char *last_sep = strrchr(dir_buf, '/');
+#ifdef _WIN32
+        if (!last_sep) last_sep = strrchr(dir_buf, '\\');
+#endif
+        if (last_sep)
+        {
+            *last_sep = '\0';
+            tdb_sync_directory(dir_buf);
+        }
+    }
+
     /* we reopen for reading */
     manifest->fp = tdb_fopen(path, "r");
 

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -5186,7 +5186,7 @@ static tidesdb_sstable_t *tidesdb_sstable_create(tidesdb_t *db, const char *base
              TDB_U64_CAST(id));
 
     /* we use XXH64 of the klog path as the btree node cache key prefix.
-     * this is globally unique across CFs (includes CF directory + SSTable ID),
+     * this is globally unique across CFs (includes CF directory + sstable id),
      * unlike sst->id which is per-CF and can collide in the shared node cache. */
     sst->cache_key_prefix = XXH64(sst->klog_path, strlen(sst->klog_path), 0);
 

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -15253,7 +15253,6 @@ static void *tidesdb_sstable_reaper_thread(void *arg)
 
         if (candidate_count == 0)
         {
-            TDB_DEBUG_LOG(TDB_LOG_WARN, "Reaper: no closeable SSTables found");
             if (!use_stack) free(candidates);
             continue;
         }

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -5185,6 +5185,11 @@ static tidesdb_sstable_t *tidesdb_sstable_create(tidesdb_t *db, const char *base
     snprintf(sst->vlog_path, path_len, "%s_" TDB_U64_FMT TDB_SSTABLE_VLOG_EXT, base_path,
              TDB_U64_CAST(id));
 
+    /* we use XXH64 of the klog path as the btree node cache key prefix.
+     * this is globally unique across CFs (includes CF directory + SSTable ID),
+     * unlike sst->id which is per-CF and can collide in the shared node cache. */
+    sst->cache_key_prefix = XXH64(sst->klog_path, strlen(sst->klog_path), 0);
+
     /* we cache CF name from path to avoid repeated parsing during reads */
     if (tidesdb_get_cf_name_from_path(sst->klog_path, sst->cf_name) != 0)
     {
@@ -6344,11 +6349,10 @@ static int tidesdb_sstable_write_from_memtable_btree(tidesdb_t *db, tidesdb_ssta
             continue;
         }
 
-        /* wwe rite value to vlog and get offset. we compress the value if the column
-         * family uses compression, matching the compaction merge path and the
-         * block-based klog flush path (tidesdb_write_vlog_entry). */
+        /* we write value to vlog if it exceeds the threshold, matching the
+         * compaction merge path. small values are stored inline in the btree. */
         uint64_t vlog_offset = 0;
-        if (value && value_size > 0 && !deleted)
+        if (value && value_size > 0 && !deleted && value_size >= sst->config->klog_value_threshold)
         {
             const uint8_t *final_data = value;
             size_t final_size = value_size;
@@ -6379,10 +6383,13 @@ static int tidesdb_sstable_write_from_memtable_btree(tidesdb_t *db, tidesdb_ssta
             free(compressed);
         }
 
-        /* we add to btree */
+        /* we add to btree inline value for small entries, vlog reference for large */
+        const uint8_t *value_to_store = (vlog_offset > 0) ? NULL : value;
+        const size_t value_size_to_store = (vlog_offset > 0) ? 0 : value_size;
         const uint8_t flags = deleted ? 1 : 0; /* BTREE_ENTRY_FLAG_TOMBSTONE = 1 */
-        if (btree_builder_add(builder, key, key_size, NULL, value_size, vlog_offset, seq, ttl,
-                              flags) != 0)
+
+        if (btree_builder_add(builder, key, key_size, value_to_store, value_size_to_store,
+                              vlog_offset, seq, ttl, flags) != 0)
         {
             TDB_DEBUG_LOG(TDB_LOG_ERROR, "SSTable %" PRIu64 " failed to add entry to btree",
                           sst->id);
@@ -7111,7 +7118,7 @@ static int tidesdb_sstable_get_btree(tidesdb_t *db, tidesdb_sstable_t *sst, cons
                                .cmp_type = comparator_fn ? BTREE_CMP_CUSTOM : BTREE_CMP_MEMCMP,
                                .compression_algo = sst->config->compression_algorithm},
                     .node_cache = db->btree_node_cache,
-                    .cache_key_prefix = sst->id};
+                    .cache_key_prefix = sst->cache_key_prefix};
 
     uint8_t *value = NULL;
     size_t value_size = 0;
@@ -9537,7 +9544,7 @@ static tidesdb_merge_source_t *tidesdb_merge_source_from_btree(tidesdb_t *db,
     tree->config.cmp_type = comparator_fn ? BTREE_CMP_CUSTOM : BTREE_CMP_MEMCMP;
     tree->config.compression_algo = sst->config->compression_algorithm;
     tree->node_cache = db->btree_node_cache;
-    tree->cache_key_prefix = sst->id;
+    tree->cache_key_prefix = sst->cache_key_prefix;
 
     btree_cursor_t *cursor = NULL;
     if (btree_cursor_init(&cursor, tree) != 0)
@@ -11019,7 +11026,6 @@ static void tidesdb_cleanup_merged_sstables(tidesdb_column_family_t *cf, queue_t
             {
                 TDB_DEBUG_LOG(TDB_LOG_INFO, "Removed SSTable %" PRIu64 " from level %d", sst->id,
                               lvl->level_num);
-                atomic_fetch_add_explicit(&cf->next_sstable_id, 1, memory_order_release);
                 tidesdb_bump_sstable_layout_version(cf);
                 removed = 1;
                 removed_level = lvl->level_num;
@@ -14706,6 +14712,8 @@ static void *tidesdb_sstable_reaper_thread(void *arg)
 
     while (atomic_load(&db->sstable_reaper_active))
     {
+        TDB_DEBUG_LOG(TDB_LOG_DEBUG, "Reaper: loop top");
+
         time_t now = tdb_get_current_time();
         atomic_store_explicit(&db->cached_current_time, now, memory_order_seq_cst);
 
@@ -14724,11 +14732,15 @@ static void *tidesdb_sstable_reaper_thread(void *arg)
             ts.tv_nsec -= TDB_NANOSECONDS_PER_SECOND;
         }
 
+        TDB_DEBUG_LOG(TDB_LOG_DEBUG, "Reaper: before mutex_lock");
         pthread_mutex_lock(&db->reaper_thread_mutex);
+        TDB_DEBUG_LOG(TDB_LOG_DEBUG, "Reaper: before timedwait");
 
         if (atomic_load(&db->sstable_reaper_active))
         {
-            pthread_cond_timedwait(&db->reaper_thread_cond, &db->reaper_thread_mutex, &ts);
+            int wait_rc =
+                pthread_cond_timedwait(&db->reaper_thread_cond, &db->reaper_thread_mutex, &ts);
+            TDB_DEBUG_LOG(TDB_LOG_DEBUG, "Reaper: timedwait returned %d", wait_rc);
         }
         int should_exit = !atomic_load(&db->sstable_reaper_active);
         pthread_mutex_unlock(&db->reaper_thread_mutex);
@@ -15035,6 +15047,11 @@ static void *tidesdb_sstable_reaper_thread(void *arg)
 
         /* replica MANIFEST sync and WAL replay. throttled by replica_sync_interval_us
          * converted to reaper cycle count (each cycle is TDB_SSTABLE_REAPER_SLEEP_US). */
+        {
+            int rm = atomic_load_explicit(&db->replica_mode, memory_order_relaxed);
+            int os = db->object_store ? 1 : 0;
+            TDB_DEBUG_LOG(TDB_LOG_DEBUG, "Reaper: replica_mode=%d object_store=%d", rm, os);
+        }
         if (atomic_load_explicit(&db->replica_mode, memory_order_relaxed) && db->object_store)
         {
             uint64_t sync_interval_us =
@@ -15044,11 +15061,15 @@ static void *tidesdb_sstable_reaper_thread(void *arg)
             int cycles_per_sync = (int)(sync_interval_us / TDB_SSTABLE_REAPER_SLEEP_US);
             if (cycles_per_sync < 1) cycles_per_sync = 1;
 
-            if (atomic_fetch_add(&db->replica_sync_counter, 1) + 1 >= cycles_per_sync)
+            int counter = atomic_fetch_add(&db->replica_sync_counter, 1) + 1;
+            TDB_DEBUG_LOG(TDB_LOG_DEBUG, "Reaper: sync counter=%d/%d", counter, cycles_per_sync);
+
+            if (counter >= cycles_per_sync)
             {
                 atomic_store(&db->replica_sync_counter, 0);
                 atomic_store_explicit(&db->replica_sync_in_progress, 1, memory_order_release);
 
+                TDB_DEBUG_LOG(TDB_LOG_INFO, "Reaper: running replica sync now");
                 tdb_replica_sync_manifests(db);
 
                 if (db->config.object_store_config &&
@@ -20687,7 +20708,13 @@ static uint8_t *tidesdb_txn_serialize_wal(const tidesdb_txn_t *txn,
         if (op->cf == cf)
         {
             cf_op_count++;
-            estimated_size += 24 + op->key_size + op->value_size;
+            const size_t entry_size = 24 + (size_t)op->key_size + (size_t)op->value_size;
+            if (estimated_size + entry_size < estimated_size) /* overflow check */
+            {
+                *out_size = 0;
+                return NULL;
+            }
+            estimated_size += entry_size;
         }
     }
 
@@ -20775,7 +20802,14 @@ static uint8_t *tidesdb_txn_serialize_wal_unified(const tidesdb_txn_t *txn, size
     for (int i = 0; i < txn->num_ops; i++)
     {
         const tidesdb_txn_op_t *op = &txn->ops[i];
-        estimated_size += TDB_UNIFIED_CF_PREFIX_SIZE + 24 + op->key_size + op->value_size;
+        const size_t entry_size =
+            TDB_UNIFIED_CF_PREFIX_SIZE + 24 + (size_t)op->key_size + (size_t)op->value_size;
+        if (estimated_size + entry_size < estimated_size) /* overflow check */
+        {
+            *out_size = 0;
+            return NULL;
+        }
+        estimated_size += entry_size;
     }
 
     uint8_t *wal_batch;
@@ -21634,8 +21668,6 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
             umt = atomic_load_explicit(&txn->db->unified_mt.active, memory_order_acquire);
             if (!umt || !tidesdb_memtable_try_ref(umt))
             {
-                tidesdb_commit_status_mark(txn->db->commit_status, txn->commit_seq,
-                                           TDB_COMMIT_STATUS_IN_PROGRESS);
                 return TDB_ERR_UNKNOWN;
             }
         }
@@ -21648,8 +21680,6 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
         if (!uwal_batch && uwal_size > 0)
         {
             atomic_fetch_sub_explicit(&umt->refcount, 1, memory_order_release);
-            tidesdb_commit_status_mark(txn->db->commit_status, txn->commit_seq,
-                                       TDB_COMMIT_STATUS_IN_PROGRESS);
             return TDB_ERR_MEMORY;
         }
 
@@ -21662,8 +21692,6 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
             {
                 if (uwal_batch != uwal_stack_buf) free(uwal_batch);
                 atomic_fetch_sub_explicit(&umt->refcount, 1, memory_order_release);
-                tidesdb_commit_status_mark(txn->db->commit_status, txn->commit_seq,
-                                           TDB_COMMIT_STATUS_IN_PROGRESS);
                 return TDB_ERR_IO;
             }
         }
@@ -21684,8 +21712,6 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
             if (result != TDB_SUCCESS)
             {
                 atomic_fetch_sub_explicit(&umt->refcount, 1, memory_order_release);
-                tidesdb_commit_status_mark(txn->db->commit_status, txn->commit_seq,
-                                           TDB_COMMIT_STATUS_IN_PROGRESS);
                 return result;
             }
         }
@@ -21695,8 +21721,6 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
         if (result != TDB_SUCCESS)
         {
             atomic_fetch_sub_explicit(&umt->refcount, 1, memory_order_release);
-            tidesdb_commit_status_mark(txn->db->commit_status, txn->commit_seq,
-                                       TDB_COMMIT_STATUS_IN_PROGRESS);
             return result;
         }
 
@@ -21821,10 +21845,21 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
         if (!tidesdb_memtable_try_ref(mt))
         {
             mt = atomic_load_explicit(&cf->active_memtable, memory_order_acquire);
-            (void)tidesdb_memtable_try_ref(mt); /* new active should always succeed */
+            if (!mt || !tidesdb_memtable_try_ref(mt))
+            {
+                /* memtable rotation is racing; we release previously acquired refs and retry */
+                for (int j = 0; j < cf_idx; j++)
+                {
+                    if (cf_memtables[j])
+                        atomic_fetch_sub_explicit(&cf_memtables[j]->refcount, 1,
+                                                  memory_order_release);
+                }
+                result = TDB_ERR_UNKNOWN;
+                goto cleanup;
+            }
         }
         cf_memtables[cf_idx] = mt;
-        cf_skiplists[cf_idx] = mt ? mt->skip_list : NULL;
+        cf_skiplists[cf_idx] = mt->skip_list;
 
         /* stack buffer for small WAL payloads; avoids malloc/free per txn */
         uint8_t wal_stack_buf[TDB_WAL_STACK_BUFFER_SIZE];

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -4820,6 +4820,7 @@ static void *tdb_cold_start_download_worker(void *arg)
     char cf_dir[TDB_MAX_PATH_LEN - 32];
     snprintf(cf_dir, sizeof(cf_dir), "%s" PATH_SEPARATOR "%s", db->db_path, cf_name);
     mkdir(cf_dir, TDB_DIR_PERMISSIONS);
+    tdb_sync_directory(db->db_path);
 
     /* we download config.ini */
     char config_key[TDB_MAX_PATH_LEN];
@@ -4965,6 +4966,7 @@ static void tdb_replica_discover_new_cfs(tidesdb_t *db)
         char cf_dir[TDB_MAX_PATH_LEN];
         snprintf(cf_dir, sizeof(cf_dir), "%s" PATH_SEPARATOR "%s", db->db_path, cf_name);
         mkdir(cf_dir, 0755);
+        tdb_sync_directory(db->db_path);
 
         char config_key[TDB_MAX_PATH_LEN];
         snprintf(config_key, sizeof(config_key),
@@ -5337,6 +5339,23 @@ static void tidesdb_sstable_free(tidesdb_sstable_t *sst)
         }
         tdb_unlink(sst->klog_path);
         tdb_unlink(sst->vlog_path);
+
+        /* we sync the parent directory to persist the unlink operations */
+        if (sst->klog_path)
+        {
+            char dir_buf[TDB_MAX_PATH_LEN];
+            strncpy(dir_buf, sst->klog_path, sizeof(dir_buf) - 1);
+            dir_buf[sizeof(dir_buf) - 1] = '\0';
+            char *sep = strrchr(dir_buf, '/');
+#ifdef _WIN32
+            if (!sep) sep = strrchr(dir_buf, '\\');
+#endif
+            if (sep)
+            {
+                *sep = '\0';
+                tdb_sync_directory(dir_buf);
+            }
+        }
     }
 
     free(sst->klog_path);
@@ -14291,6 +14310,7 @@ static void *tidesdb_flush_worker_thread(void *arg)
             block_manager_close(wal);
             imm->wal = NULL;
             tdb_unlink(wal_path_to_delete);
+            tdb_sync_directory(cf->directory);
             free(wal_path_to_delete);
         }
 
@@ -17561,6 +17581,9 @@ static int tidesdb_drop_column_family_internal(tidesdb_t *db, const char *name,
     TDB_DEBUG_LOG(TDB_LOG_INFO, "Deleted column family directory: %s (result: %d)",
                   cf_to_drop->directory, result);
 
+    /* we sync parent directory to persist the directory removal */
+    tdb_sync_directory(db->db_path);
+
     tidesdb_column_family_free(cf_to_drop);
 
     return TDB_SUCCESS;
@@ -18221,6 +18244,9 @@ static int tidesdb_flush_memtable_internal(tidesdb_column_family_t *cf,
             return TDB_ERR_IO;
         }
     }
+
+    /* we sync CF directory to persist new WAL file entry */
+    if (new_wal) tdb_sync_directory(cf->directory);
 
     /* we create new tidesdb_memtable_t structure pairing skip_list and wal */
     tidesdb_memtable_t *new_mt = malloc(sizeof(tidesdb_memtable_t));
@@ -21508,6 +21534,7 @@ static int tidesdb_unified_flush_immutable(tidesdb_t *db, tidesdb_memtable_t *um
                     /* sync block until upload completes, we then delete locally */
                     tdb_objstore_upload_file_sync(db, wal_path);
                     tdb_unlink(wal_path);
+                    tdb_sync_directory(db->db_path);
                 }
                 else
                 {
@@ -21520,6 +21547,7 @@ static int tidesdb_unified_flush_immutable(tidesdb_t *db, tidesdb_memtable_t *um
             {
                 /* no object store or replicate_wal disabled -- just delete */
                 tdb_unlink(wal_path);
+                tdb_sync_directory(db->db_path);
             }
             free(wal_path);
         }
@@ -21575,6 +21603,9 @@ static int tidesdb_unified_memtable_rotate(tidesdb_t *db)
         skip_list_free(new_sl);
         return TDB_ERR_IO;
     }
+
+    /* we sync db directory to persist new unified WAL file entry */
+    tdb_sync_directory(db->db_path);
 
     tidesdb_memtable_t *new_mt = malloc(sizeof(tidesdb_memtable_t));
     if (!new_mt)

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -201,8 +201,11 @@ typedef enum
 #define TDB_DEFAULT_INDEX_SAMPLE_RATIO          1
 #define TDB_DEFAULT_BLOCK_INDEX_PREFIX_LEN      16
 #define TDB_DEFAULT_MIN_DISK_SPACE              (100 * 1024 * 1024)
-#define TDB_DEFAULT_MAX_OPEN_SSTABLES \
-    256 /* x2 each sstable has 2 fds, so really the default is 512 */
+#if defined(__OpenBSD__)
+#define TDB_DEFAULT_MAX_OPEN_SSTABLES 64 /* x2 OpenBSD has lower default fd limits */
+#else
+#define TDB_DEFAULT_MAX_OPEN_SSTABLES 256 /* x2 each sstable has 2 fds, so really 512 */
+#endif
 #define TDB_DEFAULT_ACTIVE_TXN_BUFFER_SIZE (1024 * 64)
 #define TDB_DEFAULT_BLOCK_CACHE_SIZE       (64 * 1024 * 1024)
 #define TDB_DEFAULT_SYNC_INTERVAL_US       128000

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -539,6 +539,7 @@ struct tidesdb_column_family_t
  * @param cached_comparator_fn cached comparator function for fast iteration
  * @param cached_comparator_ctx cached comparator context for fast iteration
  * @param is_reverse flag indicating sstable is reverse sorted
+ * @param cache_key_prefix globally unique prefix for btree node cache keys 
  */
 struct tidesdb_sstable_t
 {
@@ -576,7 +577,7 @@ struct tidesdb_sstable_t
     skip_list_comparator_fn cached_comparator_fn;
     void *cached_comparator_ctx;
     int is_reverse;
-    uint64_t cache_key_prefix; /* globally unique prefix for btree node cache keys */
+    uint64_t cache_key_prefix;
 };
 
 /**

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -576,6 +576,7 @@ struct tidesdb_sstable_t
     skip_list_comparator_fn cached_comparator_fn;
     void *cached_comparator_ctx;
     int is_reverse;
+    uint64_t cache_key_prefix; /* globally unique prefix for btree node cache keys */
 };
 
 /**

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -539,7 +539,7 @@ struct tidesdb_column_family_t
  * @param cached_comparator_fn cached comparator function for fast iteration
  * @param cached_comparator_ctx cached comparator context for fast iteration
  * @param is_reverse flag indicating sstable is reverse sorted
- * @param cache_key_prefix globally unique prefix for btree node cache keys 
+ * @param cache_key_prefix globally unique prefix for btree node cache keys
  */
 struct tidesdb_sstable_t
 {

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -26126,6 +26126,153 @@ static void test_primary_replica_failover(void)
     cleanup_test_dir();
 }
 
+static void test_btree_multi_cf_vlog_isolation(void)
+{
+    cleanup_test_dir();
+
+    tidesdb_config_t config = tidesdb_default_config();
+    config.db_path = TEST_DB_PATH;
+    config.unified_memtable = 1;
+    config.unified_memtable_write_buffer_size = 32768;
+    config.log_level = TDB_LOG_WARN;
+
+    tidesdb_t *db = NULL;
+    ASSERT_EQ(tidesdb_open(&config, &db), 0);
+
+    /* btree with small values (inline, under threshold) */
+    tidesdb_column_family_config_t cfg1 = tidesdb_default_column_family_config();
+    cfg1.use_btree = 1;
+    cfg1.write_buffer_size = 32768;
+    cfg1.klog_value_threshold = 512;
+    cfg1.compression_algorithm = TDB_COMPRESS_NONE;
+    ASSERT_EQ(tidesdb_create_column_family(db, "bt_small", &cfg1), 0);
+
+    /* btree with large values (vlog, over threshold) */
+    tidesdb_column_family_config_t cfg2 = tidesdb_default_column_family_config();
+    cfg2.use_btree = 1;
+    cfg2.write_buffer_size = 32768;
+    cfg2.klog_value_threshold = 512;
+    cfg2.compression_algorithm = TDB_COMPRESS_NONE;
+    ASSERT_EQ(tidesdb_create_column_family(db, "bt_large", &cfg2), 0);
+
+    tidesdb_column_family_t *cf_small = tidesdb_get_column_family(db, "bt_small");
+    tidesdb_column_family_t *cf_large = tidesdb_get_column_family(db, "bt_large");
+    ASSERT_TRUE(cf_small != NULL);
+    ASSERT_TRUE(cf_large != NULL);
+
+    const int NUM = 500;
+    const int SMALL_SIZE = 64;
+    const int LARGE_SIZE = 2048;
+
+    uint8_t *small_val = malloc(SMALL_SIZE);
+    uint8_t *large_val = malloc(LARGE_SIZE);
+    ASSERT_TRUE(small_val != NULL && large_val != NULL);
+
+    /* we write same keys to both CFs with different value sizes */
+    for (int i = 0; i < NUM; i++)
+    {
+        char key[64];
+        snprintf(key, sizeof(key), "shared_key_%06d", i);
+
+        /* we fill with deterministic patterns */
+        for (int j = 0; j < SMALL_SIZE; j++) small_val[j] = (uint8_t)((i * 17 + j * 3) & 0xFF);
+        for (int j = 0; j < LARGE_SIZE; j++) large_val[j] = (uint8_t)((i * 41 + j * 11) & 0xFF);
+
+        tidesdb_txn_t *txn = NULL;
+        ASSERT_EQ(tidesdb_txn_begin(db, &txn), 0);
+        ASSERT_EQ(tidesdb_txn_put(txn, cf_small, (uint8_t *)key, strlen(key) + 1, small_val,
+                                  SMALL_SIZE, 0),
+                  0);
+        ASSERT_EQ(tidesdb_txn_put(txn, cf_large, (uint8_t *)key, strlen(key) + 1, large_val,
+                                  LARGE_SIZE, 0),
+                  0);
+        ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+        tidesdb_txn_free(txn);
+    }
+
+    /* we force flush to SSTables */
+    tidesdb_purge_cf(cf_small);
+    tidesdb_purge_cf(cf_large);
+
+    /* we wait for background flush */
+    for (int w = 0; w < 100; w++)
+    {
+        if (queue_size(db->flush_queue) == 0 && !atomic_load(&db->unified_mt.is_flushing)) break;
+        usleep(50000);
+    }
+    usleep(500000);
+
+    /* we verify CF1 (small values, inline) */
+    printf("  verifying small CF (%d entries, %d bytes each)...\n", NUM, SMALL_SIZE);
+    int small_ok = 0;
+    for (int i = 0; i < NUM; i++)
+    {
+        char key[64];
+        snprintf(key, sizeof(key), "shared_key_%06d", i);
+
+        tidesdb_txn_t *txn = NULL;
+        ASSERT_EQ(tidesdb_txn_begin(db, &txn), 0);
+        uint8_t *rv = NULL;
+        size_t rs = 0;
+        int rc = tidesdb_txn_get(txn, cf_small, (uint8_t *)key, strlen(key) + 1, &rv, &rs);
+        tidesdb_txn_free(txn);
+
+        if (rc != 0)
+        {
+            printf("  FAIL: key %d not found (rc=%d)\n", i, rc);
+            ASSERT_EQ(rc, 0);
+        }
+        if (rs != (size_t)SMALL_SIZE)
+        {
+            printf("  FAIL: key %d size mismatch: got %zu expected %d, value=%p\n", i, rs,
+                   SMALL_SIZE, (void *)rv);
+            if (rv && rs > 0)
+            {
+                printf("  first bytes: %02x %02x %02x %02x\n", rv[0], rs > 1 ? rv[1] : 0,
+                       rs > 2 ? rv[2] : 0, rs > 3 ? rv[3] : 0);
+            }
+            free(rv);
+            ASSERT_EQ(rs, (size_t)SMALL_SIZE);
+        }
+
+        for (int j = 0; j < SMALL_SIZE; j++) small_val[j] = (uint8_t)((i * 17 + j * 3) & 0xFF);
+        ASSERT_TRUE(memcmp(rv, small_val, SMALL_SIZE) == 0);
+        free(rv);
+        small_ok++;
+    }
+    printf("  small CF: %d/%d OK\n", small_ok, NUM);
+
+    /* we verify CF2 (large values, vlog) */
+    printf("  verifying large CF (%d entries, %d bytes each)...\n", NUM, LARGE_SIZE);
+    int large_ok = 0;
+    for (int i = 0; i < NUM; i++)
+    {
+        char key[64];
+        snprintf(key, sizeof(key), "shared_key_%06d", i);
+
+        tidesdb_txn_t *txn = NULL;
+        ASSERT_EQ(tidesdb_txn_begin(db, &txn), 0);
+        uint8_t *rv = NULL;
+        size_t rs = 0;
+        int rc = tidesdb_txn_get(txn, cf_large, (uint8_t *)key, strlen(key) + 1, &rv, &rs);
+        tidesdb_txn_free(txn);
+
+        ASSERT_EQ(rc, 0);
+        ASSERT_EQ(rs, (size_t)LARGE_SIZE);
+
+        for (int j = 0; j < LARGE_SIZE; j++) large_val[j] = (uint8_t)((i * 41 + j * 11) & 0xFF);
+        ASSERT_TRUE(memcmp(rv, large_val, LARGE_SIZE) == 0);
+        free(rv);
+        large_ok++;
+    }
+    printf("  large CF: %d/%d OK\n", large_ok, NUM);
+
+    free(small_val);
+    free(large_val);
+    tidesdb_close(db);
+    cleanup_test_dir();
+}
+
 #ifdef TIDESDB_WITH_S3
 #include "../src/objstore_s3.h"
 
@@ -26731,6 +26878,7 @@ int main(int argc, char **argv)
     RUN_TEST(test_objstore_stats, tests_passed);
     RUN_TEST(test_objstore_frozen_point_lookup, tests_passed);
     RUN_TEST(test_objstore_wal_sync_on_commit, tests_passed);
+    RUN_TEST(test_btree_multi_cf_vlog_isolation, tests_passed);
     RUN_TEST(test_replica_mode, tests_passed);
     RUN_TEST(test_primary_replica_failover, tests_passed);
 #ifdef TIDESDB_WITH_S3

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -26133,7 +26133,7 @@ static void test_btree_multi_cf_vlog_isolation(void)
     tidesdb_config_t config = tidesdb_default_config();
     config.db_path = TEST_DB_PATH;
     config.unified_memtable = 1;
-    config.unified_memtable_write_buffer_size = 32768;
+    config.unified_memtable_write_buffer_size = 256 * 1024;
     config.log_level = TDB_LOG_WARN;
 
     tidesdb_t *db = NULL;
@@ -26142,7 +26142,7 @@ static void test_btree_multi_cf_vlog_isolation(void)
     /* btree with small values (inline, under threshold) */
     tidesdb_column_family_config_t cfg1 = tidesdb_default_column_family_config();
     cfg1.use_btree = 1;
-    cfg1.write_buffer_size = 32768;
+    cfg1.write_buffer_size = 256 * 1024;
     cfg1.klog_value_threshold = 512;
     cfg1.compression_algorithm = TDB_COMPRESS_NONE;
     ASSERT_EQ(tidesdb_create_column_family(db, "bt_small", &cfg1), 0);
@@ -26150,7 +26150,7 @@ static void test_btree_multi_cf_vlog_isolation(void)
     /* btree with large values (vlog, over threshold) */
     tidesdb_column_family_config_t cfg2 = tidesdb_default_column_family_config();
     cfg2.use_btree = 1;
-    cfg2.write_buffer_size = 32768;
+    cfg2.write_buffer_size = 256 * 1024;
     cfg2.klog_value_threshold = 512;
     cfg2.compression_algorithm = TDB_COMPRESS_NONE;
     ASSERT_EQ(tidesdb_create_column_family(db, "bt_large", &cfg2), 0);

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -26190,7 +26190,7 @@ static void test_btree_multi_cf_vlog_isolation(void)
         tidesdb_txn_free(txn);
     }
 
-    /* we force flush to SSTables */
+    /* we force flush to sstables */
     tidesdb_purge_cf(cf_small);
     tidesdb_purge_cf(cf_large);
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tidesdb",
-  "version-string": "9.0.4",
+  "version-string": "9.0.5",
   "description": "TidesDB is a high-performance durable, transactional embeddable storage engine designed for flash and RAM optimization with optional object storage support for unlimited data scaling.",
   "dependencies": [
     "zstd",


### PR DESCRIPTION
corrected next_sstable_id incorrectly incremented during sstable cleanup, remove redundant commit status re-marks on error paths,
handle second try_ref failure in non-unified commit, add wal batch size overflow checks, correct btree memtable flush vlog
threshold and value_size encoding, and fix btree node cache key collisions across column families. the cleanup function was
incrementing next_sstable_id per sstable removed which wasted id space and caused manifest sequence inconsistency. unified commit
error paths were redundantly re-marking status as in_progress which it already was. the non-unified commit path silently ignored
a second try_ref failure via void cast which could lead to lost transaction data if the active memtable was null. added size_t  
overflow guards in both per-cf and unified wal serialization estimation loops for safety on 32-bit architectures. the btree
memtable flush path was writing all values to vlog regardless of size without checking klog_value_threshold and was passing the  
original value_size to btree_builder_add for vlog entries instead of zero, causing a mismatch between the stored metadata and the
actual inline/vlog storage. the btree node cache used sst->id as the cache key prefix which is per-cf and not globally unique,
causing cross-cf cache collisions when multiple btree column families had sstables with the same id at the same block offset.
replaced with xxh64 hash of the klog path which is inherently unique across all column families.