### PR TITLE
TidesDB 9 MINOR (v9.1.0)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 project(tidesdb C)
 
 set(CMAKE_C_STANDARD 11)
-set(PROJECT_VERSION 9.0.9)
+set(PROJECT_VERSION 9.1.0)
 
 configure_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/src/tidesdb_version.h.in"

--- a/src/btree.c
+++ b/src/btree.c
@@ -131,10 +131,10 @@ static inline size_t btree_signed_varint_decode(const uint8_t *buf, int64_t *val
  * @param len2 length of second key
  * @return the number of common prefix bytes
  */
-static inline size_t btree_compute_prefix_len(const uint8_t *key1, size_t len1, const uint8_t *key2,
-                                              size_t len2)
+static inline size_t btree_compute_prefix_len(const uint8_t *key1, const size_t len1,
+                                              const uint8_t *key2, const size_t len2)
 {
-    size_t min_len = (len1 < len2) ? len1 : len2;
+    const size_t min_len = (len1 < len2) ? len1 : len2;
     size_t prefix_len = 0;
     while (prefix_len < min_len && key1[prefix_len] == key2[prefix_len])
     {
@@ -358,7 +358,7 @@ int btree_comparator_memcmp(const uint8_t *key1, size_t key1_size, const uint8_t
                             size_t key2_size, void *ctx)
 {
     (void)ctx;
-    size_t min_size = key1_size < key2_size ? key1_size : key2_size;
+    const size_t min_size = key1_size < key2_size ? key1_size : key2_size;
     const int cmp = memcmp(key1, key2, min_size);
     if (cmp != 0) return cmp < 0 ? -1 : 1;
     return (key1_size < key2_size) ? -1 : (key1_size > key2_size) ? 1 : 0;
@@ -1590,12 +1590,11 @@ static int btree_builder_flush_leaf(btree_builder_t *builder)
 
 int btree_builder_add(btree_builder_t *builder, const uint8_t *key, const size_t key_size,
                       const uint8_t *value, const size_t value_size, const uint64_t vlog_offset,
-                      const uint64_t seq, const int64_t ttl, const uint8_t deleted)
+                      const uint64_t seq, const int64_t ttl, const uint8_t entry_flags)
 {
     if (!builder || !key || key_size == 0) return -1;
 
-    uint8_t flags = 0;
-    if (deleted) flags |= BTREE_ENTRY_FLAG_TOMBSTONE;
+    uint8_t flags = entry_flags & (BTREE_ENTRY_FLAG_TOMBSTONE | BTREE_ENTRY_FLAG_SINGLE_DELETE);
     if (ttl != 0) flags |= BTREE_ENTRY_FLAG_HAS_TTL;
     if (vlog_offset > 0) flags |= BTREE_ENTRY_FLAG_VLOG_REF;
 
@@ -2202,7 +2201,12 @@ int btree_get(btree_t *tree, const uint8_t *key, const size_t key_size, uint8_t 
     if (vlog_offset) *vlog_offset = entry->vlog_offset;
     if (seq) *seq = entry->seq;
     if (ttl) *ttl = entry->ttl;
-    if (deleted) *deleted = (entry->flags & BTREE_ENTRY_FLAG_TOMBSTONE) ? 1 : 0;
+    /* deleted returns the persisted tombstone/single-delete bits so compaction
+     * can distinguish single-delete from regular delete. the low bit still
+     * equals BTREE_ENTRY_FLAG_TOMBSTONE, so callers that treat *deleted as a
+     * bool keep working unchanged. */
+    if (deleted)
+        *deleted = entry->flags & (BTREE_ENTRY_FLAG_TOMBSTONE | BTREE_ENTRY_FLAG_SINGLE_DELETE);
 
     btree_node_done(node, using_cache);
     return 0;
@@ -2723,7 +2727,12 @@ int btree_cursor_get(btree_cursor_t *cursor, uint8_t **key, size_t *key_size, ui
     if (vlog_offset) *vlog_offset = entry->vlog_offset;
     if (seq) *seq = entry->seq;
     if (ttl) *ttl = entry->ttl;
-    if (deleted) *deleted = (entry->flags & BTREE_ENTRY_FLAG_TOMBSTONE) ? 1 : 0;
+    /* deleted returns the persisted tombstone/single-delete bits so compaction
+     * can distinguish single-delete from regular delete. the low bit still
+     * equals BTREE_ENTRY_FLAG_TOMBSTONE, so callers that treat *deleted as a
+     * bool keep working unchanged. */
+    if (deleted)
+        *deleted = entry->flags & (BTREE_ENTRY_FLAG_TOMBSTONE | BTREE_ENTRY_FLAG_SINGLE_DELETE);
 
     return 0;
 }

--- a/src/btree.h
+++ b/src/btree.h
@@ -44,6 +44,10 @@
 #define BTREE_ENTRY_FLAG_TOMBSTONE 0x01
 #define BTREE_ENTRY_FLAG_HAS_TTL   0x02
 #define BTREE_ENTRY_FLAG_VLOG_REF  0x04 /* value is in vlog, not inline */
+#define BTREE_ENTRY_FLAG_SINGLE_DELETE       \
+    0x10 /* single-delete tombstone subtype, \
+          * always set alongside             \
+          * BTREE_ENTRY_FLAG_TOMBSTONE */
 
 /* default configuration */
 #define BTREE_DEFAULT_NODE_SIZE    (64 * 1024) /* 64KB target node size */
@@ -369,12 +373,15 @@ int btree_builder_new(btree_builder_t **builder, block_manager_t *bm, const btre
  * @param vlog_offset vlog offset if value is external (0 = inline)
  * @param seq sequence number
  * @param ttl time-to-live (0 = no expiry)
- * @param deleted tombstone flag
+ * @param entry_flags bitmask of BTREE_ENTRY_FLAG_* to persist on this entry
+ *                    (TOMBSTONE, SINGLE_DELETE). HAS_TTL and VLOG_REF are
+ *                    derived from ttl and vlog_offset. passing 1 (a bare
+ *                    tombstone) stays valid because 1 == TOMBSTONE.
  * @return 0 on success, -1 on failure
  */
 int btree_builder_add(btree_builder_t *builder, const uint8_t *key, size_t key_size,
                       const uint8_t *value, size_t value_size, uint64_t vlog_offset, uint64_t seq,
-                      int64_t ttl, uint8_t deleted);
+                      int64_t ttl, uint8_t entry_flags);
 
 /**
  * btree_builder_finish

--- a/src/db.h
+++ b/src/db.h
@@ -561,6 +561,8 @@ int tidesdb_txn_get(tidesdb_txn_t *txn, tidesdb_column_family_t *cf, const uint8
                     size_t key_size, uint8_t **value, size_t *value_size);
 int tidesdb_txn_delete(tidesdb_txn_t *txn, tidesdb_column_family_t *cf, const uint8_t *key,
                        size_t key_size);
+int tidesdb_txn_single_delete(tidesdb_txn_t *txn, tidesdb_column_family_t *cf, const uint8_t *key,
+                              size_t key_size);
 int tidesdb_txn_commit(tidesdb_txn_t *txn);
 int tidesdb_txn_rollback(tidesdb_txn_t *txn);
 int tidesdb_txn_reset(tidesdb_txn_t *txn, tidesdb_isolation_level_t isolation);

--- a/src/skip_list.c
+++ b/src/skip_list.c
@@ -666,13 +666,13 @@ int skip_list_comparator_numeric(const uint8_t *key1, size_t key1_size, const ui
  * @param value value data
  * @param value_size size of value
  * @param ttl time-to-live
- * @param deleted tombstone flag
+ * @param flags version flags (bitmask of SKIP_LIST_FLAG_*)
  * @param seq sequence number for MVCC
  * @return pointer to new version, NULL on failure
  */
 static skip_list_version_t *skip_list_create_version(const skip_list_t *list, const uint8_t *value,
                                                      const size_t value_size, const int64_t ttl,
-                                                     const uint8_t deleted, uint64_t seq)
+                                                     const uint8_t flags, uint64_t seq)
 {
     /* we combine version struct + value data into a single allocation
      * this halves malloc calls and improves cache locality */
@@ -693,7 +693,7 @@ static skip_list_version_t *skip_list_create_version(const skip_list_t *list, co
         version->value_size = 0;
     }
 
-    atomic_init(&version->flags, deleted ? SKIP_LIST_FLAG_DELETED : 0);
+    atomic_init(&version->flags, flags);
     atomic_init(&version->seq, seq);
     version->ttl = ttl;
     atomic_init(&version->next, NULL);
@@ -758,7 +758,7 @@ static skip_list_node_t *skip_list_create_sentinel(const int level)
 
 skip_list_node_t *skip_list_create_node(const int level, const uint8_t *key, size_t key_size,
                                         const uint8_t *value, const size_t value_size,
-                                        const int64_t ttl, const uint8_t deleted)
+                                        const int64_t ttl, const uint8_t flags)
 {
     if (key == NULL || key_size == 0) return NULL;
 
@@ -775,15 +775,16 @@ skip_list_node_t *skip_list_create_node(const int level, const uint8_t *key, siz
     node->level = (uint8_t)level;
     node->node_flags = 0; /* not a sentinel */
 
+    const int is_tombstone = (flags & SKIP_LIST_FLAG_DELETED) != 0;
     skip_list_version_t *initial_version = NULL;
-    if (value != NULL || deleted)
+    if (value != NULL || is_tombstone)
     {
-        initial_version = skip_list_create_version(NULL, value, value_size, ttl, deleted, 0);
+        initial_version = skip_list_create_version(NULL, value, value_size, ttl, flags, 0);
         if (initial_version == NULL)
         {
             /* for non-tombstones, version creation failure is fatal
-             * for tombstones (deleted=true), NULL version is acceptable */
-            if (!deleted)
+             * for tombstones, NULL version is acceptable */
+            if (!is_tombstone)
             {
                 free(node);
                 return NULL;
@@ -1540,10 +1541,19 @@ int skip_list_cursor_get_with_seq(skip_list_cursor_t *cursor, uint8_t **key, siz
     if (ttl != NULL) *ttl = version->ttl;
     if (seq != NULL) *seq = atomic_load_explicit(&version->seq, memory_order_acquire);
 
+    /* *deleted returns the version flag bits (SKIP_LIST_FLAG_*) so callers can
+     * see single-delete and not just plain tombstone.  the low bit is always set
+     * when the caller should treat this entry as a tombstone (tombstone or
+     * expired ttl), matching the old bool-like contract for existing callers. */
+    const uint8_t version_flags = atomic_load_explicit(&version->flags, memory_order_acquire);
+
     /* we check if version is invalid (expired or deleted) */
     if (skip_list_version_is_invalid_with_time(version, skip_list_get_current_time(cursor->list)))
     {
-        if (deleted != NULL) *deleted = 1;
+        if (deleted != NULL)
+        {
+            *deleted = SKIP_LIST_FLAG_DELETED | (version_flags & SKIP_LIST_FLAG_SINGLE_DELETE);
+        }
         *value = NULL;
         *value_size = 0;
         return 0;
@@ -1756,9 +1766,10 @@ int skip_list_cursor_seek_for_prev(skip_list_cursor_t *cursor, const uint8_t *ke
 
 int skip_list_put_with_seq(skip_list_t *list, const uint8_t *key, size_t key_size,
                            const uint8_t *value, size_t value_size, int64_t ttl, uint64_t seq,
-                           uint8_t deleted)
+                           uint8_t flags)
 {
-    if (list == NULL || key == NULL || key_size == 0 || (!deleted && value == NULL)) return -1;
+    const int is_tombstone = (flags & SKIP_LIST_FLAG_DELETED) != 0;
+    if (list == NULL || key == NULL || key_size == 0 || (!is_tombstone && value == NULL)) return -1;
 
     skip_list_node_t *header = atomic_load_explicit(&list->header, memory_order_acquire);
     const int max_level = atomic_load_explicit(&list->level, memory_order_acquire);
@@ -1831,7 +1842,6 @@ int skip_list_put_with_seq(skip_list_t *list, const uint8_t *key, size_t key_siz
                 return -1;
             }
 
-            const uint8_t flags = deleted ? SKIP_LIST_FLAG_DELETED : 0;
             skip_list_version_t *new_version =
                 skip_list_create_version(list, value, value_size, ttl, flags, seq);
             if (new_version == NULL)
@@ -1867,7 +1877,6 @@ int skip_list_put_with_seq(skip_list_t *list, const uint8_t *key, size_t key_siz
                 return -1;
             }
 
-            const uint8_t flags = deleted ? SKIP_LIST_FLAG_DELETED : 0;
             skip_list_version_t *new_version =
                 skip_list_create_version(list, value, value_size, ttl, flags, seq);
             if (new_version == NULL)
@@ -1916,7 +1925,6 @@ int skip_list_put_with_seq(skip_list_t *list, const uint8_t *key, size_t key_siz
     new_node->level = (uint8_t)new_level;
     new_node->node_flags = 0;
 
-    const uint8_t flags = deleted ? SKIP_LIST_FLAG_DELETED : 0;
     skip_list_version_t *initial_version =
         skip_list_create_version(list, value, value_size, ttl, flags, seq);
     if (initial_version == NULL)
@@ -1956,9 +1964,8 @@ int skip_list_put_with_seq(skip_list_t *list, const uint8_t *key, size_t key_siz
                     return -1;
                 }
 
-                const uint8_t version_flags = deleted ? SKIP_LIST_FLAG_DELETED : 0;
                 skip_list_version_t *new_version =
-                    skip_list_create_version(list, value, value_size, ttl, version_flags, seq);
+                    skip_list_create_version(list, value, value_size, ttl, flags, seq);
                 if (new_version == NULL)
                 {
                     skip_list_free_node_internal(list, new_node);
@@ -2008,9 +2015,8 @@ int skip_list_put_with_seq(skip_list_t *list, const uint8_t *key, size_t key_siz
                     return -1;
                 }
 
-                const uint8_t version_flags = deleted ? SKIP_LIST_FLAG_DELETED : 0;
                 skip_list_version_t *new_version =
-                    skip_list_create_version(list, value, value_size, ttl, version_flags, seq);
+                    skip_list_create_version(list, value, value_size, ttl, flags, seq);
                 if (new_version == NULL)
                 {
                     skip_list_free_node_internal(list, new_node);
@@ -2129,7 +2135,7 @@ int skip_list_put_batch(skip_list_t *list, const skip_list_batch_entry_t *entrie
         const skip_list_batch_entry_t *entry = &entries[e];
 
         if (entry->key == NULL || entry->key_size == 0) continue;
-        if (!entry->deleted && entry->value == NULL) continue;
+        if (!(entry->flags & SKIP_LIST_FLAG_DELETED) && entry->value == NULL) continue;
 
         const int max_level = atomic_load_explicit(&list->level, memory_order_acquire);
 
@@ -2216,9 +2222,8 @@ int skip_list_put_batch(skip_list_t *list, const skip_list_batch_entry_t *entrie
                     continue; /* skip this entry */
                 }
 
-                const uint8_t flags = entry->deleted ? SKIP_LIST_FLAG_DELETED : 0;
                 skip_list_version_t *new_version = skip_list_create_version(
-                    list, entry->value, entry->value_size, entry->ttl, flags, entry->seq);
+                    list, entry->value, entry->value_size, entry->ttl, entry->flags, entry->seq);
                 if (new_version == NULL)
                 {
                     continue;
@@ -2261,9 +2266,8 @@ int skip_list_put_batch(skip_list_t *list, const skip_list_batch_entry_t *entrie
         new_node->level = (uint8_t)new_level;
         new_node->node_flags = 0;
 
-        const uint8_t flags = entry->deleted ? SKIP_LIST_FLAG_DELETED : 0;
         skip_list_version_t *initial_version = skip_list_create_version(
-            list, entry->value, entry->value_size, entry->ttl, flags, entry->seq);
+            list, entry->value, entry->value_size, entry->ttl, entry->flags, entry->seq);
         if (initial_version == NULL)
         {
             skip_list_dealloc(list, new_node);
@@ -2299,10 +2303,9 @@ int skip_list_put_batch(skip_list_t *list, const skip_list_batch_entry_t *entrie
                         atomic_load_explicit(&next_at_0->versions, memory_order_acquire);
                     if (skip_list_validate_sequence(latest, entry->seq) == 0)
                     {
-                        const uint8_t version_flags = entry->deleted ? SKIP_LIST_FLAG_DELETED : 0;
                         skip_list_version_t *new_version =
                             skip_list_create_version(list, entry->value, entry->value_size,
-                                                     entry->ttl, version_flags, entry->seq);
+                                                     entry->ttl, entry->flags, entry->seq);
                         if (new_version != NULL)
                         {
                             if (skip_list_insert_version_cas(&next_at_0->versions, new_version,

--- a/src/skip_list.h
+++ b/src/skip_list.h
@@ -84,6 +84,12 @@ struct skip_list_arena_t
 
 /* skip_list_version_t flag bits */
 #define SKIP_LIST_FLAG_DELETED 0x01 /* version is tombstone */
+#define SKIP_LIST_FLAG_SINGLE_DELETE                         \
+    0x02 /* tombstone subtype, always set together with      \
+          * SKIP_LIST_FLAG_DELETED. caller promises the key  \
+          * has been put at most once since the last         \
+          * single-delete or start, so put+single-delete can \
+          * be reaped together at compaction. */
 
 /**
  * skip_list_cmp_type_t
@@ -268,12 +274,12 @@ int skip_list_comparator_numeric(const uint8_t *key1, size_t key1_size, const ui
  * @param value value data
  * @param value_size size of value
  * @param ttl time-to-live
- * @param deleted tombstone flag
+ * @param flags version flags (bitmask of SKIP_LIST_FLAG_*)
  * @return pointer to new node, NULL on failure
  */
 skip_list_node_t *skip_list_create_node(int level, const uint8_t *key, size_t key_size,
                                         const uint8_t *value, size_t value_size, int64_t ttl,
-                                        uint8_t deleted);
+                                        uint8_t flags);
 
 /**
  * skip_list_free_node
@@ -373,12 +379,15 @@ int skip_list_compare_keys(const skip_list_t *list, const uint8_t *key1, size_t 
  * @param value_size value size
  * @param ttl time-to-live
  * @param seq sequence number for MVCC
- * @param deleted whether this is a tombstone marker
+ * @param flags bitmask of SKIP_LIST_FLAG_*; 0 means a live put, SKIP_LIST_FLAG_DELETED
+ *              means a tombstone, optionally OR'd with SKIP_LIST_FLAG_SINGLE_DELETE.
+ *              passing 1 for a regular tombstone remains valid because the value 1
+ *              equals SKIP_LIST_FLAG_DELETED.
  * @return 0 on success, -1 on failure
  */
 int skip_list_put_with_seq(skip_list_t *list, const uint8_t *key, size_t key_size,
                            const uint8_t *value, size_t value_size, int64_t ttl, uint64_t seq,
-                           uint8_t deleted);
+                           uint8_t flags);
 
 /**
  * skip_list_delete
@@ -394,6 +403,11 @@ int skip_list_delete(skip_list_t *list, const uint8_t *key, size_t key_size, uin
 /**
  * skip_list_batch_entry_t
  * entry for batch put operations
+ *
+ * flags is a bitmask of SKIP_LIST_FLAG_*. a live put leaves flags = 0; a regular
+ * tombstone sets SKIP_LIST_FLAG_DELETED; a single-delete tombstone also sets
+ * SKIP_LIST_FLAG_SINGLE_DELETE on top. callers that previously set deleted = 1
+ * continue to work unchanged because the value 1 equals SKIP_LIST_FLAG_DELETED.
  */
 typedef struct
 {
@@ -403,7 +417,7 @@ typedef struct
     size_t value_size;
     uint64_t seq;
     int64_t ttl;
-    uint8_t deleted;
+    uint8_t flags;
 } skip_list_batch_entry_t;
 
 /**

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -136,6 +136,13 @@ typedef tidesdb_memtable_t tidesdb_immutable_memtable_t;
 #define TDB_KV_FLAG_ARENA    0x80
 #define TDB_KV_FLAG_POP_BUF  0x20 /* lives in reusable pop buffer, do not free */
 
+/* the kv entry-flag bits that describe tombstone-ness and must flow through
+ * every copy / materialisation path (pop_buf, inline_kv for sstable and
+ * memtable sources, kv_pair_create from an sstable entry, etc).  using this
+ * single mask prevents forgetting the single-delete bit at a site that only
+ * remembered the plain tombstone bit. */
+#define TDB_KV_TOMBSTONE_FLAG_MASK (TDB_KV_FLAG_TOMBSTONE | TDB_KV_FLAG_SINGLE_DELETE)
+
 #define TDB_LOG_FILE               "LOG"
 #define TDB_WAL_PREFIX             "wal_"
 #define TDB_WAL_EXT                ".log"
@@ -1224,6 +1231,7 @@ typedef struct
 
 static void *tidesdb_flush_worker_thread(void *arg);
 static int tidesdb_unified_flush_immutable(tidesdb_t *db, tidesdb_memtable_t *umt_imm);
+static int tidesdb_unified_memtable_rotate(tidesdb_t *db);
 static void *tidesdb_compaction_worker_thread(void *arg);
 static void *tidesdb_sync_worker_thread(void *arg);
 static void *tidesdb_sstable_reaper_thread(void *arg);
@@ -8932,7 +8940,7 @@ static tidesdb_kv_pair_t *tidesdb_merge_heap_pop_max(tidesdb_merge_heap_t *heap)
 
                 bkv->entry = result->entry;
                 bkv->entry.flags =
-                    (result->entry.flags & TDB_KV_FLAG_TOMBSTONE) | TDB_KV_FLAG_POP_BUF;
+                    (result->entry.flags & TDB_KV_TOMBSTONE_FLAG_MASK) | TDB_KV_FLAG_POP_BUF;
                 bkv->key = buf + sizeof(tidesdb_kv_pair_t);
                 memcpy(bkv->key, result->key, ks);
                 if (vs > 0)
@@ -8951,14 +8959,15 @@ static tidesdb_kv_pair_t *tidesdb_merge_heap_pop_max(tidesdb_merge_heap_t *heap)
                 result = tidesdb_kv_pair_create(result->key, result->entry.key_size, result->value,
                                                 result->entry.value_size, result->entry.ttl,
                                                 result->entry.seq,
-                                                result->entry.flags & TDB_KV_FLAG_TOMBSTONE);
+                                                result->entry.flags & TDB_KV_TOMBSTONE_FLAG_MASK);
             }
         }
         else
         {
-            result = tidesdb_kv_pair_create(
-                result->key, result->entry.key_size, result->value, result->entry.value_size,
-                result->entry.ttl, result->entry.seq, result->entry.flags & TDB_KV_FLAG_TOMBSTONE);
+            result = tidesdb_kv_pair_create(result->key, result->entry.key_size, result->value,
+                                            result->entry.value_size, result->entry.ttl,
+                                            result->entry.seq,
+                                            result->entry.flags & TDB_KV_TOMBSTONE_FLAG_MASK);
         }
     }
     top->current_kv = NULL;
@@ -9110,7 +9119,7 @@ static tidesdb_kv_pair_t *tidesdb_merge_heap_pop(tidesdb_merge_heap_t *heap,
 
                 bkv->entry = result->entry;
                 bkv->entry.flags =
-                    (result->entry.flags & TDB_KV_FLAG_TOMBSTONE) | TDB_KV_FLAG_POP_BUF;
+                    (result->entry.flags & TDB_KV_TOMBSTONE_FLAG_MASK) | TDB_KV_FLAG_POP_BUF;
                 bkv->key = buf + sizeof(tidesdb_kv_pair_t);
                 memcpy(bkv->key, result->key, ks);
                 if (vs > 0)
@@ -9130,14 +9139,15 @@ static tidesdb_kv_pair_t *tidesdb_merge_heap_pop(tidesdb_merge_heap_t *heap,
                 result = tidesdb_kv_pair_create(result->key, result->entry.key_size, result->value,
                                                 result->entry.value_size, result->entry.ttl,
                                                 result->entry.seq,
-                                                result->entry.flags & TDB_KV_FLAG_TOMBSTONE);
+                                                result->entry.flags & TDB_KV_TOMBSTONE_FLAG_MASK);
             }
         }
         else
         {
-            result = tidesdb_kv_pair_create(
-                result->key, result->entry.key_size, result->value, result->entry.value_size,
-                result->entry.ttl, result->entry.seq, result->entry.flags & TDB_KV_FLAG_TOMBSTONE);
+            result = tidesdb_kv_pair_create(result->key, result->entry.key_size, result->value,
+                                            result->entry.value_size, result->entry.ttl,
+                                            result->entry.seq,
+                                            result->entry.flags & TDB_KV_TOMBSTONE_FLAG_MASK);
         }
     }
     top->current_kv = NULL;
@@ -9739,10 +9749,11 @@ static tidesdb_merge_source_t *tidesdb_merge_source_from_sstable_klog(tidesdb_t 
                 value = vlog_value;
             }
 
-            source->current_kv = tidesdb_kv_pair_create(
-                klog_block->keys[0], klog_block->entries[0].key_size, value,
-                klog_block->entries[0].value_size, klog_block->entries[0].ttl,
-                klog_block->entries[0].seq, klog_block->entries[0].flags & TDB_KV_FLAG_TOMBSTONE);
+            source->current_kv =
+                tidesdb_kv_pair_create(klog_block->keys[0], klog_block->entries[0].key_size, value,
+                                       klog_block->entries[0].value_size,
+                                       klog_block->entries[0].ttl, klog_block->entries[0].seq,
+                                       klog_block->entries[0].flags & TDB_KV_TOMBSTONE_FLAG_MASK);
             free(vlog_value);
 
             if (!source->current_kv)
@@ -10334,14 +10345,14 @@ static int tidesdb_merge_source_advance(tidesdb_merge_source_t *source)
                                                     (size_t)vs, &vlog_value);
                             source->current_kv =
                                 tidesdb_kv_pair_create(key_ptr, mk_sz, vlog_value, (size_t)vs, ttl,
-                                                       abs_seq, flags & TDB_KV_FLAG_TOMBSTONE);
+                                                       abs_seq, flags & TDB_KV_TOMBSTONE_FLAG_MASK);
                             free(vlog_value);
                         }
                         else
                         {
                             tidesdb_kv_pair_t *ikv = &source->inline_kv;
                             ikv->entry.flags =
-                                (flags & TDB_KV_FLAG_TOMBSTONE) | TDB_KV_FLAG_BORROWED;
+                                (flags & TDB_KV_TOMBSTONE_FLAG_MASK) | TDB_KV_FLAG_BORROWED;
                             ikv->entry.key_size = mk_sz;
                             ikv->entry.value_size = (uint32_t)vs;
                             ikv->entry.seq = abs_seq;
@@ -10415,14 +10426,14 @@ static int tidesdb_merge_source_advance(tidesdb_merge_source_t *source)
                                         e->vlog_offset, e->value_size, &vlog_value);
                 source->current_kv =
                     tidesdb_kv_pair_create(kb->keys[idx], e->key_size, vlog_value, e->value_size,
-                                           e->ttl, e->seq, e->flags & TDB_KV_FLAG_TOMBSTONE);
+                                           e->ttl, e->seq, e->flags & TDB_KV_TOMBSTONE_FLAG_MASK);
                 free(vlog_value);
             }
             else
             {
                 tidesdb_kv_pair_t *ikv = &source->inline_kv;
                 ikv->entry = *e;
-                ikv->entry.flags = (e->flags & TDB_KV_FLAG_TOMBSTONE) | TDB_KV_FLAG_BORROWED;
+                ikv->entry.flags = (e->flags & TDB_KV_TOMBSTONE_FLAG_MASK) | TDB_KV_FLAG_BORROWED;
                 ikv->key = kb->keys[idx];
                 ikv->value = (uint8_t *)kb->inline_values[idx];
                 source->current_kv = ikv;
@@ -10586,14 +10597,14 @@ static int tidesdb_merge_source_advance(tidesdb_merge_source_t *source)
                                             vlog_offset, (size_t)vs, &vlog_value);
                                         source->current_kv = tidesdb_kv_pair_create(
                                             key_ptr, mk_sz, vlog_value, (size_t)vs, ttl, abs_seq,
-                                            flags & TDB_KV_FLAG_TOMBSTONE);
+                                            flags & TDB_KV_TOMBSTONE_FLAG_MASK);
                                         free(vlog_value);
                                     }
                                     else
                                     {
                                         tidesdb_kv_pair_t *ikv = &source->inline_kv;
-                                        ikv->entry.flags =
-                                            (flags & TDB_KV_FLAG_TOMBSTONE) | TDB_KV_FLAG_BORROWED;
+                                        ikv->entry.flags = (flags & TDB_KV_TOMBSTONE_FLAG_MASK) |
+                                                           TDB_KV_FLAG_BORROWED;
                                         ikv->entry.key_size = mk_sz;
                                         ikv->entry.value_size = (uint32_t)vs;
                                         ikv->entry.seq = abs_seq;
@@ -10710,14 +10721,15 @@ static int tidesdb_merge_source_advance(tidesdb_merge_source_t *source)
                                             e0->vlog_offset, e0->value_size, &vlog_value);
                     source->current_kv = tidesdb_kv_pair_create(
                         current_kb->keys[0], e0->key_size, vlog_value, e0->value_size, e0->ttl,
-                        e0->seq, (e0->flags & TDB_KV_FLAG_TOMBSTONE) != 0);
+                        e0->seq, e0->flags & TDB_KV_TOMBSTONE_FLAG_MASK);
                     free(vlog_value);
                 }
                 else
                 {
                     tidesdb_kv_pair_t *ikv = &source->inline_kv;
                     ikv->entry = *e0;
-                    ikv->entry.flags = (e0->flags & TDB_KV_FLAG_TOMBSTONE) | TDB_KV_FLAG_BORROWED;
+                    ikv->entry.flags =
+                        (e0->flags & TDB_KV_TOMBSTONE_FLAG_MASK) | TDB_KV_FLAG_BORROWED;
                     ikv->key = current_kb->keys[0];
                     ikv->value = (uint8_t *)current_kb->inline_values[0];
                     source->current_kv = ikv;
@@ -10856,7 +10868,7 @@ static int tidesdb_merge_source_retreat(tidesdb_merge_source_t *source)
                                         e->vlog_offset, e->value_size, &vlog_value);
                 source->current_kv =
                     tidesdb_kv_pair_create(kb->keys[idx], e->key_size, vlog_value, e->value_size,
-                                           e->ttl, e->seq, e->flags & TDB_KV_FLAG_TOMBSTONE);
+                                           e->ttl, e->seq, e->flags & TDB_KV_TOMBSTONE_FLAG_MASK);
                 free(vlog_value);
             }
             else
@@ -10864,7 +10876,7 @@ static int tidesdb_merge_source_retreat(tidesdb_merge_source_t *source)
                 /* zero-copy borrowed */
                 tidesdb_kv_pair_t *ikv = &source->inline_kv;
                 ikv->entry = *e;
-                ikv->entry.flags = (e->flags & TDB_KV_FLAG_TOMBSTONE) | TDB_KV_FLAG_BORROWED;
+                ikv->entry.flags = (e->flags & TDB_KV_TOMBSTONE_FLAG_MASK) | TDB_KV_FLAG_BORROWED;
                 ikv->key = kb->keys[idx];
                 ikv->value = (uint8_t *)kb->inline_values[idx];
                 source->current_kv = ikv;
@@ -10987,7 +10999,7 @@ static int tidesdb_merge_source_retreat(tidesdb_merge_source_t *source)
                     current_kb->keys[idx], current_kb->entries[idx].key_size, value,
                     current_kb->entries[idx].value_size, current_kb->entries[idx].ttl,
                     current_kb->entries[idx].seq,
-                    (current_kb->entries[idx].flags & TDB_KV_FLAG_TOMBSTONE) != 0);
+                    current_kb->entries[idx].flags & TDB_KV_TOMBSTONE_FLAG_MASK);
 
                 free(vlog_value);
                 return TDB_SUCCESS;
