### PR TITLE
TidesDB 9 PATCH (v9.2.1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 project(tidesdb C)
 
 set(CMAKE_C_STANDARD 11)
-set(PROJECT_VERSION 9.2.0)
+set(PROJECT_VERSION 9.2.1)
 
 # build everything position-independent so the static archive (BUILD_SHARED_LIBS=OFF)
 # can still link into a shared module like the mariadb plugin without recompile-with-fPIC errors

--- a/src/skip_list.c
+++ b/src/skip_list.c
@@ -929,10 +929,18 @@ int skip_list_new_with_arena(skip_list_t **list, const int max_level, const floa
                                                            comparator_ctx, cached_time);
     if (rc != 0) return rc;
 
-    (*list)->arena = skip_list_arena_create(arena_initial_capacity);
-    /* arena is optional -- if the initial block is too large for the address
-     * space (e.g. 128 MB on a 32-bit build under ASAN) the skip list falls
-     * back to per-node malloc which is slower but correct. */
+    /* cap the first block so a large write_buffer_size config does not ask for
+     * a >100 MB allocation up front.  the arena grows on demand so capping the
+     * initial block does not bound how much data the memtable can hold. */
+    size_t initial_cap = arena_initial_capacity;
+    if (initial_cap > SKIP_LIST_ARENA_MAX_INITIAL_BLOCK)
+    {
+        initial_cap = SKIP_LIST_ARENA_MAX_INITIAL_BLOCK;
+    }
+
+    (*list)->arena = skip_list_arena_create(initial_cap);
+    /* arena is optional -- on the rare path where even the capped allocation
+     * fails, skip_list_alloc/dealloc fall back to per-node malloc/free. */
 
     return 0;
 }

--- a/src/skip_list.c
+++ b/src/skip_list.c
@@ -930,12 +930,9 @@ int skip_list_new_with_arena(skip_list_t **list, const int max_level, const floa
     if (rc != 0) return rc;
 
     (*list)->arena = skip_list_arena_create(arena_initial_capacity);
-    if ((*list)->arena == NULL)
-    {
-        skip_list_free(*list);
-        *list = NULL;
-        return -1;
-    }
+    /* arena is optional -- if the initial block is too large for the address
+     * space (e.g. 128 MB on a 32-bit build under ASAN) the skip list falls
+     * back to per-node malloc which is slower but correct. */
 
     return 0;
 }

--- a/src/skip_list.h
+++ b/src/skip_list.h
@@ -45,6 +45,12 @@ typedef struct skip_list_arena_t skip_list_arena_t;
 /* default size for thread-local blocks (smaller than shared block to save memory) */
 #define SKIP_LIST_ARENA_TL_BLOCK_SIZE (64 * 1024)
 
