### PR TITLE
TidesDB 9 PATCH (v9.0.8)

### DIFF
--- a/bench/tidesdb__bench.c
+++ b/bench/tidesdb__bench.c
@@ -177,12 +177,12 @@ static uint8_t zipf_next(double zipf_exponent, double off, double imax)
     double xmin = 0.5;
     double xmax = imax + 0.5;
 
-    /* calculate hlow, hupp and tot_area */
+    /* we calculate hlow, hupp and tot_area */
     double hlow = calc_continuous_approximation(off, zipf_exponent, xmin);
     double hupp = calc_continuous_approximation(off, zipf_exponent, xmax);
     double tot_area = hupp - hlow;
 
-    /* Find next uint64 zipf value */
+    /* we find next uint64 zipf value */
     int accepted = 0;
     double u, k, c_area;
 
@@ -277,7 +277,7 @@ void add_to_ht(ht_key_t** head, uint8_t* ky, int* counter)
     assert(head != NULL);
     ht_key_t* k = NULL;
 
-    /* Check if key already exists and add if it doesn't */
+    /* we check if key already exists and add if it doesn't */
     HASH_FIND(hh, *head, ky, strlen((char*)ky), k);
     if (k == NULL)
     {
@@ -289,10 +289,10 @@ void add_to_ht(ht_key_t** head, uint8_t* ky, int* counter)
         }
 
         k->key = ky;
-        /* add to hash table */
+        /* we add to hash table */
         HASH_ADD_KEYPTR(hh, *head, k->key, strlen((char*)k->key), k);
 
-        /* new item added. increment counter. */
+        /* new item added now we increment counter. */
         *counter += 1;
     }
 }
@@ -332,7 +332,6 @@ int count_distinct_keys(uint8_t** key_arr, int num_operations)
         add_to_ht(&ht_head, key_arr[i], &count);
     }
 
-    /* clear and free */
     clear_ht(&ht_head);
 
     printf(BOLDMAGENTA "%d distinct keys found\n" RESET, count);