@@ -11740,10 +11752,10 @@ static int tidesdb_full_preemptive_merge(tidesdb_column_family_t *cf, int start_
     uint8_t *block_last_key = NULL;
     size_t block_last_key_size = 0;
 
-    /* single-step lookahead: we buffer the pending first-for-key entry so a
-     * put+single-delete pair detected in the same merge input cancels together
-     * at any level instead of carrying the tombstone forward. same-key dedup,
-     * largest-level tombstone drop, and ttl drop fire when pending resolves. */
+    /**** single-step lookahead in which we buffer the pending first-for-key entry so a
+     ***  put+single-delete pair detected in the same merge input cancels together
+     **   at any level instead of carrying the tombstone forward. same-key dedup,
+     *    largest-level tombstone drop, and ttl drop fire when pending resolves. */
     tidesdb_kv_pair_t *pending = NULL;
     int pending_is_single_delete = 0;
     int pending_sd_paired_with_put = 0;
@@ -18589,7 +18601,28 @@ int tidesdb_list_column_families(tidesdb_t *db, char ***names, int *count)
 
 int tidesdb_flush_memtable(tidesdb_column_family_t *cf)
 {
-    return tidesdb_flush_memtable_internal(cf, 0, 0);
+    if (!cf) return TDB_ERR_INVALID_ARGS;
+
+    /* callers of this public api want a flush to actually happen; the old
+     * "no-op below write_buffer threshold" behaviour made tidesdb_flush_memtable
+     * surprising for tests and tooling that just wanted to ensure any in-memory
+     * writes land on disk.  we pass force=1 so the memtable flushes regardless
+     * of its current size. */
+
+    /* in unified memtable mode the cf->active_memtable is a per-cf wrapper but
+     * the real active memtable lives on db->unified_mt.  we rotate the unified
+     * memtable so the current contents enqueue for flush, and then fall through
+     * to the per-cf flush path to cover any stragglers or immutable wrappers. */
+    if (cf->db && cf->db->config.unified_memtable)
+    {
+        const int rot_rc = tidesdb_unified_memtable_rotate(cf->db);
+        if (rot_rc != TDB_SUCCESS && rot_rc != TDB_ERR_LOCKED)
+        {
+            return rot_rc;
+        }
+    }
+
+    return tidesdb_flush_memtable_internal(cf, 0, 1);
 }
 
 int tidesdb_is_flushing(tidesdb_column_family_t *cf)
@@ -23760,7 +23793,8 @@ static tidesdb_kv_pair_t *tidesdb_iter_create_kv_from_block(const tidesdb_iter_t
 
     tidesdb_kv_pair_t *kv = tidesdb_kv_pair_create(
         kb->keys[idx], kb->entries[idx].key_size, value, kb->entries[idx].value_size,
-        kb->entries[idx].ttl, kb->entries[idx].seq, kb->entries[idx].flags & TDB_KV_FLAG_TOMBSTONE);
+        kb->entries[idx].ttl, kb->entries[idx].seq,
+        kb->entries[idx].flags & TDB_KV_TOMBSTONE_FLAG_MASK);
 
     free(vlog_value);
     return kv;
@@ -24088,7 +24122,7 @@ static void tidesdb_iter_seek_sstable_source_forward(const tidesdb_iter_t *iter,
                 }
                 source->current_kv =
                     tidesdb_kv_pair_create(fkey, (size_t)k_sz, fvalue, (size_t)vs, ttl, seq,
-                                           (flags & TDB_KV_FLAG_TOMBSTONE) != 0);
+                                           flags & TDB_KV_TOMBSTONE_FLAG_MASK);
                 free(vlog_value);
 
                 source->source.sstable.lazy.entry_idx = found;
@@ -24154,7 +24188,7 @@ static void tidesdb_iter_seek_sstable_source_forward(const tidesdb_iter_t *iter,
             }
             source->current_kv =
                 tidesdb_kv_pair_create(bdata + fk_off, (size_t)fk_sz, fvalue, (size_t)vs, ttl, seq,
-                                       (flags & TDB_KV_FLAG_TOMBSTONE) != 0);
+                                       flags & TDB_KV_TOMBSTONE_FLAG_MASK);
             free(vlog_value);
             source->source.sstable.lazy.entry_idx = 0;
             source->source.sstable.current_entry_idx = 0;
