### PR TITLE
issue #618 on Linux, TidesDB was hard-coding -lzstd -lsnappy -llz4, w…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ if(TIDESDB_WITH_SANITIZER)
     if(MSVC)
         # debug flags for MSVC
         # MSVC ASAN can be unstable, so we only enable warnings for CI
-        # suppress noisy warnings: 4311 (pointer truncation), 4244 (conversion), 4047 (pointer indirection)
+        # suppress noisy warnings 4311 (pointer truncation), 4244 (conversion), 4047 (pointer indirection)
         # 4127 (constant expression in conditional), 4305 (type truncation),
         # 4702 (unreachable code -- triggered inside uthash macro expansions in the bench)
         add_compile_options(/W4 /std:c17 /experimental:c11atomics /wd4311 /wd4244 /wd4047 /wd4189 /wd4101 /wd4459 /wd4127 /wd4305 /wd4702)
@@ -111,7 +111,7 @@ endif()
 include_directories(external) # for external libraries linking internally
 
 # create library (respects BUILD_SHARED_LIBS option)
-# note: on Windows, STATIC is recommended to avoid DLL export/import complexity
+# note on Windows, STATIC is recommended to avoid DLL export/import complexity
 # users can override with -DBUILD_SHARED_LIBS=ON/OFF
 set(TIDESDB_SOURCES
     src/tidesdb.c src/block_manager.c src/skip_list.c src/compress.c src/bloom_filter.c
@@ -132,8 +132,8 @@ target_include_directories(tidesdb PRIVATE src)
 
 # find compression libraries.
 # MSVC builds rely on vcpkg, which ships full CMake config packages.
-# MinGW (MSYS2): zstd and lz4 ship only pkg-config (.pc) files, no CMake
-# configs, so use PkgConfig for them. snappy is the opposite: upstream
+# MinGW (MSYS2) zstd and lz4 ship only pkg-config (.pc) files, no CMake
+# configs, so use PkgConfig for them. snappy is the opposite, upstream
 # snappy installs SnappyConfig.cmake but no .pc (so the x86 from-source
 # build in CI cannot use pkg-config), while MSYS2's prebuilt snappy ships
 # both. CONFIG mode works for snappy across all three setups.
@@ -373,7 +373,7 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "DragonFly")
     endif()
 elseif(CMAKE_SYSTEM_NAME STREQUAL "SunOS")
     # OmniOS/Illumos -- OpenIndiana Community Edition packages in /opt/ooce
-    # Note: snappy is not available in OmniOS repos, using only lz4 and zstd
+    # Note that snappy is not available in OmniOS repos, using only lz4 and zstd
     target_include_directories(tidesdb PUBLIC /opt/ooce/include /usr/include)
     target_link_directories(tidesdb PUBLIC /opt/ooce/lib/amd64 /usr/lib/amd64)
     target_link_libraries(tidesdb PUBLIC
@@ -393,12 +393,40 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "SunOS")
     endif()
 else()
     # for linux and other unix systems