@@ -429,7 +428,7 @@ void* thread_get(void* arg)
             if (tidesdb_txn_get(txn, data->cf, data->keys[j], data->key_sizes[j], &value_out,
                                 &value_len) == 0)
             {
-                /* verify the value matches what we wrote */
+                /* we verify the value matches what we wrote */
                 if (value_len != data->value_sizes[j] ||
                     memcmp(value_out, data->values[j], value_len) != 0)
                 {

--- a/src/block_manager.c
+++ b/src/block_manager.c
@@ -1391,7 +1391,7 @@ int block_manager_validate_last_block(block_manager_t *bm,
         return truncate_to_header(bm);
     }
 
-    /* O(1) validation, read footer of last block */
+    /* O(1) validation, we read footer of last block */
     unsigned char footer_buf[BLOCK_MANAGER_FOOTER_SIZE];
     const off_t footer_offset = (off_t)(file_size - BLOCK_MANAGER_FOOTER_SIZE);
     const ssize_t n = pread(bm->fd, footer_buf, BLOCK_MANAGER_FOOTER_SIZE, footer_offset);

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -127,6 +127,7 @@ typedef tidesdb_memtable_t tidesdb_immutable_memtable_t;
 #define TDB_KV_FLAG_DELTA_SEQ 0x08
 #define TDB_KV_FLAG_BORROWED  0x40
 #define TDB_KV_FLAG_ARENA     0x80
+#define TDB_KV_FLAG_POP_BUF   0x20 /* lives in reusable pop buffer, do not free */
 
 #define TDB_LOG_FILE               "LOG"
 #define TDB_WAL_PREFIX             "wal_"
@@ -327,7 +328,7 @@ static inline size_t tdb_build_prefixed_key(const uint32_t cf_index, const uint8
 #define TDB_MEMORY_AUTO_LIMIT_RATIO        0.50 /* auto limit = 50% of total memory */
 #define TDB_MEMORY_MIN_LIMIT_RATIO         0.05 /* minimum limit = 5% of total memory */
 #define TDB_MEMORY_OS_CHECK_INTERVAL       50
-#define TDB_MEMORY_OS_CRITICAL_RATIO       0.05 /* OS critically low if < 5% free */
+#define TDB_MEMORY_OS_CRITICAL_RATIO       0.05 /* OS critically low if < N% free */
 
 /* lock-free immutable snapshot configuration */
 #define TDB_IMM_SNAP_ACQUIRE_SPIN_LIMIT 4 /* spins before yielding in snapshot acquire */
@@ -753,6 +754,9 @@ struct tidesdb_merge_heap_t
     int capacity;
     skip_list_comparator_fn comparator;
     void *comparator_ctx;
+    uint8_t *pop_buf[2]; /* double-buffered arena for borrowed KV materialization */
+    size_t pop_buf_cap[2];
+    int pop_buf_slot; /* active slot (toggled by iterator between next/prev calls) */
 };
 
 /**
@@ -2130,6 +2134,9 @@ static void tidesdb_kv_pair_free(tidesdb_kv_pair_t *kv)
 
     /* borrowed kv pairs point into block data -- nothing to free */
     if (kv->entry.flags & TDB_KV_FLAG_BORROWED) return;
+
+    /* pop buffer kv pairs live in reusable heap arena -- nothing to free */
+    if (kv->entry.flags & TDB_KV_FLAG_POP_BUF) return;
 
     /* arena-allocated KV pairs use single allocation for struct + key + value
      * however, value may be loaded separately (e.g., from vlog) after creation
@@ -5294,11 +5301,13 @@ static void tidesdb_sstable_free(tidesdb_sstable_t *sst)
         tidesdb_invalidate_btree_cache_for_sstable(sst->db, sst->id);
     }
 
-    /* we invalidate block cache entries for this sstable before freeing */
-    if (sst->db && sst->db->clock_cache && sst->cf_name[0] != '\0' && sst->klog_path)
-    {
-        tidesdb_invalidate_block_cache_for_sstable(sst->db, sst->cf_name, sst->klog_path);
-    }
+    /* we skip eager block cache invalidation here.  the cache entries for this
+     * sstable are already dead -- klog filenames include the monotonic SST ID
+     * so no future lookup will construct their cache key.  the clock sweep
+     * reclaims them naturally when it needs space (dead entries have no readers
+     * so their ref_bit stays clear, making them the first eviction victims).
+     * removing the O(total_slots) prefix scan eliminates atomic contention
+     * between compaction and concurrent iterators on the cache ref_bit. */
 
     /* if marked for deletion, evict file data from page cache before closing
      * this prevents cache pollution from compacted-away sstables */
@@ -8532,7 +8541,7 @@ static int tidesdb_level_remove_sstable(const tidesdb_t *db, tidesdb_level_t *le
 
             return TDB_SUCCESS;
         }
-        /* CAS failed, release reader count, cleanup and retry */
+        /* CAS failed, we release reader count, cleanup and retry */
         atomic_fetch_sub_explicit(&level->array_readers, 1, memory_order_release);
         for (int i = 0; i < new_idx; i++)
         {
@@ -8814,7 +8823,7 @@ static tidesdb_kv_pair_t *tidesdb_merge_heap_pop_max(tidesdb_merge_heap_t *heap)
         }
         heap->sources[0] = heap->sources[heap->num_sources - 1];
         heap->num_sources--;
-        if (heap->num_sources > 0) heap_sift_down_max(heap, 0);
+        if (heap->num_sources > 1) heap_sift_down_max(heap, 0);
         return NULL;
     }
 
@@ -8824,9 +8833,60 @@ static tidesdb_kv_pair_t *tidesdb_merge_heap_pop_max(tidesdb_merge_heap_t *heap)
     tidesdb_kv_pair_t *result = top->current_kv;
     if (result && (result->entry.flags & TDB_KV_FLAG_BORROWED))
     {
-        result = tidesdb_kv_pair_create(
-            result->key, result->entry.key_size, result->value, result->entry.value_size,
-            result->entry.ttl, result->entry.seq, result->entry.flags & TDB_KV_FLAG_TOMBSTONE);
+        const uint32_t ks = result->entry.key_size;
+        const uint32_t vs = (result->value) ? result->entry.value_size : 0;
+        const size_t needed = sizeof(tidesdb_kv_pair_t) + ks + vs;
+
+        /* we use pre-allocated pop buffer when available to avoid malloc */
+        if (heap->pop_buf[0])
+        {
+            const int slot = heap->pop_buf_slot;
+            if (heap->pop_buf_cap[slot] < needed)
+            {
+                const size_t new_cap = (needed > 256) ? needed : 256;
+                uint8_t *nb = realloc(heap->pop_buf[slot], new_cap);
+                if (nb)
+                {
+                    heap->pop_buf[slot] = nb;
+                    heap->pop_buf_cap[slot] = new_cap;
+                }
+            }
+
+            if (heap->pop_buf_cap[slot] >= needed)
+            {
+                uint8_t *buf = heap->pop_buf[slot];
+                tidesdb_kv_pair_t *bkv = (tidesdb_kv_pair_t *)buf;
+
+                bkv->entry = result->entry;
+                bkv->entry.flags =
+                    (result->entry.flags & TDB_KV_FLAG_TOMBSTONE) | TDB_KV_FLAG_POP_BUF;
+                bkv->key = buf + sizeof(tidesdb_kv_pair_t);
+                memcpy(bkv->key, result->key, ks);
+                if (vs > 0)
+                {
+                    bkv->value = bkv->key + ks;
+                    memcpy(bkv->value, result->value, vs);
+                }
+                else
+                {
+                    bkv->value = NULL;
+                }
+                result = bkv;
+            }
+            else
+            {
+                result = tidesdb_kv_pair_create(result->key, result->entry.key_size, result->value,
+                                                result->entry.value_size, result->entry.ttl,
+                                                result->entry.seq,
+                                                result->entry.flags & TDB_KV_FLAG_TOMBSTONE);
+            }
+        }
+        else
+        {
+            result = tidesdb_kv_pair_create(
+                result->key, result->entry.key_size, result->value, result->entry.value_size,
+                result->entry.ttl, result->entry.seq, result->entry.flags & TDB_KV_FLAG_TOMBSTONE);
+        }
     }
     top->current_kv = NULL;
 
@@ -8843,7 +8903,7 @@ static tidesdb_kv_pair_t *tidesdb_merge_heap_pop_max(tidesdb_merge_heap_t *heap)
     }
 
     /* restore max-heap property */