@@ -24410,7 +24444,7 @@ static void tidesdb_iter_seek_sstable_source_forward(const tidesdb_iter_t *iter,
             }
             source->current_kv = tidesdb_kv_pair_create(
                 found_key, found_entry.key_size, value, found_entry.value_size, found_entry.ttl,
-                found_entry.seq, (found_entry.flags & TDB_KV_FLAG_TOMBSTONE) != 0);
+                found_entry.seq, found_entry.flags & TDB_KV_TOMBSTONE_FLAG_MASK);
             free(vlog_value);
 
             /* we set up lazy state, the full deserialization is deferred to next().
@@ -25142,7 +25176,7 @@ int tidesdb_iter_seek_to_first(tidesdb_iter_t *iter)
                         cs->current_kv = tidesdb_kv_pair_create(
                             kb->keys[0], kb->entries[0].key_size, val, kb->entries[0].value_size,
                             kb->entries[0].ttl, kb->entries[0].seq,
-                            kb->entries[0].flags & TDB_KV_FLAG_TOMBSTONE);
+                            kb->entries[0].flags & TDB_KV_TOMBSTONE_FLAG_MASK);
                         free(vv);
 
                         if (cs->current_kv) tidesdb_merge_heap_add_source(iter->heap, cs);
@@ -25393,7 +25427,7 @@ int tidesdb_iter_seek_to_last(tidesdb_iter_t *iter)
                                 kb->keys[idx], kb->entries[idx].key_size, value,
                                 kb->entries[idx].value_size, kb->entries[idx].ttl,
                                 kb->entries[idx].seq,
-                                kb->entries[idx].flags & TDB_KV_FLAG_TOMBSTONE);
+                                kb->entries[idx].flags & TDB_KV_TOMBSTONE_FLAG_MASK);
 
                             free(vlog_value);
                         }

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -9074,6 +9074,100 @@ static tidesdb_kv_pair_t *tidesdb_merge_heap_pop(tidesdb_merge_heap_t *heap,
 }
 
 /**
+ * tidesdb_merge_heap_pop_discard
+ * advance the top source without materializing a popped kv pair.
+ *
+ * equivalent to tidesdb_merge_heap_pop followed by tidesdb_kv_pair_free, but
+ * avoids the pop_buf memcpy for BORROWED sources. used by the tombstone-skip
+ * loop in tidesdb_iter_find_visible_entry where the popped entry is discarded
+ * immediately.
+ *
+ * returns 0 on success, -1 if the heap was empty.
+ */
+static int tidesdb_merge_heap_pop_discard(tidesdb_merge_heap_t *heap)
+{
+    if (heap->num_sources == 0) return -1;
+    tidesdb_merge_source_t *top = heap->sources[0];
+    if (!top->current_kv) return -1;
+
+    /* for ARENA/POP_BUF kvs we must free before the advance overwrites the
+     * pointer; for BORROWED (inline_kv) the free is a no-op, so we skip both
+     * the materialization and the free. */
+    if (!(top->current_kv->entry.flags & (TDB_KV_FLAG_BORROWED | TDB_KV_FLAG_POP_BUF)))
+    {
+        tidesdb_kv_pair_free(top->current_kv);
+    }
+    top->current_kv = NULL;
+
+    const int advance_result = tidesdb_merge_source_advance(top);
+    if (advance_result != 0)
+    {
+        heap->sources[0] = heap->sources[heap->num_sources - 1];
+        heap->num_sources--;
+        if (!top->is_cached) tidesdb_merge_source_free(top);
+    }
+
+    if (heap->num_sources > 1) heap_sift_down(heap, 0);
+    return 0;
+}
+
+/**
+ * tidesdb_iter_skip_tombstone_versions
+ * skip all heap entries whose key equals the just-popped tombstone's key.
+ *
+ * used by every tombstone-skip loop in the iterator (next, prev, seek_to_first,
+ * seek_to_last, find_visible_entry). copies the tombstone key into a stable
+ * buffer first, because kv->key may point into pop_buf which is reused by
+ * subsequent heap_pop calls for BORROWED sources. forward direction uses the
+ * pop_discard variant to avoid the pop_buf memcpy on every skip.
+ *
+ * returns TDB_SUCCESS, or TDB_ERR_MEMORY if a very large tombstone key cannot
+ * be copied to the fallback buffer.
+ */
+static int tidesdb_iter_skip_tombstone_versions(tidesdb_iter_t *iter, const tidesdb_kv_pair_t *kv,
+                                                const int direction)
+{
+    uint8_t tombstone_key_stack[TDB_PREFIXED_KEY_STACK_MAX];
+    uint8_t *tombstone_key;
+    const size_t tombstone_key_size = kv->entry.key_size;
+
+    if (tombstone_key_size <= sizeof(tombstone_key_stack))
+    {
+        memcpy(tombstone_key_stack, kv->key, tombstone_key_size);
+        tombstone_key = tombstone_key_stack;
+    }
+    else
+    {
+        tombstone_key = malloc(tombstone_key_size);
+        if (!tombstone_key) return TDB_ERR_MEMORY;
+        memcpy(tombstone_key, kv->key, tombstone_key_size);
+    }
+
+    while (!tidesdb_merge_heap_empty(iter->heap))
+    {
+        tidesdb_kv_pair_t *peek = iter->heap->sources[0]->current_kv;
+        if (!peek) break;
+
+        const int cmp = iter->heap->comparator(peek->key, peek->entry.key_size, tombstone_key,
+                                               tombstone_key_size, iter->heap->comparator_ctx);
+        if (cmp != 0) break;
+
+        if (direction > 0)
+        {
+            tidesdb_merge_heap_pop_discard(iter->heap);
+        }
+        else
+        {
+            tidesdb_kv_pair_t *dup = tidesdb_merge_heap_pop_max(iter->heap);
+            tidesdb_kv_pair_free(dup);
+        }
+    }
+
+    if (tombstone_key != tombstone_key_stack) free(tombstone_key);
+    return TDB_SUCCESS;
+}
+
+/**
  * tidesdb_merge_heap_empty
  * check if a merge heap is empty
  * @param heap merge heap to check
@@ -9082,6 +9176,39 @@ static tidesdb_kv_pair_t *tidesdb_merge_heap_pop(tidesdb_merge_heap_t *heap,
 static int tidesdb_merge_heap_empty(const tidesdb_merge_heap_t *heap)
 {
     return heap->num_sources == 0;
+}
+
+/**
+ * tidesdb_memtable_source_set_inline_borrowed
+ * populate source->inline_kv with borrowed pointers into the skip-list node
+ * and set source->current_kv = &inline_kv with TDB_KV_FLAG_BORROWED.
+ *
+ * this avoids the per-advance malloc+memcpy+free of tidesdb_kv_pair_create
+ * on the memtable read path. heap_pop materializes a stable owned copy into
+ * pop_buf when the caller keeps the kv; tombstone-skip discards in
+ * tidesdb_iter_find_visible_entry free (no-op on borrowed) without a copy.
+ *
+ * key/value pointers are stable while the cursor holds this position, which
+ * is the same invariant the sstable inline_kv path already relies on. the
+ * iterator pins the memtable (active via try_ref, immutable via refcount)
+ * for its lifetime, so the node memory is not reclaimed under us.
+ */
+static inline void tidesdb_memtable_source_set_inline_borrowed(tidesdb_merge_source_t *source,
+                                                               const uint8_t *key, size_t key_size,
+                                                               const uint8_t *value,
+                                                               size_t value_size, int64_t ttl,
+                                                               uint64_t seq, uint8_t deleted)
+{
+    tidesdb_kv_pair_t *ikv = &source->inline_kv;
+    ikv->entry.flags = (deleted ? TDB_KV_FLAG_TOMBSTONE : 0) | TDB_KV_FLAG_BORROWED;
+    ikv->entry.key_size = (uint32_t)key_size;
+    ikv->entry.value_size = (uint32_t)value_size;
+    ikv->entry.ttl = ttl;
+    ikv->entry.seq = seq;
+    ikv->entry.vlog_offset = 0;
+    ikv->key = (uint8_t *)key;
+    ikv->value = (value_size > 0) ? (uint8_t *)value : NULL;
+    source->current_kv = ikv;
 }
 
 /**
@@ -9129,8 +9256,8 @@ static tidesdb_merge_source_t *tidesdb_merge_source_from_memtable(
         if (skip_list_cursor_get_with_seq(source->source.memtable.cursor, &key, &key_size, &value,
                                           &value_size, &ttl, &deleted, &seq) == 0)
         {
-            source->current_kv =
-                tidesdb_kv_pair_create(key, key_size, value, value_size, ttl, seq, deleted);
+            tidesdb_memtable_source_set_inline_borrowed(source, key, key_size, value, value_size,
+                                                        ttl, seq, deleted);
         }
     }
 
@@ -9165,11 +9292,11 @@ static int tidesdb_unified_source_advance_to_cf(tidesdb_merge_source_t *source, 
         if (key_size >= TDB_UNIFIED_CF_PREFIX_SIZE &&
             memcmp(key, prefix, TDB_UNIFIED_CF_PREFIX_SIZE) == 0)
         {
-            /* we strip the prefix when creating the kv_pair */
+            /* we strip the prefix by borrowing a pointer past it -- no copy */
             const uint8_t *real_key = key + TDB_UNIFIED_CF_PREFIX_SIZE;
             const size_t real_key_size = key_size - TDB_UNIFIED_CF_PREFIX_SIZE;
-            source->current_kv = tidesdb_kv_pair_create(real_key, real_key_size, value, value_size,
-                                                        ttl, seq, deleted);
+            tidesdb_memtable_source_set_inline_borrowed(source, real_key, real_key_size, value,
+                                                        value_size, ttl, seq, deleted);
             return 1;
         }
 
@@ -9958,8 +10085,8 @@ static int tidesdb_merge_source_advance(tidesdb_merge_source_t *source)
             if (skip_list_cursor_get_with_seq(source->source.memtable.cursor, &key, &key_size,
                                               &value, &value_size, &ttl, &deleted, &seq) == 0)
             {
-                source->current_kv =
-                    tidesdb_kv_pair_create(key, key_size, value, value_size, ttl, seq, deleted);
+                tidesdb_memtable_source_set_inline_borrowed(source, key, key_size, value,
+                                                            value_size, ttl, seq, deleted);
                 return TDB_SUCCESS;
             }
         }