-    # we use -l flags to avoid collision with CMake MODULE targets that some distros
-    # (e.g. Oracle Linux 8, RHEL 8) ship in their zstd-devel CMake configs
+    # prefer a CMake target if a parent project (FetchContent / add_subdirectory)
+    # has already created one for the compression lib; otherwise fall back to a
+    # bare -l<name> linker flag. the -l fallback exists because some distros
+    # (e.g. Oracle Linux 8, RHEL 8) ship zstd-devel CMake configs that define
+    # zstd::libzstd as a MODULE target and break find_package(zstd CONFIG) for
+    # plain linking. the if(TARGET ...) probe is safe as it only matches when the
+    # parent build has already produced the target, so stand-alone builds on
+    # those distros still take the -l path exactly like before.
+    function(_tidesdb_link_compression libname)
+        set(candidates "")
+        if(libname STREQUAL "zstd")
+            list(APPEND candidates
+                    zstd::libzstd_shared zstd::libzstd_static zstd::libzstd
+                    libzstd_shared libzstd_static libzstd zstd)
+        elseif(libname STREQUAL "snappy")
+            list(APPEND candidates Snappy::snappy snappy)
+        elseif(libname STREQUAL "lz4")
+            list(APPEND candidates lz4::lz4 LZ4::lz4 lz4)
+        endif()
+        foreach(tgt IN LISTS candidates)
+            if(TARGET ${tgt})
+                target_link_libraries(tidesdb PUBLIC ${tgt})
+                message(STATUS "tidesdb: linking ${libname} via existing target ${tgt}")
+                return()
+            endif()
+        endforeach()
+        target_link_libraries(tidesdb PUBLIC -l${libname})
+    endfunction()
+
+    _tidesdb_link_compression(zstd)
+    _tidesdb_link_compression(snappy)
+    _tidesdb_link_compression(lz4)
+
     target_link_libraries(tidesdb PUBLIC
-            -lzstd
-            -lsnappy
-            -llz4
             pthread
             m           # math library
             stdc++      # C++ standard library (required by Snappy)

--- a/src/objstore_fs.c
+++ b/src/objstore_fs.c
@@ -265,23 +265,28 @@ static int fs_exists(void *ctx, const char *key, size_t *size_out)
 }
 
 /**
- * fs_list_recurse
- * recursively walk a directory and invoke the callback for each regular file
- * @param dir_path directory to walk
- * @param root_dir root directory for computing relative keys
- * @param root_len length of root_dir string
- * @param cb callback invoked for each file (key, size, cb_ctx)
+ * fs_list_walk
+ * recursively walk abs_dir and invoke cb for each regular file whose
+ * relative key starts with prefix. subdirectories whose relative path
+ * already diverges from prefix are not descended into.
+ * @param abs_dir absolute filesystem path of the directory to walk
+ * @param rel_dir relative key path of abs_dir within the store ("" at root)
+ * @param rel_dir_len cached strlen(rel_dir)
+ * @param prefix target key prefix
+ * @param prefix_len cached strlen(prefix)
+ * @param cb callback invoked for each matching file (key, size, cb_ctx)
  * @param cb_ctx opaque context passed to callback
- * @param count running count of objects listed
- * @return updated count of objects listed
+ * @param count running count of objects emitted
+ * @return updated count
  */