-    if (heap->num_sources > 0) heap_sift_down_max(heap, 0);
+    if (heap->num_sources > 1) heap_sift_down_max(heap, 0);
 
     return result;
 }
@@ -8894,6 +8954,8 @@ static void tidesdb_merge_heap_free(tidesdb_merge_heap_t *heap)
     }
 
     free(heap->sources);
+    free(heap->pop_buf[0]);
+    free(heap->pop_buf[1]);
     free(heap);
 }
 
@@ -8948,9 +9010,62 @@ static tidesdb_kv_pair_t *tidesdb_merge_heap_pop(tidesdb_merge_heap_t *heap,
     tidesdb_kv_pair_t *result = top->current_kv;
     if (result && (result->entry.flags & TDB_KV_FLAG_BORROWED))
     {
-        result = tidesdb_kv_pair_create(
-            result->key, result->entry.key_size, result->value, result->entry.value_size,
-            result->entry.ttl, result->entry.seq, result->entry.flags & TDB_KV_FLAG_TOMBSTONE);
+        const uint32_t ks = result->entry.key_size;
+        const uint32_t vs = (result->value) ? result->entry.value_size : 0;
+        const size_t needed = sizeof(tidesdb_kv_pair_t) + ks + vs;
+
+        /* we use pre-allocated pop buffer when available to avoid malloc.
+         * the iterator enables this via heap->pop_buf; compaction leaves it NULL. */
+        if (heap->pop_buf[0])
+        {
+            const int slot = heap->pop_buf_slot;
+            if (heap->pop_buf_cap[slot] < needed)
+            {
+                const size_t new_cap = (needed > 256) ? needed : 256;
+                uint8_t *nb = realloc(heap->pop_buf[slot], new_cap);
+                if (nb)
+                {
+                    heap->pop_buf[slot] = nb;
+                    heap->pop_buf_cap[slot] = new_cap;
+                }
+            }
+
+            if (heap->pop_buf_cap[slot] >= needed)
+            {
+                uint8_t *buf = heap->pop_buf[slot];
+                tidesdb_kv_pair_t *bkv = (tidesdb_kv_pair_t *)buf;
+
+                bkv->entry = result->entry;
+                bkv->entry.flags =
+                    (result->entry.flags & TDB_KV_FLAG_TOMBSTONE) | TDB_KV_FLAG_POP_BUF;
+                bkv->key = buf + sizeof(tidesdb_kv_pair_t);
+                memcpy(bkv->key, result->key, ks);
+                if (vs > 0)
+                {
+                    bkv->value = bkv->key + ks;
+                    memcpy(bkv->value, result->value, vs);
+                }
+                else
+                {
+                    bkv->value = NULL;
+                }
+                result = bkv;
+            }
+            else
+            {
+                /* realloc failed, we fall back to malloc */
+                result = tidesdb_kv_pair_create(result->key, result->entry.key_size, result->value,
+                                                result->entry.value_size, result->entry.ttl,
+                                                result->entry.seq,
+                                                result->entry.flags & TDB_KV_FLAG_TOMBSTONE);
+            }
+        }
+        else
+        {
+            result = tidesdb_kv_pair_create(
+                result->key, result->entry.key_size, result->value, result->entry.value_size,
+                result->entry.ttl, result->entry.seq, result->entry.flags & TDB_KV_FLAG_TOMBSTONE);
+        }
     }
     top->current_kv = NULL;
 
@@ -8977,7 +9092,7 @@ static tidesdb_kv_pair_t *tidesdb_merge_heap_pop(tidesdb_merge_heap_t *heap,
         }
     }
 
-    if (heap->num_sources > 0)
+    if (heap->num_sources > 1)
     {
         heap_sift_down(heap, 0);
     }