@@ -13977,7 +14104,7 @@ static int tidesdb_wal_recover(tidesdb_column_family_t *cf, const char *wal_path
             block_manager_block_t *block = block_manager_cursor_read(cursor);
             if (!block)
             {
-                /* partial write: header valid but footer absent -- skip slot and resume */
+                /* partial write, header valid but footer absent -- skip slot and resume */
                 if (block_manager_cursor_skip_corrupt(cursor) == 0)
                 {
                     TDB_DEBUG_LOG(TDB_LOG_WARN,
@@ -23154,8 +23281,8 @@ static void tidesdb_iter_seek_memtable_source(tidesdb_merge_source_t *source, co
                 if (skip_list_cursor_get_with_seq(cursor, &k, &k_size, &v, &v_size, &ttl, &deleted,
                                                   &seq) == 0)
                 {
-                    source->current_kv =
-                        tidesdb_kv_pair_create(k, k_size, v, v_size, ttl, seq, deleted);
+                    tidesdb_memtable_source_set_inline_borrowed(source, k, k_size, v, v_size, ttl,
+                                                                seq, deleted);
                 }
             }
         }
@@ -23175,8 +23302,8 @@ static void tidesdb_iter_seek_memtable_source(tidesdb_merge_source_t *source, co
             if (skip_list_cursor_get_with_seq(cursor, &k, &k_size, &v, &v_size, &ttl, &deleted,
                                               &seq) == 0)
             {
-                source->current_kv =
-                    tidesdb_kv_pair_create(k, k_size, v, v_size, ttl, seq, deleted);
+                tidesdb_memtable_source_set_inline_borrowed(source, k, k_size, v, v_size, ttl, seq,
+                                                            deleted);
             }
         }
     }
@@ -24482,28 +24609,7 @@ static int tidesdb_iter_find_visible_entry(tidesdb_iter_t *iter, const int direc
         const int visible = tidesdb_iter_kv_visible(iter, kv);
         if (visible == -1)
         {
-            /*** tombstone -- we skip all versions of this key */
-            const uint8_t *tombstone_key = kv->key;
-            const size_t tombstone_key_size = kv->entry.key_size;
-
-            /* we pop and discard all entries with the same key */
-            while (!tidesdb_merge_heap_empty(iter->heap))
-            {
-                tidesdb_kv_pair_t *peek =
-                    iter->heap->sources[0]->current_kv; /* peek at top without popping */
-                if (!peek) break;
-
-                const int cmp =
-                    iter->heap->comparator(peek->key, peek->entry.key_size, tombstone_key,
-                                           tombstone_key_size, iter->heap->comparator_ctx);
-                if (cmp != 0) break; /* different key, stop skipping */
-
-                /* same key, we pop and discard */
-                tidesdb_kv_pair_t *dup = (direction > 0) ? tidesdb_merge_heap_pop(iter->heap, NULL)
-                                                         : tidesdb_merge_heap_pop_max(iter->heap);
-                tidesdb_kv_pair_free(dup);
-            }
-
+            tidesdb_iter_skip_tombstone_versions(iter, kv, direction);
             tidesdb_kv_pair_free(kv);
             continue;
         }
@@ -24874,25 +24980,7 @@ int tidesdb_iter_seek_to_first(tidesdb_iter_t *iter)
         const int visible = tidesdb_iter_kv_visible(iter, kv);
         if (visible == -1)
         {
-            /* tombstone -- we skip all versions of this key */
-            const uint8_t *tombstone_key = kv->key;
-            const size_t tombstone_key_size = kv->entry.key_size;
-
-            /* we pop and discard all entries with the same key */
-            while (!tidesdb_merge_heap_empty(iter->heap))
-            {
-                tidesdb_kv_pair_t *peek = iter->heap->sources[0]->current_kv;
-                if (!peek) break;
-
-                const int cmp =
-                    iter->heap->comparator(peek->key, peek->entry.key_size, tombstone_key,
-                                           tombstone_key_size, iter->heap->comparator_ctx);
-                if (cmp != 0) break;
-
-                tidesdb_kv_pair_t *dup = tidesdb_merge_heap_pop(iter->heap, NULL);
-                tidesdb_kv_pair_free(dup);
-            }
-
+            tidesdb_iter_skip_tombstone_versions(iter, kv, 1);
             tidesdb_kv_pair_free(kv);
             continue;
         }
@@ -25231,25 +25319,7 @@ int tidesdb_iter_next(tidesdb_iter_t *iter)
         const int visible = tidesdb_iter_kv_visible(iter, kv);
         if (visible == -1)
         {
-            /* tombstone -- we skip all versions of this key */
-            const uint8_t *tombstone_key = kv->key;
-            const size_t tombstone_key_size = kv->entry.key_size;
-
-            /* we pop and discard all entries with the same key */
-            while (!tidesdb_merge_heap_empty(iter->heap))
-            {
-                tidesdb_kv_pair_t *peek = iter->heap->sources[0]->current_kv;
-                if (!peek) break;
-
-                const int cmp =
-                    iter->heap->comparator(peek->key, peek->entry.key_size, tombstone_key,
-                                           tombstone_key_size, iter->heap->comparator_ctx);
-                if (cmp != 0) break;
-
-                tidesdb_kv_pair_t *dup = tidesdb_merge_heap_pop(iter->heap, NULL);
-                tidesdb_kv_pair_free(dup);
-            }
-
+            tidesdb_iter_skip_tombstone_versions(iter, kv, 1);
             tidesdb_kv_pair_free(kv);
             continue;
         }
@@ -25337,25 +25407,7 @@ int tidesdb_iter_prev(tidesdb_iter_t *iter)
         const int visible = tidesdb_iter_kv_visible(iter, kv);
         if (visible == -1)
         {
-            /* tombstone -- we skip all versions of this key */
-            const uint8_t *tombstone_key = kv->key;
-            const size_t tombstone_key_size = kv->entry.key_size;
-
-            /* we pop and discard all entries with the same key */
-            while (!tidesdb_merge_heap_empty(iter->heap))
-            {
-                tidesdb_kv_pair_t *peek = iter->heap->sources[0]->current_kv;
-                if (!peek) break;
-
-                const int cmp =
-                    iter->heap->comparator(peek->key, peek->entry.key_size, tombstone_key,
-                                           tombstone_key_size, iter->heap->comparator_ctx);
-                if (cmp != 0) break;
-
-                tidesdb_kv_pair_t *dup = tidesdb_merge_heap_pop_max(iter->heap);
-                tidesdb_kv_pair_free(dup);
-            }
-
+            tidesdb_iter_skip_tombstone_versions(iter, kv, -1);
             tidesdb_kv_pair_free(kv);
             continue;
         }

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -125,9 +125,16 @@ typedef tidesdb_memtable_t tidesdb_immutable_memtable_t;
 #define TDB_KV_FLAG_HAS_TTL   0x02
 #define TDB_KV_FLAG_HAS_VLOG  0x04
 #define TDB_KV_FLAG_DELTA_SEQ 0x08
-#define TDB_KV_FLAG_BORROWED  0x40
-#define TDB_KV_FLAG_ARENA     0x80
-#define TDB_KV_FLAG_POP_BUF   0x20 /* lives in reusable pop buffer, do not free */
+#define TDB_KV_FLAG_SINGLE_DELETE                                \
+    0x10 /* tombstone subtype -- caller promises the key was put \
+          * at most once since the last single-delete or start,  \
+          * so put+single-delete can be dropped together at any  \
+          * compaction that sees both in the same merge input.   \
+          * always set alongside TDB_KV_FLAG_TOMBSTONE so every  \
+          * existing tombstone check keeps working unchanged. */
+#define TDB_KV_FLAG_BORROWED 0x40
+#define TDB_KV_FLAG_ARENA    0x80
+#define TDB_KV_FLAG_POP_BUF  0x20 /* lives in reusable pop buffer, do not free */
 
 #define TDB_LOG_FILE               "LOG"
 #define TDB_WAL_PREFIX             "wal_"
@@ -612,7 +619,8 @@ struct tidesdb_compaction_work_t
  * @param value value
  * @param value_size value size
  * @param ttl time-to-live
- * @param is_delete delete flag
+ * @param is_delete delete flag (set for both regular and single-delete tombstones)
+ * @param is_single_delete single-delete flag (implies is_delete)
  * @param cf column family (for multi-cf transactions)
  */
 struct tidesdb_txn_op_t
@@ -623,8 +631,51 @@ struct tidesdb_txn_op_t
     size_t value_size;
     time_t ttl;
     int is_delete;
+    int is_single_delete;
     tidesdb_column_family_t *cf;
 };
+
+/**
+ * tidesdb_txn_op_sl_flags
+ * compute the skip-list version flag bitmask for a txn op.
+ * a live put is 0, a regular delete is SKIP_LIST_FLAG_DELETED, and a
+ * single-delete is both bits together so SKIP_LIST_FLAG_DELETED checks
+ * keep treating it as a tombstone.
+ */
+static inline uint8_t tidesdb_txn_op_sl_flags(const tidesdb_txn_op_t *op)
+{
+    if (op->is_single_delete) return SKIP_LIST_FLAG_DELETED | SKIP_LIST_FLAG_SINGLE_DELETE;
+    if (op->is_delete) return SKIP_LIST_FLAG_DELETED;
+    return 0;
+}
+
+/**
+ * tidesdb_sl_flags_to_kv_flags
+ * translate skip-list version flag bits into tidesdb kv_pair entry flags.
+ * the two namespaces overlap on the tombstone bit (both are 0x01) but the
+ * single-delete bit sits in different positions (0x02 on the skip list,
+ * 0x10 in the kv_pair flag byte) because kv_pair flags are persisted on
+ * disk and share the byte with serialization-time markers.
+ */
+static inline uint8_t tidesdb_sl_flags_to_kv_flags(uint8_t sl_flags)
+{
+    uint8_t kv = 0;
+    if (sl_flags & SKIP_LIST_FLAG_DELETED) kv |= TDB_KV_FLAG_TOMBSTONE;
+    if (sl_flags & SKIP_LIST_FLAG_SINGLE_DELETE) kv |= TDB_KV_FLAG_SINGLE_DELETE;
+    return kv;
+}
+
+/**
+ * tidesdb_txn_op_kv_flags
+ * compute the tidesdb kv_pair tombstone flag bits for a txn op.
+ * used when materialising a txn op as a kv_pair for a merge source.
+ */
+static inline uint8_t tidesdb_txn_op_kv_flags(const tidesdb_txn_op_t *op)
+{
+    if (op->is_single_delete) return TDB_KV_FLAG_TOMBSTONE | TDB_KV_FLAG_SINGLE_DELETE;
+    if (op->is_delete) return TDB_KV_FLAG_TOMBSTONE;
+    return 0;
+}
 
 /* forward declaration for ref-counted block type */
 typedef struct tidesdb_ref_counted_block_t tidesdb_ref_counted_block_t;
@@ -1178,7 +1229,7 @@ static void *tidesdb_sync_worker_thread(void *arg);
 static void *tidesdb_sstable_reaper_thread(void *arg);
 static tidesdb_kv_pair_t *tidesdb_kv_pair_create(const uint8_t *key, size_t key_size,
                                                  const uint8_t *value, size_t value_size,
-                                                 time_t ttl, uint64_t seq, int is_tombstone);
+                                                 time_t ttl, uint64_t seq, uint8_t tombstone_flags);
 static void tidesdb_kv_pair_free(tidesdb_kv_pair_t *kv);
 static int tidesdb_iter_kv_visible(tidesdb_iter_t *iter, tidesdb_kv_pair_t *kv);
 static int tidesdb_sstable_ensure_open(tidesdb_t *db, tidesdb_sstable_t *sst);
@@ -2082,13 +2133,16 @@ tidesdb_config_t tidesdb_default_config(void)
  * @param value_size value size
  * @param ttl time to live
  * @param seq sequence number
- * @param is_tombstone is tombstone
+ * @param tombstone_flags bitmask of tombstone-related kv flags to set on the
+ *                        entry (TDB_KV_FLAG_TOMBSTONE, TDB_KV_FLAG_SINGLE_DELETE).
+ *                        bits outside that mask are ignored. passing 0 or 1
+ *                        continues to behave as the previous bool-like argument.
  * @return new KV pair
  */
 static tidesdb_kv_pair_t *tidesdb_kv_pair_create(const uint8_t *key, const size_t key_size,
                                                  const uint8_t *value, const size_t value_size,
                                                  const time_t ttl, const uint64_t seq,
-                                                 const int is_tombstone)
+                                                 const uint8_t tombstone_flags)
 {
     /* arena allocation -- single malloc for struct + key + value
      * [tidesdb_kv_pair_t][key_data][value_data]
@@ -2101,7 +2155,8 @@ static tidesdb_kv_pair_t *tidesdb_kv_pair_create(const uint8_t *key, const size_
 
     tidesdb_kv_pair_t *kv = (tidesdb_kv_pair_t *)arena;
 
-    kv->entry.flags = (is_tombstone ? TDB_KV_FLAG_TOMBSTONE : 0) | TDB_KV_FLAG_ARENA;
+    kv->entry.flags =
+        (tombstone_flags & (TDB_KV_FLAG_TOMBSTONE | TDB_KV_FLAG_SINGLE_DELETE)) | TDB_KV_FLAG_ARENA;
     kv->entry.key_size = (uint32_t)key_size;
     kv->entry.value_size = (uint32_t)value_size;
     kv->entry.ttl = ttl;
@@ -6395,13 +6450,19 @@ static int tidesdb_sstable_write_from_memtable_btree(tidesdb_t *db, tidesdb_ssta
             free(compressed);
         }
 
-        /* we add to btree inline value for small entries, vlog reference for large */
+        /* we add to btree inline value for small entries, vlog reference for large.
+         * deleted carries the full skip-list flag byte so single-delete survives
+         * the flush into the btree sstable's on-disk flag byte. the low bit of
+         * deleted equals BTREE_ENTRY_FLAG_TOMBSTONE by design so callers that
+         * previously passed a 0/1 bool still behave unchanged. */
         const uint8_t *value_to_store = (vlog_offset > 0) ? NULL : value;
         const size_t value_size_to_store = (vlog_offset > 0) ? 0 : value_size;
-        const uint8_t flags = deleted ? 1 : 0; /* BTREE_ENTRY_FLAG_TOMBSTONE = 1 */
+        uint8_t entry_flags = 0;
+        if (deleted & SKIP_LIST_FLAG_DELETED) entry_flags |= BTREE_ENTRY_FLAG_TOMBSTONE;
+        if (deleted & SKIP_LIST_FLAG_SINGLE_DELETE) entry_flags |= BTREE_ENTRY_FLAG_SINGLE_DELETE;
 
         if (btree_builder_add(builder, key, key_size, value_to_store, value_size_to_store,
-                              vlog_offset, seq, ttl, flags) != 0)
+                              vlog_offset, seq, ttl, entry_flags) != 0)
         {
             TDB_DEBUG_LOG(TDB_LOG_ERROR, "SSTable %" PRIu64 " failed to add entry to btree",
                           sst->id);
@@ -6567,129 +6628,168 @@ static int tidesdb_sstable_write_from_heap_btree(tidesdb_column_family_t *cf,
         return TDB_ERR_MEMORY;
     }
 
-    uint8_t *last_key = NULL;
-    size_t last_key_size = 0;
     uint64_t entry_count = 0;
     uint64_t max_seq = 0;
     uint64_t vlog_block_num = 0;
 
-    while (!tidesdb_merge_heap_empty(heap))
-    {
-        tidesdb_sstable_t *corrupted_sst = NULL;
-        tidesdb_kv_pair_t *kv = tidesdb_merge_heap_pop(heap, &corrupted_sst);
+    /* we keep one kv buffered ("pending") so we can do a single-step lookahead.
+     * the merge heap emits same-key versions in (key asc, seq desc) order, so
+     * after we pop the newest version for a key we peek the next pop to see
+     * whether an older same-key version follows. that lookahead lets us detect
+     * a put+single-delete pair in one merge input and drop both together at
+     * any level instead of carrying the single-delete forward. it also keeps
+     * the original same-key dedup, largest-level tombstone drop, and ttl drop
+     * behaviours -- they now fire when pending gets resolved rather than the
+     * moment pending was popped. */
+    tidesdb_kv_pair_t *pending = NULL;
+    int pending_is_single_delete = 0;
+    int pending_sd_paired_with_put = 0;
 
-        if (corrupted_sst && sstables_to_delete)
+    int abort_io = 0;
+
+    while (!tidesdb_merge_heap_empty(heap) || pending != NULL)
+    {
+        tidesdb_kv_pair_t *kv = NULL;
+
+        if (!tidesdb_merge_heap_empty(heap))
         {
-            queue_enqueue(sstables_to_delete, corrupted_sst);
+            tidesdb_sstable_t *corrupted_sst = NULL;
+            kv = tidesdb_merge_heap_pop(heap, &corrupted_sst);
+
+            if (corrupted_sst && sstables_to_delete)
+            {
+                queue_enqueue(sstables_to_delete, corrupted_sst);
+            }
+
+            if (!kv)
+            {
+                /* heap is drained -- fall through to flush pending */
+            }
+        }
+
+        if (kv && pending && pending->entry.key_size == kv->entry.key_size &&
+            memcmp(pending->key, kv->key, pending->entry.key_size) == 0)
+        {
+            /* older same-key version -- drop silently.  if pending is a
+             * single-delete and this older version is a live put (not itself
+             * a tombstone), we've found the put+single-delete pair and can
+             * cancel the single-delete once we finish consuming the group. */
+            if (pending_is_single_delete && !(kv->entry.flags & TDB_KV_FLAG_TOMBSTONE))
+            {
+                pending_sd_paired_with_put = 1;
+            }
+            tidesdb_kv_pair_free(kv);
+            continue;
+        }
+
+        /* new key arrived (or heap exhausted) -- decide the fate of pending */
+        if (pending)
+        {
+            const int sd_pair_drop = pending_is_single_delete && pending_sd_paired_with_put;
+            const int tombstone_drop =
+                (pending->entry.flags & TDB_KV_FLAG_TOMBSTONE) && is_largest_level;
+            const int ttl_drop =
+                pending->entry.ttl > 0 &&
+                pending->entry.ttl <
+                    atomic_load_explicit(&cf->db->cached_current_time, memory_order_relaxed);
+
+            if (!sd_pair_drop && !tombstone_drop && !ttl_drop)
+            {
+                if (bloom)
+                {
+                    bloom_filter_add(bloom, pending->key, pending->entry.key_size);
+                }
+
+                uint64_t vlog_offset = 0;
+                if (pending->entry.value_size >= cf->config.klog_value_threshold && pending->value)
+                {
+                    const uint8_t *final_data = pending->value;
+                    size_t final_size = pending->entry.value_size;
+                    uint8_t *compressed = NULL;
+
+                    if (sst->config->compression_algorithm != TDB_COMPRESS_NONE)
+                    {
+                        size_t compressed_size;
+                        compressed =
+                            compress_data(pending->value, pending->entry.value_size,
+                                          &compressed_size, sst->config->compression_algorithm);
+                        if (compressed)
+                        {
+                            final_data = compressed;
+                            final_size = compressed_size;
+                        }
+                    }
+
+                    block_manager_block_t *vlog_block =
+                        block_manager_block_create(final_size, final_data);
+                    if (vlog_block)
+                    {
+                        const int64_t block_offset = block_manager_block_write(vlog_bm, vlog_block);
+                        if (block_offset >= 0)
+                        {
+                            vlog_offset = (uint64_t)block_offset;
+                            vlog_block_num++;
+                        }
+                        block_manager_block_release(vlog_block);
+                    }
+                    free(compressed);
+                }
+
+                const uint8_t *value_to_store = (vlog_offset > 0) ? NULL : pending->value;
+                const size_t value_size_to_store =
+                    (vlog_offset > 0) ? 0 : pending->entry.value_size;
+                const uint8_t entry_flags =
+                    pending->entry.flags & (TDB_KV_FLAG_TOMBSTONE | TDB_KV_FLAG_SINGLE_DELETE);
+
+                if (btree_builder_add(builder, pending->key, pending->entry.key_size,
+                                      value_to_store, value_size_to_store, vlog_offset,
+                                      pending->entry.seq, pending->entry.ttl, entry_flags) != 0)
+                {
+                    abort_io = 1;
+                }
+                else
+                {
+                    if (pending->entry.seq > max_seq) max_seq = pending->entry.seq;
+
+                    if (!sst->min_key)
+                    {
+                        sst->min_key = malloc(pending->entry.key_size);
+                        if (sst->min_key)
+                        {
+                            memcpy(sst->min_key, pending->key, pending->entry.key_size);
+                            sst->min_key_size = pending->entry.key_size;
+                        }
+                    }
+
+                    free(sst->max_key);
+                    sst->max_key = malloc(pending->entry.key_size);
+                    if (sst->max_key)
+                    {
+                        memcpy(sst->max_key, pending->key, pending->entry.key_size);
+                        sst->max_key_size = pending->entry.key_size;
+                    }
+
+                    entry_count++;
+                }
+            }
+
+            tidesdb_kv_pair_free(pending);
+            pending = NULL;
+
+            if (abort_io)
+            {
+                if (kv) tidesdb_kv_pair_free(kv);
+                btree_builder_free(builder);
+                return TDB_ERR_IO;
+            }
         }
 
         if (!kv) break;
 
-        if (last_key && last_key_size == kv->entry.key_size &&
-            memcmp(last_key, kv->key, last_key_size) == 0)
-        {
-            tidesdb_kv_pair_free(kv);
-            continue;
-        }
-
-        free(last_key);
-        last_key = malloc(kv->entry.key_size);
-        if (last_key)
-        {
-            memcpy(last_key, kv->key, kv->entry.key_size);
-            last_key_size = kv->entry.key_size;
-        }
-
-        /* we only drop tombstones when merging into the largest level */
-        if ((kv->entry.flags & TDB_KV_FLAG_TOMBSTONE) && is_largest_level)
-        {
-            tidesdb_kv_pair_free(kv);
-            continue;
-        }
-
-        if (kv->entry.ttl > 0 && kv->entry.ttl < atomic_load_explicit(&cf->db->cached_current_time,
-                                                                      memory_order_relaxed))
-        {
-            tidesdb_kv_pair_free(kv);
-            continue;
-        }
-
-        if (bloom)
-        {
-            bloom_filter_add(bloom, kv->key, kv->entry.key_size);
-        }
-
-        uint64_t vlog_offset = 0;
-        if (kv->entry.value_size >= cf->config.klog_value_threshold && kv->value)
-        {
-            const uint8_t *final_data = kv->value;
-            size_t final_size = kv->entry.value_size;
-            uint8_t *compressed = NULL;
-
-            if (sst->config->compression_algorithm != TDB_COMPRESS_NONE)
-            {
-                size_t compressed_size;
-                compressed = compress_data(kv->value, kv->entry.value_size, &compressed_size,
-                                           sst->config->compression_algorithm);
-                if (compressed)
-                {
-                    final_data = compressed;
-                    final_size = compressed_size;
-                }
-            }
-
-            block_manager_block_t *vlog_block = block_manager_block_create(final_size, final_data);
-            if (vlog_block)
-            {
-                const int64_t block_offset = block_manager_block_write(vlog_bm, vlog_block);
-                if (block_offset >= 0)
-                {
-                    vlog_offset = (uint64_t)block_offset;
-                    vlog_block_num++;
-                }
-                block_manager_block_release(vlog_block);
-            }
-            free(compressed);
-        }
-
-        const uint8_t *value_to_store = (vlog_offset > 0) ? NULL : kv->value;
-        const size_t value_size_to_store = (vlog_offset > 0) ? 0 : kv->entry.value_size;
-
-        if (btree_builder_add(builder, kv->key, kv->entry.key_size, value_to_store,
-                              value_size_to_store, vlog_offset, kv->entry.seq, kv->entry.ttl,
-                              (kv->entry.flags & TDB_KV_FLAG_TOMBSTONE) != 0) != 0)
-        {
-            tidesdb_kv_pair_free(kv);
-            free(last_key);
-            btree_builder_free(builder);
-            return TDB_ERR_IO;
-        }
-
-        if (kv->entry.seq > max_seq) max_seq = kv->entry.seq;
-
-        if (!sst->min_key)
-        {
-            sst->min_key = malloc(kv->entry.key_size);
-            if (sst->min_key)
-            {
-                memcpy(sst->min_key, kv->key, kv->entry.key_size);
-                sst->min_key_size = kv->entry.key_size;
-            }
-        }
-
-        free(sst->max_key);
-        sst->max_key = malloc(kv->entry.key_size);
-        if (sst->max_key)
-        {
-            memcpy(sst->max_key, kv->key, kv->entry.key_size);
-            sst->max_key_size = kv->entry.key_size;
-        }
-
-        entry_count++;
-        tidesdb_kv_pair_free(kv);
+        pending = kv;
+        pending_is_single_delete = (kv->entry.flags & TDB_KV_FLAG_SINGLE_DELETE) != 0;
+        pending_sd_paired_with_put = 0;
     }
-
-    free(last_key);
 
     btree_t *tree = NULL;
     if (btree_builder_finish(builder, &tree) != 0 || !tree)
@@ -6893,7 +6993,7 @@ static int tidesdb_sstable_write_from_memtable(tidesdb_t *db, tidesdb_sstable_t 
             kv_stack.entry.value_size = (uint32_t)value_size;
             kv_stack.entry.ttl = ttl;
             kv_stack.entry.seq = seq;
-            kv_stack.entry.flags = deleted ? TDB_KV_FLAG_TOMBSTONE : 0;
+            kv_stack.entry.flags = tidesdb_sl_flags_to_kv_flags(deleted);
             if (ttl != 0) kv_stack.entry.flags |= TDB_KV_FLAG_HAS_TTL;
             kv_stack.entry.vlog_offset = 0;
 
@@ -9197,10 +9297,10 @@ static inline void tidesdb_memtable_source_set_inline_borrowed(tidesdb_merge_sou
                                                                const uint8_t *key, size_t key_size,
                                                                const uint8_t *value,
                                                                size_t value_size, int64_t ttl,
-                                                               uint64_t seq, uint8_t deleted)
+                                                               uint64_t seq, uint8_t sl_flags)
 {
     tidesdb_kv_pair_t *ikv = &source->inline_kv;
-    ikv->entry.flags = (deleted ? TDB_KV_FLAG_TOMBSTONE : 0) | TDB_KV_FLAG_BORROWED;
+    ikv->entry.flags = tidesdb_sl_flags_to_kv_flags(sl_flags) | TDB_KV_FLAG_BORROWED;
     ikv->entry.key_size = (uint32_t)key_size;
     ikv->entry.value_size = (uint32_t)value_size;
     ikv->entry.ttl = ttl;
@@ -9503,7 +9603,7 @@ static tidesdb_merge_source_t *tidesdb_merge_source_from_txn_ops(
     const tidesdb_txn_op_t *first_op = &txn->ops[sorted_indices[0]];
     source->current_kv = tidesdb_kv_pair_create(first_op->key, first_op->key_size, first_op->value,
                                                 first_op->value_size, first_op->ttl, UINT64_MAX,
-                                                first_op->is_delete);
+                                                tidesdb_txn_op_kv_flags(first_op));
 
     return source;
 }
@@ -10150,7 +10250,7 @@ static int tidesdb_merge_source_advance(tidesdb_merge_source_t *source)
 
             source->current_kv =
                 tidesdb_kv_pair_create(op->key, op->key_size, op->value, op->value_size, op->ttl,
-                                       UINT64_MAX, op->is_delete);
+                                       UINT64_MAX, tidesdb_txn_op_kv_flags(op));
             return TDB_SUCCESS;
         }
         return TDB_ERR_NOT_FOUND;
