### PR TITLE
TidesDB 9 PATCH (v9.0.6)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 project(tidesdb C)
 
 set(CMAKE_C_STANDARD 11)
-set(PROJECT_VERSION 9.0.5)
+set(PROJECT_VERSION 9.0.6)
 
 configure_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/src/tidesdb_version.h.in"

--- a/src/compat.h
+++ b/src/compat.h
@@ -3264,4 +3264,61 @@ static inline time_t tdb_get_current_time(void)
 #endif
 }
 
+/**
+ * tdb_gmtime_r
+ * cross-platform thread-safe gmtime
+ * @param timep pointer to time_t value
+ * @param result pointer to struct tm to fill
+ * @return pointer to result on success, NULL on failure
+ */
+static inline struct tm *tdb_gmtime_r(const time_t *timep, struct tm *result)
+{
+#if defined(_WIN32)
+    return (gmtime_s(result, timep) == 0) ? result : NULL;
+#else
+    return gmtime_r(timep, result);
+#endif
+}
+
+/**
+ * tdb_fmemopen
+ * cross-platform fmemopen
+ * opens a memory buffer as a FILE stream for reading
+ * @param buf pointer to memory buffer
+ * @param size size of buffer in bytes
+ * @param mode fopen mode string (e.g. "rb")
+ * @return FILE pointer or NULL on failure
+ */
+static inline FILE *tdb_fmemopen(void *buf, size_t size, const char *mode)
+{
+#if defined(_WIN32)
+    /* windows has no fmemopen -- we write to a temp file and reopen */
+    (void)mode;
+    char temp_path[MAX_PATH];
+    char temp_file[MAX_PATH];
+    if (GetTempPathA(MAX_PATH, temp_path) == 0) return NULL;
+    if (GetTempFileNameA(temp_path, "tdb", 0, temp_file) == 0) return NULL;
+
+    FILE *fp = fopen(temp_file, "wb");
+    if (!fp) return NULL;
+
+    if (size > 0 && buf)
+    {
+        if (fwrite(buf, 1, size, fp) != size)
+        {
+            fclose(fp);
+            DeleteFileA(temp_file);
+            return NULL;
+        }
+    }
+    fclose(fp);
+
+    fp = fopen(temp_file, "rb");
+    DeleteFileA(temp_file); /* the file stays open until fclose */
+    return fp;
+#else
+    return fmemopen(buf, size, mode);
+#endif
+}
+
 #endif /* __COMPAT_H__ */

--- a/src/objstore_s3.c
+++ b/src/objstore_s3.c
@@ -162,7 +162,7 @@ static void s3_get_timestamp(char *date8, char *timestamp16)
 {
     time_t now = time(NULL);
     struct tm gm;
-    gmtime_r(&now, &gm);
+    tdb_gmtime_r(&now, &gm);
     strftime(date8, TDB_S3_DATE_LEN, "%Y%m%d", &gm);
     strftime(timestamp16, TDB_S3_TIMESTAMP_LEN, "%Y%m%dT%H%M%SZ", &gm);
 }
@@ -477,7 +477,7 @@ static int s3_put(void *ctx, const char *key, const char *local_path)
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, s3_write_discard);
 
-    FILE *mem_fp = fmemopen(file_data, file_size > 0 ? file_size : 1, "rb");
+    FILE *mem_fp = tdb_fmemopen(file_data, file_size > 0 ? file_size : 1, "rb");
     curl_easy_setopt(curl, CURLOPT_READDATA, mem_fp);
 
     CURLcode res = curl_easy_perform(curl);

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tidesdb",
-  "version-string": "9.0.5",
+  "version-string": "9.0.6",
   "description": "TidesDB is a high-performance durable, transactional embeddable storage engine designed for flash and RAM optimization with optional object storage support for unlimited data scaling.",
   "dependencies": [
     "zstd",


### PR DESCRIPTION
windows object storage corrections, required abstractions thus addition of tdb_gmtime_r for abstraction on windows, linux, macOS, bsd and tdb_fmemopen addition that uses native fmemopen on POSIX, temp-file fallback on windows (windows has no memory-backed FILE stream)