@@ -10193,25 +10308,129 @@ static int tidesdb_merge_source_advance(tidesdb_merge_source_t *source)
                     source->source.sstable.klog_cursor->current_pos, &cached_size, &pin);
                 if (cached_data)
                 {
-                    data = cached_data;
-                    data_size = cached_size;
-
-                    /* strip indexed block header if present (variable-size header
-                     * with magic + hdr_size field, matching tidesdb_iter_read_klog_block) */
+                    /* when the cached block has an index (from a prior seek),
+                     * we set up lazy state and parse the first entry via the
+                     * index.  this avoids the O(N) full klog_block_deserialize
+                     * and instead uses O(1) per-entry incremental parsing --
+                     * the same path that seek uses. */
                     if (cached_size >= TDB_BLOCK_INDEX_HDR_BASE)
                     {
                         const uint32_t maybe_magic = decode_uint32_le_compat(cached_data);
                         if (maybe_magic == TDB_BLOCK_INDEX_MAGIC)
                         {
                             const uint32_t hdr_size = decode_uint32_le_compat(cached_data + 4);
-                            if (hdr_size < cached_size)
+                            const uint32_t idx_count = decode_uint32_le_compat(cached_data + 8);
+                            if (hdr_size < cached_size && idx_count > 0)
                             {
-                                data = cached_data + hdr_size;
-                                data_size = cached_size - hdr_size;
+                                const uint8_t *idx_base = cached_data + TDB_BLOCK_INDEX_HDR_BASE;
+                                const uint8_t *bdata = cached_data + hdr_size;
+                                const size_t bdata_size = cached_size - hdr_size;
+
+                                /* we parse first entry from block index */
+                                const uint8_t *fie = idx_base;
+                                const uint32_t e_off =
+                                    decode_uint32_le_compat(fie + TDB_BLOCK_IDX_ENTRY_OFF);
+                                const uint32_t mk_off =
+                                    decode_uint32_le_compat(fie + TDB_BLOCK_IDX_KEY_OFF);
+                                const uint32_t mk_sz =
+                                    decode_uint32_le_compat(fie + TDB_BLOCK_IDX_KEY_SIZE);
+                                const uint32_t sq_lo =
+                                    decode_uint32_le_compat(fie + TDB_BLOCK_IDX_SEQ_LO);
+                                const uint32_t sq_hi =
+                                    decode_uint32_le_compat(fie + TDB_BLOCK_IDX_SEQ_HI);
+
+                                if (e_off < bdata_size)
+                                {
+                                    const uint8_t *eptr = bdata + e_off;
+                                    size_t erem = bdata_size - e_off;
+                                    const uint8_t flags = *eptr++;
+                                    erem--;
+
+                                    uint64_t ks, vs;
+                                    int br = decode_varint(eptr, &ks, (int)erem);
+                                    eptr += br;
+                                    erem -= br;
+                                    br = decode_varint(eptr, &vs, (int)erem);
+                                    eptr += br;
+                                    erem -= br;
+                                    uint64_t seq_skip;
+                                    br = decode_varint(eptr, &seq_skip, (int)erem);
+                                    eptr += br;
+                                    erem -= br;
+                                    int64_t ttl = 0;
+                                    if (flags & TDB_KV_FLAG_HAS_TTL)
+                                    {
+                                        if (erem >= sizeof(int64_t))
+                                        {
+                                            ttl = decode_int64_le_compat(eptr);
+                                            eptr += sizeof(int64_t);
+                                            erem -= sizeof(int64_t);
+                                        }
+                                    }
+                                    uint64_t vlog_offset = 0;
+                                    if (flags & TDB_KV_FLAG_HAS_VLOG)
+                                    {
+                                        uint64_t vo;
+                                        decode_varint(eptr, &vo, (int)erem);
+                                        vlog_offset = vo;
+                                    }
+
+                                    const uint64_t abs_seq = ((uint64_t)sq_hi << 32) | sq_lo;
+                                    const uint8_t *key_ptr = bdata + mk_off;
+
+                                    if (vlog_offset > 0)
+                                    {
+                                        uint8_t *vlog_value = NULL;
+                                        tidesdb_vlog_read_value(
+                                            source->source.sstable.db, source->source.sstable.sst,
+                                            vlog_offset, (size_t)vs, &vlog_value);
+                                        source->current_kv = tidesdb_kv_pair_create(
+                                            key_ptr, mk_sz, vlog_value, (size_t)vs, ttl, abs_seq,
+                                            flags & TDB_KV_FLAG_TOMBSTONE);
+                                        free(vlog_value);
+                                    }
+                                    else
+                                    {
+                                        tidesdb_kv_pair_t *ikv = &source->inline_kv;
+                                        ikv->entry.flags =
+                                            (flags & TDB_KV_FLAG_TOMBSTONE) | TDB_KV_FLAG_BORROWED;
+                                        ikv->entry.key_size = mk_sz;
+                                        ikv->entry.value_size = (uint32_t)vs;
+                                        ikv->entry.seq = abs_seq;
+                                        ikv->entry.ttl = ttl;
+                                        ikv->entry.vlog_offset = 0;
+                                        ikv->key = (uint8_t *)key_ptr;
+                                        ikv->value =
+                                            (vs > 0) ? (uint8_t *)(bdata + mk_off + mk_sz) : NULL;
+                                        source->current_kv = ikv;
+                                    }
+
+                                    /* we set up lazy state so subsequent advance() calls
+                                     * parse entries incrementally from the index */
+                                    tidesdb_iter_clear_lazy(source);
+                                    source->source.sstable.lazy.data = cached_data;
+                                    source->source.sstable.lazy.size = cached_size;
+                                    source->source.sstable.lazy.pin = pin;
+                                    source->source.sstable.lazy.block_data = bdata;
+                                    source->source.sstable.lazy.block_data_size = bdata_size;
+                                    source->source.sstable.lazy.idx_base = idx_base;
+                                    source->source.sstable.lazy.idx_count = idx_count;
+                                    source->source.sstable.lazy.entry_idx = 0;
+                                    source->source.sstable.lazy.bmblock = NULL;
+                                    source->source.sstable.lazy.decompressed = NULL;
+                                    source->source.sstable.current_entry_idx = 0;
+                                    source->source.sstable.klog_cursor->current_block_size =
+                                        bdata_size;
+                                    source->source.sstable.klog_cursor->block_size_valid = 1;
+                                    return TDB_SUCCESS;
+                                }
                             }
                         }
                     }
 
+                    /* non-indexed cache hit -- fall through to full deserialize */
+                    data = cached_data;
+                    data_size = cached_size;
                     source->source.sstable.cache_pin = pin;
                     goto advance_deserialize;
                 }