+/* cap the initial arena block to avoid asking malloc for an allocation that would
+ * exhaust the address space on 32 bit builds or trip address sanitizer's hard
+ * out of memory abort.  the arena grows on demand (TL_BLOCK_SIZE per new block)
+ * so capping the first block does not bound total memtable size. */
+#define SKIP_LIST_ARENA_MAX_INITIAL_BLOCK (4 * 1024 * 1024)
+
 /**
  * skip_list_arena_block_t
  * a single contiguous memory block in the arena's linked list

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -691,12 +691,17 @@ struct tidesdb_unified_flush_barrier_t
  * @param cf column family
  * @param start_level starting level
  * @param target_level target level
+ * @param witness_triggered set when the compaction was scheduled by the tombstone
+ *                          density witness path. lets the merge drop tombstones
+ *                          earlier than the largest level when the read path
+ *                          cannot find the key in any older sstable.
  */
 struct tidesdb_compaction_work_t
 {
     tidesdb_column_family_t *cf;
     int start_level;
     int target_level;
+    int witness_triggered;
 };
 
 /**
@@ -1271,12 +1276,14 @@ static void tidesdb_merge_source_free(tidesdb_merge_source_t *source);
 static int tidesdb_merge_source_advance(tidesdb_merge_source_t *source);
 static int tidesdb_merge_source_retreat(tidesdb_merge_source_t *source);
 static int tidesdb_full_preemptive_merge(tidesdb_column_family_t *cf, int start_level,
-                                         int target_level);
-static int tidesdb_dividing_merge(tidesdb_column_family_t *cf, int target_level);
-static int tidesdb_partitioned_merge(tidesdb_column_family_t *cf, int start_level, int end_level);
+                                         int target_level, int witness_triggered);
+static int tidesdb_dividing_merge(tidesdb_column_family_t *cf, int target_level,
+                                  int witness_triggered);
+static int tidesdb_partitioned_merge(tidesdb_column_family_t *cf, int start_level, int end_level,
+                                     int witness_triggered);
 static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t **inputs,
                                   int input_count, int min_input_level, int max_input_level,
-                                  int target_level);
+                                  int target_level, int witness_triggered);
 static int tdb_partitioned_merge_finalize_sst(tidesdb_column_family_t *cf, tidesdb_sstable_t *sst,
                                               block_manager_t *klog_bm, block_manager_t *vlog_bm,
                                               bloom_filter_t *bloom,
@@ -1288,8 +1295,12 @@ static int tidesdb_sstable_write_from_heap_btree(tidesdb_column_family_t *cf,
                                                  tidesdb_sstable_t *sst, tidesdb_merge_heap_t *heap,
                                                  block_manager_t *klog_bm, block_manager_t *vlog_bm,
                                                  bloom_filter_t *bloom, queue_t *sstables_to_delete,
-                                                 int is_largest_level);
-static int tidesdb_trigger_compaction(tidesdb_column_family_t *cf);
+                                                 int is_largest_level, int target_level,
+                                                 int witness_triggered);
+static int tidesdb_trigger_compaction(tidesdb_column_family_t *cf, int witness_triggered);
+static int tidesdb_compact_with_flags(tidesdb_column_family_t *cf, int witness_triggered);
+static int tdb_no_older_sst_has_key(tidesdb_column_family_t *cf, int target_level,
+                                    const uint8_t *key, size_t key_size);
 static int tidesdb_wal_recover(tidesdb_column_family_t *cf, const char *wal_path,
                                skip_list_t **memtable);
 static size_t tidesdb_calculate_level_capacity(int level_num, size_t base_capacity, size_t ratio);
@@ -6732,7 +6743,8 @@ static int tidesdb_sstable_write_from_heap_btree(tidesdb_column_family_t *cf,
                                                  tidesdb_sstable_t *sst, tidesdb_merge_heap_t *heap,
                                                  block_manager_t *klog_bm, block_manager_t *vlog_bm,
                                                  bloom_filter_t *bloom, queue_t *sstables_to_delete,
-                                                 const int is_largest_level)
+                                                 const int is_largest_level, const int target_level,
+                                                 const int witness_triggered)
 {
     if (!cf || !sst || !heap || !klog_bm || !vlog_bm) return TDB_ERR_INVALID_ARGS;
 
@@ -6815,7 +6827,10 @@ static int tidesdb_sstable_write_from_heap_btree(tidesdb_column_family_t *cf,
         {
             const int sd_pair_drop = pending_is_single_delete && pending_sd_paired_with_put;
             const int tombstone_drop =
-                (pending->entry.flags & TDB_KV_FLAG_TOMBSTONE) && is_largest_level;
+                (pending->entry.flags & TDB_KV_FLAG_TOMBSTONE) &&
+                (is_largest_level ||
+                 (witness_triggered && tdb_no_older_sst_has_key(cf, target_level, pending->key,
+                                                                pending->entry.key_size)));
             const int ttl_drop =
                 pending->entry.ttl > 0 &&
                 pending->entry.ttl <
@@ -11658,7 +11673,7 @@ static void tidesdb_cleanup_merged_sstables(tidesdb_column_family_t *cf, queue_t
  * @return TDB_SUCCESS on success, TDB_ERR_INVALID_ARGS on failure
  */
 static int tidesdb_full_preemptive_merge(tidesdb_column_family_t *cf, int start_level,
-                                         int target_level)
+                                         int target_level, int witness_triggered)
 {
     int num_levels = atomic_load_explicit(&cf->num_active_levels, memory_order_acquire);
 
@@ -11852,7 +11867,8 @@ static int tidesdb_full_preemptive_merge(tidesdb_column_family_t *cf, int start_
     if (cf->config.use_btree)
     {
         int btree_result = tidesdb_sstable_write_from_heap_btree(
-            cf, new_sst, heap, klog_bm, vlog_bm, bloom, sstables_to_delete, is_largest_level);
+            cf, new_sst, heap, klog_bm, vlog_bm, bloom, sstables_to_delete, is_largest_level,
+            target_level, witness_triggered);
         block_manager_close(klog_bm);
         block_manager_close(vlog_bm);
         tidesdb_merge_heap_free(heap);
@@ -11929,7 +11945,10 @@ static int tidesdb_full_preemptive_merge(tidesdb_column_family_t *cf, int start_
         {
             const int sd_pair_drop = pending_is_single_delete && pending_sd_paired_with_put;
             const int tombstone_drop =
-                (pending->entry.flags & TDB_KV_FLAG_TOMBSTONE) && is_largest_level;
+                (pending->entry.flags & TDB_KV_FLAG_TOMBSTONE) &&
+                (is_largest_level ||
+                 (witness_triggered && tdb_no_older_sst_has_key(cf, target_level, pending->key,
+                                                                pending->entry.key_size)));
             const int ttl_drop =
                 pending->entry.ttl > 0 &&
                 pending->entry.ttl <
@@ -12385,7 +12404,7 @@ merge_complete:;
  */
 static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t **inputs,
                                   int input_count, int min_input_level, int max_input_level,
-                                  int target_level)
+                                  int target_level, int witness_triggered)
 {
     if (!cf || !inputs || input_count <= 0) return TDB_ERR_INVALID_ARGS;
     if (min_input_level < 0 || max_input_level < min_input_level) return TDB_ERR_INVALID_ARGS;
@@ -12493,7 +12512,8 @@ static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t
     if (cf->config.use_btree)
     {
         int btree_result = tidesdb_sstable_write_from_heap_btree(
-            cf, new_sst, heap, klog_bm, vlog_bm, bloom, sstables_to_delete, is_largest_level);
+            cf, new_sst, heap, klog_bm, vlog_bm, bloom, sstables_to_delete, is_largest_level,
+            target_level, witness_triggered);
         block_manager_close(klog_bm);
         block_manager_close(vlog_bm);
         tidesdb_merge_heap_free(heap);
@@ -12556,7 +12576,10 @@ static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t
         {
             const int sd_pair_drop = pending_is_single_delete && pending_sd_paired_with_put;
             const int tombstone_drop =
-                (pending->entry.flags & TDB_KV_FLAG_TOMBSTONE) && is_largest_level;
+                (pending->entry.flags & TDB_KV_FLAG_TOMBSTONE) &&
+                (is_largest_level ||
+                 (witness_triggered && tdb_no_older_sst_has_key(cf, target_level, pending->key,
+                                                                pending->entry.key_size)));
             const int ttl_drop =
                 pending->entry.ttl > 0 &&
                 pending->entry.ttl <
@@ -12945,7 +12968,8 @@ merge_complete:;
  * @param target_level target level
  * @return 0 on success, negative on failure
  */
-static int tidesdb_dividing_merge(tidesdb_column_family_t *cf, int target_level)
+static int tidesdb_dividing_merge(tidesdb_column_family_t *cf, int target_level,
+                                  int witness_triggered)
 {
     int num_levels = atomic_load_explicit(&cf->num_active_levels, memory_order_acquire);
 
@@ -12979,7 +13003,7 @@ static int tidesdb_dividing_merge(tidesdb_column_family_t *cf, int target_level)
             TDB_DEBUG_LOG(TDB_LOG_INFO, "Added level, now have %d levels", num_levels);
         }
 
-        return tidesdb_full_preemptive_merge(cf, 0, target_level);
+        return tidesdb_full_preemptive_merge(cf, 0, target_level, witness_triggered);
     }
 
     tidesdb_level_t *target = cf->levels[target_level];
@@ -13061,7 +13085,7 @@ static int tidesdb_dividing_merge(tidesdb_column_family_t *cf, int target_level)
     /* if no boundaries, do a simple full merge */
     if (num_boundaries == 0)
     {
-        int result = tidesdb_full_preemptive_merge(cf, 0, target_level);
+        int result = tidesdb_full_preemptive_merge(cf, 0, target_level, witness_triggered);
 
         while (!queue_is_empty(sstables_to_delete))
         {
@@ -13277,7 +13301,8 @@ static int tidesdb_dividing_merge(tidesdb_column_family_t *cf, int target_level)
             klog_block = NULL;
 
             int btree_result = tidesdb_sstable_write_from_heap_btree(
-                cf, new_sst, partition_heap, klog_bm, vlog_bm, bloom, NULL, 0);
+                cf, new_sst, partition_heap, klog_bm, vlog_bm, bloom, NULL, 0, target_level + 1,
+                witness_triggered);
             block_manager_close(klog_bm);
             block_manager_close(vlog_bm);
             tidesdb_merge_heap_free(partition_heap);
@@ -13946,7 +13971,8 @@ static int tdb_partitioned_merge_finalize_sst(
     return 0;
 }
 
-static int tidesdb_partitioned_merge(tidesdb_column_family_t *cf, int start_level, int end_level)
+static int tidesdb_partitioned_merge(tidesdb_column_family_t *cf, int start_level, int end_level,
+                                     int witness_triggered)
 {
     int num_levels = atomic_load_explicit(&cf->num_active_levels, memory_order_acquire);
 
@@ -13978,7 +14004,7 @@ static int tidesdb_partitioned_merge(tidesdb_column_family_t *cf, int start_leve
          * tidesdb_full_preemptive_merge expects 0-indexed array indices, not 1-indexed level
          * numbers */
 
-        return tidesdb_full_preemptive_merge(cf, start_idx, end_idx);
+        return tidesdb_full_preemptive_merge(cf, start_idx, end_idx, witness_triggered);
     }
 
     queue_t *sstables_to_delete = queue_new();
@@ -14191,8 +14217,9 @@ static int tidesdb_partitioned_merge(tidesdb_column_family_t *cf, int start_leve
              * partitioned merge goes to the level before largest, so not largest level */
             if (cf->config.use_btree)
             {
-                int btree_result = tidesdb_sstable_write_from_heap_btree(cf, new_sst, heap, klog_bm,
-                                                                         vlog_bm, bloom, NULL, 0);
+                int btree_result = tidesdb_sstable_write_from_heap_btree(
+                    cf, new_sst, heap, klog_bm, vlog_bm, bloom, NULL, 0, end_idx,
+                    witness_triggered);
                 block_manager_close(klog_bm);
                 block_manager_close(vlog_bm);
                 tidesdb_merge_heap_free(heap);
@@ -14646,6 +14673,81 @@ static int tidesdb_partitioned_merge(tidesdb_column_family_t *cf, int start_leve
 }
 
 /**
+ * tdb_no_older_sst_has_key
+ * returns 1 if no sstable at any level deeper than target_level can possibly
+ * contain the given key, 0 otherwise. used by the tombstone density witness
+ * path to drop a regular tombstone earlier than the largest level when the
+ * read path cannot find an older version of the key elsewhere in the tree.
+ *
+ * correctness rests on the merge feeding levels [0, target_level] inclusive,
+ * so any older version masked by the tombstone now lives only at levels
+ * strictly greater than target_level. range and bloom checks are both one
+ * sided (false positive only), so a definitive miss is trustworthy and a
+ * positive answer conservatively keeps the tombstone.
+ *
+ * conservative when range bounds are not loaded, when the bloom filter is
+ * absent (cf opted out), or when the column family has only one level and
+ * target_level already names the largest. in those cases we return 0 so the
+ * caller falls back to the existing largest-level rule.
+ */
+static int tdb_no_older_sst_has_key(tidesdb_column_family_t *cf, int target_level,
+                                    const uint8_t *key, size_t key_size)
+{
+    if (!cf || !key || key_size == 0) return 0;
+
+    skip_list_comparator_fn cmp_fn = NULL;
+    void *cmp_ctx = NULL;
+    tidesdb_resolve_comparator(cf->db, &cf->config, &cmp_fn, &cmp_ctx);
+    if (!cmp_fn) cmp_fn = skip_list_comparator_memcmp;
+
+    const int num_levels = atomic_load_explicit(&cf->num_active_levels, memory_order_acquire);
+    for (int lv = target_level + 1; lv < num_levels; lv++)
+    {
+        tidesdb_level_t *lvl = cf->levels[lv];
+        if (!lvl) continue;
+
+        atomic_fetch_add_explicit(&lvl->array_readers, 1, memory_order_acq_rel);
+
+        const int num_ssts = atomic_load_explicit(&lvl->num_sstables, memory_order_acquire);
+        tidesdb_sstable_t **ssts = atomic_load_explicit(&lvl->sstables, memory_order_acquire);
+
+        int may_contain = 0;
+        for (int i = 0; ssts && i < num_ssts; i++)
+        {
+            tidesdb_sstable_t *sst = ssts[i];
+            if (!sst) continue;
+
+            /*** range check first because it is a single comparator call and
+             **  filters out the common case where the key is well outside the
+             *   sstable's covered span. on missing bounds we cannot prove a
+             *** miss and have to keep the tombstone. */
+            if (!sst->min_key || !sst->max_key || sst->min_key_size == 0 || sst->max_key_size == 0)
+            {
+                may_contain = 1;
+                break;
+            }
+            if (cmp_fn(key, key_size, sst->min_key, sst->min_key_size, cmp_ctx) < 0) continue;
+            if (cmp_fn(key, key_size, sst->max_key, sst->max_key_size, cmp_ctx) > 0) continue;
+
+            /*** range overlaps so consult the bloom filter for a definitive
+             **  miss. if the cf disabled bloom filters the range hit is the
+             *   strongest signal we have and we conservatively keep. */
+            if (sst->bloom_filter)
+            {
+                if (!bloom_filter_contains(sst->bloom_filter, key, key_size)) continue;
+            }
+
+            may_contain = 1;
+            break;
+        }
+
+        atomic_fetch_sub_explicit(&lvl->array_readers, 1, memory_order_release);
+        if (may_contain) return 0;
+    }
+    return 1;
+}
+
+/**
  * tidesdb_cf_dense_tombstone_witness
  * walks every level looking for an sstable whose tombstone density is at or above
  * the configured trigger ratio. on a hit we record the offending sstable's level
@@ -14728,7 +14830,7 @@ static int tidesdb_cf_dense_tombstone_witness(tidesdb_column_family_t *cf, doubl
  * @param cf the column family
  * @return TDB_SUCCESS on success, error code on failure
  */
-int tidesdb_trigger_compaction(tidesdb_column_family_t *cf)
+int tidesdb_trigger_compaction(tidesdb_column_family_t *cf, int witness_triggered)
 {
     /* we check if CF is marked for deletion before doing any work */
     if (atomic_load_explicit(&cf->marked_for_deletion, memory_order_acquire))
@@ -14817,17 +14919,17 @@ int tidesdb_trigger_compaction(tidesdb_column_family_t *cf)
     if (target_lvl < X)
     {
         TDB_DEBUG_LOG(TDB_LOG_INFO, "Full preemptive merge levels 1 to %d", target_lvl);
-        result = tidesdb_full_preemptive_merge(cf, 0, target_lvl - 1); /* convert to 0-indexed */
+        result = tidesdb_full_preemptive_merge(cf, 0, target_lvl - 1, witness_triggered);
     }
     else if (target_lvl == X)
     {
         TDB_DEBUG_LOG(TDB_LOG_INFO, "Dividing merge at level %d", X);
-        result = tidesdb_dividing_merge(cf, X - 1); /* convert to 0-indexed */
+        result = tidesdb_dividing_merge(cf, X - 1, witness_triggered);
     }
     else
     {
         TDB_DEBUG_LOG(TDB_LOG_WARN, "Target_lvl > X, defaulting to dividing merge");
-        result = tidesdb_dividing_merge(cf, X - 1); /* convert to 0-indexed */
+        result = tidesdb_dividing_merge(cf, X - 1, witness_triggered);
     }
 
     /* we reload num_levels atomically after compaction */
@@ -14897,7 +14999,7 @@ int tidesdb_trigger_compaction(tidesdb_column_family_t *cf)
     {
         TDB_DEBUG_LOG(TDB_LOG_INFO, "Level %d is full, triggering partitioned preemptive merge", X);
         TDB_DEBUG_LOG(TDB_LOG_INFO, "Partitioned preemptive merge levels %d to %d", X, z);
-        result = tidesdb_partitioned_merge(cf, X, z);
+        result = tidesdb_partitioned_merge(cf, X, z, witness_triggered);
 
         /* we reload num_levels after merge */
         num_levels = atomic_load_explicit(&cf->num_active_levels, memory_order_acquire);
@@ -15653,7 +15755,7 @@ static void *tidesdb_flush_worker_thread(void *arg)
                               cf->name, cf->levels[0]->level_num, trigger_reason, num_l1_sstables,
                               cf->config.l1_file_count_trigger, level1_size, level1_capacity);
             }
-            tidesdb_compact(cf);
+            tidesdb_compact_with_flags(cf, density_witness_level > 0 ? 1 : 0);
         }
 
         /* we release our reference -- the level now owns it */
@@ -15908,7 +16010,7 @@ static void *tidesdb_compaction_worker_thread(void *arg)
         }
 
         TDB_DEBUG_LOG(TDB_LOG_INFO, "Compacting CF '%s'", cf->name);
-        const int result = tidesdb_trigger_compaction(cf);
+        const int result = tidesdb_trigger_compaction(cf, work->witness_triggered);
         if (result != TDB_SUCCESS)
         {
             TDB_DEBUG_LOG(TDB_LOG_WARN, "CF '%s' compaction failed with error %d", cf->name,
@@ -19852,17 +19954,21 @@ static int tidesdb_flush_memtable_internal(tidesdb_column_family_t *cf,
     return TDB_SUCCESS;
 }
 
-int tidesdb_compact(tidesdb_column_family_t *cf)
+/**
+ * tidesdb_compact_with_flags
+ * internal entry point used when the caller knows whether this compaction was
+ * scheduled by the tombstone density witness. the public tidesdb_compact wraps
+ * this with witness_triggered=0.
+ */
+static int tidesdb_compact_with_flags(tidesdb_column_family_t *cf, int witness_triggered)
 {
     if (!cf) return TDB_ERR_INVALID_ARGS;
 
     if (atomic_load_explicit(&cf->is_compacting, memory_order_acquire))
     {
-        /* compaction already running, skip */
         return TDB_SUCCESS;
     }
 
-    /* we enqueue compaction work */
     tidesdb_compaction_work_t *work = malloc(sizeof(tidesdb_compaction_work_t));
     if (!work)
     {
@@ -19870,6 +19976,9 @@ int tidesdb_compact(tidesdb_column_family_t *cf)
     }
 
     work->cf = cf;
+    work->start_level = 0;
+    work->target_level = 0;
+    work->witness_triggered = witness_triggered;
     if (queue_enqueue(cf->db->compaction_queue, work) != 0)
     {
         free(work);
@@ -19877,6 +19986,11 @@ int tidesdb_compact(tidesdb_column_family_t *cf)
     }
 
     return TDB_SUCCESS;
+}
+
+int tidesdb_compact(tidesdb_column_family_t *cf)
+{
+    return tidesdb_compact_with_flags(cf, 0);
 }
 
 /**
@@ -20026,8 +20140,13 @@ int tidesdb_compact_range(tidesdb_column_family_t *cf, const uint8_t *start_key,
      * meet their dead puts get a shot at dropping when the target is the bottom */
     const int target_level = max_input_level;
 
+    /*** tidesdb_compact_range is operator-driven reclaim. callers issued the
+     **  range delete and then this api specifically to reclaim the tombstones
+     *   right away. set witness_triggered so the merge can drop tombstones at
+     *** the targeted output level when no older sstable can possibly hold the
+     **  key, instead of carrying them down to the largest level. */
     const int merge_result = tidesdb_targeted_merge(cf, inputs, input_count, min_input_level,
-                                                    max_input_level, target_level);
+                                                    max_input_level, target_level, 1);
     free(inputs);
 
     atomic_store_explicit(&cf->is_compacting, 0, memory_order_release);
@@ -28200,7 +28319,7 @@ int tidesdb_purge_cf(tidesdb_column_family_t *cf)
     if (atomic_compare_exchange_strong_explicit(&cf->is_compacting, &expected, 1,
                                                 memory_order_acquire, memory_order_relaxed))
     {
-        tidesdb_trigger_compaction(cf);
+        tidesdb_trigger_compaction(cf, 0);
         atomic_store_explicit(&cf->is_compacting, 0, memory_order_release);
     }
 

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -11607,12 +11607,17 @@ static void tidesdb_add_ssts_to_merge_heap(tidesdb_t *db, tidesdb_sstable_t **ss
                       sst->id, sst->num_klog_blocks, sst->klog_data_end_offset);
 
         tidesdb_merge_source_t *source = tidesdb_merge_source_from_sstable(db, sst);
+        int source_added = 0;
         if (source)
         {
             if (source->current_kv)
             {
                 TDB_DEBUG_LOG(TDB_LOG_INFO, "Added merge source for SSTable %" PRIu64, sst->id);
-                if (tidesdb_merge_heap_add_source(heap, source) != TDB_SUCCESS)
+                if (tidesdb_merge_heap_add_source(heap, source) == TDB_SUCCESS)
+                {
+                    source_added = 1;
+                }
+                else
                 {
                     TDB_DEBUG_LOG(TDB_LOG_ERROR,
                                   "Failed to add merge source for SSTable %" PRIu64 " to heap",
@@ -11634,7 +11639,14 @@ static void tidesdb_add_ssts_to_merge_heap(tidesdb_t *db, tidesdb_sstable_t **ss
                           sst->id);
         }
 
-        queue_enqueue(delete_queue, sst);
+        if (source_added)
+        {
+            queue_enqueue(delete_queue, sst);
+        }
+        else
+        {
+            tidesdb_sstable_unref(db, sst);
+        }
     }
 }
 
@@ -15933,12 +15945,14 @@ static void *tidesdb_flush_worker_thread(void *arg)
                 }
             }
 
+            /** we always republish the snapshot after the dequeue-re-enqueue loop.
+             * a concurrent rotation can call tidesdb_imm_snap_publish while an item
+             * is temporarily out of the queue, orphaning it from the snapshot.
+             * republishing here ensures every re-enqueued item is visible to readers */
+            tidesdb_imm_snap_publish(cf);
+
             if (cleaned > 0)
             {
-                /** we republish lock-free snapshot -- non-blocking, rebuilds without
-                 * the removed items and swaps active index immediately */
-                tidesdb_imm_snap_publish(cf);
-
                 /** we wait for old-slot readers to drain before freeing
                  * this is the only path that needs blocking drain (items being freed) */
                 tidesdb_imm_snap_drain_previous(cf);

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -15481,6 +15481,37 @@ static void *tidesdb_flush_worker_thread(void *arg)
         /* unified flush dispatch -- cf==NULL means this is a unified memtable flush */
         if (!cf && imm)
         {
+            /* wait for in-flight writers to drain before reading the memtable.
+             * writers hold a refcount while writing to the unified WAL + skip list.
+             * without this drain barrier_finish can close the WAL while a writer
+             * is still inside block_manager_write_raw on the same handle.
+             * baseline -- 1 (original) + 1 (work ref) = 2 when no external refs */
+            int drain_iterations = 0;
+            while (atomic_load_explicit(&imm->refcount, memory_order_acquire) >
+                   TDB_REFCOUNT_DRAIN_BASELINE)
+            {
+                drain_iterations++;
+                if (drain_iterations < TDB_REFCOUNT_DRAIN_SPIN_THRESHOLD)
+                {
+                    cpu_pause();
+                }
+                else if (drain_iterations < TDB_REFCOUNT_DRAIN_YIELD_THRESHOLD)
+                {
+                    cpu_yield();
+                }
+                else
+                {
+                    usleep(TDB_REFCOUNT_DRAIN_SLEEP_US);
+                }
+                if ((drain_iterations & TDB_REFCOUNT_DRAIN_LOG_INTERVAL) == 0)
+                {
+                    TDB_DEBUG_LOG(
+                        TDB_LOG_WARN,
+                        "Unified flush worker waiting for memtable refcount to drain (current=%d)",
+                        atomic_load_explicit(&imm->refcount, memory_order_acquire));
+                }
+            }
+
             TDB_DEBUG_LOG(TDB_LOG_INFO, "Flush worker processing unified memtable flush");
             int uflush_rc = tidesdb_unified_flush_immutable(db, imm);
             if (uflush_rc != TDB_SUCCESS)
@@ -15488,9 +15519,8 @@ static void *tidesdb_flush_worker_thread(void *arg)
                 TDB_DEBUG_LOG(TDB_LOG_ERROR, "Unified flush failed (error %d)", uflush_rc);
             }
 
-            /* we do not free imm here -- it is still in unified_mt.immutables queue
-             * and readers may be scanning it. tidesdb_unified_flush_immutable already
-             * marks it flushed and deletes the WAL. close path handles cleanup. */
+            /* release the work ref taken during rotation */
+            tidesdb_immutable_memtable_unref(imm);
 
             free(work);
             atomic_fetch_sub_explicit(&db->flush_pending_count, 1, memory_order_release);
@@ -16270,8 +16300,7 @@ static void *tidesdb_sstable_reaper_thread(void *arg)
 
         if (atomic_load(&db->sstable_reaper_active))
         {
-            int wait_rc =
-                pthread_cond_timedwait(&db->reaper_thread_cond, &db->reaper_thread_mutex, &ts);
+            (void)pthread_cond_timedwait(&db->reaper_thread_cond, &db->reaper_thread_mutex, &ts);
         }
         int should_exit = !atomic_load(&db->sstable_reaper_active);
         pthread_mutex_unlock(&db->reaper_thread_mutex);
@@ -23495,6 +23524,11 @@ static int tidesdb_unified_memtable_rotate(tidesdb_t *db)
     /* we enqueue old to immutable queue (for read path scanning) */
     queue_enqueue(db->unified_mt.immutables, old_mt);
 
+    /* we take a work ref so the drain baseline matches per-CF flush
+     * (1 original + 1 work = TDB_REFCOUNT_DRAIN_BASELINE).  same helper as per-CF
+     * rotation uses so the memory ordering matches. */
+    tidesdb_immutable_memtable_ref(old_mt);
+
     /* we enqueue flush work item with cf=NULL to signal unified flush */
     tidesdb_flush_work_t *uwork = malloc(sizeof(tidesdb_flush_work_t));
     if (uwork)
@@ -23509,8 +23543,13 @@ static int tidesdb_unified_memtable_rotate(tidesdb_t *db)
         {
             free(uwork);
             atomic_fetch_sub_explicit(&db->flush_pending_count, 1, memory_order_release);
+            tidesdb_immutable_memtable_unref(old_mt);
             TDB_DEBUG_LOG(TDB_LOG_ERROR, "Failed to enqueue unified flush work");
         }
+    }
+    else
+    {
+        tidesdb_immutable_memtable_unref(old_mt);
     }
 
     TDB_DEBUG_LOG(TDB_LOG_INFO, "Unified memtable rotated (gen=%" PRIu64 ", WAL=%s)", new_gen,

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -322,6 +322,7 @@ static inline size_t tdb_build_prefixed_key(const uint32_t cf_index, const uint8
 #define TDB_OPENING_WAIT_MAX_MS                     100
 #define TDB_MAX_FFLUSH_RETRY_ATTEMPTS               5
 #define TDB_FLUSH_RETRY_BACKOFF_US                  100000
+#define TDB_TXN_ACTIVE_RELOAD_MAX_ATTEMPTS          16
 #define TDB_SHUTDOWN_BROADCAST_ATTEMPTS             10
 #define TDB_SHUTDOWN_BROADCAST_INTERVAL_US          5000
 
@@ -23601,8 +23602,11 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
     /* with the unified path, we do single WAL + single skip list */
     if (txn->db->unified_mt.enabled)
     {
-        tidesdb_memtable_t *umt =
-            atomic_load_explicit(&txn->db->unified_mt.active, memory_order_acquire);
+        tidesdb_memtable_t *umt;
+        int umt_load_attempts = 0;
+
+    reload_unified_active:
+        umt = atomic_load_explicit(&txn->db->unified_mt.active, memory_order_acquire);
         if (!umt || !tidesdb_memtable_try_ref(umt))
         {
             umt = atomic_load_explicit(&txn->db->unified_mt.active, memory_order_acquire);
@@ -23610,6 +23614,20 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
             {
                 return TDB_ERR_UNKNOWN;
             }
+        }
+
+        /*** phantom-writer guard -- after we hold a ref, verify umt is still the active
+         **  unified memtable.  if a rotation completed between our load and our try_ref,
+         *   umt is now an immutable that the flush worker may already be reading.  unref
+         *** and retry so our writes always land on the current active memtable. */
+        if (atomic_load_explicit(&txn->db->unified_mt.active, memory_order_acquire) != umt)
+        {
+            tidesdb_immutable_memtable_unref(umt);
+            if (++umt_load_attempts > TDB_TXN_ACTIVE_RELOAD_MAX_ATTEMPTS)
+            {
+                return TDB_ERR_UNKNOWN;
+            }
+            goto reload_unified_active;
         }
 
         /* we serialize unified WAL batch */
@@ -23777,7 +23795,11 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
     for (int cf_idx = 0; cf_idx < txn->num_cfs; cf_idx++)
     {
         tidesdb_column_family_t *cf = txn->cfs[cf_idx];
-        tidesdb_memtable_t *mt = atomic_load_explicit(&cf->active_memtable, memory_order_acquire);
+        tidesdb_memtable_t *mt;
+        int load_attempts = 0;
+
+    reload_active:
+        mt = atomic_load_explicit(&cf->active_memtable, memory_order_acquire);
 
         /*** we use CAS-based try_ref to safely handle the case where the loaded
          **  memtable was rotated to immutable and freed between our load and ref.
@@ -23797,6 +23819,27 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
                 result = TDB_ERR_UNKNOWN;
                 goto cleanup;
             }
+        }
+
+        /*** phantom-writer guard -- after we hold a ref, verify mt is still the active.
+         **  if a rotation completed between our load and our try_ref, mt is now an
+         *   immutable that the flush worker may already be reading.  unref and retry
+         *** so our writes always land on the current active memtable. */
+        if (atomic_load_explicit(&cf->active_memtable, memory_order_acquire) != mt)
+        {
+            tidesdb_immutable_memtable_unref(mt);
+            if (++load_attempts > TDB_TXN_ACTIVE_RELOAD_MAX_ATTEMPTS)
+            {
+                for (int j = 0; j < cf_idx; j++)
+                {
+                    if (cf_memtables[j])
+                        atomic_fetch_sub_explicit(&cf_memtables[j]->refcount, 1,
+                                                  memory_order_release);
+                }
+                result = TDB_ERR_UNKNOWN;
+                goto cleanup;
+            }
+            goto reload_active;
         }
         cf_memtables[cf_idx] = mt;
         cf_skiplists[cf_idx] = mt->skip_list;

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -23105,7 +23105,7 @@ static int tidesdb_unified_write_cf_sstable(tidesdb_t *db, tidesdb_column_family
     }
     if (num_l1 >= cf->config.l1_file_count_trigger || density_hit)
     {
-        tidesdb_compact(cf);
+        tidesdb_compact_with_flags(cf, density_hit ? 1 : 0);
     }
 
     tidesdb_sstable_unref(db, sst);

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -6047,6 +6047,26 @@ static int tidesdb_memtable_try_ref(tidesdb_memtable_t *mt)
  */
 static void tidesdb_imm_snap_publish(tidesdb_column_family_t *cf)
 {
+    /*** serialize concurrent publishers via CAS admission.  per-CF flush cleanup
+     **  loop and rotation can both call this at overlapping times.  without this
+     *   guard the two callers would race on the same inactive slot's items[]
+     *** array, producing an interleaved snapshot.  publish is uncommon (one per
+     **  rotation/cleanup) so a brief spin is fine and avoids introducing a mutex.
+     *   the loser still serves a useful purpose -- by the time it runs, the
+     *   queue may have changed again, so it re-snapshots the current state. */
+    int expected = 0;
+    int admit_spins = 0;
+    while (!atomic_compare_exchange_weak_explicit(&cf->imm_snap_publishing, &expected, 1,
+                                                  memory_order_acquire, memory_order_relaxed))
+    {
+        expected = 0;
+        if (admit_spins < TDB_IMM_SNAP_ACQUIRE_SPIN_LIMIT)
+            cpu_pause();
+        else
+            cpu_yield();
+        admit_spins++;
+    }
+
     const int active = atomic_load_explicit(&cf->imm_snap_active, memory_order_acquire);
     const int next_idx = 1 - active;
     tidesdb_imm_snap_t *next = &cf->imm_snaps[next_idx];
@@ -6078,6 +6098,8 @@ static void tidesdb_imm_snap_publish(tidesdb_column_family_t *cf)
      ** NON-BLOCKING**** old slot readers drain on their own, no spin-wait here
      * this avoids the flush worker stalling on slow readers (sstable I/O) */
     atomic_store_explicit(&cf->imm_snap_active, next_idx, memory_order_release);
+
+    atomic_store_explicit(&cf->imm_snap_publishing, 0, memory_order_release);
 }
 
 /**
@@ -11652,6 +11674,24 @@ static void tidesdb_add_ssts_to_merge_heap(tidesdb_t *db, tidesdb_sstable_t **ss
 }
 
 /**
+ * tidesdb_release_merge_source_refs
+ * release the per-source refs that tidesdb_collect_ssts_from_snapshot added when
+ * building delete_queue, without touching the level arrays.  used on merge error
+ * paths before the new sstable has been published so source sstables stay
+ * reachable in their levels and no committed data is lost.
+ * @param db the database
+ * @param delete_queue queue of source sstables to release refs on
+ */
+static void tidesdb_release_merge_source_refs(const tidesdb_t *db, queue_t *delete_queue)
+{
+    while (!queue_is_empty(delete_queue))
+    {
+        tidesdb_sstable_t *sst = queue_dequeue(delete_queue);
+        if (sst) tidesdb_sstable_unref(db, sst);
+    }
+}
+
+/**
  * tidesdb_cleanup_merged_sstables
  * remove old sstables from levels and manifest after merge
  * @param cf the column family
@@ -11800,7 +11840,7 @@ static int tidesdb_full_preemptive_merge(tidesdb_column_family_t *cf, int start_
     if (!new_sst)
     {
         tidesdb_merge_heap_free(heap);
-        tidesdb_cleanup_merged_sstables(cf, sstables_to_delete, start_level, target_level);
+        tidesdb_release_merge_source_refs(cf->db, sstables_to_delete);
         queue_free(sstables_to_delete);
         tidesdb_cleanup_snapshot_ids(sstable_ids_snapshot);
         return TDB_ERR_MEMORY;
@@ -11816,7 +11856,7 @@ static int tidesdb_full_preemptive_merge(tidesdb_column_family_t *cf, int start_
     {
         tidesdb_sstable_unref(cf->db, new_sst);
         tidesdb_merge_heap_free(heap);
-        tidesdb_cleanup_merged_sstables(cf, sstables_to_delete, start_level, target_level);
+        tidesdb_release_merge_source_refs(cf->db, sstables_to_delete);
         queue_free(sstables_to_delete);
         tidesdb_cleanup_snapshot_ids(sstable_ids_snapshot);
         return TDB_ERR_IO;
@@ -11830,7 +11870,7 @@ static int tidesdb_full_preemptive_merge(tidesdb_column_family_t *cf, int start_
         block_manager_close(klog_bm);
         tidesdb_sstable_unref(cf->db, new_sst);
         tidesdb_merge_heap_free(heap);
-        tidesdb_cleanup_merged_sstables(cf, sstables_to_delete, start_level, target_level);
+        tidesdb_release_merge_source_refs(cf->db, sstables_to_delete);
         queue_free(sstables_to_delete);
         tidesdb_cleanup_snapshot_ids(sstable_ids_snapshot);
         return TDB_ERR_IO;
@@ -11923,7 +11963,7 @@ static int tidesdb_full_preemptive_merge(tidesdb_column_family_t *cf, int start_
         if (btree_result != TDB_SUCCESS)
         {
             tidesdb_sstable_unref(cf->db, new_sst);
-            tidesdb_cleanup_merged_sstables(cf, sstables_to_delete, start_level, target_level);
+            tidesdb_release_merge_source_refs(cf->db, sstables_to_delete);
             queue_free(sstables_to_delete);
             tidesdb_cleanup_snapshot_ids(sstable_ids_snapshot);
             return btree_result;
@@ -12496,7 +12536,7 @@ static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t
     if (!new_sst)
     {
         tidesdb_merge_heap_free(heap);
-        tidesdb_cleanup_merged_sstables(cf, sstables_to_delete, min_input_level, max_input_level);
+        tidesdb_release_merge_source_refs(cf->db, sstables_to_delete);
         queue_free(sstables_to_delete);
         return TDB_ERR_MEMORY;
     }
@@ -12511,7 +12551,7 @@ static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t
     {
         tidesdb_sstable_unref(cf->db, new_sst);
         tidesdb_merge_heap_free(heap);
-        tidesdb_cleanup_merged_sstables(cf, sstables_to_delete, min_input_level, max_input_level);
+        tidesdb_release_merge_source_refs(cf->db, sstables_to_delete);
         queue_free(sstables_to_delete);
         return TDB_ERR_IO;
     }
@@ -12524,7 +12564,7 @@ static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t
         block_manager_close(klog_bm);
         tidesdb_sstable_unref(cf->db, new_sst);
         tidesdb_merge_heap_free(heap);
-        tidesdb_cleanup_merged_sstables(cf, sstables_to_delete, min_input_level, max_input_level);
+        tidesdb_release_merge_source_refs(cf->db, sstables_to_delete);
         queue_free(sstables_to_delete);
         return TDB_ERR_IO;
     }
@@ -12568,8 +12608,7 @@ static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t
         if (btree_result != TDB_SUCCESS)
         {
             tidesdb_sstable_unref(cf->db, new_sst);
-            tidesdb_cleanup_merged_sstables(cf, sstables_to_delete, min_input_level,
-                                            max_input_level);
+            tidesdb_release_merge_source_refs(cf->db, sstables_to_delete);
             queue_free(sstables_to_delete);
             return btree_result;
         }
@@ -18767,6 +18806,7 @@ int tidesdb_create_column_family(tidesdb_t *db, const char *name,
         atomic_init(&cf->imm_snaps[s].readers, 0);
     }
     atomic_init(&cf->imm_snap_active, 0);
+    atomic_init(&cf->imm_snap_publishing, 0);
 
     /*** in unified memtable mode, writes go through the unified WAL so
      **  per-CF WAL files are not needed. skip creation to avoid wasted
@@ -24262,14 +24302,18 @@ int tidesdb_iter_new(tidesdb_txn_t *txn, tidesdb_column_family_t *cf, tidesdb_it
     (*iter)->heap->pop_buf_cap[1] = (*iter)->heap->pop_buf[1] ? TDB_MERGE_POP_BUF_INITIAL_CAP : 0;
     (*iter)->heap->pop_buf_slot = 0;
 
-    size_t imm_count = 0;
-    tidesdb_immutable_memtable_t **imm_snapshot =
-        tidesdb_snapshot_immutable_memtables(cf, &imm_count);
-
     /*** we pin the active memtable with try_ref to prevent use-after-free
      *   if rotation+flush races between our load and merge_source_from_memtable's ref.
      **  without try_ref, the memtable could rotate to immutable, flush, and free
-     *** before the unconditional ref in merge_source_from_memtable fires. */
+     *** before the unconditional ref in merge_source_from_memtable fires.
+     *
+     ** the active memtable load must come BEFORE the immutable snapshot.
+     *  rotation order is queue_enqueue(immutables, mt) -> imm_snap_publish ->
+     *  atomic_store(active, new).  if we sample the imm snap first and then load
+     *  active, a rotation that lands in between gives us an old snap (without mt)
+     *  and a new active (without the data, since it was in mt) -- iterator misses
+     *  every entry that just rotated.  loading active first means any later snap
+     *  acquire sees a state at least as new as the one we observed for active. */
     tidesdb_memtable_t *active_mt_struct =
         atomic_load_explicit(&cf->active_memtable, memory_order_acquire);
     if (active_mt_struct && !tidesdb_memtable_try_ref(active_mt_struct))
@@ -24283,6 +24327,10 @@ int tidesdb_iter_new(tidesdb_txn_t *txn, tidesdb_column_family_t *cf, tidesdb_it
 
     /* we ensure consistent view */
     atomic_thread_fence(memory_order_acquire);
+
+    size_t imm_count = 0;
+    tidesdb_immutable_memtable_t **imm_snapshot =
+        tidesdb_snapshot_immutable_memtables(cf, &imm_count);
 
     if (txn->isolation_level == TDB_ISOLATION_READ_COMMITTED)
     {

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -24418,6 +24418,19 @@ int tidesdb_iter_new(tidesdb_txn_t *txn, tidesdb_column_family_t *cf, tidesdb_it
                             atomic_fetch_sub_explicit(&imm->refcount, 1, memory_order_release);
                             continue;
                         }
+
+                        /*** cached_mt_sources was sized using uimm_size_hint; the queue
+                         **  may have grown between that load and the snapshot above so
+                         *   snap_count can exceed the reserved budget.  bail before we
+                         *** would overrun the buffer.  the unwritten immutables are
+                         **  still safe -- they will be flushed to sst and the iterator
+                         *   reads them from disk on the next refresh. */
+                        if ((*iter)->num_cached_mt_sources >= mt_capacity)
+                        {
+                            atomic_fetch_sub_explicit(&imm->refcount, 1, memory_order_release);
+                            continue;
+                        }
+
                         tidesdb_merge_source_t *src = tidesdb_merge_source_from_unified_memtable(
                             imm->skip_list, &cf->config, imm, cf->unified_cf_index);
                         /* merge_source_from_unified_memtable took its own ref */

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -7552,10 +7552,11 @@ static int tidesdb_sstable_get(tidesdb_t *db, tidesdb_sstable_t *sst, const uint
     const int has_cf_name = (cf_name[0] != '\0');
 
     /* we utilize block indexes to find the target klog block.
-     * when block index covers all blocks (index_sample_ratio == 1), we do a
-     * single-block lookup -- no scan loop needed. this eliminates the O(N) scan
-     * that was the #1 source of slow reads (each scanned block triggers decompress
-     * + deserialize + cache_put). */
+     * when block index covers all blocks (index_sample_ratio == 1) and the prefix
+     * uniquely identifies the block, a single-block lookup suffices.  however, when
+     * the search key is longer than the index prefix, multiple consecutive blocks
+     * can share the same prefix and the index cannot pinpoint which one holds the
+     * key.  in that case we scan forward through all prefix-matching blocks. */
     uint64_t start_file_position = 0;
     int block_index_definitive = 0;
     if (sst->block_indexes && sst->block_indexes->count > 0)
@@ -7564,9 +7565,6 @@ static int tidesdb_sstable_get(tidesdb_t *db, tidesdb_sstable_t *sst, const uint
             sst->block_indexes, key, key_size, &start_file_position);
         if (index_result == 0)
         {
-            /* block index covers all blocks when count matches num_klog_blocks
-             * (index_sample_ratio == 1). in this case the lookup is definitive:
-             * if the key isn't in the pointed block, it's not in the sstable. */
             block_index_definitive =
                 (sst->block_indexes->count >= sst->num_klog_blocks && start_file_position > 0);
         }
@@ -7741,9 +7739,43 @@ full_download_path:
         return TDB_ERR_NOT_FOUND;
     }
 
-    /* when block index is definitive, we read exactly one block and search it.
-     * this is O(1) disk reads per point lookup instead of O(N) scan. */
-    const uint64_t max_blocks_to_scan = block_index_definitive ? 1 : sst->num_klog_blocks;
+    /* when block index is definitive, scan only the blocks whose prefix range
+     * includes the search key.  with prefix truncation several consecutive blocks
+     * can share the same min/max prefix, so we count them starting from the
+     * leftmost match returned by find_predecessor. */
+    uint64_t max_blocks_to_scan = sst->num_klog_blocks;
+    if (block_index_definitive && sst->block_indexes)
+    {
+        const tidesdb_block_index_t *bi = sst->block_indexes;
+        int64_t start_slot = -1;
+        for (int64_t s = 0; s < (int64_t)bi->count; s++)
+        {
+            if (bi->file_positions[s] == start_file_position)
+            {
+                start_slot = s;
+                break;
+            }
+        }
+        if (start_slot >= 0)
+        {
+            uint8_t search_pfx[TDB_BLOCK_INDEX_PREFIX_MAX];
+            const size_t cl = (key_size < bi->prefix_len) ? key_size : bi->prefix_len;
+            memcpy(search_pfx, key, cl);
+            if (cl < bi->prefix_len) memset(search_pfx + cl, 0, bi->prefix_len - cl);
+
+            uint64_t span = 1;
+            for (int64_t s = start_slot + 1; s < (int64_t)bi->count; s++)
+            {
+                const uint8_t *s_min = bi->min_key_prefixes + (s * bi->prefix_len);
+                int cmp = bi->comparator ? bi->comparator(s_min, bi->prefix_len, search_pfx,
+                                                          bi->prefix_len, bi->comparator_ctx)
+                                         : memcmp(s_min, search_pfx, bi->prefix_len);
+                if (cmp > 0) break;
+                span++;
+            }
+            max_blocks_to_scan = span;
+        }
+    }
 
     uint64_t blocks_scanned = 0;
 
@@ -10775,9 +10807,11 @@ static int tidesdb_merge_source_advance(tidesdb_merge_source_t *source)
                                     source->source.sstable.lazy.bmblock = NULL;
                                     source->source.sstable.lazy.decompressed = NULL;
                                     source->source.sstable.current_entry_idx = 0;
-                                    source->source.sstable.klog_cursor->current_block_size =
-                                        bdata_size;
-                                    source->source.sstable.klog_cursor->block_size_valid = 1;
+                                    /* do NOT overwrite klog_cursor->current_block_size with
+                                       the post-strip bdata_size -- cursor_next expects the
+                                       on-disk size that was already set by the upstream
+                                       block_manager_cursor_read.  overwriting causes a short
+                                       advance and exhausts the source after one block. */
                                     return TDB_SUCCESS;
                                 }
                             }
@@ -24163,7 +24197,17 @@ int tidesdb_iter_new(tidesdb_txn_t *txn, tidesdb_column_family_t *cf, tidesdb_it
     }
 
     const int has_unified = txn->db->unified_mt.enabled ? 1 : 0;
-    const int mt_capacity = 2 + (int)imm_count + (txn->num_ops > 0 ? 1 : 0) + has_unified;
+    /* unified immutable count -- snapshot under the read lock below; this
+       atomic load is just for sizing the cached_mt_sources buffer.  worst
+       case the queue grows between this load and the snapshot, in which
+       case extra immutables get skipped (still safe -- they'll be flushed
+       to SST and read from disk). */
+    size_t uimm_size_hint = 0;
+    if (has_unified && txn->db->unified_mt.immutables)
+        uimm_size_hint =
+            atomic_load_explicit(&txn->db->unified_mt.immutables->size, memory_order_relaxed);
+    const int mt_capacity =
+        2 + (int)imm_count + (txn->num_ops > 0 ? 1 : 0) + has_unified + (int)uimm_size_hint;
     (*iter)->cached_mt_sources = malloc(mt_capacity * sizeof(tidesdb_merge_source_t *));
     (*iter)->num_cached_mt_sources = 0;
 
@@ -24227,6 +24271,71 @@ int tidesdb_iter_new(tidesdb_txn_t *txn, tidesdb_column_family_t *cf, tidesdb_it
             {
                 /* try_ref succeeded but no skip_list, thus we release */
                 atomic_fetch_sub_explicit(&umt->refcount, 1, memory_order_release);
+            }
+
+            /***** unified-mode immutable memtables -- entries that have
+             ****  rotated out of the active memtable but whose flush to
+             ***   SST has not yet completed.  point lookups walk this
+             **    queue (see tidesdb_txn_get); iterators must too or
+             *     scans silently miss every entry currently in flight. */
+            queue_t *uimm_q = txn->db->unified_mt.immutables;
+            if (uimm_q)
+            {
+                const size_t uimm_count = atomic_load_explicit(&uimm_q->size, memory_order_relaxed);
+                if (uimm_count > 0)
+                {
+                    tidesdb_memtable_t *uimm_stack[TDB_STACK_IMM_SNAPSHOT];
+                    tidesdb_memtable_t **uimm_ptrs = uimm_stack;
+                    if (uimm_count > TDB_STACK_IMM_SNAPSHOT)
+                    {
+                        uimm_ptrs = malloc(uimm_count * sizeof(tidesdb_memtable_t *));
+                        if (!uimm_ptrs) uimm_ptrs = uimm_stack;
+                    }
+
+                    size_t snap_count = 0;
+                    pthread_rwlock_rdlock(&uimm_q->read_lock);
+                    {
+                        queue_node_t *cur = uimm_q->head ? uimm_q->head->next : NULL;
+                        size_t max =
+                            (uimm_ptrs == uimm_stack) ? TDB_STACK_IMM_SNAPSHOT : uimm_count;
+                        for (size_t i = 0; i < max && cur != NULL; i++, cur = cur->next)
+                        {
+                            tidesdb_memtable_t *imm = (tidesdb_memtable_t *)cur->data;
+                            /* try_ref so a racing flush+free doesn't unmap underneath us;
+                               failed try_ref means the memtable is already being torn
+                               down (its data is in SST) -- safe to skip. */
+                            if (imm && tidesdb_memtable_try_ref(imm)) uimm_ptrs[snap_count++] = imm;
+                        }
+                    }
+                    pthread_rwlock_unlock(&uimm_q->read_lock);
+
+                    for (size_t qi = 0; qi < snap_count; qi++)
+                    {
+                        tidesdb_memtable_t *imm = uimm_ptrs[qi];
+                        /* if flushed flag is set the data lives in SST now and
+                           the SST source covers it; skip to avoid double-counting */
+                        if (atomic_load_explicit(&imm->flushed, memory_order_acquire) ||
+                            !imm->skip_list)
+                        {
+                            atomic_fetch_sub_explicit(&imm->refcount, 1, memory_order_release);
+                            continue;
+                        }
+                        tidesdb_merge_source_t *src = tidesdb_merge_source_from_unified_memtable(
+                            imm->skip_list, &cf->config, imm, cf->unified_cf_index);
+                        /* merge_source_from_unified_memtable took its own ref */
+                        atomic_fetch_sub_explicit(&imm->refcount, 1, memory_order_release);
+                        if (src)
+                        {
+                            src->is_cached = 1;
+                            ((tidesdb_merge_source_t **)(*iter)
+                                 ->cached_mt_sources)[(*iter)->num_cached_mt_sources++] = src;
+                            if (src->current_kv != NULL)
+                                tidesdb_merge_heap_add_source((*iter)->heap, src);
+                        }
+                    }
+
+                    if (uimm_ptrs != uimm_stack) free(uimm_ptrs);
+                }
             }
         }
 
@@ -25371,9 +25480,10 @@ static void tidesdb_iter_seek_sstable_source_forward(const tidesdb_iter_t *iter,
 
                 source->source.sstable.lazy.entry_idx = found;
                 source->source.sstable.current_entry_idx = found;
-                /* cache block size so cursor_next skips pread */
-                cursor->current_block_size = source->source.sstable.lazy.block_data_size;
-                cursor->block_size_valid = 1;
+                /* do not overwrite cursor->current_block_size with the
+                   post-strip block_data_size -- cursor_next expects the
+                   on-disk size set by cursor_read.  overwriting causes a
+                   short advance and exhausts the source after one block. */
                 return;
             }
         }
@@ -25720,15 +25830,20 @@ static void tidesdb_iter_seek_sstable_source_forward(const tidesdb_iter_t *iter,
             source->source.sstable.lazy.bmblock = bmblock;
             source->source.sstable.lazy.decompressed = decompressed;
             source->source.sstable.current_entry_idx = found_idx;
-            cursor->current_block_size = block_data_size;
-            cursor->block_size_valid = 1;
+            /* DO NOT overwrite cursor->current_block_size here.
+               block_data_size is the post-strip / post-decompress data size,
+               but cursor_next expects the on-disk block size (set by
+               block_manager_cursor_read above).  overwriting with the
+               stripped size makes cursor_next advance by less than a full
+               on-disk block, landing mid-block on the next read and
+               silently exhausting the source after one block.  the
+               on-disk size is already cached by cursor_read, leave it. */
             return;
         }
 
-        /** target is past this block -- we set cached block size so
-         *  cursor_next can advance without a pread syscall */
-        cursor->current_block_size = block_data_size;
-        cursor->block_size_valid = 1;
+        /** target is past this block -- the cached cursor block size is
+         *  already set to the on-disk size by cursor_read above; do NOT
+         *  overwrite with the post-strip size, that breaks cursor_next. */
 
         if (pin) clock_cache_release(pin);
         if (decompressed) free(decompressed);
@@ -29557,7 +29672,7 @@ int tidesdb_clone_column_family(tidesdb_t *db, const char *src_name, const char 
     /* we create the new column family structure by loading from disk */
     tidesdb_column_family_config_t clone_config = src_cf->config;
 
-    /* we clear cached comparator pointers -- they will be re-resolved */
+    /* we clear cached comparator pointers as they will be re-resolved */
     clone_config.comparator_fn_cached = NULL;
     clone_config.comparator_ctx_cached = NULL;
 
@@ -30274,8 +30389,12 @@ static int compact_block_index_find_predecessor(const tidesdb_block_index_t *ind
         return 0;
     }
 
-    /* we utilize binary search to find the rightmost block where min_key <= search_key <= max_key
-     * or the last block where min_key <= search_key if no exact range match */
+    /* we use binary search to find the leftmost block where min_key <= search_key <= max_key.
+     * leftmost (not rightmost) is critical because prefix truncation can make multiple
+     * consecutive blocks appear identical when key_len > prefix_len, several blocks
+     * may share the same min/max prefix yet contain different full keys.  returning
+     * the leftmost ensures the caller's forward scan covers all candidate blocks.
+     * if no exact range match, we fall back to the last block where min_key <= search_key */
     int64_t left = 0;
     int64_t right = index->count - 1;
     int64_t exact_match = -1;
@@ -30309,10 +30428,11 @@ static int compact_block_index_find_predecessor(const tidesdb_block_index_t *ind
 
             if (cmp_max <= 0)
             {
-                /* key lies inside this block; we must remember and search right for the rightmost
-                 * match */
+                /* key lies inside this block's prefix range; search LEFT for the
+                 * leftmost such block so the caller's forward scan covers all
+                 * blocks that share this prefix */
                 exact_match = mid;
-                left = mid + 1;
+                right = mid - 1;
             }
             else
             {
@@ -30418,7 +30538,7 @@ static int compact_block_index_find_slot(const tidesdb_block_index_t *index, con
             if (cmp_max <= 0)
             {
                 exact_match = mid;
-                left = mid + 1;
+                right = mid - 1;
             }
             else
             {

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -16234,8 +16234,6 @@ static void *tidesdb_sstable_reaper_thread(void *arg)
 
     while (atomic_load(&db->sstable_reaper_active))
     {
-        TDB_DEBUG_LOG(TDB_LOG_DEBUG, "Reaper: loop top");
-
         time_t now = tdb_get_current_time();
         atomic_store_explicit(&db->cached_current_time, now, memory_order_seq_cst);
 
@@ -16254,15 +16252,12 @@ static void *tidesdb_sstable_reaper_thread(void *arg)
             ts.tv_nsec -= TDB_NANOSECONDS_PER_SECOND;
         }
 
-        TDB_DEBUG_LOG(TDB_LOG_DEBUG, "Reaper: before mutex_lock");
         pthread_mutex_lock(&db->reaper_thread_mutex);
-        TDB_DEBUG_LOG(TDB_LOG_DEBUG, "Reaper: before timedwait");
 
         if (atomic_load(&db->sstable_reaper_active))
         {
             int wait_rc =
                 pthread_cond_timedwait(&db->reaper_thread_cond, &db->reaper_thread_mutex, &ts);
-            TDB_DEBUG_LOG(TDB_LOG_DEBUG, "Reaper: timedwait returned %d", wait_rc);
         }
         int should_exit = !atomic_load(&db->sstable_reaper_active);
         pthread_mutex_unlock(&db->reaper_thread_mutex);
@@ -16626,10 +16621,16 @@ static void *tidesdb_sstable_reaper_thread(void *arg)
             time_t last_access;
         } sstable_candidate_t;
 
-        /* stack buffer for common case (≤N open SSTs), heap fallback for large configs */
+        /* stack buffer for common case (≤N open SSTs), heap fallback for large configs.
+         * current_open is a snapshot; concurrent flushes can add more SSTables between
+         * the snapshot and the scan below.  we add headroom to reduce the chance of
+         * hitting the cap, and enforce a bounds check when inserting candidates. */
 #define TDB_REAPER_STACK_CANDIDATES 256
         sstable_candidate_t stack_candidates[TDB_REAPER_STACK_CANDIDATES];
         sstable_candidate_t *candidates;
+        const int candidates_capacity = (current_open <= TDB_REAPER_STACK_CANDIDATES)
+                                            ? TDB_REAPER_STACK_CANDIDATES
+                                            : current_open + (current_open / 4) + 64;
         const int use_stack = (current_open <= TDB_REAPER_STACK_CANDIDATES);
         if (use_stack)
         {
@@ -16637,7 +16638,7 @@ static void *tidesdb_sstable_reaper_thread(void *arg)
         }
         else
         {
-            candidates = malloc(current_open * sizeof(sstable_candidate_t));
+            candidates = malloc(candidates_capacity * sizeof(sstable_candidate_t));
             if (!candidates)
             {
                 TDB_DEBUG_LOG(TDB_LOG_ERROR, "Reaper: failed to allocate candidates array");
@@ -16716,7 +16717,8 @@ static void *tidesdb_sstable_reaper_thread(void *arg)
                         }
 
                         /* now we check if we're the only extra ref (refcount should be 2) */
-                        if (atomic_load(&sst->refcount) == 2)
+                        if (atomic_load(&sst->refcount) == 2 &&
+                            candidate_count < candidates_capacity)
                         {
                             candidates[candidate_count].sst = sst;
                             candidates[candidate_count].last_access =
@@ -16725,7 +16727,7 @@ static void *tidesdb_sstable_reaper_thread(void *arg)
                         }
                         else
                         {
-                            /* someone else is using it, we must release our ref */
+                            /* someone else is using it or buffer full, release our ref */
                             tidesdb_sstable_unref(db, sst);
                         }
                     }

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -513,7 +513,8 @@ struct tidesdb_column_family_t
      * readers acquire active slot, use items, release when done
      * writers rebuild in inactive slot, swap active, wait for old readers */
     tidesdb_imm_snap_t imm_snaps[TDB_IMM_SNAP_SLOTS];
-    _Atomic(int) imm_snap_active; /* 0 or 1, index of current snapshot */
+    _Atomic(int) imm_snap_active;     /* 0 or 1, index of current snapshot */
+    _Atomic(int) imm_snap_publishing; /* CAS-admission flag serializing concurrent publishers */
 
     /* unified memtable mode -- 4-byte big-endian CF prefix for keys in the shared skip list */
     uint32_t unified_cf_index;

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -11786,6 +11786,283 @@ static void test_background_flush_multiple_immutable_memtables(void)
     cleanup_test_dir();
 }
 
+/* test configuration constants for the active memtable rotation race repro
+ * the race lives in tidesdb_txn_commit at the per-cf try_ref loop. a writer
+ * thread loads cf->active_memtable, gets preempted, the flush worker takes
+ * the immutable through flush + cleanup which CAS the refcount from 1 to 0,
+ * then the writer's try_ref reads refcount as 0 and returns 0. the existing
+ * 2 shot retry handles the common case but loses the race when rotations are
+ * happening faster than the writer's load + try_ref pair. small write buffer
+ * plus many committers plus multi-cf commits amplifies the race because every
+ * commit hits the per-cf loop num_cfs times, and a sync_wal thread constantly
+ * holds a competing ref on the active memtable to widen the transient zero
+ * window observed by other writers */
+#define TEST_RACE_COMMITTER_THREADS    16
+#define TEST_RACE_TXN_PER_COMMITTER    3000
+#define TEST_RACE_WRITE_BUFFER_BYTES   512
+#define TEST_RACE_NUM_CFS              8
+#define TEST_RACE_KEY_BUF_BYTES        48
+#define TEST_RACE_VAL_BUF_BYTES        96
+#define TEST_RACE_CF_NAME_BUF          32
+#define TEST_RACE_FLUSH_DRAIN_MAX_ITER 600
+#define TEST_RACE_FLUSH_DRAIN_INT_US   50000
+#define TEST_RACE_SYNCER_SLEEP_US      0
+#define TEST_RACE_CF_NAME_FMT          "rotation_race_cf_%d"
+#define TEST_RACE_KEY_FMT              "rrk_c%d_t%03d_%07d"
+#define TEST_RACE_VAL_FMT              "rrv_c%d_t%03d_%07d"
+
+typedef struct
+{
+    tidesdb_t *db;
+    tidesdb_column_family_t **cfs;
+    int num_cfs;
+    int thread_id;
+    int num_txns;
+    uint8_t *committed_flags;
+    _Atomic(int) *unknown_errors;
+    _Atomic(int) *unexpected_errors;
+    _Atomic(int) committed_count;
+} active_mt_race_writer_t;
+
+typedef struct
+{
+    tidesdb_t *db;
+    tidesdb_column_family_t **cfs;
+    int num_cfs;
+    _Atomic(int) *stop;
+} active_mt_race_syncer_t;
+
+/* secondary thread that hammers tidesdb_sync_wal on every cf in a tight loop.
+ * sync_wal also does try_ref on cf->active_memtable, so it pushes the active
+ * memtable refcount through transient values (1 -> 2 -> 1 -> ...) constantly,
+ * which widens the window where a cleanup CAS can witness refcount == 1 and
+ * race against a writer's two-shot try_ref */
+static void *active_mt_race_syncer_thread(void *arg)
+{
+    active_mt_race_syncer_t *data = (active_mt_race_syncer_t *)arg;
+    while (!atomic_load(data->stop))
+    {
+        for (int i = 0; i < data->num_cfs; i++)
+        {
+            (void)tidesdb_sync_wal(data->cfs[i]);
+        }
+        if (TEST_RACE_SYNCER_SLEEP_US > 0) usleep(TEST_RACE_SYNCER_SLEEP_US);
+    }
+    return NULL;
+}
+
+static void *active_mt_race_writer_thread(void *arg)
+{
+    active_mt_race_writer_t *data = (active_mt_race_writer_t *)arg;
+    char key[TEST_RACE_KEY_BUF_BYTES];
+    char value[TEST_RACE_VAL_BUF_BYTES];
+
+    for (int i = 0; i < data->num_txns; i++)
+    {
+        tidesdb_txn_t *txn = NULL;
+        int begin_rc = tidesdb_txn_begin(data->db, &txn);
+        if (begin_rc != 0)
+        {
+            atomic_fetch_add(data->unexpected_errors, 1);
+            continue;
+        }
+
+        /* multi-cf commit, one put per cf so the per-cf try_ref loop in
+         * tidesdb_txn_commit iterates num_cfs times per commit */
+        int put_failed = 0;
+        for (int c = 0; c < data->num_cfs; c++)
+        {
+            snprintf(key, sizeof(key), TEST_RACE_KEY_FMT, c, data->thread_id, i);
+            snprintf(value, sizeof(value), TEST_RACE_VAL_FMT, c, data->thread_id, i);
+            int put_rc = tidesdb_txn_put(txn, data->cfs[c], (uint8_t *)key, strlen(key) + 1,
+                                         (uint8_t *)value, strlen(value) + 1, 0);
+            if (put_rc != 0)
+            {
+                atomic_fetch_add(data->unexpected_errors, 1);
+                put_failed = 1;
+                break;
+            }
+        }
+        if (put_failed)
+        {
+            tidesdb_txn_free(txn);
+            continue;
+        }
+
+        int commit_rc = tidesdb_txn_commit(txn);
+        if (commit_rc == TDB_ERR_UNKNOWN)
+        {
+            atomic_fetch_add(data->unknown_errors, 1);
+        }
+        else if (commit_rc != 0)
+        {
+            atomic_fetch_add(data->unexpected_errors, 1);
+        }
+        else
+        {
+            data->committed_flags[i] = 1;
+            atomic_fetch_add(&data->committed_count, 1);
+        }
+
+        tidesdb_txn_free(txn);
+    }
+
+    return NULL;
+}
+
+/* test_active_memtable_rotation_race
+ * stress reproducer for the per cf rotation race in tidesdb_txn_commit. forces
+ * frequent rotation by sizing the write buffer to a few kilobytes, runs many
+ * committer threads in parallel, and asserts that no commit returns
+ * TDB_ERR_UNKNOWN and that every successfully committed key is readable on a
+ * final scan. the test reproduces the race deterministically against the
+ * unfixed binary, which surfaces the symptom as one or more TDB_ERR_UNKNOWN
+ * returns from tidesdb_txn_commit. unified mode is not exercised here because
+ * the unified active memtable refcount is only mutated by writers themselves
+ * and never reaches zero during runtime, so the same race does not apply on
+ * that path */
+static void test_active_memtable_rotation_race(void)
+{
+    cleanup_test_dir();
+    tidesdb_t *db = create_test_db();
+
+    tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
+    cf_config.write_buffer_size = TEST_RACE_WRITE_BUFFER_BYTES;
+    cf_config.compression_algorithm = TDB_COMPRESS_NONE;
+
+    tidesdb_column_family_t *cfs[TEST_RACE_NUM_CFS];
+    char cf_name[TEST_RACE_CF_NAME_BUF];
+    for (int c = 0; c < TEST_RACE_NUM_CFS; c++)
+    {
+        snprintf(cf_name, sizeof(cf_name), TEST_RACE_CF_NAME_FMT, c);
+        ASSERT_EQ(tidesdb_create_column_family(db, cf_name, &cf_config), 0);
+        cfs[c] = tidesdb_get_column_family(db, cf_name);
+        ASSERT_TRUE(cfs[c] != NULL);
+    }
+
+    _Atomic(int) unknown_errors = 0;
+    _Atomic(int) unexpected_errors = 0;
+    _Atomic(int) syncer_stop = 0;
+
+    /* syncer thread disabled while we isolate the data loss source */
+    pthread_t syncer;
+    active_mt_race_syncer_t syncer_data = {
+        .db = db, .cfs = cfs, .num_cfs = TEST_RACE_NUM_CFS, .stop = &syncer_stop};
+    (void)syncer;
+    (void)syncer_data;
+    (void)active_mt_race_syncer_thread;
+
+    pthread_t *threads = malloc(sizeof(pthread_t) * TEST_RACE_COMMITTER_THREADS);
+    active_mt_race_writer_t *thread_data =
+        malloc(sizeof(active_mt_race_writer_t) * TEST_RACE_COMMITTER_THREADS);
+    ASSERT_TRUE(threads != NULL);
+    ASSERT_TRUE(thread_data != NULL);
+
+    printf("\n  Launching %d committer threads, each running %d transactions\n",
+           TEST_RACE_COMMITTER_THREADS, TEST_RACE_TXN_PER_COMMITTER);
+    printf("  Write buffer size %d bytes, %d cfs per commit\n", TEST_RACE_WRITE_BUFFER_BYTES,
+           TEST_RACE_NUM_CFS);
+
+    for (int i = 0; i < TEST_RACE_COMMITTER_THREADS; i++)
+    {
+        thread_data[i].db = db;
+        thread_data[i].cfs = cfs;
+        thread_data[i].num_cfs = TEST_RACE_NUM_CFS;
+        thread_data[i].thread_id = i;
+        thread_data[i].num_txns = TEST_RACE_TXN_PER_COMMITTER;
+        thread_data[i].committed_flags = calloc((size_t)TEST_RACE_TXN_PER_COMMITTER, 1);
+        ASSERT_TRUE(thread_data[i].committed_flags != NULL);
+        thread_data[i].unknown_errors = &unknown_errors;
+        thread_data[i].unexpected_errors = &unexpected_errors;
+        atomic_init(&thread_data[i].committed_count, 0);
+        pthread_create(&threads[i], NULL, active_mt_race_writer_thread, &thread_data[i]);
+    }
+
+    for (int i = 0; i < TEST_RACE_COMMITTER_THREADS; i++)
+    {
+        pthread_join(threads[i], NULL);
+    }
+
+    atomic_store(&syncer_stop, 1);
+
+    int total_committed = 0;
+    for (int i = 0; i < TEST_RACE_COMMITTER_THREADS; i++)
+    {
+        total_committed += atomic_load(&thread_data[i].committed_count);
+    }
+
+    int unknown = atomic_load(&unknown_errors);
+    int unexpected = atomic_load(&unexpected_errors);
+
+    printf("  Successful commits %d / %d\n", total_committed,
+           TEST_RACE_COMMITTER_THREADS * TEST_RACE_TXN_PER_COMMITTER);
+    printf("  TDB_ERR_UNKNOWN returns %d\n", unknown);
+    printf("  Other unexpected errors %d\n", unexpected);
+    fflush(stdout);
+
+    for (int i = 0; i < TEST_RACE_FLUSH_DRAIN_MAX_ITER; i++)
+    {
+        if (queue_size(db->flush_queue) == 0) break;
+        usleep(TEST_RACE_FLUSH_DRAIN_INT_US);
+    }
+
+    tidesdb_txn_t *verify_txn = NULL;
+    ASSERT_EQ(tidesdb_txn_begin(db, &verify_txn), 0);
+
+    int verified = 0;
+    int missing = 0;
+    char key[TEST_RACE_KEY_BUF_BYTES];
+    char expected[TEST_RACE_VAL_BUF_BYTES];
+    for (int t = 0; t < TEST_RACE_COMMITTER_THREADS; t++)
+    {
+        for (int i = 0; i < TEST_RACE_TXN_PER_COMMITTER; i++)
+        {
+            if (!thread_data[t].committed_flags[i]) continue;
+            for (int c = 0; c < TEST_RACE_NUM_CFS; c++)
+            {
+                snprintf(key, sizeof(key), TEST_RACE_KEY_FMT, c, t, i);
+                snprintf(expected, sizeof(expected), TEST_RACE_VAL_FMT, c, t, i);
+
+                uint8_t *retrieved_value = NULL;
+                size_t retrieved_size = 0;
+                int rc = tidesdb_txn_get(verify_txn, cfs[c], (uint8_t *)key, strlen(key) + 1,
+                                         &retrieved_value, &retrieved_size);
+                if (rc == 0 && retrieved_value != NULL &&
+                    strcmp((char *)retrieved_value, expected) == 0)
+                {
+                    verified++;
+                }
+                else
+                {
+                    missing++;
+                }
+                if (retrieved_value) free(retrieved_value);
+            }
+        }
+    }
+    tidesdb_txn_free(verify_txn);
+
+    int expected_total_keys = total_committed * TEST_RACE_NUM_CFS;
+    printf("  Verified %d / %d committed keys (missing %d)\n", verified, expected_total_keys,
+           missing);
+    fflush(stdout);
+
+    ASSERT_EQ(unknown, 0);
+    ASSERT_EQ(unexpected, 0);
+    ASSERT_EQ(missing, 0);
+    ASSERT_EQ(verified, expected_total_keys);
+
+    for (int i = 0; i < TEST_RACE_COMMITTER_THREADS; i++)
+    {
+        free(thread_data[i].committed_flags);
+    }
+    free(threads);
+    free(thread_data);
+
+    ASSERT_EQ(tidesdb_close(db), 0);
+    cleanup_test_dir();
+}
+
 static void test_multi_cf_transaction_atomicity_recovery(void)
 {
     cleanup_test_dir();
@@ -28125,6 +28402,121 @@ static void test_btree_cache_invalidation_on_sstable_free(void)
     cleanup_test_dir();
 }
 
+static void test_unified_bulk_commit_reset_scan(void)
+{
+    cleanup_test_dir();
+
+    tidesdb_config_t config = tidesdb_default_config();
+    config.db_path = TEST_DB_PATH;
+    config.unified_memtable = 1;
+    /* small enough that 100k ~50-byte entries rotate the memtable
+       multiple times during the run  */
+    config.unified_memtable_write_buffer_size = 1024 * 1024; /* 1 MB */
+    config.unified_memtable_sync_mode = 0;                   /* NONE */
+
+    tidesdb_t *db = NULL;
+    ASSERT_EQ(tidesdb_open(&config, &db), 0);
+    ASSERT_TRUE(db != NULL);
+
+    tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
+    ASSERT_EQ(tidesdb_create_column_family(db, "loss_cf", &cf_config), 0);
+    tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "loss_cf");
+    ASSERT_TRUE(cf != NULL);
+
+    /* we mimic mariadb per-statement shape exactly where 1000 puts split into
+       two 500-op mid-commits, then a final empty commit (the autocommit
+       hton_commit fires on an already-empty txn after the second mid-commit
+       cleared it).  next iteration recycles the same handle via reset. */
+    const int stmts = 5000;
+    const int ops_per_stmt = 1000;
+    const int batch_size = 500;
+    const int total = stmts * ops_per_stmt;
+
+    /* one long-lived txn handle, recycled via tidesdb_txn_reset every
+       ops_per_stmt puts -- exact mirror of ha_tidesdb's maybe_bulk_commit. */
+    tidesdb_txn_t *txn = NULL;
+    ASSERT_EQ(tidesdb_txn_begin_with_isolation(db, TDB_ISOLATION_READ_COMMITTED, &txn), 0);
+
+    int next_id = 1;
+    for (int s = 0; s < stmts; s++)
+    {
+        int put_in_batch = 0;
+        for (int k = 0; k < ops_per_stmt; k++)
+        {
+            uint8_t key[16];
+            uint8_t value[40];
+            int written = snprintf((char *)key, sizeof(key), "k%010d", next_id);
+            ASSERT_TRUE(written > 0 && written < (int)sizeof(key));
+            size_t key_size = (size_t)written + 1;
+            memset(value, 'v', sizeof(value));
+            value[sizeof(value) - 1] = '\0';
+
+            ASSERT_EQ(tidesdb_txn_put(txn, cf, key, key_size, value, sizeof(value), 0), 0);
+            next_id++;
+            put_in_batch++;
+
+            /* mid-statement commit at every batch_size, mirrors maybe_bulk_commit */
+            if (put_in_batch >= batch_size)
+            {
+                ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+                ASSERT_EQ(tidesdb_txn_reset(txn, TDB_ISOLATION_READ_COMMITTED), 0);
+                put_in_batch = 0;
+            }
+        }
+        /* end-of-statement commit (autocommit -> hton_commit), often empty
+           because the last mid-commit just cleared the txn */
+        ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+        ASSERT_EQ(tidesdb_txn_reset(txn, TDB_ISOLATION_READ_COMMITTED), 0);
+    }
+
+    tidesdb_txn_free(txn);
+
+    /* we scan right away without waiting for flush queue or compactions to
+       drain -- this is what the user's repro does (SELECT COUNT(*) at the
+       end of the script).  background flushes and compactions are very
+       likely still in flight. */
+    tidesdb_txn_t *rtxn = NULL;
+    ASSERT_EQ(tidesdb_txn_begin_with_isolation(db, TDB_ISOLATION_READ_COMMITTED, &rtxn), 0);
+
+    tidesdb_iter_t *iter = NULL;
+    ASSERT_EQ(tidesdb_iter_new(rtxn, cf, &iter), 0);
+    ASSERT_TRUE(iter != NULL);
+    /* mirror ha_tidesdb's rnd_init where seek with a one-byte data namespace
+       prefix instead of seek_to_first.  this routes through
+       tidesdb_iter_seek_sstable_source_forward (the path the plugin
+       actually exercises) which handles lazy SST sources differently
+       than seek_to_first. */
+    uint8_t data_prefix = 'k';
+    tidesdb_iter_seek(iter, &data_prefix, 1);
+
+    int seen = 0;
+    while (tidesdb_iter_valid(iter))
+    {
+        uint8_t *k = NULL;
+        size_t ks = 0;
+        if (tidesdb_iter_key(iter, &k, &ks) != 0) break;
+        seen++;
+        if (tidesdb_iter_next(iter) != 0) break;
+    }
+
+    tidesdb_iter_free(iter);
+    tidesdb_txn_free(rtxn);
+
+    /* if the bug fires, seen < total.  print both numbers either way so a
+       failing run shows the loss percentage in the test output.  fflush
+       so the diagnostic lands before assert() aborts the process. */
+    if (seen != total)
+    {
+        fprintf(stderr, BOLDRED "\n  scan saw %d / %d expected (%.2f%% loss)\n" RESET, seen, total,
+                100.0 * (total - seen) / total);
+        fflush(stderr);
+    }
+    ASSERT_EQ(seen, total);
+
+    tidesdb_close(db);
+    cleanup_test_dir();
+}
+
 int main(int argc, char **argv)
 {
     INIT_TEST_FILTER(argc, argv);
@@ -28140,6 +28532,7 @@ int main(int argc, char **argv)
     RUN_TEST(test_multiple_column_families, tests_passed);
     RUN_TEST(test_memtable_flush, tests_passed);
     RUN_TEST(test_background_flush_multiple_immutable_memtables, tests_passed);
+    RUN_TEST(test_active_memtable_rotation_race, tests_passed);
     RUN_TEST(test_persistence_and_recovery, tests_passed);
     RUN_TEST(test_backup_basic, tests_passed);
     RUN_TEST(test_backup_concurrent_writes, tests_passed);
@@ -28490,6 +28883,7 @@ int main(int argc, char **argv)
     RUN_TEST(test_objstore_cold_start, tests_passed);
     RUN_TEST(test_objstore_compaction_and_iterators, tests_passed);
     RUN_TEST(test_unified_iterator_consistency, tests_passed);
+    RUN_TEST(test_unified_bulk_commit_reset_scan, tests_passed);
     RUN_TEST(test_objstore_paired_eviction, tests_passed);
     RUN_TEST(test_objstore_stats, tests_passed);
     RUN_TEST(test_objstore_frozen_point_lookup, tests_passed);

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -11799,7 +11799,7 @@ static void test_background_flush_multiple_immutable_memtables(void)
  * window observed by other writers */
 #define TEST_RACE_COMMITTER_THREADS    16
 #define TEST_RACE_TXN_PER_COMMITTER    3000
-#define TEST_RACE_WRITE_BUFFER_BYTES   512
+#define TEST_RACE_WRITE_BUFFER_BYTES   4096
 #define TEST_RACE_NUM_CFS              8
 #define TEST_RACE_KEY_BUF_BYTES        48
 #define TEST_RACE_VAL_BUF_BYTES        96

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -27307,6 +27307,199 @@ static void test_tombstone_stats_observability(void)
     cleanup_test_dir();
 }
 
+/*** witness path drops tombstones at non-largest target when no older sstable
+ **  can possibly contain the key. setup keeps deeper levels empty so the helper
+ *   walks them and sees nothing. expectation is that after the density trigger
+ **  fires and the merge runs, total_tombstones converges to zero even though
+ *** the merge target is not the largest level. */
+static void test_tombstone_witness_drops_when_no_older(void)
+{
+    cleanup_test_dir();
+    tidesdb_t *db = create_test_db();
+    tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
+    cf_config.compression_algorithm = TDB_COMPRESS_NONE;
+    cf_config.write_buffer_size = 4096;
+    cf_config.l1_file_count_trigger = 1000;
+    cf_config.tombstone_density_trigger = 0.5;
+    cf_config.tombstone_density_min_entries = 8;
+    cf_config.enable_bloom_filter = 1;
+    cf_config.bloom_fpr = 0.01;
+
+    ASSERT_EQ(tidesdb_create_column_family(db, "twno_cf", &cf_config), 0);
+    tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "twno_cf");
+    ASSERT_TRUE(cf != NULL);
+
+    const int num_keys = 200;
+
+    for (int i = 0; i < num_keys; i++) td_put(db, cf, i);
+    tidesdb_flush_memtable(cf);
+    wait_for_flush_complete(db, cf);
+
+    for (int i = 0; i < num_keys; i++) td_delete(db, cf, i);
+    tidesdb_flush_memtable(cf);
+    wait_for_flush_complete(db, cf);
+    wait_for_compaction_idle(db, cf);
+
+    tidesdb_stats_t *stats = NULL;
+    ASSERT_EQ(tidesdb_get_stats(cf, &stats), 0);
+    ASSERT_TRUE(stats != NULL);
+    ASSERT_EQ((int)stats->total_tombstones, 0);
+    tidesdb_free_stats(stats);
+
+    /* every key must read as NOT_FOUND, the deletes are still observable */
+    for (int i = 0; i < num_keys; i += 17)
+    {
+        tidesdb_txn_t *txn = NULL;
+        ASSERT_EQ(tidesdb_txn_begin(db, &txn), 0);
+        char key[32];
+        snprintf(key, sizeof(key), "tdkey_%06d", i);
+        uint8_t *val = NULL;
+        size_t vs = 0;
+        ASSERT_EQ(tidesdb_txn_get(txn, cf, (uint8_t *)key, strlen(key) + 1, &val, &vs),
+                  TDB_ERR_NOT_FOUND);
+        tidesdb_txn_free(txn);
+    }
+
+    ASSERT_EQ(tidesdb_close(db), TDB_SUCCESS);
+    cleanup_test_dir();
+}
+
+/*** witness path preserves tombstones when an older sstable at a deeper level
+ **  may still contain the masked put. setup sinks an older put into a deep
+ *   level via repeated flush+compact, then layers a tombstone for the same key
+ **  at L1. the merge would rule the deletion safe to drop only if the helper
+ *** told it nothing older holds the key, which here it cannot. correctness
+ **  bar is that the deleted key reads as NOT_FOUND after the witness path
+ *   runs. tombstones may or may not still be present depending on which level
+ **  the merge landed in. */
+static void test_tombstone_witness_preserves_when_older_exists(void)
+{
+    cleanup_test_dir();
+    tidesdb_t *db = create_test_db();
+    tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
+    cf_config.compression_algorithm = TDB_COMPRESS_NONE;
+    cf_config.write_buffer_size = 4096;
+    cf_config.l1_file_count_trigger = 4;
+    cf_config.tombstone_density_trigger = 0.5;
+    cf_config.tombstone_density_min_entries = 8;
+    cf_config.enable_bloom_filter = 1;
+    cf_config.bloom_fpr = 0.01;
+    cf_config.min_levels = 3;
+
+    ASSERT_EQ(tidesdb_create_column_family(db, "twpe_cf", &cf_config), 0);
+    tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "twpe_cf");
+    ASSERT_TRUE(cf != NULL);
+
+    const int num_keys = 100;
+
+    /* first wave of puts, push them down the tree by triggering several
+     * structural compactions before the deletes arrive */
+    for (int wave = 0; wave < 5; wave++)
+    {
+        for (int i = 0; i < num_keys; i++) td_put(db, cf, i);
+        tidesdb_flush_memtable(cf);
+        wait_for_flush_complete(db, cf);
+        ASSERT_EQ(tidesdb_compact(cf), TDB_SUCCESS);
+        wait_for_compaction_idle(db, cf);
+    }
+
+    /* tombstones for the same keys at L1, density above the trigger */
+    for (int i = 0; i < num_keys; i++) td_delete(db, cf, i);
+    tidesdb_flush_memtable(cf);
+    wait_for_flush_complete(db, cf);
+    wait_for_compaction_idle(db, cf);
+
+    /* correctness, every deleted key must be invisible regardless of which
+     * level the surviving tombstones (if any) ended up at */
+    for (int i = 0; i < num_keys; i += 7)
+    {
+        tidesdb_txn_t *txn = NULL;
+        ASSERT_EQ(tidesdb_txn_begin(db, &txn), 0);
+        char key[32];
+        snprintf(key, sizeof(key), "tdkey_%06d", i);
+        uint8_t *val = NULL;
+        size_t vs = 0;
+        ASSERT_EQ(tidesdb_txn_get(txn, cf, (uint8_t *)key, strlen(key) + 1, &val, &vs),
+                  TDB_ERR_NOT_FOUND);
+        tidesdb_txn_free(txn);
+    }
+
+    ASSERT_EQ(tidesdb_close(db), TDB_SUCCESS);
+    cleanup_test_dir();
+}
+
+/*** tidesdb_compact_range is operator-driven reclaim and threads
+ **  witness_triggered=1 into the targeted merge. expectation is that the
+ *   tombstones from a range delete drop within the targeted slice when no
+ **  older sstable holds the key. */
+static void test_tombstone_compact_range_drops(void)
+{
+    cleanup_test_dir();
+    tidesdb_t *db = create_test_db();
+    tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
+    cf_config.compression_algorithm = TDB_COMPRESS_NONE;
+    cf_config.write_buffer_size = 4096;
+    cf_config.enable_bloom_filter = 1;
+    cf_config.bloom_fpr = 0.01;
+
+    ASSERT_EQ(tidesdb_create_column_family(db, "tcrd_cf", &cf_config), 0);
+    tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "tcrd_cf");
+    ASSERT_TRUE(cf != NULL);
+
+    const int num_keys = 300;
+    for (int i = 0; i < num_keys; i++) td_put(db, cf, i);
+    tidesdb_flush_memtable(cf);
+    wait_for_flush_complete(db, cf);
+
+    /* delete a contiguous middle slice, then call the targeted compaction
+     * api over exactly that range */
+    const int del_lo = num_keys * 30 / 100;
+    const int del_hi = num_keys * 70 / 100;
+    for (int i = del_lo; i < del_hi; i++) td_delete(db, cf, i);
+    tidesdb_flush_memtable(cf);
+    wait_for_flush_complete(db, cf);
+
+    char start_key[32];
+    char end_key[32];
+    snprintf(start_key, sizeof(start_key), "tdkey_%06d", del_lo);
+    snprintf(end_key, sizeof(end_key), "tdkey_%06d", del_hi);
+    ASSERT_EQ(tidesdb_compact_range(cf, (uint8_t *)start_key, strlen(start_key) + 1,
+                                    (uint8_t *)end_key, strlen(end_key) + 1),
+              TDB_SUCCESS);
+    wait_for_compaction_idle(db, cf);
+
+    tidesdb_stats_t *stats = NULL;
+    ASSERT_EQ(tidesdb_get_stats(cf, &stats), 0);
+    ASSERT_TRUE(stats != NULL);
+    ASSERT_EQ((int)stats->total_tombstones, 0);
+    tidesdb_free_stats(stats);
+
+    /* keys outside the range still readable, keys inside still hidden */
+    for (int i = 0; i < num_keys; i += 11)
+    {
+        tidesdb_txn_t *txn = NULL;
+        ASSERT_EQ(tidesdb_txn_begin(db, &txn), 0);
+        char key[32];
+        snprintf(key, sizeof(key), "tdkey_%06d", i);
+        uint8_t *val = NULL;
+        size_t vs = 0;
+        const int rc = tidesdb_txn_get(txn, cf, (uint8_t *)key, strlen(key) + 1, &val, &vs);
+        if (i >= del_lo && i < del_hi)
+        {
+            ASSERT_EQ(rc, TDB_ERR_NOT_FOUND);
+        }
+        else
+        {
+            ASSERT_EQ(rc, TDB_SUCCESS);
+            free(val);
+        }
+        tidesdb_txn_free(txn);
+    }
+
+    ASSERT_EQ(tidesdb_close(db), TDB_SUCCESS);
+    cleanup_test_dir();
+}
+
 static void test_tombstone_count_heavy_compaction(void)
 {
     cleanup_test_dir();
@@ -27706,7 +27899,7 @@ static void test_compact_range_partial_range(void)
     tidesdb_flush_memtable(cf);
     wait_for_flush_complete(db, cf);
 
-    /* compact only the deleted range -- keys outside the range may incidentally
+    /* we compact only the deleted range -- keys outside the range may incidentally
      * get rewritten if they live in the same sstables, which is by design */
     char start[32];
     char end[32];
@@ -27890,7 +28083,7 @@ static void test_btree_cache_invalidation_on_sstable_free(void)
     wait_for_flush_complete(db, cf);
     wait_for_compaction_idle(db, cf);
 
-    /* read every key to populate the btree node cache */
+    /* we read every key to populate the btree node cache */
     {
         tidesdb_txn_t *txn = NULL;
         ASSERT_EQ(tidesdb_txn_begin(db, &txn), 0);
@@ -27911,7 +28104,7 @@ static void test_btree_cache_invalidation_on_sstable_free(void)
     clock_cache_get_stats(db->btree_node_cache, &before);
     ASSERT_TRUE(before.total_entries > 0);
 
-    /* compact all the way through every level so the original sstables get freed
+    /* we compact all the way through every level so the original sstables get freed
      * and trigger tidesdb_invalidate_btree_cache_for_sstable for each */
     for (int i = 0; i < 8; i++)
     {
@@ -28262,6 +28455,9 @@ int main(int argc, char **argv)
     RUN_TEST(test_tombstone_density_trigger_fires, tests_passed);
     RUN_TEST(test_tombstone_density_trigger_ignores_tiny, tests_passed);
     RUN_TEST(test_tombstone_stats_observability, tests_passed);
+    RUN_TEST(test_tombstone_witness_drops_when_no_older, tests_passed);
+    RUN_TEST(test_tombstone_witness_preserves_when_older_exists, tests_passed);
+    RUN_TEST(test_tombstone_compact_range_drops, tests_passed);
     RUN_TEST(test_tombstone_count_heavy_compaction, tests_passed);
     RUN_TEST(test_tombstone_count_cascade_invariants, tests_passed);
     RUN_TEST(test_tombstone_count_unified_memtable, tests_passed);

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -12002,7 +12002,9 @@ static void test_active_memtable_rotation_race(void)
 
     for (int i = 0; i < TEST_RACE_FLUSH_DRAIN_MAX_ITER; i++)
     {
-        if (queue_size(db->flush_queue) == 0) break;
+        if (queue_size(db->flush_queue) == 0 &&
+            atomic_load_explicit(&db->flush_pending_count, memory_order_acquire) == 0)
+            break;
         usleep(TEST_RACE_FLUSH_DRAIN_INT_US);
     }
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tidesdb",
-  "version-string": "9.2.0",
+  "version-string": "9.2.1",
   "description": "TidesDB is a high-performance durable, transactional embeddable storage engine designed for flash and RAM optimization with optional object storage support for unlimited data scaling.",
   "dependencies": ["zstd", "snappy", "lz4", "pthreads"],
   "features": {


### PR DESCRIPTION
bloom and range aware early tombstone drop on density witness merges

addresses upstream tidesql issue 125 at github.com/tidesdb/tidesql/issues/125

before this change the only rule that let a merge discard tombstones was target_level equal to largest_level. tombstones at any other target had to be preserved because a deeper level could still hold an older live value for the same key. the density witness path therefore could not actually reclaim until later rounds dragged the dense sstable to the largest level, which is the bulk of the read amp pain mark callaghan flagged.

this patch adds a per key check used only when a merge was scheduled by the tombstone density witness (witness_triggered equals 1). for each tombstone considered for drop the helper walks every level deeper than target, and per sstable skips when min_key max_key does not cover the key (single comparator call, common case). on range hit it consults the sstable bloom filter, where misses are one sided so a definitive miss is trustworthy. on range hit with bloom hit, or on range hit with no bloom present, the tombstone is conservatively kept.

if no deeper sstable claims the key the tombstone is dropped at the non largest target. fallback to the existing rule happens when range bounds are missing on a deeper sstable, when the cf opted out of bloom filters and a deeper range overlaps, and when the cf is single level so target already names the largest level.

the witness flag is plumbed through tidesdb_trigger_compaction and the underlying spooky merge entry points (full preemptive, dividing, partitioned, targeted) so the helper only runs where there is reason to believe reclaim will pay for the extra checks. structural triggers (file count, size) keep the original semantics with witness equal to 0.

tidesdb_compact_range passes witness equal to 1 unconditionally since the caller is explicitly asking for reclaim over a slice. tidesdb_compact stays at witness equal to 0 for callers expecting the old behavior.

three tests cover the new branches. drop fires when no older sstable holds the key, drop is suppressed when an older sstable does, and the public compact_range api drops on the same path