-static int fs_list_recurse(const char *dir_path, const char *root_dir, size_t root_len,
-                           void (*cb)(const char *key, size_t size, void *cb_ctx), void *cb_ctx,
-                           int count)
+static int fs_list_walk(const char *abs_dir, const char *rel_dir, size_t rel_dir_len,
+                        const char *prefix, size_t prefix_len,
+                        void (*cb)(const char *key, size_t size, void *cb_ctx), void *cb_ctx,
+                        int count)
 {
 #ifdef _WIN32
-    char pattern[TDB_FS_MAX_PATH];
-    snprintf(pattern, sizeof(pattern), "%s\\*", dir_path);
+    char pattern[TDB_FS_MAX_PATH * 2];
+    snprintf(pattern, sizeof(pattern), "%s\\*", abs_dir);
 
     struct _finddata_t fd;
     intptr_t handle = _findfirst(pattern, &fd);
@@ -289,62 +294,103 @@ static int fs_list_recurse(const char *dir_path, const char *root_dir, size_t ro
 
     do
     {
-        if (fd.name[0] == '.') continue;
+        if (fd.name[0] == '.' && (fd.name[1] == '\0' || (fd.name[1] == '.' && fd.name[2] == '\0')))
+            continue;
 
-        char full[TDB_FS_MAX_PATH * 2];
-        snprintf(full, sizeof(full), "%s\\%s", dir_path, fd.name);
+        char child_rel[TDB_FS_MAX_PATH];
+        int n = (rel_dir_len == 0)
+                    ? snprintf(child_rel, sizeof(child_rel), "%s", fd.name)
+                    : snprintf(child_rel, sizeof(child_rel), "%s/%s", rel_dir, fd.name);
+        if (n < 0 || (size_t)n >= sizeof(child_rel)) continue;
+        size_t child_rel_len = (size_t)n;
 
         if (fd.attrib & _A_SUBDIR)
         {
-            count = fs_list_recurse(full, root_dir, root_len, cb, cb_ctx, count);
-        }
-        else
-        {
-            const char *relative = full + root_len;
-            if (*relative == '/' || *relative == '\\') relative++;
+            size_t cmp = child_rel_len < prefix_len ? child_rel_len : prefix_len;
+            if (cmp && strncmp(child_rel, prefix, cmp) != 0) continue;
 
-            /** the must normalize backslashes to forward slashes so object keys are
-             *  platform-independent (e.g. "cf_name/MANIFEST" not "cf_name\MANIFEST") */
-            char normalized[TDB_FS_MAX_PATH];
-            strncpy(normalized, relative, sizeof(normalized) - 1);
-            normalized[sizeof(normalized) - 1] = '\0';
-            for (char *p = normalized; *p; p++)
-            {
-                if (*p == '\\') *p = '/';
-            }
-
-            cb(normalized, (size_t)fd.size, cb_ctx);
-            count++;
+            char child_abs[TDB_FS_MAX_PATH * 2];
+            snprintf(child_abs, sizeof(child_abs), "%s\\%s", abs_dir, fd.name);
+            count = fs_list_walk(child_abs, child_rel, child_rel_len, prefix, prefix_len, cb,
+                                 cb_ctx, count);
+            continue;
         }
+
+        if (prefix_len != 0 &&
+            (child_rel_len < prefix_len || strncmp(child_rel, prefix, prefix_len) != 0))
+            continue;
+
+        cb(child_rel, (size_t)fd.size, cb_ctx);
+        count++;
     } while (_findnext(handle, &fd) == 0);
 
     _findclose(handle);
 #else
-    DIR *d = opendir(dir_path);
+    DIR *d = opendir(abs_dir);
     if (!d) return count;
 
     struct dirent *ent;
     while ((ent = readdir(d)) != NULL)
     {
-        if (ent->d_name[0] == '.') continue;
+        if (ent->d_name[0] == '.' &&
+            (ent->d_name[1] == '\0' || (ent->d_name[1] == '.' && ent->d_name[2] == '\0')))
+            continue;
 
-        char full[TDB_FS_MAX_PATH * 2];
-        snprintf(full, sizeof(full), "%s/%s", dir_path, ent->d_name);
+        char child_rel[TDB_FS_MAX_PATH];
+        int n = (rel_dir_len == 0)
+                    ? snprintf(child_rel, sizeof(child_rel), "%s", ent->d_name)
+                    : snprintf(child_rel, sizeof(child_rel), "%s/%s", rel_dir, ent->d_name);
+        if (n < 0 || (size_t)n >= sizeof(child_rel)) continue;
+        size_t child_rel_len = (size_t)n;
 
-        struct stat st;
-        if (stat(full, &st) != 0) continue;
-
-        if (S_ISDIR(st.st_mode))
-        {
-            count = fs_list_recurse(full, root_dir, root_len, cb, cb_ctx, count);
-        }
+        /* prefer dirent::d_type; fall back to stat() only when the FS reports DT_UNKNOWN */
+        int is_dir = 0, is_reg = 0;
+#ifdef DT_DIR
+        if (ent->d_type == DT_DIR)
+            is_dir = 1;
+        else if (ent->d_type == DT_REG)
+            is_reg = 1;
+        else if (ent->d_type != DT_UNKNOWN)
+            continue;
         else
+#endif
         {
-            const char *relative = full + root_len;
-            if (*relative == '/') relative++;
-            cb(relative, (size_t)st.st_size, cb_ctx);
-            count++;
+            char child_abs[TDB_FS_MAX_PATH * 2];
+            snprintf(child_abs, sizeof(child_abs), "%s/%s", abs_dir, ent->d_name);
+            struct stat st;
+            if (stat(child_abs, &st) != 0) continue;
+            if (S_ISDIR(st.st_mode))
+                is_dir = 1;
+            else if (S_ISREG(st.st_mode))
+                is_reg = 1;
+            else
+                continue;
         }
+
+        if (is_dir)
+        {
+            size_t cmp = child_rel_len < prefix_len ? child_rel_len : prefix_len;
+            if (cmp && strncmp(child_rel, prefix, cmp) != 0) continue;
+
+            char child_abs[TDB_FS_MAX_PATH * 2];
+            snprintf(child_abs, sizeof(child_abs), "%s/%s", abs_dir, ent->d_name);
+            count = fs_list_walk(child_abs, child_rel, child_rel_len, prefix, prefix_len, cb,
+                                 cb_ctx, count);
+            continue;
+        }
+
+        if (!is_reg) continue;
+
+        if (prefix_len != 0 &&
+            (child_rel_len < prefix_len || strncmp(child_rel, prefix, prefix_len) != 0))
+            continue;
+
+        char child_abs[TDB_FS_MAX_PATH * 2];
+        snprintf(child_abs, sizeof(child_abs), "%s/%s", abs_dir, ent->d_name);
+        struct stat st;
+        if (stat(child_abs, &st) != 0) continue;
+        cb(child_rel, (size_t)st.st_size, cb_ctx);
+        count++;
     }
 
     closedir(d);
@@ -354,9 +400,11 @@ static int fs_list_recurse(const char *dir_path, const char *root_dir, size_t ro
 
 /**
  * fs_list
- * enumerate all objects under a key prefix
+ * enumerate all objects whose key starts with prefix. matches S3
+ * ListObjectsV2(prefix=...) semantics: the prefix is matched byte-wise
+ * against the key and need not align to a directory boundary.
  * @param ctx opaque connector context
- * @param prefix key prefix to list (e.g. "cf_name/")
+ * @param prefix key prefix to list (e.g. "cf_name/" or "uwal_")
  * @param cb callback invoked for each object (key, size, cb_ctx)
  * @param cb_ctx opaque context passed to callback
  * @return number of objects listed, -1 on error
@@ -365,17 +413,34 @@ static int fs_list(void *ctx, const char *prefix,
                    void (*cb)(const char *key, size_t size, void *cb_ctx), void *cb_ctx)
 {
     fs_ctx_t *fs = (fs_ctx_t *)ctx;
-    char dir_path[TDB_FS_MAX_PATH + TDB_FS_MAX_PATH];
 
-    snprintf(dir_path, sizeof(dir_path), "%s/%s", fs->root_dir, prefix);
-
-    size_t len = strlen(dir_path);
-    while (len > 0 && (dir_path[len - 1] == '/' || dir_path[len - 1] == '\\'))
+    /* descend straight to the deepest directory component embedded in prefix
+     * so we don't walk ancestors that cannot contain a matching key */
+    const char *last_sep = strrchr(prefix, '/');
+#ifdef _WIN32
     {
-        dir_path[--len] = '\0';
+        const char *bs = strrchr(prefix, '\\');
+        if (bs && (!last_sep || bs > last_sep)) last_sep = bs;
+    }
+#endif
+
+    char start_abs[TDB_FS_MAX_PATH * 2];
+    char start_rel[TDB_FS_MAX_PATH];
+    size_t start_rel_len = 0;
+    if (last_sep && last_sep != prefix)
+    {
+        size_t dir_len = (size_t)(last_sep - prefix);
+        snprintf(start_abs, sizeof(start_abs), "%s/%.*s", fs->root_dir, (int)dir_len, prefix);
+        snprintf(start_rel, sizeof(start_rel), "%.*s", (int)dir_len, prefix);
+        start_rel_len = dir_len;
+    }
+    else
+    {
+        snprintf(start_abs, sizeof(start_abs), "%s", fs->root_dir);
+        start_rel[0] = '\0';
     }
 
-    return fs_list_recurse(dir_path, fs->root_dir, strlen(fs->root_dir), cb, cb_ctx, 0);
+    return fs_list_walk(start_abs, start_rel, start_rel_len, prefix, strlen(prefix), cb, cb_ctx, 0);
 }
 
 /**

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -5138,8 +5138,11 @@ static int tdb_replica_replay_single_wal(tidesdb_t *db, const char *wal_local,
                     remaining -= value_size_u64;
                 }
 
-                /* we skip entries already replayed (idempotent) */
-                if (seq_value <= max_seq) continue;
+                /* skip entries strictly below max_seq; equal-seq entries are
+                 * sibling puts from the same txn (one commit_seq, many keys)
+                 * and must all be applied. skip_list_put_with_seq rejects
+                 * duplicate (key, seq) pairs, so re-replay is harmless. */
+                if (seq_value < max_seq) continue;
 
                 const size_t pk_total = TDB_UNIFIED_CF_PREFIX_SIZE + key_size_u64;
                 TDB_PREFIXED_KEY_ALLOC(prefixed, pk_total, _pk_stack_r);
@@ -5248,7 +5251,10 @@ static void tdb_replica_replay_wal(tidesdb_t *db)
     char wal_local[TDB_MAX_PATH_LEN];
     snprintf(wal_local, sizeof(wal_local), "%s" PATH_SEPARATOR TDB_REPLICA_WAL_TMP, db->db_path);
 
-    uint64_t max_seq = atomic_load_explicit(&db->global_seq, memory_order_acquire);
+    /* global_seq is the next seq to assign; max_seq here means the highest
+     * seq already applied, so derive it by subtracting one (clamped at 0) */
+    uint64_t cur_global = atomic_load_explicit(&db->global_seq, memory_order_acquire);
+    uint64_t max_seq = cur_global > 0 ? cur_global - 1 : 0;
     int total_replayed = 0;
 
     for (int wi = 0; wi < discovery.count; wi++)
@@ -17583,6 +17589,23 @@ int tidesdb_open(const tidesdb_config_t *config, tidesdb_t **db)
 
     memcpy(&(*db)->config, config, sizeof(tidesdb_config_t));
 
+    /* object_store_config is a caller-owned pointer the user typically passes
+     * from a stack variable -- deep-copy it so the db keeps a stable view
+     * even after the caller's frame is gone */
+    if (config->object_store_config)
+    {
+        tidesdb_objstore_config_t *owned = malloc(sizeof(tidesdb_objstore_config_t));
+        if (!owned)
+        {
+            free((*db)->db_path);
+            free(*db);
+            *db = NULL;
+            return TDB_ERR_MEMORY;
+        }
+        memcpy(owned, config->object_store_config, sizeof(tidesdb_objstore_config_t));
+        (*db)->config.object_store_config = owned;
+    }
+
     /* object store mode requires unified memtable!! */
     if ((*db)->config.object_store != NULL && !(*db)->config.unified_memtable)
     {
@@ -19072,6 +19095,12 @@ int tidesdb_close(tidesdb_t *db)
     }
 
     free(db->db_path);
+    /* free the owned copy of object_store_config created in tidesdb_open */
+    if (db->config.object_store_config)
+    {
+        free((tidesdb_objstore_config_t *)db->config.object_store_config);
+        db->config.object_store_config = NULL;
+    }
 
     if (db->clock_cache)
     {
@@ -20067,6 +20096,13 @@ int tidesdb_create_column_family(tidesdb_t *db, const char *name,
     if (db->object_store && save_result == TDB_SUCCESS)
     {
         tdb_objstore_upload_file_sync(db, config_path);
+
+        /* commit + upload the empty MANIFEST so replicas can discover this CF
+         * before its first flush -- discovery keys off <cf>/MANIFEST */
+        if (tidesdb_manifest_commit(cf->manifest, cf->manifest->path) == 0)
+        {
+            tdb_objstore_upload_file_sync(db, cf->manifest->path);
+        }
     }
 
     TDB_DEBUG_LOG(TDB_LOG_INFO, "Created CF '%s' (total: %d)", name, db->num_column_families);

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -26356,6 +26356,96 @@ static void test_objstore_frozen_point_lookup(void)
     cleanup_test_dir();
 }
 
+/* counts list() callback invocations */
+typedef struct
+{
+    int count;
+} list_count_ctx_t;
+
+static void list_count_cb(const char *key, size_t size, void *cb_ctx)
+{
+    (void)key;
+    (void)size;
+    ((list_count_ctx_t *)cb_ctx)->count++;
+}
+
+static void test_objstore_list_prefix(void)
+{
+    cleanup_test_dir();
+    const char *objstore_dir = "./test_list_prefix_store";
+    remove_directory(objstore_dir);
+
+    tidesdb_objstore_t *store = tidesdb_objstore_fs_create(objstore_dir);
+    ASSERT_TRUE(store != NULL);
+
+    tidesdb_objstore_config_t os_cfg = tidesdb_objstore_default_config();
+    os_cfg.wal_sync_on_commit = 1; /* sync-upload the unified WAL on every commit */
+    os_cfg.replicate_wal = 1;
+
+    tidesdb_config_t config = tidesdb_default_config();
+    config.db_path = TEST_DB_PATH;
+    config.object_store = store;
+    config.object_store_config = &os_cfg;
+    /* deliberately large write buffer so the 3 small writes below stay in the
+     * active memtable (no rotation, no sstable upload, the unified WAL is the
+     * only object at the store root besides UNIMAP) */
+    config.unified_memtable_write_buffer_size = 64ULL * 1024 * 1024;
+
+    tidesdb_t *db = NULL;
+    ASSERT_EQ(tidesdb_open(&config, &db), 0);
+    ASSERT_TRUE(db->unified_mt.enabled);
+
+    tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
+    ASSERT_EQ(tidesdb_create_column_family(db, "list_prefix_cf", &cf_config), 0);
+    tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "list_prefix_cf");
+    ASSERT_TRUE(cf != NULL);
+
+    for (int i = 0; i < 3; i++)
+    {
+        tidesdb_txn_t *txn = NULL;
+        ASSERT_EQ(tidesdb_txn_begin(db, &txn), 0);
+        char key[64], value[64];
+        snprintf(key, sizeof(key), "lpkey_%04d", i);
+        snprintf(value, sizeof(value), "lpval_%04d", i);
+        ASSERT_EQ(tidesdb_txn_put(txn, cf, (uint8_t *)key, strlen(key) + 1, (uint8_t *)value,
+                                  strlen(value) + 1, 0),
+                  0);
+        ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+        tidesdb_txn_free(txn);
+    }
+
+    /* still pre-rotation -- the WAL is the only root-level object we expect */
+    ASSERT_EQ(queue_size(db->flush_queue), 0);
+    ASSERT_FALSE(atomic_load(&db->unified_mt.is_flushing));
+
+    /* probe with a second connector handle, mirroring how a replica process
+     * would see the shared store */
+    tidesdb_objstore_t *probe = tidesdb_objstore_fs_create(objstore_dir);
+    ASSERT_TRUE(probe != NULL);
+
+    size_t wal_obj_size = 0;
+    int wal_present = probe->exists(probe->ctx, "uwal_0.log", &wal_obj_size);
+    printf("  list_prefix: uwal_0.log present=%d size=%zu bytes\n", wal_present, wal_obj_size);
+    fflush(stdout);
+    ASSERT_EQ(wal_present, 1); /* fs_exists returns 1 when present, 0 when missing */
+    ASSERT_TRUE(wal_obj_size > 0);
+
+    list_count_ctx_t lctx = {0};
+    int listed = probe->list(probe->ctx, "uwal_", list_count_cb, &lctx);
+    printf("  list_prefix: list(\"uwal_\") returned %d entries (cb_count=%d)\n", listed,
+           lctx.count);
+    fflush(stdout);
+    ASSERT_TRUE(lctx.count >= 1);
+    ASSERT_TRUE(listed >= 1);
+
+    probe->destroy(probe->ctx);
+    free(probe);
+
+    tidesdb_close(db);
+    remove_directory(objstore_dir);
+    cleanup_test_dir();
+}
+
 static void test_objstore_wal_sync_on_commit(void)
 {
     cleanup_test_dir();
@@ -28629,6 +28719,7 @@ int main(int argc, char **argv)
     RUN_TEST(test_objstore_paired_eviction, tests_passed);
     RUN_TEST(test_objstore_stats, tests_passed);
     RUN_TEST(test_objstore_frozen_point_lookup, tests_passed);
+    RUN_TEST(test_objstore_list_prefix, tests_passed);
     RUN_TEST(test_objstore_wal_sync_on_commit, tests_passed);
     RUN_TEST(test_btree_multi_cf_vlog_isolation, tests_passed);
     RUN_TEST(test_replica_mode, tests_passed);


### PR DESCRIPTION
…hich forces the linker to

resolve against system-installed libraries and silently bypasses any imported targets a parent project (FetchContent / add_subdirectory) had already created. I added a _tidesdb_link_compression helper in CMakeLists.txt that first probes for common imported target names (e.g. zstd::libzstd_static, Snappy::snappy, lz4::lz4) and only falls back to -l<name> when none exist, so stand-alone builds on RHEL/Oracle 8 keep the original behavior, and consumers who vendor their own compression libs get them picked up correctly