@@ -10242,7 +10461,10 @@ static int tidesdb_merge_source_advance(tidesdb_merge_source_t *source)
                 }
             }
 
-            /* populate cache for future iterations over this block */
+            /* populate cache for future iterations over this block.
+             * we cache raw data here (not indexed) because sequential advance
+             * reads each block once; building the index would be wasted CPU.
+             * the seek path builds indexed format on its own cache-insert. */
             if (sst->db && sst->db->clock_cache && has_cf_name)
             {
                 tidesdb_cache_raw_block_put(sst->db, cf_name, sst->klog_filename,
@@ -22331,6 +22553,16 @@ int tidesdb_iter_new(tidesdb_txn_t *txn, tidesdb_column_family_t *cf, tidesdb_it
         return TDB_ERR_MEMORY;
     }
 
+    /* we enable double-buffered pop arena to avoid malloc during borrowed KV
+     * materialization in merge_heap_pop. each buffer holds one materialized
+     * result; the iterator toggles between them so prev and current never
+     * share the same slot. */
+    (*iter)->heap->pop_buf[0] = malloc(256);
+    (*iter)->heap->pop_buf[1] = malloc(256);
+    (*iter)->heap->pop_buf_cap[0] = (*iter)->heap->pop_buf[0] ? 256 : 0;
+    (*iter)->heap->pop_buf_cap[1] = (*iter)->heap->pop_buf[1] ? 256 : 0;
+    (*iter)->heap->pop_buf_slot = 0;
+
     size_t imm_count = 0;
     tidesdb_immutable_memtable_t **imm_snapshot =
         tidesdb_snapshot_immutable_memtables(cf, &imm_count);
@@ -24972,6 +25204,10 @@ int tidesdb_iter_next(tidesdb_iter_t *iter)
     if (!iter) return TDB_ERR_INVALID_ARGS;
     if (!iter->valid) return TDB_ERR_INVALID_ARGS;
 
+    /* we toggle pop buffer slot so new pops write to a different
+     * buffer than the previous iter->current (avoids clobbering prev) */
+    iter->heap->pop_buf_slot ^= 1;
+
     /* we check if direction changed from backward to forward */
     const int direction_changed = (iter->direction == -1);
 
@@ -25051,9 +25287,15 @@ int tidesdb_iter_next(tidesdb_iter_t *iter)
             continue;
         }
 
-        /* snapshot isolation -- we track read for conflict detection */
-        tidesdb_txn_add_to_read_set(iter->txn, iter->cf, kv->key, kv->entry.key_size,
-                                    kv->entry.seq);
+        /* we only track reads for isolation levels that need conflict detection
+         * (REPEATABLE_READ and SERIALIZABLE).  for READ_COMMITTED and below the
+         * function would just early-exit, but skipping the call entirely avoids
+         * the overhead of alot of function calls during a full scan. */
+        if (iter->txn->isolation_level >= TDB_ISOLATION_REPEATABLE_READ)
+        {
+            tidesdb_txn_add_to_read_set(iter->txn, iter->cf, kv->key, kv->entry.key_size,
+                                        kv->entry.seq);
+        }
 
         tidesdb_kv_pair_free(prev);
         iter->current = kv;
@@ -25069,6 +25311,10 @@ int tidesdb_iter_prev(tidesdb_iter_t *iter)
 {
     if (!iter) return TDB_ERR_INVALID_ARGS;
     if (!iter->valid) return TDB_ERR_INVALID_ARGS;
+
+    /* we toggle pop buffer slot so new pops write to a different
+     * buffer than the previous iter->current (avoids clobbering prev) */
+    iter->heap->pop_buf_slot ^= 1;
 
     /* we check if direction changed from forward to backward */
     const int direction_changed = (iter->direction == 1);
@@ -25147,9 +25393,12 @@ int tidesdb_iter_prev(tidesdb_iter_t *iter)
             continue;
         }
 
-        /* snapshot isolation -- we track read for conflict detection */
-        tidesdb_txn_add_to_read_set(iter->txn, iter->cf, kv->key, kv->entry.key_size,
-                                    kv->entry.seq);
+        /* we only track reads for REPEATABLE_READ and SERIALIZABLE */
+        if (iter->txn->isolation_level >= TDB_ISOLATION_REPEATABLE_READ)
+        {
+            tidesdb_txn_add_to_read_set(iter->txn, iter->cf, kv->key, kv->entry.key_size,
+                                        kv->entry.seq);
+        }
 
         tidesdb_kv_pair_free(prev);
         iter->current = kv;

--- a/test/block_manager__tests.c
+++ b/test/block_manager__tests.c
@@ -17,9 +17,9 @@
  * limitations under the License.
  */
 
+#include "../external/xxhash.h"
 #include "../src/block_manager.h"
 #include "test_utils.h"
-#include "../external/xxhash.h"
 #ifndef _WIN32
 #include <signal.h>
 #include <sys/time.h>
@@ -930,15 +930,8 @@ void test_block_manager_open_safety()
     }
 }
 