@@ -10731,7 +10831,7 @@ static int tidesdb_merge_source_retreat(tidesdb_merge_source_t *source)
 
             source->current_kv =
                 tidesdb_kv_pair_create(op->key, op->key_size, op->value, op->value_size, op->ttl,
-                                       UINT64_MAX, op->is_delete);
+                                       UINT64_MAX, tidesdb_txn_op_kv_flags(op));
             return TDB_SUCCESS;
         }
         return TDB_ERR_NOT_FOUND;
@@ -11634,217 +11734,228 @@ static int tidesdb_full_preemptive_merge(tidesdb_column_family_t *cf, int start_
     uint64_t vlog_block_num = 0;
     uint64_t max_seq = 0;
 
-    uint8_t *last_key = NULL;
-    size_t last_key_size = 0;
-
     /* we track first and last key of current block for block index */
     uint8_t *block_first_key = NULL;
     size_t block_first_key_size = 0;
     uint8_t *block_last_key = NULL;
     size_t block_last_key_size = 0;
 
+    /* single-step lookahead: we buffer the pending first-for-key entry so a
+     * put+single-delete pair detected in the same merge input cancels together
+     * at any level instead of carrying the tombstone forward. same-key dedup,
+     * largest-level tombstone drop, and ttl drop fire when pending resolves. */
+    tidesdb_kv_pair_t *pending = NULL;
+    int pending_is_single_delete = 0;
+    int pending_sd_paired_with_put = 0;
+
     /* merge using heap */
-    while (!tidesdb_merge_heap_empty(heap))
+    while (!tidesdb_merge_heap_empty(heap) || pending != NULL)
     {
-        tidesdb_sstable_t *corrupted_sst = NULL;
-        tidesdb_kv_pair_t *kv = tidesdb_merge_heap_pop(heap, &corrupted_sst);
+        tidesdb_kv_pair_t *kv = NULL;
 
-        /* if corruption detected, add to deletion queue */
-        if (corrupted_sst)
+        if (!tidesdb_merge_heap_empty(heap))
         {
-            TDB_DEBUG_LOG(TDB_LOG_ERROR,
-                          "Detected corrupted SSTable %" PRIu64 ", marking for deletion",
-                          corrupted_sst->id);
-            queue_enqueue(sstables_to_delete, corrupted_sst);
+            tidesdb_sstable_t *corrupted_sst = NULL;
+            kv = tidesdb_merge_heap_pop(heap, &corrupted_sst);
+
+            /* if corruption detected, add to deletion queue */
+            if (corrupted_sst)
+            {
+                TDB_DEBUG_LOG(TDB_LOG_ERROR,
+                              "Detected corrupted SSTable %" PRIu64 ", marking for deletion",
+                              corrupted_sst->id);
+                queue_enqueue(sstables_to_delete, corrupted_sst);
+            }
         }
 
-        if (!kv)
+        if (kv && pending && pending->entry.key_size == kv->entry.key_size &&
+            memcmp(pending->key, kv->key, pending->entry.key_size) == 0)
         {
-            break;
-        }
-
-        /* we skip duplicate keys (keep newest based on seq) */
-        if (last_key && last_key_size == kv->entry.key_size &&
-            memcmp(last_key, kv->key, last_key_size) == 0)
-        {
+            /* older same-key version -- drop silently.  record whether the
+             * trailing version is a live put so a pending single-delete can
+             * pair-cancel with it when we resolve pending. */
+            if (pending_is_single_delete && !(kv->entry.flags & TDB_KV_FLAG_TOMBSTONE))
+            {
+                pending_sd_paired_with_put = 1;
+            }
             tidesdb_kv_pair_free(kv);
             continue;
         }
 
-        /* we update last key */
-        free(last_key);
-        last_key = malloc(kv->entry.key_size);
-        if (last_key)
+        /* new key arrived (or heap exhausted) -- decide the fate of pending */
+        if (pending)
         {
-            memcpy(last_key, kv->key, kv->entry.key_size);
-            last_key_size = kv->entry.key_size;
-        }
+            const int sd_pair_drop = pending_is_single_delete && pending_sd_paired_with_put;
+            const int tombstone_drop =
+                (pending->entry.flags & TDB_KV_FLAG_TOMBSTONE) && is_largest_level;
+            const int ttl_drop =
+                pending->entry.ttl > 0 &&
+                pending->entry.ttl <
+                    atomic_load_explicit(&cf->db->cached_current_time, memory_order_relaxed);
 
-        /* we only drop tombstones when merging into the largest level
-         * tombstones must be preserved in upper levels to mask deleted keys in lower levels */
-        if ((kv->entry.flags & TDB_KV_FLAG_TOMBSTONE) && is_largest_level)
-        {
-            tidesdb_kv_pair_free(kv);
-            continue;
-        }
-
-        if (kv->entry.ttl > 0 && kv->entry.ttl < atomic_load_explicit(&cf->db->cached_current_time,
-                                                                      memory_order_relaxed))
-        {
-            tidesdb_kv_pair_free(kv);
-            continue;
-        }
-
-        if (kv->entry.value_size >= cf->config.klog_value_threshold && kv->value)
-        {
-            /* we write value directly to vlog */
-            uint8_t *final_data = kv->value;
-            size_t final_size = kv->entry.value_size;
-            uint8_t *compressed = NULL;
-
-            if (new_sst->config->compression_algorithm != TDB_COMPRESS_NONE)
+            if (!sd_pair_drop && !tombstone_drop && !ttl_drop)
             {
-                size_t compressed_size;
-                compressed = compress_data(kv->value, kv->entry.value_size, &compressed_size,
-                                           new_sst->config->compression_algorithm);
-                if (compressed)
+                if (pending->entry.value_size >= cf->config.klog_value_threshold && pending->value)
                 {
-                    final_data = compressed;
-                    final_size = compressed_size;
-                }
-            }
+                    /* we write value directly to vlog */
+                    uint8_t *final_data = pending->value;
+                    size_t final_size = pending->entry.value_size;
+                    uint8_t *compressed = NULL;
 
-            block_manager_block_t *vlog_block = block_manager_block_create(final_size, final_data);
-            if (vlog_block)
-            {
-                int64_t block_offset = block_manager_block_write(vlog_bm, vlog_block);
-                if (block_offset >= 0)
-                {
-                    kv->entry.vlog_offset = (uint64_t)block_offset;
-                    vlog_block_num++;
-                }
-                block_manager_block_release(vlog_block);
-            }
-            free(compressed);
-        }
-
-        /* we check if this is the first entry in a new block */
-        int is_first_entry_in_block = (current_klog_block->num_entries == 0);
-
-        tidesdb_klog_block_add_entry(current_klog_block, kv, &cf->config, comparator_fn,
-                                     comparator_ctx);
-
-        /* we track first key of block */
-        if (is_first_entry_in_block)
-        {
-            free(block_first_key);
-            block_first_key = malloc(kv->entry.key_size);
-            if (block_first_key)
-            {
-                memcpy(block_first_key, kv->key, kv->entry.key_size);
-                block_first_key_size = kv->entry.key_size;
-            }
-        }
-
-        /* we always update last key of block */
-        free(block_last_key);
-        block_last_key = malloc(kv->entry.key_size);
-        if (block_last_key)
-        {
-            memcpy(block_last_key, kv->key, kv->entry.key_size);
-            block_last_key_size = kv->entry.key_size;
-        }
-
-        if (tidesdb_klog_block_is_full(current_klog_block, TDB_KLOG_BLOCK_SIZE))
-        {
-            uint8_t *klog_data;
-            size_t klog_size;
-            if (tidesdb_klog_block_serialize(current_klog_block, &klog_data, &klog_size) == 0)
-            {
-                uint8_t *final_data = klog_data;
-                size_t final_size = klog_size;
-
-                if (cf->config.compression_algorithm != TDB_COMPRESS_NONE)
-                {
-                    size_t compressed_size;
-                    uint8_t *compressed = compress_data(klog_data, klog_size, &compressed_size,
-                                                        cf->config.compression_algorithm);
-                    if (compressed)
+                    if (new_sst->config->compression_algorithm != TDB_COMPRESS_NONE)
                     {
-                        free(klog_data);
-                        final_data = compressed;
-                        final_size = compressed_size;
-                    }
-                }
-
-                block_manager_block_t *klog_block =
-                    block_manager_block_create(final_size, final_data);
-                if (klog_block)
-                {
-                    uint64_t block_file_position = atomic_load(&klog_bm->current_file_size);
-                    block_manager_block_write(klog_bm, klog_block);
-                    block_manager_block_release(klog_block);
-
-                    if (block_indexes && block_first_key && block_last_key)
-                    {
-                        if (klog_block_num % cf->config.index_sample_ratio == 0)
+                        size_t compressed_size;
+                        compressed =
+                            compress_data(pending->value, pending->entry.value_size,
+                                          &compressed_size, new_sst->config->compression_algorithm);
+                        if (compressed)
                         {
-                            compact_block_index_add(block_indexes, block_first_key,
-                                                    block_first_key_size, block_last_key,
-                                                    block_last_key_size, block_file_position);
+                            final_data = compressed;
+                            final_size = compressed_size;
                         }
                     }
 
-                    klog_block_num++;
+                    block_manager_block_t *vlog_block =
+                        block_manager_block_create(final_size, final_data);
+                    if (vlog_block)
+                    {
+                        int64_t block_offset = block_manager_block_write(vlog_bm, vlog_block);
+                        if (block_offset >= 0)
+                        {
+                            pending->entry.vlog_offset = (uint64_t)block_offset;
+                            vlog_block_num++;
+                        }
+                        block_manager_block_release(vlog_block);
+                    }
+                    free(compressed);
                 }
-                free(final_data);
+
+                /* we check if this is the first entry in a new block */
+                int is_first_entry_in_block = (current_klog_block->num_entries == 0);
+
+                tidesdb_klog_block_add_entry(current_klog_block, pending, &cf->config,
+                                             comparator_fn, comparator_ctx);
+
+                /* we track first key of block */
+                if (is_first_entry_in_block)
+                {
+                    free(block_first_key);
+                    block_first_key = malloc(pending->entry.key_size);
+                    if (block_first_key)
+                    {
+                        memcpy(block_first_key, pending->key, pending->entry.key_size);
+                        block_first_key_size = pending->entry.key_size;
+                    }
+                }
+
+                /* we always update last key of block */
+                free(block_last_key);
+                block_last_key = malloc(pending->entry.key_size);
+                if (block_last_key)
+                {
+                    memcpy(block_last_key, pending->key, pending->entry.key_size);
+                    block_last_key_size = pending->entry.key_size;
+                }
+
+                if (tidesdb_klog_block_is_full(current_klog_block, TDB_KLOG_BLOCK_SIZE))
+                {
+                    uint8_t *klog_data;
+                    size_t klog_size;
+                    if (tidesdb_klog_block_serialize(current_klog_block, &klog_data, &klog_size) ==
+                        0)
+                    {
+                        uint8_t *final_data = klog_data;
+                        size_t final_size = klog_size;
+
+                        if (cf->config.compression_algorithm != TDB_COMPRESS_NONE)
+                        {
+                            size_t compressed_size;
+                            uint8_t *compressed =
+                                compress_data(klog_data, klog_size, &compressed_size,
+                                              cf->config.compression_algorithm);
+                            if (compressed)
+                            {
+                                free(klog_data);
+                                final_data = compressed;
+                                final_size = compressed_size;
+                            }
+                        }
+
+                        block_manager_block_t *klog_block =
+                            block_manager_block_create(final_size, final_data);
+                        if (klog_block)
+                        {
+                            uint64_t block_file_position = atomic_load(&klog_bm->current_file_size);
+                            block_manager_block_write(klog_bm, klog_block);
+                            block_manager_block_release(klog_block);
+
+                            if (block_indexes && block_first_key && block_last_key)
+                            {
+                                if (klog_block_num % cf->config.index_sample_ratio == 0)
+                                {
+                                    compact_block_index_add(
+                                        block_indexes, block_first_key, block_first_key_size,
+                                        block_last_key, block_last_key_size, block_file_position);
+                                }
+                            }
+
+                            klog_block_num++;
+                        }
+                        free(final_data);
+                    }
+
+                    tidesdb_klog_block_free(current_klog_block);
+                    current_klog_block = tidesdb_klog_block_create();
+
+                    free(block_first_key);
+                    free(block_last_key);
+                    block_first_key = NULL;
+                    block_last_key = NULL;
+                }
+
+                if (pending->entry.seq > max_seq)
+                {
+                    max_seq = pending->entry.seq;
+                }
+
+                if (bloom)
+                {
+                    bloom_filter_add(bloom, pending->key, pending->entry.key_size);
+                }
+
+                if (!new_sst->min_key)
+                {
+                    new_sst->min_key = malloc(pending->entry.key_size);
+                    if (new_sst->min_key)
+                    {
+                        memcpy(new_sst->min_key, pending->key, pending->entry.key_size);
+                        new_sst->min_key_size = pending->entry.key_size;
+                    }
+                }
+
+                free(new_sst->max_key);
+                new_sst->max_key = malloc(pending->entry.key_size);
+                if (new_sst->max_key)
+                {
+                    memcpy(new_sst->max_key, pending->key, pending->entry.key_size);
+                    new_sst->max_key_size = pending->entry.key_size;
+                }
+
+                new_sst->num_entries++;
             }
 
-            tidesdb_klog_block_free(current_klog_block);
-            current_klog_block = tidesdb_klog_block_create();
-
-            free(block_first_key);
-            free(block_last_key);
-            block_first_key = NULL;
-            block_last_key = NULL;
+            tidesdb_kv_pair_free(pending);
+            pending = NULL;
         }
 
-        if (kv->entry.seq > max_seq)
-        {
-            max_seq = kv->entry.seq;
-        }
+        if (!kv) break;
 
-        if (bloom)
-        {
-            bloom_filter_add(bloom, kv->key, kv->entry.key_size);
-        }
-
-        if (!new_sst->min_key)
-        {
-            new_sst->min_key = malloc(kv->entry.key_size);
-            if (new_sst->min_key)
-            {
-                memcpy(new_sst->min_key, kv->key, kv->entry.key_size);
-                new_sst->min_key_size = kv->entry.key_size;
-            }
-        }
-
-        free(new_sst->max_key);
-        new_sst->max_key = malloc(kv->entry.key_size);
-        if (new_sst->max_key)
-        {
-            memcpy(new_sst->max_key, kv->key, kv->entry.key_size);
-            new_sst->max_key_size = kv->entry.key_size;
-        }
-
-        new_sst->num_entries++;
-
-        tidesdb_kv_pair_free(kv);
+        pending = kv;
+        pending_is_single_delete = (kv->entry.flags & TDB_KV_FLAG_SINGLE_DELETE) != 0;
+        pending_sd_paired_with_put = 0;
     }
 
     new_sst->max_seq = max_seq;
-
-    free(last_key);
 
     if (current_klog_block->num_entries > 0)
     {
@@ -12478,170 +12589,197 @@ static int tidesdb_dividing_merge(tidesdb_column_family_t *cf, int target_level)
             continue;
         }
 
+        /* single-step lookahead pretty much same pair-cancel pattern as full-preemptive merge.
+         * dividing merge never goes to the largest level so there's no
+         * tombstone-at-largest-level drop here, only ttl drop and single-
+         * delete pair-cancel. */
+        tidesdb_kv_pair_t *pending = NULL;
+        int pending_is_single_delete = 0;
+        int pending_sd_paired_with_put = 0;
+
         /* we process entries from partition-specific heap -- filter keys by partition range */
-        while (!tidesdb_merge_heap_empty(partition_heap))
+        while (!tidesdb_merge_heap_empty(partition_heap) || pending != NULL)
         {
-            tidesdb_kv_pair_t *kv = tidesdb_merge_heap_pop(partition_heap, NULL);
+            tidesdb_kv_pair_t *kv = NULL;
+
+            if (!tidesdb_merge_heap_empty(partition_heap))
+            {
+                kv = tidesdb_merge_heap_pop(partition_heap, NULL);
+
+                if (kv)
+                {
+                    /* we filter keys by partition range -- merge source reads
+                     * all keys from sst but we only want keys within this
+                     * partition's boundaries.  range-filtered keys cannot pair
+                     * with pending because pending's key is in range. */
+                    if (range_start && comparator_fn(kv->key, kv->entry.key_size, range_start,
+                                                     range_start_size, comparator_ctx) < 0)
+                    {
+                        tidesdb_kv_pair_free(kv);
+                        kv = NULL;
+                        continue;
+                    }
+                    if (range_end && comparator_fn(kv->key, kv->entry.key_size, range_end,
+                                                   range_end_size, comparator_ctx) >= 0)
+                    {
+                        tidesdb_kv_pair_free(kv);
+                        kv = NULL;
+                        continue;
+                    }
+                }
+            }
+
+            if (kv && pending && pending->entry.key_size == kv->entry.key_size &&
+                memcmp(pending->key, kv->key, pending->entry.key_size) == 0)
+            {
+                /* older same-key version -- drop silently.  a pending single-
+                 * delete pairs with a live put here and cancels on resolve. */
+                if (pending_is_single_delete && !(kv->entry.flags & TDB_KV_FLAG_TOMBSTONE))
+                {
+                    pending_sd_paired_with_put = 1;
+                }
+                tidesdb_kv_pair_free(kv);
+                continue;
+            }
+
+            /* new key arrived (or heap exhausted) -- decide the fate of pending */
+            if (pending)
+            {
+                const int sd_pair_drop = pending_is_single_delete && pending_sd_paired_with_put;
+                const int ttl_drop =
+                    pending->entry.ttl > 0 &&
+                    pending->entry.ttl <
+                        atomic_load_explicit(&cf->db->cached_current_time, memory_order_relaxed);
+
+                if (!sd_pair_drop && !ttl_drop)
+                {
+                    /* we add to sst */
+                    if (!first_key)
+                    {
+                        first_key = malloc(pending->entry.key_size);
+                        if (first_key)
+                        {
+                            memcpy(first_key, pending->key, pending->entry.key_size);
+                            first_key_size = pending->entry.key_size;
+                        }
+                    }
+
+                    free(last_key);
+                    last_key = malloc(pending->entry.key_size);
+                    if (last_key)
+                    {
+                        memcpy(last_key, pending->key, pending->entry.key_size);
+                        last_key_size = pending->entry.key_size;
+                    }
+
+                    if (bloom)
+                    {
+                        bloom_filter_add(bloom, pending->key, pending->entry.key_size);
+                    }
+
+                    /* we check if this is the first entry in a new block */
+                    int is_first_entry_in_block = (klog_block->num_entries == 0);
+
+                    tidesdb_klog_block_add_entry(klog_block, pending, &cf->config, comparator_fn,
+                                                 comparator_ctx);
+
+                    /* we track first key of block */
+                    if (is_first_entry_in_block)
+                    {
+                        free(block_first_key);
+                        block_first_key = malloc(pending->entry.key_size);
+                        if (block_first_key)
+                        {
+                            memcpy(block_first_key, pending->key, pending->entry.key_size);
+                            block_first_key_size = pending->entry.key_size;
+                        }
+                    }
+
+                    /* we always update last key of block */
+                    free(block_last_key);
+                    block_last_key = malloc(pending->entry.key_size);
+                    if (block_last_key)
+                    {
+                        memcpy(block_last_key, pending->key, pending->entry.key_size);
+                        block_last_key_size = pending->entry.key_size;
+                    }
+
+                    if (tidesdb_klog_block_is_full(klog_block, TDB_KLOG_BLOCK_SIZE))
+                    {
+                        uint8_t *klog_data;
+                        size_t klog_size;
+                        if (tidesdb_klog_block_serialize(klog_block, &klog_data, &klog_size) == 0)
+                        {
+                            uint8_t *final_klog_data = klog_data;
+                            size_t final_klog_size = klog_size;
+
+                            if (cf->config.compression_algorithm != TDB_COMPRESS_NONE)
+                            {
+                                size_t compressed_size;
+                                uint8_t *compressed =
+                                    compress_data(klog_data, klog_size, &compressed_size,
+                                                  cf->config.compression_algorithm);
+                                if (compressed)
+                                {
+                                    free(klog_data);
+                                    final_klog_data = compressed;
+                                    final_klog_size = compressed_size;
+                                }
+                            }
+
+                            block_manager_block_t *klog_bm_block =
+                                block_manager_block_create(final_klog_size, final_klog_data);
+                            if (klog_bm_block)
+                            {
+                                uint64_t block_file_position =
+                                    atomic_load(&klog_bm->current_file_size);
+                                block_manager_block_write(klog_bm, klog_bm_block);
+                                block_manager_block_release(klog_bm_block);
+
+                                if (block_indexes && block_first_key && block_last_key)
+                                {
+                                    if (klog_block_num % cf->config.index_sample_ratio == 0)
+                                    {
+                                        compact_block_index_add(block_indexes, block_first_key,
+                                                                block_first_key_size,
+                                                                block_last_key, block_last_key_size,
+                                                                block_file_position);
+                                    }
+                                }
+
+                                klog_block_num++;
+                            }
+                            free(final_klog_data);
+                        }
+
+                        tidesdb_klog_block_free(klog_block);
+                        klog_block = tidesdb_klog_block_create();
+
+                        /* we reset block tracking for new block */
+                        free(block_first_key);
+                        free(block_last_key);
+                        block_first_key = NULL;
+                        block_last_key = NULL;
+                    }
+
+                    /* we track maximum sequence number */
+                    if (pending->entry.seq > max_seq)
+                    {
+                        max_seq = pending->entry.seq;
+                    }
+
+                    entry_count++;
+                }
+
+                tidesdb_kv_pair_free(pending);
+                pending = NULL;
+            }
+
             if (!kv) break;
 
-            /* we filter keys by partition range -- merge source reads all keys from sst
-             * but we only want keys that fall within this partitions boundaries */
-            if (range_start && comparator_fn(kv->key, kv->entry.key_size, range_start,
-                                             range_start_size, comparator_ctx) < 0)
-            {
-                /* key is before partition range, skip */
-                tidesdb_kv_pair_free(kv);
-                continue;
-            }
-            if (range_end && comparator_fn(kv->key, kv->entry.key_size, range_end, range_end_size,
-                                           comparator_ctx) >= 0)
-            {
-                /* key is at or after partition end, skip */
-                tidesdb_kv_pair_free(kv);
-                continue;
-            }
-
-            /* we skip duplicate keys (keep newest based on seq) */
-            if (last_key && last_key_size == kv->entry.key_size &&
-                memcmp(last_key, kv->key, last_key_size) == 0)
-            {
-                tidesdb_kv_pair_free(kv);
-                continue;
-            }
-
-            /* we update last key for duplicate detection */
-            free(last_key);
-            last_key = malloc(kv->entry.key_size);
-            if (last_key)
-            {
-                memcpy(last_key, kv->key, kv->entry.key_size);
-                last_key_size = kv->entry.key_size;
-            }
-
-            /* dividing merge never goes to largest level, so we preserve tombstones */
-            if (kv->entry.ttl > 0 &&
-                kv->entry.ttl <
-                    atomic_load_explicit(&cf->db->cached_current_time, memory_order_relaxed))
-            {
-                tidesdb_kv_pair_free(kv);
-                continue;
-            }
-
-            /* we add to sst */
-            if (!first_key)
-            {
-                first_key = malloc(kv->entry.key_size);
-                if (first_key)
-                {
-                    memcpy(first_key, kv->key, kv->entry.key_size);
-                    first_key_size = kv->entry.key_size;
-                }
-            }
-
-            if (last_key) free(last_key);
-            last_key = malloc(kv->entry.key_size);
-            if (last_key)
-            {
-                memcpy(last_key, kv->key, kv->entry.key_size);
-                last_key_size = kv->entry.key_size;
-            }
-
-            if (bloom)
-            {
-                bloom_filter_add(bloom, kv->key, kv->entry.key_size);
-            }
-
-            /* we check if this is the first entry in a new block */
-            int is_first_entry_in_block = (klog_block->num_entries == 0);
-
-            tidesdb_klog_block_add_entry(klog_block, kv, &cf->config, comparator_fn,
-                                         comparator_ctx);
-
-            /* we track first key of block */
-            if (is_first_entry_in_block)
-            {
-                free(block_first_key);
-                block_first_key = malloc(kv->entry.key_size);
-                if (block_first_key)
-                {
-                    memcpy(block_first_key, kv->key, kv->entry.key_size);
-                    block_first_key_size = kv->entry.key_size;
-                }
-            }
-
-            /* we always update last key of block */
-            free(block_last_key);
-            block_last_key = malloc(kv->entry.key_size);
-            if (block_last_key)
-            {
-                memcpy(block_last_key, kv->key, kv->entry.key_size);
-                block_last_key_size = kv->entry.key_size;
-            }
-
-            if (tidesdb_klog_block_is_full(klog_block, TDB_KLOG_BLOCK_SIZE))
-            {
-                uint8_t *klog_data;
-                size_t klog_size;
-                if (tidesdb_klog_block_serialize(klog_block, &klog_data, &klog_size) == 0)
-                {
-                    uint8_t *final_klog_data = klog_data;
-                    size_t final_klog_size = klog_size;
-
-                    if (cf->config.compression_algorithm != TDB_COMPRESS_NONE)
-                    {
-                        size_t compressed_size;
-                        uint8_t *compressed = compress_data(klog_data, klog_size, &compressed_size,
-                                                            cf->config.compression_algorithm);
-                        if (compressed)
-                        {
-                            free(klog_data);
-                            final_klog_data = compressed;
-                            final_klog_size = compressed_size;
-                        }
-                    }
-
-                    block_manager_block_t *klog_bm_block =
-                        block_manager_block_create(final_klog_size, final_klog_data);
-                    if (klog_bm_block)
-                    {
-                        uint64_t block_file_position = atomic_load(&klog_bm->current_file_size);
-                        block_manager_block_write(klog_bm, klog_bm_block);
-                        block_manager_block_release(klog_bm_block);
-
-                        if (block_indexes && block_first_key && block_last_key)
-                        {
-                            if (klog_block_num % cf->config.index_sample_ratio == 0)
-                            {
-                                compact_block_index_add(block_indexes, block_first_key,
-                                                        block_first_key_size, block_last_key,
-                                                        block_last_key_size, block_file_position);
-                            }
-                        }
-
-                        klog_block_num++;
-                    }
-                    free(final_klog_data);
-                }
-
-                tidesdb_klog_block_free(klog_block);
-                klog_block = tidesdb_klog_block_create();
-
-                /* we reset block tracking for new block */
-                free(block_first_key);
-                free(block_last_key);
-                block_first_key = NULL;
-                block_last_key = NULL;
-            }
-
-            /* we track maximum sequence number */
-            if (kv->entry.seq > max_seq)
-            {
-                max_seq = kv->entry.seq;
-            }
-
-            entry_count++;
-
-            tidesdb_kv_pair_free(kv);
+            pending = kv;
+            pending_is_single_delete = (kv->entry.flags & TDB_KV_FLAG_SINGLE_DELETE) != 0;
+            pending_sd_paired_with_put = 0;
         }
 
         tidesdb_merge_heap_free(partition_heap);
@@ -13423,6 +13561,26 @@ static int tidesdb_partitioned_merge(tidesdb_column_family_t *cf, int start_leve
                 {
                     memcpy(last_seen_key, kv->key, kv->entry.key_size);
                     last_seen_key_size = kv->entry.key_size;
+                }
+
+                /* single-delete pair-cancel if kv is a single-delete and the
+                 * next entry still on the heap is a live put for the same key,
+                 * both can be dropped together.  we peek the heap's top source
+                 * instead of restructuring this loop with a one-step buffer
+                 * because this path has a mid-loop sstable-split on file_max
+                 * that is awkward to reorder.  the same-key dedup below then
+                 * sweeps the paired put on the next iteration. */
+                if ((kv->entry.flags & TDB_KV_FLAG_SINGLE_DELETE) &&
+                    !tidesdb_merge_heap_empty(heap))
+                {
+                    const tidesdb_kv_pair_t *peek = heap->sources[0]->current_kv;
+                    if (peek && peek->entry.key_size == kv->entry.key_size &&
+                        memcmp(peek->key, kv->key, kv->entry.key_size) == 0 &&
+                        !(peek->entry.flags & TDB_KV_FLAG_TOMBSTONE))
+                    {
+                        tidesdb_kv_pair_free(kv);
+                        continue;
+                    }
                 }
 
                 /* partitioned merge goes to level before largest, so preserve tombstones */
@@ -14222,8 +14380,14 @@ static int tidesdb_wal_recover(tidesdb_column_family_t *cf, const char *wal_path
 
                 if (entry.flags & TDB_KV_FLAG_TOMBSTONE)
                 {
+                    /* preserve the single-delete subtype across crash so compaction
+                     * can still pair-cancel put+single-delete for entries that were
+                     * only in the wal at the time of the crash. */
+                    uint8_t sl_flags = SKIP_LIST_FLAG_DELETED;
+                    if (entry.flags & TDB_KV_FLAG_SINGLE_DELETE)
+                        sl_flags |= SKIP_LIST_FLAG_SINGLE_DELETE;
                     skip_list_put_with_seq(*memtable, key, entry.key_size, NULL, 0, 0, entry.seq,
-                                           1);
+                                           sl_flags);
                 }
                 else
                 {
@@ -20130,8 +20294,19 @@ unified_sst_search:;
     return TDB_ERR_NOT_FOUND;
 }
 
-int tidesdb_txn_delete(tidesdb_txn_t *txn, tidesdb_column_family_t *cf, const uint8_t *key,
-                       const size_t key_size)
+/**
+ * tidesdb_txn_delete_internal
+ * shared implementation for tidesdb_txn_delete and tidesdb_txn_single_delete.
+ * @param txn transaction handle
+ * @param cf column family to delete from
+ * @param key key to delete
+ * @param key_size size of key
+ * @param is_single_delete 1 for single-delete semantics, 0 for a regular delete
+ * @return 0 on success, -n on failure
+ */
+static int tidesdb_txn_delete_internal(tidesdb_txn_t *txn, tidesdb_column_family_t *cf,
+                                       const uint8_t *key, const size_t key_size,
+                                       const int is_single_delete)
 {
     if (!txn || !cf || !key || key_size == 0) return TDB_ERR_INVALID_ARGS;
 
@@ -20179,6 +20354,7 @@ int tidesdb_txn_delete(tidesdb_txn_t *txn, tidesdb_column_family_t *cf, const ui
     op->value_size = 0;
     op->ttl = 0;
     op->is_delete = 1;
+    op->is_single_delete = is_single_delete;
     op->cf = cf;
 
     txn->num_ops++;
@@ -20205,6 +20381,18 @@ int tidesdb_txn_delete(tidesdb_txn_t *txn, tidesdb_column_family_t *cf, const ui
     }
 
     return TDB_SUCCESS;
+}
+
+int tidesdb_txn_delete(tidesdb_txn_t *txn, tidesdb_column_family_t *cf, const uint8_t *key,
+                       const size_t key_size)
+{
+    return tidesdb_txn_delete_internal(txn, cf, key, key_size, 0);
+}
+
+int tidesdb_txn_single_delete(tidesdb_txn_t *txn, tidesdb_column_family_t *cf, const uint8_t *key,
+                              const size_t key_size)
+{
+    return tidesdb_txn_delete_internal(txn, cf, key, key_size, 1);
 }
 
 int tidesdb_txn_rollback(tidesdb_txn_t *txn)
@@ -20860,7 +21048,7 @@ static int tidesdb_txn_apply_ops_to_memtable(const tidesdb_txn_t *txn,
             stack_batch[batch_idx].value_size = op->value_size;
             stack_batch[batch_idx].ttl = op->ttl;
             stack_batch[batch_idx].seq = txn->commit_seq;
-            stack_batch[batch_idx].deleted = op->is_delete;
+            stack_batch[batch_idx].flags = tidesdb_txn_op_sl_flags(op);
             batch_idx++;
         }
 
@@ -20910,7 +21098,7 @@ static int tidesdb_txn_apply_ops_to_memtable(const tidesdb_txn_t *txn,
             const tidesdb_txn_op_t *op = &txn->ops[i];
             if (op->cf != cf) continue;
             if (skip_list_put_with_seq(memtable, op->key, op->key_size, op->value, op->value_size,
-                                       op->ttl, txn->commit_seq, op->is_delete) != 0)
+                                       op->ttl, txn->commit_seq, tidesdb_txn_op_sl_flags(op)) != 0)
             {
                 return TDB_ERR_MEMORY;
             }
@@ -20957,7 +21145,7 @@ static int tidesdb_txn_apply_ops_to_memtable(const tidesdb_txn_t *txn,
         if (!inserted && !is_duplicate)
         {
             if (skip_list_put_with_seq(memtable, op->key, op->key_size, op->value, op->value_size,
-                                       op->ttl, txn->commit_seq, op->is_delete) != 0)
+                                       op->ttl, txn->commit_seq, tidesdb_txn_op_sl_flags(op)) != 0)
             {
                 free(dedup_hash);
                 free(used_slots);
@@ -20993,7 +21181,7 @@ static int tidesdb_txn_apply_ops_to_memtable(const tidesdb_txn_t *txn,
                 batch_entries[batch_idx].value_size = op->value_size;
                 batch_entries[batch_idx].ttl = op->ttl;
                 batch_entries[batch_idx].seq = txn->commit_seq;
-                batch_entries[batch_idx].deleted = op->is_delete;
+                batch_entries[batch_idx].flags = tidesdb_txn_op_sl_flags(op);
                 batch_idx++;
             }
         }
@@ -21010,7 +21198,7 @@ static int tidesdb_txn_apply_ops_to_memtable(const tidesdb_txn_t *txn,
                     batch_entries[batch_idx].value_size = op->value_size;
                     batch_entries[batch_idx].ttl = op->ttl;
                     batch_entries[batch_idx].seq = txn->commit_seq;
-                    batch_entries[batch_idx].deleted = op->is_delete;
+                    batch_entries[batch_idx].flags = tidesdb_txn_op_sl_flags(op);
                     batch_idx++;
                 }
             }
@@ -21029,7 +21217,7 @@ static int tidesdb_txn_apply_ops_to_memtable(const tidesdb_txn_t *txn,
             const int slot = used_slots[i];
             const tidesdb_txn_op_t *op = &txn->ops[dedup_hash[slot].op_idx];
             if (skip_list_put_with_seq(memtable, op->key, op->key_size, op->value, op->value_size,
-                                       op->ttl, txn->commit_seq, op->is_delete) != 0)
+                                       op->ttl, txn->commit_seq, tidesdb_txn_op_sl_flags(op)) != 0)
             {
                 result = TDB_ERR_MEMORY;
                 break;
@@ -21128,6 +21316,7 @@ static uint8_t *tidesdb_txn_serialize_wal(const tidesdb_txn_t *txn,
         if (op->cf != cf) continue;
 
         uint8_t flags = op->is_delete ? TDB_KV_FLAG_TOMBSTONE : 0;
+        if (op->is_single_delete) flags |= TDB_KV_FLAG_SINGLE_DELETE;
         if (op->ttl != 0) flags |= TDB_KV_FLAG_HAS_TTL;
         *wal_ptr++ = flags;
 
@@ -21222,6 +21411,7 @@ static uint8_t *tidesdb_txn_serialize_wal_unified(const tidesdb_txn_t *txn, size
         wal_ptr += TDB_UNIFIED_CF_PREFIX_SIZE;
 
         uint8_t flags = op->is_delete ? TDB_KV_FLAG_TOMBSTONE : 0;
+        if (op->is_single_delete) flags |= TDB_KV_FLAG_SINGLE_DELETE;
         if (op->ttl != 0) flags |= TDB_KV_FLAG_HAS_TTL;
         *wal_ptr++ = flags;
 
@@ -21273,7 +21463,7 @@ static int tidesdb_txn_apply_ops_to_unified_memtable(const tidesdb_txn_t *txn,
         size_t pk_size =
             tdb_build_prefixed_key(op->cf->unified_cf_index, op->key, op->key_size, prefixed);
         int rc = skip_list_put_with_seq(memtable, prefixed, pk_size, op->value, op->value_size,
-                                        op->ttl, txn->commit_seq, op->is_delete) == 0
+                                        op->ttl, txn->commit_seq, tidesdb_txn_op_sl_flags(op)) == 0
                      ? TDB_SUCCESS
                      : TDB_ERR_MEMORY;
         TDB_PREFIXED_KEY_FREE(prefixed, _pk_stack2);
@@ -21321,7 +21511,7 @@ static int tidesdb_txn_apply_ops_to_unified_memtable(const tidesdb_txn_t *txn,
                                                         op->key_size, prefixed);
                 int rc =
                     skip_list_put_with_seq(memtable, prefixed, pk_size, op->value, op->value_size,
-                                           op->ttl, txn->commit_seq, op->is_delete);
+                                           op->ttl, txn->commit_seq, tidesdb_txn_op_sl_flags(op));
                 TDB_PREFIXED_KEY_FREE(prefixed, _pk_stack_fb);
                 if (rc != 0) return TDB_ERR_MEMORY;
                 continue;
@@ -21336,7 +21526,7 @@ static int tidesdb_txn_apply_ops_to_unified_memtable(const tidesdb_txn_t *txn,
             stack_batch[batch_idx].value_size = op->value_size;
             stack_batch[batch_idx].ttl = op->ttl;
             stack_batch[batch_idx].seq = txn->commit_seq;
-            stack_batch[batch_idx].deleted = op->is_delete;
+            stack_batch[batch_idx].flags = tidesdb_txn_op_sl_flags(op);
             batch_idx++;
         }
 
@@ -21392,7 +21582,7 @@ static int tidesdb_txn_apply_ops_to_unified_memtable(const tidesdb_txn_t *txn,
             size_t pk_size =
                 tdb_build_prefixed_key(op->cf->unified_cf_index, op->key, op->key_size, prefixed);
             int rc = skip_list_put_with_seq(memtable, prefixed, pk_size, op->value, op->value_size,
-                                            op->ttl, txn->commit_seq, op->is_delete);
+                                            op->ttl, txn->commit_seq, tidesdb_txn_op_sl_flags(op));
             TDB_PREFIXED_KEY_FREE(prefixed, _pk_stack_ndd);
             if (rc != 0) return TDB_ERR_MEMORY;
         }
@@ -21459,7 +21649,7 @@ static int tidesdb_txn_apply_ops_to_unified_memtable(const tidesdb_txn_t *txn,
             size_t pk_size =
                 tdb_build_prefixed_key(op->cf->unified_cf_index, op->key, op->key_size, prefixed);
             (void)skip_list_put_with_seq(memtable, prefixed, pk_size, op->value, op->value_size,
-                                         op->ttl, txn->commit_seq, op->is_delete);
+                                         op->ttl, txn->commit_seq, tidesdb_txn_op_sl_flags(op));
             TDB_PREFIXED_KEY_FREE(prefixed, _pk_stack_probe);
         }
     }