-/**
- * test_block_manager_write_raw
- * verifies that block_manager_write_raw produces the same on-disk format
- * as block_manager_block_write, and that blocks written with write_raw
- * are correctly readable via cursor_read after close+reopen.
- */
 void test_block_manager_write_raw(void)
 {
-    /* --- 1. basic write + read back ----------------------------------- */
     block_manager_t *bm = NULL;
     ASSERT_TRUE(block_manager_open(&bm, "test_write_raw.db", BLOCK_MANAGER_SYNC_NONE) == 0);
 
@@ -948,7 +941,6 @@ void test_block_manager_write_raw(void)
     int64_t offset = block_manager_write_raw(bm, payload, payload_size);
     ASSERT_TRUE(offset >= 0);
 
-    /* read it back immediately via cursor */
     block_manager_cursor_t *cursor = NULL;
     ASSERT_TRUE(block_manager_cursor_init(&cursor, bm) == 0);
     ASSERT_TRUE(block_manager_cursor_goto(cursor, (uint64_t)offset) == 0);
@@ -959,7 +951,6 @@ void test_block_manager_write_raw(void)
     block_manager_block_free(block);
     block_manager_cursor_free(cursor);
 
-    /* close and reopen to verify persistence */
     ASSERT_TRUE(block_manager_close(bm) == 0);
     ASSERT_TRUE(block_manager_open(&bm, "test_write_raw.db", BLOCK_MANAGER_SYNC_NONE) == 0);
 
@@ -974,7 +965,6 @@ void test_block_manager_write_raw(void)
     ASSERT_TRUE(block_manager_close(bm) == 0);
     remove("test_write_raw.db");
 
-    /* --- 2. multiple raw writes + sequential cursor iteration --------- */
     ASSERT_TRUE(block_manager_open(&bm, "test_write_raw.db", BLOCK_MANAGER_SYNC_NONE) == 0);
 
     const int num_entries = 20;
@@ -1007,7 +997,6 @@ void test_block_manager_write_raw(void)
     ASSERT_TRUE(block_manager_close(bm) == 0);
     remove("test_write_raw.db");
 
-    /* --- 3. interleave write_raw and block_write ---------------------- */
     ASSERT_TRUE(block_manager_open(&bm, "test_write_raw.db", BLOCK_MANAGER_SYNC_NONE) == 0);
 
     const char raw_data[] = "from_write_raw";
@@ -1054,7 +1043,6 @@ void test_block_manager_write_raw(void)
     ASSERT_TRUE(block_manager_close(bm) == 0);
     remove("test_write_raw.db");
 
-    /* --- 4. edge cases ------------------------------------------------ */
     ASSERT_TRUE(block_manager_open(&bm, "test_write_raw.db", BLOCK_MANAGER_SYNC_NONE) == 0);
 
     /* NULL bm, NULL data, zero size should all return -1 */
@@ -1083,11 +1071,6 @@ void test_block_manager_write_raw(void)
 #define NUM_BLOCKS 100000
 #define BLOCK_SIZE 256
 
-/**
- * benchmark_block_manager_write_raw
- * compares write throughput of block_manager_write_raw vs block_manager_block_write
- * and verifies data integrity of all blocks written via write_raw.
- */
 void benchmark_block_manager_write_raw(void)
 {
     const int bench_blocks = NUM_BLOCKS;
@@ -1107,7 +1090,6 @@ void benchmark_block_manager_write_raw(void)
         snprintf((char *)(data[i] + bench_size - 20), 20, "raw_%d", i);
     }
 
-    /* --- benchmark block_write (baseline) ----------------------------- */
     block_manager_t *bm = NULL;
     (void)remove("bench_raw_baseline.db");
     ASSERT_TRUE(block_manager_open(&bm, "bench_raw_baseline.db", BLOCK_MANAGER_SYNC_NONE) == 0);
@@ -1126,7 +1108,6 @@ void benchmark_block_manager_write_raw(void)
     ASSERT_TRUE(block_manager_close(bm) == 0);
     remove("bench_raw_baseline.db");
 
-    /* --- benchmark write_raw ------------------------------------------ */
     (void)remove("bench_raw_new.db");
     ASSERT_TRUE(block_manager_open(&bm, "bench_raw_new.db", BLOCK_MANAGER_SYNC_NONE) == 0);
 
@@ -1149,7 +1130,6 @@ void benchmark_block_manager_write_raw(void)
     printf("  write_raw:   %.3f sec (%.2f MB/s)\n" RESET, raw_sec,
            raw_sec > 0 ? (bench_blocks * bench_size) / (raw_sec * 1024 * 1024) : 0.0);
 
-    /* --- verify all blocks written by write_raw ----------------------- */
     ASSERT_TRUE(block_manager_close(bm) == 0);
     ASSERT_TRUE(block_manager_open(&bm, "bench_raw_new.db", BLOCK_MANAGER_SYNC_NONE) == 0);
 
@@ -2882,19 +2862,19 @@ void test_write_raw_hole_stops_replay(void)
     block_manager_t *bm = NULL;
     ASSERT_TRUE(block_manager_open(&bm, test_file, BLOCK_MANAGER_SYNC_NONE) == 0);
 
-    const char *payload_a  = "block_A_payload";
-    const uint32_t size_a  = (uint32_t)(strlen(payload_a) + 1);
-    int64_t offset_a       = block_manager_write_raw(bm, payload_a, size_a);
+    const char *payload_a = "block_A_payload";
+    const uint32_t size_a = (uint32_t)(strlen(payload_a) + 1);
+    int64_t offset_a = block_manager_write_raw(bm, payload_a, size_a);
     ASSERT_TRUE(offset_a >= 0);
 
-    const char *payload_b  = "block_B_payload";
-    const uint32_t size_b  = (uint32_t)(strlen(payload_b) + 1);
-    int64_t offset_b       = block_manager_write_raw(bm, payload_b, size_b);
+    const char *payload_b = "block_B_payload";
+    const uint32_t size_b = (uint32_t)(strlen(payload_b) + 1);
+    int64_t offset_b = block_manager_write_raw(bm, payload_b, size_b);
     ASSERT_TRUE(offset_b >= 0);
 
-    const char *payload_c  = "block_C_payload";
-    const uint32_t size_c  = (uint32_t)(strlen(payload_c) + 1);
-    int64_t offset_c       = block_manager_write_raw(bm, payload_c, size_c);
+    const char *payload_c = "block_C_payload";
+    const uint32_t size_c = (uint32_t)(strlen(payload_c) + 1);
+    int64_t offset_c = block_manager_write_raw(bm, payload_c, size_c);
     ASSERT_TRUE(offset_c >= 0);
 
     /*
@@ -3072,7 +3052,7 @@ void test_block_manager_write_raw_signal_safe(void)
     struct sigaction sa, old_sa;
     memset(&sa, 0, sizeof(sa));
     sa.sa_handler = test_sigalrm_handler;
-    sa.sa_flags   = 0;
+    sa.sa_flags = 0;
     sigemptyset(&sa.sa_mask);
     sigaction(SIGALRM, &sa, &old_sa);
 
@@ -3081,10 +3061,10 @@ void test_block_manager_write_raw_signal_safe(void)
      * writes may finish before any signal is delivered. Loop on wall-clock
      * time and keep driving writes until at least one signal has landed. */
     struct itimerval itv;
-    itv.it_interval.tv_sec  = 0;
+    itv.it_interval.tv_sec = 0;
     itv.it_interval.tv_usec = 500;
-    itv.it_value.tv_sec     = 0;
-    itv.it_value.tv_usec    = 500;
+    itv.it_value.tv_sec = 0;
+    itv.it_value.tv_usec = 500;
     setitimer(ITIMER_REAL, &itv, NULL);
 
     g_signal_count = 0;
@@ -3111,8 +3091,8 @@ void test_block_manager_write_raw_signal_safe(void)
 
     ASSERT_EQ(failures, 0);
     ASSERT_TRUE(g_signal_count > 0);
-    printf("  [signal-safe] %d signals delivered, 0/%d write failures\n",
-           g_signal_count, iterations);
+    printf("  [signal-safe] %d signals delivered, 0/%d write failures\n", g_signal_count,
+           iterations);
 
     ASSERT_TRUE(block_manager_close(bm) == 0);
     (void)remove(test_file);
@@ -3142,7 +3122,7 @@ void test_cursor_skip_corrupt_partial_write(void)
     ASSERT_TRUE(offset_b >= 0);
     ASSERT_TRUE(offset_c >= 0);
 
-    /* simulate partial write at B: leave header intact, zero data+footer.
+    /* simulate partial write at B leave header intact, zero data+footer.
      * the header's size field stays valid (size_b); the footer magic becomes 0. */
     const size_t zero_len = size_b + BLOCK_MANAGER_FOOTER_SIZE;
     uint8_t *zeros = (uint8_t *)calloc(1, zero_len);

--- a/test/clock_cache__tests.c
+++ b/test/clock_cache__tests.c
@@ -2250,7 +2250,6 @@ static void *oltp_reader_thread(void *arg)
 
     while (!atomic_load(a->stop_flag))
     {
-        /* Zipfian pick from block keyspace */
         int block_id = zipf_pick(&rng, OLTP_NUM_BLOCKS);
         char key[32];
         snprintf(key, sizeof(key), "blk:%05d", block_id);
@@ -2454,7 +2453,6 @@ void test_realistic_working_set_shift(void)
             free(block);
         }
 
-        /* Zipfian reads within this epoch's range */
         int hits = 0;
         for (int i = 0; i < reads_per_epoch; i++)
         {

--- a/test/local_cache__tests.c
+++ b/test/local_cache__tests.c
@@ -409,7 +409,7 @@ void test_local_cache_lru_ordering(void)
         ASSERT_EQ(tdb_local_cache_track(&cache, paths[i]), 0);
     }
 
-    /* LRU order should be: head=4, 3, 2, 1, tail=0 */
+    /* LRU order should be head=4, 3, 2, 1, tail=0 */
     ASSERT_EQ(strcmp(cache.lru_head->path, paths[4]), 0);
     ASSERT_EQ(strcmp(cache.lru_tail->path, paths[0]), 0);
 

--- a/test/queue__tests.c
+++ b/test/queue__tests.c
@@ -1159,7 +1159,6 @@ void benchmark_queue_foreach_peek_at_concurrent()
     printf("  Queue size: %d, Iterations per thread: %d\n", BENCH_FOREACH_PEEK_QUEUE_SIZE,
            BENCH_FOREACH_PEEK_ITERATIONS);
 
-    /* Benchmark queue_foreach with multiple threads */
     {
         pthread_t threads[BENCH_FOREACH_PEEK_NUM_THREADS];
         benchmark_foreach_peek_args_t args[BENCH_FOREACH_PEEK_NUM_THREADS];
@@ -1203,7 +1202,6 @@ void benchmark_queue_foreach_peek_at_concurrent()
                BENCH_FOREACH_PEEK_NUM_THREADS, ops_per_sec / 1e6, elapsed, total_visits);
     }
 
-    /* Benchmark queue_peek_at with multiple threads */
     {
         pthread_t threads[BENCH_FOREACH_PEEK_NUM_THREADS];
         benchmark_foreach_peek_args_t args[BENCH_FOREACH_PEEK_NUM_THREADS];


### PR DESCRIPTION
reduce per-entry overhead in merge heap pop by materializing borrowed kv pairs into a double-buffered arena on the heap instead of malloc/free per entry.

skip heap sift when only one source remains.

gate read set tracking behind an isolation-level check so read_committed iterators avoid the function call entirely.

when the advance path hits an indexed block in the cache, set up lazy state and parse entries incrementally via the block index instead of falling through to full o(n) klog deserialization.

remove the o(total_cache_slots) prefix scan from sstable free during compaction. dead cache entries for deleted sstables are never hit again since klog filenames include monotonic ids, so the clock sweep reclaims them naturally when it needs space.

this eliminates atomic ref_bit contention between compaction threads and concurrent iterators on the block cache.