@@ -21509,7 +21699,7 @@ static int tidesdb_txn_apply_ops_to_unified_memtable(const tidesdb_txn_t *txn,
                 size_t pk_size = tdb_build_prefixed_key(op->cf->unified_cf_index, op->key,
                                                         op->key_size, prefixed);
                 (void)skip_list_put_with_seq(memtable, prefixed, pk_size, op->value, op->value_size,
-                                             op->ttl, txn->commit_seq, op->is_delete);
+                                             op->ttl, txn->commit_seq, tidesdb_txn_op_sl_flags(op));
                 TDB_PREFIXED_KEY_FREE(prefixed, _pk_stack_fb2);
             }
         }
@@ -21539,7 +21729,7 @@ static int tidesdb_txn_apply_ops_to_unified_memtable(const tidesdb_txn_t *txn,
             batch_entries[batch_idx].value_size = op->value_size;
             batch_entries[batch_idx].ttl = op->ttl;
             batch_entries[batch_idx].seq = txn->commit_seq;
-            batch_entries[batch_idx].deleted = op->is_delete;
+            batch_entries[batch_idx].flags = tidesdb_txn_op_sl_flags(op);
             batch_idx++;
         }
     }
@@ -21562,7 +21752,7 @@ static int tidesdb_txn_apply_ops_to_unified_memtable(const tidesdb_txn_t *txn,
                 batch_entries[batch_idx].value_size = op->value_size;
                 batch_entries[batch_idx].ttl = op->ttl;
                 batch_entries[batch_idx].seq = txn->commit_seq;
-                batch_entries[batch_idx].deleted = op->is_delete;
+                batch_entries[batch_idx].flags = tidesdb_txn_op_sl_flags(op);
                 batch_idx++;
             }
         }
@@ -24315,7 +24505,7 @@ static void tidesdb_iter_seek_txn_ops_source(tidesdb_merge_source_t *source, con
             const tidesdb_txn_op_t *op = &txn->ops[indices[lo]];
             source->current_kv =
                 tidesdb_kv_pair_create(op->key, op->key_size, op->value, op->value_size, op->ttl,
-                                       UINT64_MAX, op->is_delete);
+                                       UINT64_MAX, tidesdb_txn_op_kv_flags(op));
         }
     }
     else
@@ -24340,7 +24530,7 @@ static void tidesdb_iter_seek_txn_ops_source(tidesdb_merge_source_t *source, con
             const tidesdb_txn_op_t *op = &txn->ops[indices[pos]];
             source->current_kv =
                 tidesdb_kv_pair_create(op->key, op->key_size, op->value, op->value_size, op->ttl,
-                                       UINT64_MAX, op->is_delete);
+                                       UINT64_MAX, tidesdb_txn_op_kv_flags(op));
         }
     }
 }
@@ -25128,7 +25318,7 @@ int tidesdb_iter_seek_to_last(tidesdb_iter_t *iter)
 
                 source->current_kv =
                     tidesdb_kv_pair_create(op->key, op->key_size, op->value, op->value_size,
-                                           op->ttl, UINT64_MAX, op->is_delete);
+                                           op->ttl, UINT64_MAX, tidesdb_txn_op_kv_flags(op));
             }
         }
         else

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -365,7 +365,7 @@ static inline size_t tdb_build_prefixed_key(const uint32_t cf_index, const uint8
 #define TDB_MAX_TXN_CFS                         256
 #define TDB_MAX_CF_DISCOVERY                    256
 #define TDB_MAX_PATH_LEN                        4096
-#define TDB_MAX_TXN_OPS                         100000
+#define TDB_MAX_TXN_OPS                         INT_MAX
 #define TDB_MEMORY_PERCENTAGE                   0.6
 #define TDB_MIN_KEY_VALUE_SIZE                  (1024 * 1024)
 #define TDB_MIN_LEVEL_SSTABLES_INITIAL_CAPACITY 32

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -1231,6 +1231,33 @@ int tidesdb_txn_delete(tidesdb_txn_t *txn, tidesdb_column_family_t *cf, const ui
                        size_t key_size);
 
 /**
+ * tidesdb_txn_single_delete
+ * adds a single-delete operation to a transaction
+ *
+ * the caller promises that for this key there is at most one put between this
+ * single-delete and the previous single-delete (or the beginning). with that
+ * promise compaction is free to drop the put and the single-delete together
+ * the first merge that sees both, instead of carrying the tombstone forward
+ * until the largest level. this dramatically reduces tombstone accumulation
+ * for insert-once delete-once workloads and for secondary index maintenance.
+ *
+ * calling single-delete on a key that has been put more than once since the
+ * last single-delete is a contract violation and may expose older values.
+ * when in doubt, use tidesdb_txn_delete.
+ *
+ * for visibility and normal read semantics a single-delete behaves exactly
+ * like tidesdb_txn_delete.
+ *
+ * @param txn transaction handle
+ * @param cf column family to delete from
+ * @param key key to delete
+ * @param key_size size of key
+ * @return 0 on success, -n on failure
+ */
+int tidesdb_txn_single_delete(tidesdb_txn_t *txn, tidesdb_column_family_t *cf, const uint8_t *key,
+                              size_t key_size);
+
+/**
  * tidesdb_txn_rollback
  * rolls back a transaction
  * @param txn transaction handle

--- a/test/skip_list__tests.c
+++ b/test/skip_list__tests.c
@@ -2101,7 +2101,7 @@ void test_skip_list_put_batch()
         entries[i].value_size = strlen(values[i]) + 1;
         entries[i].ttl = -1;
         entries[i].seq = (uint64_t)(i + 1);
-        entries[i].deleted = 0;
+        entries[i].flags = 0;
     }
 
     int result = skip_list_put_batch(list, entries, 5);
@@ -2152,7 +2152,7 @@ void test_skip_list_put_batch_sorted()
         entries[i].value_size = strlen(values[i]) + 1;
         entries[i].ttl = -1;
         entries[i].seq = (uint64_t)(i + 1);
-        entries[i].deleted = 0;
+        entries[i].flags = 0;
     }
 
     int result = skip_list_put_batch(list, entries, batch_size);
@@ -2217,7 +2217,7 @@ void benchmark_skip_list_batch_vs_single()
         entries[i].value_size = strlen(values[i]) + 1;
         entries[i].ttl = -1;
         entries[i].seq = (uint64_t)(i + 1);
-        entries[i].deleted = 0;
+        entries[i].flags = 0;
     }
 
     /* we benchmark single puts */
@@ -2229,7 +2229,7 @@ void benchmark_skip_list_batch_vs_single()
     {
         skip_list_put_with_seq(list_single, entries[i].key, entries[i].key_size, entries[i].value,
                                entries[i].value_size, entries[i].ttl, entries[i].seq,
-                               entries[i].deleted);
+                               entries[i].flags);
     }
     clock_t end_single = clock();
     double time_single = (double)(end_single - start_single) / CLOCKS_PER_SEC;
@@ -2317,7 +2317,7 @@ void test_skip_list_arena_batch()
         entries[i].value_size = strlen(values[i]) + 1;
         entries[i].ttl = -1;
         entries[i].seq = (uint64_t)(i + 1);
-        entries[i].deleted = 0;
+        entries[i].flags = 0;
     }
 
     ASSERT_EQ(skip_list_put_batch(list, entries, batch_size), batch_size);

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -2128,6 +2128,324 @@ static void test_compaction_with_deletes(void)
     cleanup_test_dir();
 }
 
+/* tidesdb_txn_single_delete -- basic read parity with tidesdb_txn_delete.
+ * single-delete tombstones must be indistinguishable from regular tombstones
+ * on the read path. */
+static void test_txn_single_delete_basic(void)
+{
+    cleanup_test_dir();
+    tidesdb_t *db = create_test_db();
+    tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
+
+    ASSERT_EQ(tidesdb_create_column_family(db, "test_cf", &cf_config), 0);
+    tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "test_cf");
+
+    tidesdb_txn_t *txn1 = NULL;
+    ASSERT_EQ(tidesdb_txn_begin(db, &txn1), 0);
+    uint8_t key[] = "single_delete_key";
+    uint8_t value[] = "single_delete_value";
+    ASSERT_EQ(tidesdb_txn_put(txn1, cf, key, sizeof(key), value, sizeof(value), 0), 0);
+    ASSERT_EQ(tidesdb_txn_commit(txn1), 0);
+    tidesdb_txn_free(txn1);
+
+    tidesdb_txn_t *txn2 = NULL;
+    ASSERT_EQ(tidesdb_txn_begin(db, &txn2), 0);
+    ASSERT_EQ(tidesdb_txn_single_delete(txn2, cf, key, sizeof(key)), 0);
+    ASSERT_EQ(tidesdb_txn_commit(txn2), 0);
+    tidesdb_txn_free(txn2);
+
+    tidesdb_txn_t *txn3 = NULL;
+    ASSERT_EQ(tidesdb_txn_begin(db, &txn3), 0);
+    uint8_t *retrieved_value = NULL;
+    size_t retrieved_size = 0;
+    ASSERT_EQ(tidesdb_txn_get(txn3, cf, key, sizeof(key), &retrieved_value, &retrieved_size),
+              TDB_ERR_NOT_FOUND);
+    tidesdb_txn_free(txn3);
+
+    tidesdb_close(db);
+    cleanup_test_dir();
+}
+
+/* helper used by the single-delete compaction tests -- waits for the flush
+ * queue to drain so subsequent compaction observes the flushed sstable. */
+static void wait_for_flush_queue_drain(tidesdb_t *db)
+{
+    const int max_wait = 100;
+    for (int i = 0; i < max_wait; i++)
+    {
+        usleep(10000);
+        if (queue_size(db->flush_queue) == 0) break;
+    }
+}
+
+/* helper used by the single-delete compaction tests -- waits for an in-flight
+ * compaction to finish so we can assert on post-compaction state. */
+static void wait_for_compaction_idle(tidesdb_t *db, tidesdb_column_family_t *cf)
+{
+    const int max_wait = 200;
+    for (int i = 0; i < max_wait; i++)
+    {
+        usleep(50000);
+        int is_compacting = atomic_load_explicit(&cf->is_compacting, memory_order_acquire);
+        if (queue_size(db->compaction_queue) == 0 && !is_compacting)
+        {
+            usleep(100000);
+            break;
+        }
+    }
+}
+
+/* single-delete + put pair-cancel at compaction.
+ *
+ * we lay down a sstable of puts and a separate sstable of matching single-
+ * deletes, then trigger compaction.  the pair-cancel rule drops both sides,
+ * so post-compaction total_keys must be strictly less than it would be if
+ * the tombstones had been preserved (which is what a regular tidesdb_txn_delete
+ * would do at any non-largest level).
+ *
+ * the small write_buffer_size makes each commit group a single flush, and
+ * periodic tidesdb_flush_memtable calls keep the put sstable and the single-
+ * delete sstable on disk before compaction runs. */
+static void test_single_delete_pair_cancel_at_compaction(void)
+{
+    cleanup_test_dir();
+    tidesdb_t *db = create_test_db();
+    tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
+    cf_config.write_buffer_size = 2048;
+    cf_config.level_size_ratio = 10;
+    cf_config.compression_algorithm = TDB_COMPRESS_LZ4;
+
+    ASSERT_EQ(tidesdb_create_column_family(db, "sd_pair_cf", &cf_config), 0);
+    tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "sd_pair_cf");
+    ASSERT_TRUE(cf != NULL);
+
+    const int num_keys = 200;
+
+    /* phase 1: put every key exactly once across several sstables */
+    for (int i = 0; i < num_keys; i++)
+    {
+        tidesdb_txn_t *txn = NULL;
+        ASSERT_EQ(tidesdb_txn_begin(db, &txn), 0);
+
+        char key[32];
+        char value[64];
+        snprintf(key, sizeof(key), "key_%04d", i);
+        snprintf(value, sizeof(value), "value_%04d", i);
+
+        ASSERT_EQ(tidesdb_txn_put(txn, cf, (uint8_t *)key, strlen(key) + 1, (uint8_t *)value,
+                                  strlen(value) + 1, 0),
+                  0);
+        ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+        tidesdb_txn_free(txn);
+
+        if (i % 20 == 19)
+        {
+            tidesdb_flush_memtable(cf);
+            usleep(50000);
+        }
+    }
+    tidesdb_flush_memtable(cf);
+    wait_for_flush_queue_drain(db);
+
+    /* phase 2: single-delete every key so each key has exactly one put and one
+     * single-delete on disk by the time compaction starts. */
+    for (int i = 0; i < num_keys; i++)
+    {
+        tidesdb_txn_t *txn = NULL;
+        ASSERT_EQ(tidesdb_txn_begin(db, &txn), 0);
+
+        char key[32];
+        snprintf(key, sizeof(key), "key_%04d", i);
+
+        ASSERT_EQ(tidesdb_txn_single_delete(txn, cf, (uint8_t *)key, strlen(key) + 1), 0);
+        ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+        tidesdb_txn_free(txn);
+
+        if (i % 20 == 19)
+        {
+            tidesdb_flush_memtable(cf);
+            usleep(50000);
+        }
+    }
+    tidesdb_flush_memtable(cf);
+    wait_for_flush_queue_drain(db);
+
+    tidesdb_compact(cf);
+    wait_for_compaction_idle(db, cf);
+
+    /* every key must be gone to reads */
+    tidesdb_txn_t *txn = NULL;
+    ASSERT_EQ(tidesdb_txn_begin(db, &txn), 0);
+    for (int i = 0; i < num_keys; i++)
+    {
+        char key[32];
+        snprintf(key, sizeof(key), "key_%04d", i);
+        uint8_t *value = NULL;
+        size_t value_size = 0;
+        int result = tidesdb_txn_get(txn, cf, (uint8_t *)key, strlen(key) + 1, &value, &value_size);
+        ASSERT_TRUE(result != 0 || value == NULL);
+        if (value) free(value);
+    }
+    tidesdb_txn_free(txn);
+
+    /* pair-cancel must have reaped both sides -- total_keys is at most the
+     * count of entries that never got paired (possible if some deletes and
+     * puts ended up in different compactions), but never the full 2*num_keys
+     * that regular tidesdb_txn_delete would preserve at a non-largest level. */
+    tidesdb_stats_t *stats = NULL;
+    ASSERT_EQ(tidesdb_get_stats(cf, &stats), 0);
+    ASSERT_TRUE(stats != NULL);
+    ASSERT_TRUE(stats->total_keys < (uint64_t)(2 * num_keys));
+    tidesdb_free_stats(stats);
+
+    tidesdb_close(db);
+    cleanup_test_dir();
+}
+
+/* many sources + delete-all then iterate.
+ *
+ * this mirrors the shape of the iibench insert-then-delete workload in
+ * tidesql issue #122: writes spread across many sstables, followed by a
+ * sweep of single-delete tombstones over every key.  after compaction
+ * the iterator must return no visible entries, and the column family
+ * should have strictly less residue than the regular-delete path would
+ * leave behind. */
+static void test_single_delete_many_sources_iterate_empty(void)
+{
+    cleanup_test_dir();
+    tidesdb_t *db = create_test_db();
+    tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
+    cf_config.write_buffer_size = 1024;
+    cf_config.level_size_ratio = 10;
+
+    ASSERT_EQ(tidesdb_create_column_family(db, "sd_many_cf", &cf_config), 0);
+    tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "sd_many_cf");
+    ASSERT_TRUE(cf != NULL);
+
+    const int num_keys = 300;
+
+    /* write across many sstables so the merge sees many sources */
+    for (int i = 0; i < num_keys; i++)
+    {
+        tidesdb_txn_t *txn = NULL;
+        ASSERT_EQ(tidesdb_txn_begin(db, &txn), 0);
+
+        char key[32];
+        char value[32];
+        snprintf(key, sizeof(key), "k_%05d", i);
+        snprintf(value, sizeof(value), "v_%05d", i);
+
+        ASSERT_EQ(tidesdb_txn_put(txn, cf, (uint8_t *)key, strlen(key) + 1, (uint8_t *)value,
+                                  strlen(value) + 1, 0),
+                  0);
+        ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+        tidesdb_txn_free(txn);
+
+        if (i % 10 == 9)
+        {
+            tidesdb_flush_memtable(cf);
+            usleep(30000);
+        }
+    }
+    tidesdb_flush_memtable(cf);
+    wait_for_flush_queue_drain(db);
+
+    /* single-delete every key across a second sweep of sstables */
+    for (int i = 0; i < num_keys; i++)
+    {
+        tidesdb_txn_t *txn = NULL;
+        ASSERT_EQ(tidesdb_txn_begin(db, &txn), 0);
+
+        char key[32];
+        snprintf(key, sizeof(key), "k_%05d", i);
+
+        ASSERT_EQ(tidesdb_txn_single_delete(txn, cf, (uint8_t *)key, strlen(key) + 1), 0);
+        ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+        tidesdb_txn_free(txn);
+
+        if (i % 10 == 9)
+        {
+            tidesdb_flush_memtable(cf);
+            usleep(30000);
+        }
+    }
+    tidesdb_flush_memtable(cf);
+    wait_for_flush_queue_drain(db);
+
+    tidesdb_compact(cf);
+    wait_for_compaction_idle(db, cf);
+
+    /* iterating must see no visible entries */
+    tidesdb_txn_t *itxn = NULL;
+    ASSERT_EQ(tidesdb_txn_begin(db, &itxn), 0);
+    tidesdb_iter_t *it = NULL;
+    ASSERT_EQ(tidesdb_iter_new(itxn, cf, &it), 0);
+    ASSERT_EQ(tidesdb_iter_seek_to_first(it), TDB_ERR_NOT_FOUND);
+    ASSERT_EQ(tidesdb_iter_valid(it), 0);
+    tidesdb_iter_free(it);
+    tidesdb_txn_free(itxn);
+
+    tidesdb_close(db);
+    cleanup_test_dir();
+}
+
+/* single-delete then iterate without compaction.
+ *
+ * this checks that the visibility layer treats single-delete exactly like a
+ * regular tombstone: a forward iterator over a cf whose keys have all been
+ * single-deleted must return no entries even before compaction has had a
+ * chance to pair-cancel. */
+static void test_single_delete_iterate_no_visible_entries(void)
+{
+    cleanup_test_dir();
+    tidesdb_t *db = create_test_db();
+    tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
+
+    ASSERT_EQ(tidesdb_create_column_family(db, "sd_iter_cf", &cf_config), 0);
+    tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "sd_iter_cf");
+    ASSERT_TRUE(cf != NULL);
+
+    const int num_keys = 50;
+
+    tidesdb_txn_t *put_txn = NULL;
+    ASSERT_EQ(tidesdb_txn_begin(db, &put_txn), 0);
+    for (int i = 0; i < num_keys; i++)
+    {
+        char key[32];
+        char value[32];
+        snprintf(key, sizeof(key), "iter_%03d", i);
+        snprintf(value, sizeof(value), "val_%03d", i);
+        ASSERT_EQ(tidesdb_txn_put(put_txn, cf, (uint8_t *)key, strlen(key) + 1, (uint8_t *)value,
+                                  strlen(value) + 1, 0),
+                  0);
+    }
+    ASSERT_EQ(tidesdb_txn_commit(put_txn), 0);
+    tidesdb_txn_free(put_txn);
+
+    tidesdb_txn_t *del_txn = NULL;
+    ASSERT_EQ(tidesdb_txn_begin(db, &del_txn), 0);
+    for (int i = 0; i < num_keys; i++)
+    {
+        char key[32];
+        snprintf(key, sizeof(key), "iter_%03d", i);
+        ASSERT_EQ(tidesdb_txn_single_delete(del_txn, cf, (uint8_t *)key, strlen(key) + 1), 0);
+    }
+    ASSERT_EQ(tidesdb_txn_commit(del_txn), 0);
+    tidesdb_txn_free(del_txn);
+
+    tidesdb_txn_t *itxn = NULL;
+    ASSERT_EQ(tidesdb_txn_begin(db, &itxn), 0);
+    tidesdb_iter_t *it = NULL;
+    ASSERT_EQ(tidesdb_iter_new(itxn, cf, &it), 0);
+    ASSERT_EQ(tidesdb_iter_seek_to_first(it), TDB_ERR_NOT_FOUND);
+    ASSERT_EQ(tidesdb_iter_valid(it), 0);
+    tidesdb_iter_free(it);
+    tidesdb_txn_free(itxn);
+
+    tidesdb_close(db);
+    cleanup_test_dir();
+}
+
 static void test_ttl_expiration(void)
 {
     cleanup_test_dir();
@@ -26616,6 +26934,10 @@ int main(int argc, char **argv)
     RUN_TEST(test_compression_zstd, tests_passed);
     RUN_TEST(test_compaction_basic, tests_passed);
     RUN_TEST(test_compaction_with_deletes, tests_passed);
+    RUN_TEST(test_txn_single_delete_basic, tests_passed);
+    RUN_TEST(test_single_delete_pair_cancel_at_compaction, tests_passed);
+    RUN_TEST(test_single_delete_many_sources_iterate_empty, tests_passed);
+    RUN_TEST(test_single_delete_iterate_no_visible_entries, tests_passed);
     RUN_TEST(test_concurrent_writes, tests_passed);
     RUN_TEST(test_empty_value, tests_passed);
     RUN_TEST(test_delete_nonexistent_key, tests_passed);

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -2221,7 +2221,7 @@ static void test_single_delete_pair_cancel_at_compaction(void)
 
     const int num_keys = 200;
 
-    /* phase 1: put every key exactly once across several sstables */
+    /* we write every key exactly once across several sstables */
     for (int i = 0; i < num_keys; i++)
     {
         tidesdb_txn_t *txn = NULL;
@@ -2247,8 +2247,8 @@ static void test_single_delete_pair_cancel_at_compaction(void)
     tidesdb_flush_memtable(cf);
     wait_for_flush_queue_drain(db);
 
-    /* phase 2: single-delete every key so each key has exactly one put and one
-     * single-delete on disk by the time compaction starts. */
+    /** single-delete every key so each key has exactly one put and one
+     *  single-delete on disk by the time compaction starts. */
     for (int i = 0; i < num_keys; i++)
     {
         tidesdb_txn_t *txn = NULL;
@@ -2305,7 +2305,7 @@ static void test_single_delete_pair_cancel_at_compaction(void)
 /* many sources + delete-all then iterate.
  *
  * this mirrors the shape of the iibench insert-then-delete workload in
- * tidesql issue #122: writes spread across many sstables, followed by a
+ * tidesql issue #122 writes spread across many sstables, followed by a
  * sweep of single-delete tombstones over every key.  after compaction
  * the iterator must return no visible entries, and the column family
  * should have strictly less residue than the regular-delete path would
@@ -2392,7 +2392,7 @@ static void test_single_delete_many_sources_iterate_empty(void)
 /* single-delete then iterate without compaction.
  *
  * this checks that the visibility layer treats single-delete exactly like a
- * regular tombstone: a forward iterator over a cf whose keys have all been
+ * regular tombstone a forward iterator over a cf whose keys have all been
  * single-deleted must return no entries even before compaction has had a
  * chance to pair-cancel. */
 static void test_single_delete_iterate_no_visible_entries(void)
@@ -2441,6 +2441,203 @@ static void test_single_delete_iterate_no_visible_entries(void)
     ASSERT_EQ(tidesdb_iter_valid(it), 0);
     tidesdb_iter_free(it);
     tidesdb_txn_free(itxn);
+
+    tidesdb_close(db);
+    cleanup_test_dir();
+}
+
+/* helper used by the head-to-head discrimination test -- counts the number
+ * of visible entries reachable through a forward iterator scan of the cf. */
+static int count_visible_entries(tidesdb_t *db, tidesdb_column_family_t *cf)
+{
+    tidesdb_txn_t *itxn = NULL;
+    ASSERT_EQ(tidesdb_txn_begin(db, &itxn), 0);
+
+    tidesdb_iter_t *it = NULL;
+    ASSERT_EQ(tidesdb_iter_new(itxn, cf, &it), 0);
+
+    int count = 0;
+    int rc = tidesdb_iter_seek_to_first(it);
+    while (rc == TDB_SUCCESS && tidesdb_iter_valid(it))
+    {
+        count++;
+        rc = tidesdb_iter_next(it);
+    }
+
+    tidesdb_iter_free(it);
+    tidesdb_txn_free(itxn);
+    return count;
+}
+
+/* helper used by the head-to-head discrimination test -- drives the same
+ * put-then-delete workload on a single column family.  use_single_delete
+ * selects which delete api to call for the delete sweep.  keys are grouped
+ * into num_batches batched commits per phase; every batch is flushed so
+ * each batch produces its own sstable, which keeps put versions and delete
+ * versions in separate sstables rather than collapsing them against each
+ * other in a single memtable. */
+static void run_put_then_delete_workload(tidesdb_t *db, tidesdb_column_family_t *cf, int num_keys,
+                                         int num_batches, int use_single_delete)
+{
+    const int per_batch = num_keys / num_batches;
+
+    for (int b = 0; b < num_batches; b++)
+    {
+        tidesdb_txn_t *txn = NULL;
+        ASSERT_EQ(tidesdb_txn_begin(db, &txn), 0);
+
+        const int lo = b * per_batch;
+        const int hi = (b == num_batches - 1) ? num_keys : lo + per_batch;
+
+        for (int i = lo; i < hi; i++)
+        {
+            char key[32];
+            char value[64];
+            snprintf(key, sizeof(key), "key_%05d", i);
+            snprintf(value, sizeof(value), "value_%05d_xxxxxxxxxx", i);
+
+            ASSERT_EQ(tidesdb_txn_put(txn, cf, (uint8_t *)key, strlen(key) + 1, (uint8_t *)value,
+                                      strlen(value) + 1, 0),
+                      0);
+        }
+
+        ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+        tidesdb_txn_free(txn);
+
+        tidesdb_flush_memtable(cf);
+        wait_for_flush_queue_drain(db);
+    }
+
+    for (int b = 0; b < num_batches; b++)
+    {
+        tidesdb_txn_t *txn = NULL;
+        ASSERT_EQ(tidesdb_txn_begin(db, &txn), 0);
+
+        const int lo = b * per_batch;
+        const int hi = (b == num_batches - 1) ? num_keys : lo + per_batch;
+
+        for (int i = lo; i < hi; i++)
+        {
+            char key[32];
+            snprintf(key, sizeof(key), "key_%05d", i);
+
+            if (use_single_delete)
+            {
+                ASSERT_EQ(tidesdb_txn_single_delete(txn, cf, (uint8_t *)key, strlen(key) + 1), 0);
+            }
+            else
+            {
+                ASSERT_EQ(tidesdb_txn_delete(txn, cf, (uint8_t *)key, strlen(key) + 1), 0);
+            }
+        }
+
+        ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+        tidesdb_txn_free(txn);
+
+        tidesdb_flush_memtable(cf);
+        wait_for_flush_queue_drain(db);
+    }
+}
+
+/* single-delete vs regular delete head-to-head discrimination.
+ *
+ * both column families run the exact same put-then-delete workload across
+ * many sstables.  the only difference is whether the delete sweep uses
+ * tidesdb_txn_delete (baseline) or tidesdb_txn_single_delete.  after the
+ * same compaction invocation on each:
+ *
+ *   -- iterator counts on both cfs must be zero (read parity -- a tombstone
+ *     masks its put regardless of subtype)
+ *   -- stats->total_keys on the single-delete cf must be strictly less than
+ *     on the baseline cf (pair-cancel proof -- the single-delete path
+ *     reaped puts and their tombstones together, the baseline path had to
+ *     carry the tombstones forward because the merge target is not the
+ *     largest level)
+ *
+ * small write_buffer_size + periodic flushes guarantee many sstables at
+ * the source level so the compaction's merge input contains both the put
+ * sstables and the delete sstables for every key. */
+static void test_single_delete_vs_regular_delete_discriminates(void)
+{
+    cleanup_test_dir();
+    tidesdb_t *db = create_test_db();
+    tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
+
+    /* large write_buffer + high l1 trigger -- every sstable comes from an
+     * explicit tidesdb_flush_memtable so the number of merge sources is
+     * exactly what the workload driver creates.  compression left at the
+     * default value because both cfs run the same config and we compare
+     * them to each other. */
+    cf_config.write_buffer_size = 64 * 1024 * 1024;
+    cf_config.level_size_ratio = 10;
+    cf_config.l1_file_count_trigger = 1024;
+    cf_config.l0_queue_stall_threshold = 1024;
+
+    ASSERT_EQ(tidesdb_create_column_family(db, "baseline_delete_cf", &cf_config), 0);
+    ASSERT_EQ(tidesdb_create_column_family(db, "single_delete_cf", &cf_config), 0);
+    tidesdb_column_family_t *cf_baseline = tidesdb_get_column_family(db, "baseline_delete_cf");
+    tidesdb_column_family_t *cf_sd = tidesdb_get_column_family(db, "single_delete_cf");
+    ASSERT_TRUE(cf_baseline != NULL);
+    ASSERT_TRUE(cf_sd != NULL);
+
+    /* num_batches controls how many sstables each phase produces.
+     * total merge sources for the compaction = 2 * num_batches. */
+    const int num_keys = 1000;
+    const int num_batches = 10;
+
+    run_put_then_delete_workload(db, cf_baseline, num_keys, num_batches, 0);
+    run_put_then_delete_workload(db, cf_sd, num_keys, num_batches, 1);
+
+    tidesdb_compact(cf_baseline);
+    wait_for_compaction_idle(db, cf_baseline);
+    tidesdb_compact(cf_sd);
+    wait_for_compaction_idle(db, cf_sd);
+
+    /* read parity -- every key is gone from both cfs via iterator scan */
+    ASSERT_EQ(count_visible_entries(db, cf_baseline), 0);
+    ASSERT_EQ(count_visible_entries(db, cf_sd), 0);
+
+    /* read parity -- point lookups return not-found on both cfs */
+    tidesdb_txn_t *rtxn = NULL;
+    ASSERT_EQ(tidesdb_txn_begin(db, &rtxn), 0);
+    for (int i = 0; i < num_keys; i++)
+    {
+        char key[32];
+        snprintf(key, sizeof(key), "key_%05d", i);
+
+        uint8_t *value = NULL;
+        size_t value_size = 0;
+        ASSERT_EQ(tidesdb_txn_get(rtxn, cf_baseline, (uint8_t *)key, strlen(key) + 1, &value,
+                                  &value_size),
+                  TDB_ERR_NOT_FOUND);
+        if (value)
+        {
+            free(value);
+            value = NULL;
+        }
+
+        ASSERT_EQ(
+            tidesdb_txn_get(rtxn, cf_sd, (uint8_t *)key, strlen(key) + 1, &value, &value_size),
+            TDB_ERR_NOT_FOUND);
+        if (value) free(value);
+    }
+    tidesdb_txn_free(rtxn);
+
+    /* pair-cancel discrimination -- the single-delete cf must hold strictly
+     * fewer on-disk entries than the baseline cf.  baseline carries every
+     * tombstone forward because the compaction target is not the largest
+     * level; single-delete reaps both sides of each pair. */
+    tidesdb_stats_t *stats_baseline = NULL;
+    tidesdb_stats_t *stats_sd = NULL;
+    ASSERT_EQ(tidesdb_get_stats(cf_baseline, &stats_baseline), 0);
+    ASSERT_EQ(tidesdb_get_stats(cf_sd, &stats_sd), 0);
+    ASSERT_TRUE(stats_baseline != NULL);
+    ASSERT_TRUE(stats_sd != NULL);
+
+    ASSERT_TRUE(stats_sd->total_keys < stats_baseline->total_keys);
+
+    tidesdb_free_stats(stats_baseline);
+    tidesdb_free_stats(stats_sd);
 
     tidesdb_close(db);
     cleanup_test_dir();
@@ -17052,11 +17249,18 @@ static void test_flush_below_size_threshold(void)
         tidesdb_txn_free(txn);
     }
 
+    /*** tidesdb_flush_memtable is a force-flush it rotates the active memtable
+     **  and enqueues it for the flush worker regardless of its current size.
+     *   we wait for the flush worker to drain then observe the new sstable. */
     ASSERT_EQ(tidesdb_flush_memtable(cf), 0);
-    usleep(50000);
+    for (int i = 0; i < 100; i++)
+    {
+        usleep(10000);
+        if (queue_size(db->flush_queue) == 0 && !tidesdb_is_flushing(cf)) break;
+    }
 
     int num_ssts = atomic_load_explicit(&cf->levels[0]->num_sstables, memory_order_acquire);
-    ASSERT_EQ(num_ssts, 0);
+    ASSERT_EQ(num_ssts, 1);
 
     tidesdb_txn_t *txn = NULL;
     ASSERT_EQ(tidesdb_txn_begin(db, &txn), 0);
@@ -26391,7 +26595,7 @@ static void test_primary_replica_failover(void)
         ASSERT_EQ(tidesdb_txn_commit(txn), 0);
         tidesdb_txn_free(txn);
 
-        /* verify all data readable: old cf1 + new cf1 + cf2 */
+        /* verify all data readable old cf1 + new cf1 + cf2 */
         ASSERT_EQ(tidesdb_txn_begin(db, &txn), 0);
 
         int total_cf1 = 0;
@@ -26938,6 +27142,7 @@ int main(int argc, char **argv)
     RUN_TEST(test_single_delete_pair_cancel_at_compaction, tests_passed);
     RUN_TEST(test_single_delete_many_sources_iterate_empty, tests_passed);
     RUN_TEST(test_single_delete_iterate_no_visible_entries, tests_passed);
+    RUN_TEST(test_single_delete_vs_regular_delete_discriminates, tests_passed);
     RUN_TEST(test_concurrent_writes, tests_passed);
     RUN_TEST(test_empty_value, tests_passed);
     RUN_TEST(test_delete_nonexistent_key, tests_passed);

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tidesdb",
-  "version-string": "9.0.9",
+  "version-string": "9.1.0",
   "description": "TidesDB is a high-performance durable, transactional embeddable storage engine designed for flash and RAM optimization with optional object storage support for unlimited data scaling.",
   "dependencies": ["zstd", "snappy", "lz4", "pthreads"],
   "features": {


### PR DESCRIPTION
avoid per advance alloc and pop_buf memcpy in merge iterator

iibench delete heavy workload was spending most of its time walking tombstones in tidesdb_iter_find_visible_entry before reaching a visible row
profiling highlighted skip_list_cursor_next merge_source_advance and merge_heap_pop with noticeable cost in kv_pair_create from repeated allocations

memtable and unified memtable sources were allocating a fresh kv on every cursor step leading to malloc memcpy and free for each tombstone encountered

extend the borrowed kv pattern already used by sstable sources to memtable and unified memtable paths
introduce tidesdb_memtable_source_set_inline_borrowed and apply it across merge source creation advance and seek paths
cursor stability and memtable pinning ensure borrowed pointers remain valid until the next advance
heap_pop still materializes kvs when required so external callers remain unaffected

optimize tombstone skipping by adding merge_heap_pop_discard to advance without copying into pop_buf
introduce tidesdb_iter_skip_tombstone_versions to unify duplicated skip loops across iterator paths

fix a latent bug where tombstone keys referenced pop_buf and could be overwritten during skip loops
copy key data into a stable buffer before entering the loop to guarantee correct comparisons

results show kv_pair_create removed from profile and merge_heap_pop significantly reduced
latency under heavy tombstone load drops and stabilizes with faster convergence.


working on upstream tidesql bottlenecks identified https://github.com/tidesdb/tidesql/issues/122 