### PR TITLE
TidesDB 9 PATCH (v9.2.5)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ if(TIDESDB_WITH_MIMALLOC)
 endif()
 
 project(tidesdb
-	VERSION 9.2.4
+	VERSION 9.2.5
 	LANGUAGES C)
 
 set(CMAKE_C_STANDARD 11)

--- a/src/block_manager.c
+++ b/src/block_manager.c
@@ -378,6 +378,8 @@ static int block_manager_open_internal(block_manager_t **bm, const char *file_pa
     /* we initialize atomic variable to prevent reading uninitialized memory */
     atomic_init(&new_bm->current_file_size, 0);
     atomic_init(&new_bm->preallocated_size, 0);
+    atomic_init(&new_bm->group_durable_size, 0);
+    new_bm->group_sync_active = 0;
 
     new_bm->sync_mode = sync_mode;
     new_bm->sync_full_cached = (sync_mode == BLOCK_MANAGER_SYNC_FULL);

--- a/src/block_manager.h
+++ b/src/block_manager.h
@@ -90,6 +90,9 @@ typedef enum
  *                          and skip the kernel's per-inode write lock fast path.
  *                          set to UINT64_MAX if preallocation is unsupported on this
  *                          platform/fs to disable further attempts.
+ * @param group_durable_size bytes of the file confirmed fdatasync'd, used by group-commit
+ *                           callers to tell whether their write is already durable
+ * @param group_sync_active set while a group-commit leader is mid-fdatasync on this file
  */
 typedef struct
 {
@@ -100,6 +103,8 @@ typedef struct
     /* explicit alignment for atomic uint64_t to avoid ABI issues on 32-bit platforms */
     ATOMIC_ALIGN(8) _Atomic uint64_t current_file_size;
     ATOMIC_ALIGN(8) _Atomic uint64_t preallocated_size;
+    ATOMIC_ALIGN(8) _Atomic uint64_t group_durable_size;
+    int group_sync_active;
 } block_manager_t;
 
 /**

--- a/src/bloom_filter.c
+++ b/src/bloom_filter.c
@@ -36,6 +36,18 @@
  * the multiplicative mix below. */
 #define BF_HASH_PRIME 0xc6a4a793u
 
+/* index-derivation hash versions. version 1 is the original hash. version 2
+ * appends a murmur3 fmix32 finalizer so short keys fully avalanche, which
+ * decorrelates h1/h2 and lowers the false-positive rate on small structured
+ * keys. the version is stored per filter; a filter is always queried with the
+ * same hash that built it, so existing on-disk (v1) filters stay correct. */
+#define BF_HASH_VERSION_LEGACY  1u
+#define BF_HASH_VERSION_CURRENT 2u
+/* serialized v2 filters carry a 0x00 sentinel + version byte. a v1 filter can
+ * never start with 0x00 because its first field is varint32(m) and m >= 1. */
+#define BF_SERIALIZE_VERSION_SENTINEL 0x00u
+#define BF_SERIALIZE_VERSION_BYTES    2
+
 /* upper bound on the number of hash functions accepted by bloom_filter_new.
  * derived h grows logarithmically with target false-positive rate; even at
  * p = 1e-30 the formula yields h ~ 100, so this is a generous sanity ceiling
@@ -125,6 +137,42 @@ static inline uint32_t bf_hash_inline(const uint8_t *entry, const size_t size, c
     return h;
 }
 
+/* murmur3 fmix32 -- full-avalanche finalizer. applied by the v2 hash so even a
+ * short key whose base hash had weak mixing produces well-spread index bits. */
+static inline uint32_t bf_fmix32(uint32_t h)
+{
+    h ^= h >> 16;
+    h *= 0x85ebca6bu;
+    h ^= h >> 13;
+    h *= 0xc2b2ae35u;
+    h ^= h >> 16;
+    return h;
+}
+
+/* v2 index hash: base hash plus the fmix32 finalizer */
+static inline uint32_t bf_hash_v2_inline(const uint8_t *entry, const size_t size,
+                                         const uint32_t seed)
+{
+    return bf_fmix32(bf_hash_inline(entry, size, seed));
+}
+
+/* derive the two base hashes for a filter using the hash version it was built with,
+ * so a filter is always queried with the same scheme that set its bits */
+static inline void bf_derive_hashes(const bloom_filter_t *bf, const uint8_t *entry,
+                                    const size_t size, uint32_t *h1, uint32_t *h2)
+{
+    if (bf->hash_version >= BF_HASH_VERSION_CURRENT)
+    {
+        *h1 = bf_hash_v2_inline(entry, size, 0);
+        *h2 = bf_hash_v2_inline(entry, size, 1);
+    }
+    else
+    {
+        *h1 = bf_hash_inline(entry, size, 0);
+        *h2 = bf_hash_inline(entry, size, 1);
+    }
+}
+
 int bloom_filter_new(bloom_filter_t **bf, double p, const int n)
 {
     if (p <= 0.0 || p >= 1.0 || n <= 0)
@@ -187,6 +235,9 @@ int bloom_filter_new(bloom_filter_t **bf, double p, const int n)
         return -1;
     }
 
+    /* freshly built filters use the current (best) index hash */
+    (*bf)->hash_version = BF_HASH_VERSION_CURRENT;
+
     return 0;
 }
 
@@ -200,8 +251,8 @@ void bloom_filter_add(const bloom_filter_t *bf, const uint8_t *entry, const size
     const unsigned int m = bf->m;
     uint64_t *const bitset = bf->bitset;
 
-    const uint32_t h1 = bf_hash_inline(entry, size, 0);
-    const uint32_t h2 = bf_hash_inline(entry, size, 1);
+    uint32_t h1, h2;
+    bf_derive_hashes(bf, entry, size, &h1, &h2);
 
     for (unsigned int i = 0; i < h; i++)
     {
@@ -223,8 +274,8 @@ int bloom_filter_contains(const bloom_filter_t *bf, const uint8_t *entry, const 
 
     /* k-mitzenmacher + fast range reduction
      * 2 hashes + h cheap probes instead of h full hashes + h divisions */
-    const uint32_t h1 = bf_hash_inline(entry, size, 0);
-    const uint32_t h2 = bf_hash_inline(entry, size, 1);
+    uint32_t h1, h2;
+    bf_derive_hashes(bf, entry, size, &h1, &h2);
 
     for (unsigned int i = 0; i < h; i++)
     {
@@ -295,8 +346,8 @@ uint8_t *bloom_filter_serialize(const bloom_filter_t *bf, size_t *out_size)
      * -- header            3 varint32s (m, h, non_zero_count)
      * -- sparse data       each non-zero word = varint32 index + varint64 value
      */
-    const size_t max_size =
-        BF_SERIALIZE_HEADER_MAX_BYTES + (size_t)non_zero_count * BF_SERIALIZE_WORD_MAX_BYTES;
+    const size_t max_size = BF_SERIALIZE_VERSION_BYTES + BF_SERIALIZE_HEADER_MAX_BYTES +
+                            (size_t)non_zero_count * BF_SERIALIZE_WORD_MAX_BYTES;
     uint8_t *buffer = malloc(max_size);
     if (buffer == NULL)
     {
@@ -304,6 +355,15 @@ uint8_t *bloom_filter_serialize(const bloom_filter_t *bf, size_t *out_size)
     }
 
     uint8_t *ptr = buffer;
+
+    /* v2+ filters lead with a 0x00 sentinel (impossible for a v1 filter, whose
+     * first byte is varint32(m) with m >= 1) followed by the hash version byte,
+     * so deserialize can route the filter back to the hash that built it */
+    if (bf->hash_version >= BF_HASH_VERSION_CURRENT)
+    {
+        *ptr++ = BF_SERIALIZE_VERSION_SENTINEL;
+        *ptr++ = (uint8_t)bf->hash_version;
+    }
 
     /* we write header with varint encoding */
     ptr = encode_varint32(ptr, (uint32_t)bf->m);
@@ -334,6 +394,16 @@ bloom_filter_t *bloom_filter_deserialize(const uint8_t *data)
     }
 
     const uint8_t *ptr = data;
+
+    /* a leading 0x00 marks the versioned format (v1 can never start with 0x00,
+     * its first field is varint32(m) with m >= 1). absent it, this is a legacy
+     * v1 filter that must keep being queried with the v1 hash. */
+    unsigned int hash_version = BF_HASH_VERSION_LEGACY;
+    if (ptr[0] == BF_SERIALIZE_VERSION_SENTINEL)
+    {
+        ptr++;                               /* skip sentinel */
+        hash_version = (unsigned int)*ptr++; /* read hash version */
+    }
 
     /* we read header with varint decoding */
     uint32_t m_u32, h_u32, non_zero_count;
@@ -394,6 +464,7 @@ bloom_filter_t *bloom_filter_deserialize(const uint8_t *data)
     bf->h = h;
     bf->bitset = bitset;
     bf->size_in_words = size_in_words;
+    bf->hash_version = hash_version;
 
     return bf;
 }

--- a/src/bloom_filter.h
+++ b/src/bloom_filter.h
@@ -27,6 +27,10 @@
  * @param m the size of the bloom filter in bits
  * @param h the number of hash functions
  * @param size_in_words number of uint64_t words in bitset
+ * @param hash_version index-derivation hash version 1 = legacy, 2 = fmix-finalized
+ *                     (better avalanche / lower FPR on short keys). carried with the
+ *                     filter and honored by add/contains so on-disk filters built with
+ *                     an older hash keep querying with that same hash (no false negatives).
  */
 typedef struct
 {
@@ -34,6 +38,7 @@ typedef struct
     unsigned int m;
     unsigned int h;
     unsigned int size_in_words;
+    unsigned int hash_version;
 } bloom_filter_t;
 
 /**

--- a/src/btree.c
+++ b/src/btree.c
@@ -44,6 +44,9 @@
 /* fixed-size empty-leaf encoding -- type byte, num_entries=0 varint, prev/next int64 */
 #define BTREE_LEAF_EMPTY_BUF_SIZE 32
 
+/* suffix for the temp file uncompressed leaves are staged into before compression */
+#define BTREE_LEAF_STAGE_SUFFIX ".lstmp"
+
 /* compressed-node block layout written by btree_node_serialize_with_compression and read
  * back by btree_node_read_with_compression. format is
  * [original_size:u32][prev_offset:i64][next_offset:i64][compressed_data] */
@@ -1550,8 +1553,10 @@ int btree_builder_new(btree_builder_t **builder, block_manager_t *bm, const btre
     b->leaf_bm = bm;
     if (b->config.compression_algo != TDB_COMPRESS_NONE)
     {
-        char tmp_path[MAX_FILE_PATH_LENGTH];
-        snprintf(tmp_path, sizeof(tmp_path), "%s.lstmp", bm->file_path);
+        /* sizeof the suffix literal already includes its null terminator, so this
+         * holds a full-length file_path plus the suffix without truncation */
+        char tmp_path[MAX_FILE_PATH_LENGTH + sizeof(BTREE_LEAF_STAGE_SUFFIX)];
+        snprintf(tmp_path, sizeof(tmp_path), "%s" BTREE_LEAF_STAGE_SUFFIX, bm->file_path);
         block_manager_t *tmp_bm = NULL;
         if (block_manager_open(&tmp_bm, tmp_path, BLOCK_MANAGER_SYNC_NONE) == 0 &&
             block_manager_truncate(tmp_bm) == 0)

--- a/src/skip_list.c
+++ b/src/skip_list.c
@@ -1749,6 +1749,54 @@ int skip_list_cursor_seek(skip_list_cursor_t *cursor, const uint8_t *key, size_t
     return 0;
 }
 
+int skip_list_cursor_seek_ge(skip_list_cursor_t *cursor, const uint8_t *key, const size_t key_size)
+{
+    if (cursor == NULL || key == NULL || key_size == 0) return -1;
+
+    skip_list_node_t *current = cursor->cached_header;
+    const int max_level = atomic_load_explicit(&cursor->list->level, memory_order_acquire);
+    const skip_list_cmp_type_t cmp_type = cursor->list->cmp_type;
+
+    /* we find the node before target */
+    for (int i = max_level; i >= 0; i--)
+    {
+        skip_list_node_t *next = atomic_load_explicit(&current->forward[i], memory_order_acquire);
+        while (next != NULL && !NODE_IS_SENTINEL(next))
+        {
+            int cmp = skip_list_compare_keys_with_type(cmp_type, cursor->list, next->key,
+                                                       next->key_size, key, key_size);
+            if (cmp >= 0) break;
+            current = next;
+            next = atomic_load_explicit(&current->forward[i], memory_order_acquire);
+        }
+    }
+
+    /* we land directly on the first entry >= target rather than parking before it and
+     * leaving a separate next() to read forward[0]. a concurrent put can splice a node
+     * whose key is < target into forward[0] in that window, so a seek+next pair can
+     * return a key below target; re-reading forward[0] until we pass target closes it.
+     * once current points at a node >= target, later sub-target inserts splice in before
+     * it and do not move the cursor. */
+    for (;;)
+    {
+        skip_list_node_t *nx = atomic_load_explicit(&current->forward[0], memory_order_acquire);
+        if (nx == NULL || NODE_IS_SENTINEL(nx))
+        {
+            cursor->current = nx;
+            cursor->current_version = NULL;
+            return -1;
+        }
+        if (skip_list_compare_keys_with_type(cmp_type, cursor->list, nx->key, nx->key_size, key,
+                                             key_size) >= 0)
+        {
+            cursor->current = nx;
+            cursor->current_version = NULL;
+            return 0;
+        }
+        current = nx;
+    }
+}
+
 int skip_list_cursor_seek_for_prev(skip_list_cursor_t *cursor, const uint8_t *key,
                                    const size_t key_size)
 {

--- a/src/skip_list.h
+++ b/src/skip_list.h
@@ -691,6 +691,20 @@ int skip_list_cursor_goto_first(skip_list_cursor_t *cursor);
 int skip_list_cursor_seek(skip_list_cursor_t *cursor, const uint8_t *key, size_t key_size);
 
 /**
+ * skip_list_cursor_seek_ge
+ * seeks cursor directly to the first key >= target, positioning cursor->current on it.
+ * unlike skip_list_cursor_seek (which parks on the predecessor and requires a separate
+ * skip_list_cursor_next), this folds the advance in and re-reads forward[0] so a concurrent
+ * skip_list_put that splices a node < target into the predecessor's forward[0] between the
+ * descent and the advance cannot leave the cursor on a key below target.
+ * @param cursor cursor
+ * @param key target key
+ * @param key_size size of target key
+ * @return 0 if positioned on a key >= target, -1 if no such key exists (cursor at end)
+ */
+int skip_list_cursor_seek_ge(skip_list_cursor_t *cursor, const uint8_t *key, size_t key_size);
+
+/**
  * skip_list_cursor_seek_for_prev
  * seeks cursor to last key <= target
  * @param cursor cursor

--- a/src/skip_list.h
+++ b/src/skip_list.h
@@ -487,7 +487,9 @@ typedef int (*skip_list_visibility_check_fn)(void *opaque_ctx, uint64_t seq);
  * @param ttl pointer to ttl
  * @param deleted pointer to deleted flag
  * @param seq pointer to sequence number (output)
- * @param snapshot_seq snapshot sequence number (0 = latest, >0 = read version <= snapshot_seq)
+ * @param snapshot_seq snapshot sequence number. UINT64_MAX reads the latest version with no
+ *                     snapshot filtering; any other value reads the newest version with seq <=
+ *                     snapshot_seq, so 0 matches nothing because sequence numbers start at 1
  * @param visibility_check callback to check if a sequence is committed (NULL = skip check)
  * @param visibility_ctx context for visibility check callback
  * @return 0 on success, -1 on failure
@@ -510,7 +512,8 @@ int skip_list_get_with_seq(skip_list_t *list, const uint8_t *key, size_t key_siz
  * @param ttl pointer to ttl
  * @param deleted pointer to deleted flag
  * @param seq pointer to sequence number (output)
- * @param snapshot_seq snapshot sequence number
+ * @param snapshot_seq snapshot sequence number (UINT64_MAX = latest; otherwise the newest version
+ *                     with seq <= snapshot_seq, and 0 matches nothing since seqs start at 1)
  * @param visibility_check callback to check if a sequence is committed
  * @param visibility_ctx context for visibility check callback
  * @return 0 on success, -1 on failure

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -9401,6 +9401,150 @@ static int tidesdb_level_remove_sstable(const tidesdb_t *db, tidesdb_level_t *le
 }
 
 /**
+ * tidesdb_level_remove_sstables_batch
+ * excise every sstable in the to_remove set that is currently in this level, in a single
+ * atomic array swap. removing a merge's same-level inputs one at a time lets a concurrent
+ * point get observe a level holding an input's older put without its tombstone -- the get
+ * stops at the first level that has the key, so it returns the orphaned put and a deleted
+ * key reappears until compaction settles. one swap means a reader sees all of this level's
+ * merged inputs or none of them.
+ * @param db database instance
+ * @param level level to remove from
+ * @param to_remove set of sstables to remove
+ * @param to_remove_count size of the set
+ * @param out_removed per-entry flags, set to 1 for each to_remove[j] excised here
+ * @return TDB_SUCCESS if any were removed, TDB_ERR_NOT_FOUND if none, TDB_ERR_MEMORY on alloc fail
+ */
+static int tidesdb_level_remove_sstables_batch(const tidesdb_t *db, tidesdb_level_t *level,
+                                               tidesdb_sstable_t **to_remove, int to_remove_count,
+                                               uint8_t *out_removed)
+{
+    while (1)
+    {
+        atomic_fetch_add_explicit(&level->array_readers, 1, memory_order_acq_rel);
+
+        int old_num = atomic_load_explicit(&level->num_sstables, memory_order_acquire);
+        const int old_capacity =
+            atomic_load_explicit(&level->sstables_capacity, memory_order_acquire);
+        tidesdb_sstable_t **old_arr = atomic_load_explicit(&level->sstables, memory_order_acquire);
+
+        /* we spin until (old_arr, old_num) are consistent -- see tidesdb_level_remove_sstable */
+        if (old_arr[old_num] != NULL)
+        {
+            atomic_fetch_sub_explicit(&level->array_readers, 1, memory_order_release);
+            cpu_pause();
+            continue;
+        }
+        if (old_num > 0 && old_arr[old_num - 1] == NULL)
+        {
+            atomic_fetch_sub_explicit(&level->array_readers, 1, memory_order_release);
+            cpu_pause();
+            continue;
+        }
+
+        tidesdb_sstable_t **new_arr = calloc(old_capacity + 1, sizeof(tidesdb_sstable_t *));
+        if (!new_arr)
+        {
+            atomic_fetch_sub_explicit(&level->array_readers, 1, memory_order_release);
+            return TDB_ERR_MEMORY;
+        }
+
+        int new_idx = 0;
+        int removed_here = 0;
+        for (int i = 0; i < old_num; i++)
+        {
+            int rm = 0;
+            for (int j = 0; j < to_remove_count; j++)
+            {
+                if (old_arr[i] == to_remove[j])
+                {
+                    rm = 1;
+                    break;
+                }
+            }
+            if (rm)
+            {
+                removed_here++;
+                continue;
+            }
+            new_arr[new_idx] = old_arr[i];
+            tidesdb_sstable_ref(new_arr[new_idx]);
+            new_idx++;
+        }
+
+        if (removed_here == 0)
+        {
+            atomic_fetch_sub_explicit(&level->array_readers, 1, memory_order_release);
+            free(new_arr);
+            return TDB_ERR_NOT_FOUND;
+        }
+
+        if (atomic_compare_exchange_strong_explicit(&level->sstables, &old_arr, new_arr,
+                                                    memory_order_release, memory_order_acquire))
+        {
+            atomic_fetch_sub_explicit(&level->array_readers, 1, memory_order_release);
+
+            atomic_thread_fence(memory_order_seq_cst);
+            atomic_store_explicit(&level->num_sstables, new_idx, memory_order_release);
+
+            /* we unref old array's surviving sstables -- new array holds their refs */
+            for (int i = 0; i < old_num; i++)
+            {
+                int rm = 0;
+                for (int j = 0; j < to_remove_count; j++)
+                {
+                    if (old_arr[i] == to_remove[j])
+                    {
+                        rm = 1;
+                        break;
+                    }
+                }
+                if (!rm) tidesdb_sstable_unref(db, old_arr[i]);
+            }
+
+            tidesdb_sstable_t **prev_retired = atomic_exchange_explicit(
+                &level->retired_sstables_arr, old_arr, memory_order_acq_rel);
+            tidesdb_retire_array((tidesdb_t *)db, prev_retired, level);
+
+            /* for each sstable excised in this swap we account the freed space and defer its
+             * unref until array_readers drains, since readers may still hold raw pointers
+             * from the old array */
+            for (int j = 0; j < to_remove_count; j++)
+            {
+                int was_here = 0;
+                for (int i = 0; i < old_num; i++)
+                {
+                    if (old_arr[i] == to_remove[j])
+                    {
+                        was_here = 1;
+                        break;
+                    }
+                }
+                if (!was_here) continue;
+                out_removed[j] = 1;
+                atomic_fetch_sub_explicit(&level->current_size,
+                                          to_remove[j]->klog_size + to_remove[j]->vlog_size,
+                                          memory_order_relaxed);
+                atomic_fetch_sub_explicit(&((tidesdb_t *)db)->sstable_aux_memory_bytes,
+                                          tidesdb_sstable_aux_memory_bytes(to_remove[j]),
+                                          memory_order_relaxed);
+                tidesdb_defer_removed_sst_unref((tidesdb_t *)db, level, to_remove[j]);
+            }
+
+            return TDB_SUCCESS;
+        }
+
+        /* CAS failed, we release reader count, cleanup and retry */
+        atomic_fetch_sub_explicit(&level->array_readers, 1, memory_order_release);
+        for (int i = 0; i < new_idx; i++)
+        {
+            tidesdb_sstable_unref(db, new_arr[i]);
+        }
+        free(new_arr);
+    }
+}
+
+/**
  * tidesdb_level_sort_by_min_key
  * reorder a level's sstable array ascending by min_key via a single CAS swap.
  * the spooky 4.3 skew optimization leaves skipped largest-level files at their
@@ -12357,60 +12501,106 @@ static void tidesdb_cleanup_merged_sstables(tidesdb_column_family_t *cf, queue_t
 {
     const int num_levels = atomic_load_explicit(&cf->num_active_levels, memory_order_acquire);
 
-    while (!queue_is_empty(delete_queue))
+    const int total = queue_size(delete_queue);
+    if (total <= 0) return;
+
+    /* we drain the queue into one array so each level's merged inputs are excised in a
+     * single atomic swap. removing them one at a time leaves a window where a level holds
+     * an input's older put without its tombstone, and a concurrent point get -- which
+     * stops at the first level that has the key -- returns that orphaned put, so a deleted
+     * key reappears until compaction settles. */
+    tidesdb_sstable_t **ssts = malloc((size_t)total * sizeof(tidesdb_sstable_t *));
+    if (!ssts)
     {
-        /* drop_column_family will sweep the cf directory in a moment; skip per-sstable
-         * manifest commits when the CF is on its way out */
-        if (tidesdb_cf_abort_requested(cf))
+        /* alloc failed -- last-resort one-at-a-time removal */
+        while (!queue_is_empty(delete_queue))
         {
             tidesdb_sstable_t *sst = queue_dequeue(delete_queue);
-            if (sst) tidesdb_sstable_unref(cf->db, sst);
-            continue;
-        }
-
-        tidesdb_sstable_t *sst = queue_dequeue(delete_queue);
-        if (!sst) continue;
-
-        atomic_store_explicit(&sst->marked_for_deletion, 1, memory_order_release);
-
-        int removed = 0;
-        int removed_level = -1;
-
-        for (int level = start_level; level <= end_level && level < num_levels; level++)
-        {
-            tidesdb_level_t *lvl = cf->levels[level];
-            const int result = tidesdb_level_remove_sstable(cf->db, lvl, sst);
-            if (result == TDB_SUCCESS)
+            if (!sst) continue;
+            atomic_store_explicit(&sst->marked_for_deletion, 1, memory_order_release);
+            if (!tidesdb_cf_abort_requested(cf))
             {
-                TDB_DEBUG_LOG(TDB_LOG_INFO, "Removed SSTable %" PRIu64 " from level %d", sst->id,
-                              lvl->level_num);
-                tidesdb_bump_sstable_layout_version(cf);
-                removed = 1;
-                removed_level = lvl->level_num;
-                break;
+                for (int level = start_level; level <= end_level && level < num_levels; level++)
+                {
+                    if (tidesdb_level_remove_sstable(cf->db, cf->levels[level], sst) == TDB_SUCCESS)
+                    {
+                        tidesdb_bump_sstable_layout_version(cf);
+                        break;
+                    }
+                }
             }
+            tidesdb_sstable_unref(cf->db, sst);
         }
-
-        if (removed)
-        {
-            tidesdb_manifest_remove_sstable(cf->manifest, removed_level, sst->id);
-            const int manifest_result = tidesdb_manifest_commit(cf->manifest, cf->manifest->path);
-            if (manifest_result != 0)
-            {
-                TDB_DEBUG_LOG(TDB_LOG_ERROR,
-                              "Failed to commit manifest after removing SSTable %" PRIu64
-                              " (error: %d)",
-                              sst->id, manifest_result);
-            }
-            tdb_objstore_upload_manifest(cf->db, cf);
-        }
-        else
-        {
-            TDB_DEBUG_LOG(TDB_LOG_ERROR, "SSTable %" PRIu64 " not found in any level", sst->id);
-        }
-
-        tidesdb_sstable_unref(cf->db, sst);
+        return;
     }
+
+    int n = 0;
+    while (!queue_is_empty(delete_queue))
+    {
+        tidesdb_sstable_t *sst = queue_dequeue(delete_queue);
+        if (sst) ssts[n++] = sst;
+    }
+
+    for (int i = 0; i < n; i++)
+        atomic_store_explicit(&ssts[i]->marked_for_deletion, 1, memory_order_release);
+
+    /* drop_column_family will sweep the cf directory shortly; skip the level/manifest work
+     * when the CF is on its way out, but still release our queue references below */
+    if (!tidesdb_cf_abort_requested(cf))
+    {
+        uint8_t *removed = calloc((size_t)n, 1);
+        int *removed_level = malloc((size_t)n * sizeof(int));
+        if (removed && removed_level)
+        {
+            for (int i = 0; i < n; i++) removed_level[i] = -1;
+
+            /* we remove input levels deepest-first. for any key, its tombstone input sits at
+             * a level shallower-or-equal to its older put input, so removing deep before
+             * shallow guarantees that whenever a put input is gone its tombstone input is
+             * still present (or the merged output is reachable) -- a concurrent get can never
+             * see the orphaned put alone. */
+            int deepest = (end_level < num_levels - 1) ? end_level : num_levels - 1;
+            for (int level = deepest; level >= start_level; level--)
+            {
+                tidesdb_level_t *lvl = cf->levels[level];
+                tidesdb_level_remove_sstables_batch(cf->db, lvl, ssts, n, removed);
+                for (int i = 0; i < n; i++)
+                {
+                    if (removed[i] && removed_level[i] == -1) removed_level[i] = lvl->level_num;
+                }
+            }
+
+            int any_removed = 0;
+            for (int i = 0; i < n; i++)
+            {
+                if (removed[i])
+                {
+                    any_removed = 1;
+                    tidesdb_manifest_remove_sstable(cf->manifest, removed_level[i], ssts[i]->id);
+                }
+                else
+                {
+                    TDB_DEBUG_LOG(TDB_LOG_ERROR, "SSTable %" PRIu64 " not found in any level",
+                                  ssts[i]->id);
+                }
+            }
+
+            if (any_removed)
+            {
+                tidesdb_bump_sstable_layout_version(cf);
+                if (tidesdb_manifest_commit(cf->manifest, cf->manifest->path) != 0)
+                {
+                    TDB_DEBUG_LOG(TDB_LOG_ERROR, "Failed to commit manifest after merge cleanup");
+                }
+                tdb_objstore_upload_manifest(cf->db, cf);
+            }
+        }
+        free(removed);
+        free(removed_level);
+    }
+
+    for (int i = 0; i < n; i++) tidesdb_sstable_unref(cf->db, ssts[i]);
+    free(ssts);
 }
 
 /**

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -9474,7 +9474,14 @@ static int tidesdb_level_remove_sstables_batch(const tidesdb_t *db, tidesdb_leve
 
         if (removed_here == 0)
         {
+            /* none of the targets are in this level -- new_arr already holds a ref on every
+             * survivor from the build loop above; drop those before discarding new_arr or the
+             * level's sstables leak a ref each (cleanup calls this for every level in range) */
             atomic_fetch_sub_explicit(&level->array_readers, 1, memory_order_release);
+            for (int i = 0; i < new_idx; i++)
+            {
+                tidesdb_sstable_unref(db, new_arr[i]);
+            }
             free(new_arr);
             return TDB_ERR_NOT_FOUND;
         }
@@ -9487,7 +9494,10 @@ static int tidesdb_level_remove_sstables_batch(const tidesdb_t *db, tidesdb_leve
             atomic_thread_fence(memory_order_seq_cst);
             atomic_store_explicit(&level->num_sstables, new_idx, memory_order_release);
 
-            /* we unref old array's surviving sstables -- new array holds their refs */
+            /* old_arr must be fully consumed before the atomic_exchange below puts it into
+             * retired_sstables_arr -- once retired, a concurrent tidesdb_level_add_sstable
+             * can retire it again and free it, so reading old_arr afterward is a use after
+             * free. we unref the survivors and resolve every removed sstable here first. */
             for (int i = 0; i < old_num; i++)
             {
                 int rm = 0;
@@ -9501,10 +9511,6 @@ static int tidesdb_level_remove_sstables_batch(const tidesdb_t *db, tidesdb_leve
                 }
                 if (!rm) tidesdb_sstable_unref(db, old_arr[i]);
             }
-
-            tidesdb_sstable_t **prev_retired = atomic_exchange_explicit(
-                &level->retired_sstables_arr, old_arr, memory_order_acq_rel);
-            tidesdb_retire_array((tidesdb_t *)db, prev_retired, level);
 
             /* for each sstable excised in this swap we account the freed space and defer its
              * unref until array_readers drains, since readers may still hold raw pointers
@@ -9530,6 +9536,10 @@ static int tidesdb_level_remove_sstables_batch(const tidesdb_t *db, tidesdb_leve
                                           memory_order_relaxed);
                 tidesdb_defer_removed_sst_unref((tidesdb_t *)db, level, to_remove[j]);
             }
+
+            tidesdb_sstable_t **prev_retired = atomic_exchange_explicit(
+                &level->retired_sstables_arr, old_arr, memory_order_acq_rel);
+            tidesdb_retire_array((tidesdb_t *)db, prev_retired, level);
 
             return TDB_SUCCESS;
         }

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -562,6 +562,31 @@ typedef struct
 } tidesdb_multi_cf_txn_metadata_t;
 #pragma pack(pop)
 
+/* tidesdb_kv_arena_t
+ * bump arena for a klog block's per-entry key and value copies on the write path.
+ * allocations come from reusable chunks that are reset between blocks, so filling a
+ * block needs no per-entry malloc or free. chunks are never moved once allocated, so
+ * pointers handed out stay valid until the arena is reset or destroyed.
+ * @param chunks chunk base pointers
+ * @param sizes per-chunk capacity
+ * @param count number of allocated chunks
+ * @param cap capacity of the chunks/sizes arrays
+ * @param cur current chunk being filled
+ * @param off bump offset within the current chunk
+ */
+#define TDB_KLOG_ARENA_CHUNK       (128 * 1024) /* default chunk size */
+#define TDB_KLOG_ARENA_ALIGN       8            /* allocation alignment */
+#define TDB_KLOG_ARENA_INIT_CHUNKS 4            /* initial chunks/sizes array capacity */
+typedef struct
+{
+    uint8_t **chunks;
+    size_t *sizes;
+    int count;
+    int cap;
+    int cur;
+    size_t off;
+} tidesdb_kv_arena_t;
+
 /**
  * tidesdb_klog_block_t
  * a block in the klog containing multiple key entries
@@ -576,6 +601,7 @@ typedef struct
  * @param max_key maximum key in this block
  * @param max_key_size size of maximum key
  * @param data_ref owned reference to external data buffer (freed on block_free if non-NULL)
+ * @param kv_arena bump arena holding the per-entry key/value copies (write path only)
  */
 typedef struct
 {
@@ -590,6 +616,7 @@ typedef struct
     uint8_t *max_key;
     size_t max_key_size;
     uint8_t *data_ref;
+    tidesdb_kv_arena_t kv_arena;
 } tidesdb_klog_block_t;
 
 /**
@@ -2623,6 +2650,84 @@ static void tidesdb_kv_pair_free(tidesdb_kv_pair_t *kv)
 }
 
 /**
+ * tidesdb_kv_arena_alloc
+ * bump-allocate size bytes (8-byte aligned) from the arena
+ * @param a the arena
+ * @param size number of bytes
+ * @return pointer to the allocation, NULL on out of memory
+ */
+static uint8_t *tidesdb_kv_arena_alloc(tidesdb_kv_arena_t *a, size_t size)
+{
+    const size_t need = (size + (TDB_KLOG_ARENA_ALIGN - 1)) & ~(size_t)(TDB_KLOG_ARENA_ALIGN - 1);
+
+    /* current chunk has room */
+    if (a->count > 0 && a->off + need <= a->sizes[a->cur])
+    {
+        uint8_t *p = a->chunks[a->cur] + a->off;
+        a->off += need;
+        return p;
+    }
+
+    /* reuse the next already-allocated chunk if it fits (common after a reset) */
+    if (a->cur + 1 < a->count && need <= a->sizes[a->cur + 1])
+    {
+        a->cur++;
+        a->off = need;
+        return a->chunks[a->cur];
+    }
+
+    /* grow -- append a new chunk. existing chunks are never moved so live pointers hold */
+    if (a->count == a->cap)
+    {
+        const int nc = a->cap ? a->cap * 2 : TDB_KLOG_ARENA_INIT_CHUNKS;
+        uint8_t **nch = realloc(a->chunks, (size_t)nc * sizeof(uint8_t *));
+        if (!nch) return NULL;
+        a->chunks = nch;
+        size_t *nsz = realloc(a->sizes, (size_t)nc * sizeof(size_t));
+        if (!nsz) return NULL;
+        a->sizes = nsz;
+        a->cap = nc;
+    }
+
+    const size_t csz = need > TDB_KLOG_ARENA_CHUNK ? need : TDB_KLOG_ARENA_CHUNK;
+    uint8_t *chunk = malloc(csz);
+    if (!chunk) return NULL;
+    a->chunks[a->count] = chunk;
+    a->sizes[a->count] = csz;
+    a->cur = a->count;
+    a->count++;
+    a->off = need;
+    return chunk;
+}
+
+/**
+ * tidesdb_kv_arena_reset
+ * rewinds the arena for reuse on the next block, keeping chunks allocated
+ * @param a the arena
+ */
+static void tidesdb_kv_arena_reset(tidesdb_kv_arena_t *a)
+{
+    a->cur = 0;
+    a->off = 0;
+}
+
+/**
+ * tidesdb_kv_arena_destroy
+ * frees all chunks and bookkeeping arrays
+ * @param a the arena
+ */
+static void tidesdb_kv_arena_destroy(tidesdb_kv_arena_t *a)
+{
+    for (int i = 0; i < a->count; i++) free(a->chunks[i]);
+    free(a->chunks);
+    free(a->sizes);
+    a->chunks = NULL;
+    a->sizes = NULL;
+    a->count = a->cap = a->cur = 0;
+    a->off = 0;
+}
+
+/**
  * tidesdb_klog_block_create
  * create a new klog block
  * @return new klog block
@@ -2684,18 +2789,29 @@ static void tidesdb_klog_block_free(tidesdb_klog_block_t *block)
     }
     else
     {
-        /* separate allocations thus we free each component individually */
-        for (uint32_t i = 0; i < block->num_entries; i++)
-        {
-            free(block->keys[i]);
-            free(block->inline_values[i]);
-        }
+        /* per-entry key/value copies live in the bump arena -- released in one shot */
+        tidesdb_kv_arena_destroy(&block->kv_arena);
         free(block->entries);
         free(block->keys);
         free(block->inline_values);
         free(block->max_key);
         free(block);
     }
+}
+
+/**
+ * tidesdb_klog_block_reset
+ * rewinds a klog block for reuse as the next block in a flush or merge -- clears the
+ * entry count and bump arena while keeping the arrays and chunks allocated, avoiding a
+ * free/create cycle per block
+ * @param block klog block to reset
+ */
+static void tidesdb_klog_block_reset(tidesdb_klog_block_t *block)
+{
+    if (!block) return;
+    tidesdb_kv_arena_reset(&block->kv_arena);
+    block->num_entries = 0;
+    block->block_size = 0;
 }
 
 /**
@@ -2769,13 +2885,14 @@ static int tidesdb_klog_block_add_entry(tidesdb_klog_block_t *block, const tides
 
     memcpy(&block->entries[block->num_entries], &kv->entry, sizeof(tidesdb_klog_entry_t));
 
-    block->keys[block->num_entries] = malloc(kv->entry.key_size);
+    block->keys[block->num_entries] = tidesdb_kv_arena_alloc(&block->kv_arena, kv->entry.key_size);
     if (!block->keys[block->num_entries]) return TDB_ERR_MEMORY;
     memcpy(block->keys[block->num_entries], kv->key, kv->entry.key_size);
 
     if (inline_value && kv->entry.value_size > 0)
     {
-        block->inline_values[block->num_entries] = malloc(kv->entry.value_size);
+        block->inline_values[block->num_entries] =
+            tidesdb_kv_arena_alloc(&block->kv_arena, kv->entry.value_size);
         if (!block->inline_values[block->num_entries]) return TDB_ERR_MEMORY;
         memcpy(block->inline_values[block->num_entries], kv->value, kv->entry.value_size);
         block->entries[block->num_entries].vlog_offset = 0;
@@ -7650,8 +7767,7 @@ static int tidesdb_sstable_write_from_memtable(tidesdb_t *db, tidesdb_column_fam
                         goto cleanup;
                     }
 
-                    tidesdb_klog_block_free(current_klog_block);
-                    current_klog_block = tidesdb_klog_block_create();
+                    tidesdb_klog_block_reset(current_klog_block);
 
                     /* we reset sizes but keep buffers for reuse */
                     block_first_key_size = 0;
@@ -12714,8 +12830,7 @@ static int tidesdb_full_preemptive_merge(tidesdb_column_family_t *cf, int start_
                         free(final_data);
                     }
 
-                    tidesdb_klog_block_free(current_klog_block);
-                    current_klog_block = tidesdb_klog_block_create();
+                    tidesdb_klog_block_reset(current_klog_block);
 
                     free(block_first_key);
                     free(block_last_key);
@@ -13399,8 +13514,7 @@ static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t
                         free(final_data);
                     }
 
-                    tidesdb_klog_block_free(current_klog_block);
-                    current_klog_block = tidesdb_klog_block_create();
+                    tidesdb_klog_block_reset(current_klog_block);
 
                     free(block_first_key);
                     free(block_last_key);
@@ -18623,7 +18737,9 @@ int tidesdb_open(const tidesdb_config_t *config, tidesdb_t **db)
         const float umt_probability = config->unified_memtable_skip_list_probability > 0.0f
                                           ? config->unified_memtable_skip_list_probability
                                           : TDB_SKIP_LIST_PROBABILITY;
-        const int umt_sync_mode = config->unified_memtable_sync_mode;
+        /* the unified WAL is opened without block-manager self-sync; durability is owned by
+         * the commit-path group fsync (FULL) or the sync worker (INTERVAL) */
+        const int umt_sync_mode = BLOCK_MANAGER_SYNC_NONE;
 
         /* we create the initial unified skip_list + WAL */
         skip_list_t *umt_sl = NULL;
@@ -18761,6 +18877,8 @@ int tidesdb_open(const tidesdb_config_t *config, tidesdb_t **db)
         (*db)->unified_mt.cf_index_map_count = 0;
         (*db)->unified_mt.cf_index_map_capacity = 0;
         pthread_mutex_init(&(*db)->unified_mt.cf_index_map_lock, NULL);
+        pthread_mutex_init(&(*db)->unified_mt.wal_group_sync_lock, NULL);
+        pthread_cond_init(&(*db)->unified_mt.wal_group_sync_cond, NULL);
         /* a cold-started node (no local UNIMAP) pulls the map from the object
          * store so its cf indexes match the primary that wrote the uploaded
          * unified wal; a node with a local map keeps its own */
@@ -20161,6 +20279,8 @@ static void tidesdb_unimap_free(tidesdb_t *db)
     db->unified_mt.cf_index_map_count = 0;
     db->unified_mt.cf_index_map_capacity = 0;
     pthread_mutex_destroy(&db->unified_mt.cf_index_map_lock);
+    pthread_mutex_destroy(&db->unified_mt.wal_group_sync_lock);
+    pthread_cond_destroy(&db->unified_mt.wal_group_sync_cond);
 }
 
 int tidesdb_create_column_family(tidesdb_t *db, const char *name,
@@ -25433,6 +25553,59 @@ static int tidesdb_unified_flush_immutable(tidesdb_t *db, tidesdb_memtable_t *um
 }
 
 /**
+ * tidesdb_unified_wal_group_sync
+ * group commit -- coalesce the fdatasync of concurrent committers on the unified WAL. one
+ * committer (the leader) fdatasyncs the WAL once, making every committer whose bytes were
+ * already written durable; the rest wait for it instead of each issuing their own fsync.
+ * durability is preserved -- a commit returns only once the WAL is fdatasync'd past its end
+ * offset. durable progress is tracked per WAL (on the block manager), so a rotation that
+ * swaps the active WAL cannot make a new-WAL committer see old-WAL durability.
+ * @param db database instance
+ * @param wal the committer's pinned unified WAL block manager
+ * @param my_end the WAL offset that must be durable before this commit returns
+ * @return 0 on success, -1 if the fdatasync failed
+ */
+static int tidesdb_unified_wal_group_sync(tidesdb_t *db, block_manager_t *wal, uint64_t my_end)
+{
+    /* fast path -- a recent leader already flushed past us */
+    if (atomic_load_explicit(&wal->group_durable_size, memory_order_acquire) >= my_end) return 0;
+
+    pthread_mutex_lock(&db->unified_mt.wal_group_sync_lock);
+    while (atomic_load_explicit(&wal->group_durable_size, memory_order_relaxed) < my_end)
+    {
+        if (wal->group_sync_active)
+        {
+            /* follower -- wait for the in-flight leader's fsync to publish */
+            pthread_cond_wait(&db->unified_mt.wal_group_sync_cond,
+                              &db->unified_mt.wal_group_sync_lock);
+            continue;
+        }
+
+        /* leader -- capture the high-water, fsync once, publish */
+        wal->group_sync_active = 1;
+        const uint64_t flush_to =
+            atomic_load_explicit(&wal->current_file_size, memory_order_acquire);
+        pthread_mutex_unlock(&db->unified_mt.wal_group_sync_lock);
+
+        const int rc = block_manager_escalate_fsync(wal);
+
+        pthread_mutex_lock(&db->unified_mt.wal_group_sync_lock);
+        if (rc == 0 &&
+            flush_to > atomic_load_explicit(&wal->group_durable_size, memory_order_relaxed))
+            atomic_store_explicit(&wal->group_durable_size, flush_to, memory_order_release);
+        wal->group_sync_active = 0;
+        pthread_cond_broadcast(&db->unified_mt.wal_group_sync_cond);
+        if (rc != 0)
+        {
+            pthread_mutex_unlock(&db->unified_mt.wal_group_sync_lock);
+            return -1;
+        }
+    }
+    pthread_mutex_unlock(&db->unified_mt.wal_group_sync_lock);
+    return 0;
+}
+
+/**
  * tidesdb_unified_memtable_rotate
  * rotate the unified active memtable -- push current to immutable queue, create new active
  * caller must hold db->unified_mt.is_flushing CAS admission (set to 1)
@@ -25454,7 +25627,9 @@ static int tidesdb_unified_memtable_rotate(tidesdb_t *db)
     const float umt_probability = db->config.unified_memtable_skip_list_probability > 0.0f
                                       ? db->config.unified_memtable_skip_list_probability
                                       : TDB_SKIP_LIST_PROBABILITY;
-    const int umt_sync_mode = db->config.unified_memtable_sync_mode;
+    /* the unified WAL is opened without block-manager self-sync; durability is owned by
+     * the commit-path group fsync (FULL) or the sync worker (INTERVAL) */
+    const int umt_sync_mode = BLOCK_MANAGER_SYNC_NONE;
 
     skip_list_t *new_sl = NULL;
     if (skip_list_new_with_arena(&new_sl, umt_max_level, umt_probability,
@@ -25634,6 +25809,21 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
         }
 
         if (uwal_batch && uwal_batch != uwal_stack_buf) free(uwal_batch);
+
+        /* group-commit durability -- one fdatasync per batch of concurrent committers.
+         * runs while writers is still held so a rotation cannot swap this WAL out from under
+         * us. only when configured FULL; INTERVAL is handled by the sync worker, NONE skips. */
+        if (txn->db->config.unified_memtable_sync_mode == TDB_SYNC_FULL && umt->wal)
+        {
+            const uint64_t my_end =
+                atomic_load_explicit(&umt->wal->current_file_size, memory_order_acquire);
+            if (tidesdb_unified_wal_group_sync(txn->db, umt->wal, my_end) != 0)
+            {
+                atomic_fetch_sub_explicit(&umt->writers, 1, memory_order_release);
+                atomic_fetch_sub_explicit(&umt->refcount, 1, memory_order_release);
+                return TDB_ERR_IO;
+            }
+        }
 
         /* sync-on-commit WAL upload for RPO=0 replication */
         if (txn->db->object_store && txn->db->config.object_store_config &&

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -10321,11 +10321,10 @@ static tidesdb_merge_source_t *tidesdb_merge_source_from_unified_memtable(
     }
 
     /*** we seek to the start of this CF's key range.
-     **  skip_list_cursor_seek positions before target, cursor_next moves to first >= target.
-     *   then advance_to_cf filters to entries matching our CF prefix. */
-    if (skip_list_cursor_seek(source->source.unified.cursor, source->source.unified.prefix,
-                              TDB_UNIFIED_CF_PREFIX_SIZE) == 0 &&
-        skip_list_cursor_next(source->source.unified.cursor) == 0)
+     **  seek_ge lands on the first key >= the CF prefix and is robust to a concurrent put
+     *   splicing a sub-target node into forward[0]; advance_to_cf then filters to our CF. */
+    if (skip_list_cursor_seek_ge(source->source.unified.cursor, source->source.unified.prefix,
+                                 TDB_UNIFIED_CF_PREFIX_SIZE) == 0)
     {
         tidesdb_unified_source_advance_to_cf(source, 1);
     }
@@ -27107,24 +27106,22 @@ static void tidesdb_iter_seek_memtable_source(tidesdb_merge_source_t *source, co
 
     if (direction > 0)
     {
-        /** forward seek -- we find first entry >= key
-         *  skip_list_cursor_seek positions at node before target, must call next */
-        if (skip_list_cursor_seek(cursor, (uint8_t *)key, key_size) == 0)
+        /** forward seek -- first entry >= key. seek_ge folds the advance in and is
+         *  robust to a concurrent put splicing a sub-target node into forward[0],
+         *  which a seek+next pair would return as a key below target */
+        if (skip_list_cursor_seek_ge(cursor, (uint8_t *)key, key_size) == 0)
         {
-            if (skip_list_cursor_next(cursor) == 0)
-            {
-                uint8_t *k, *v;
-                size_t k_size, v_size;
-                int64_t ttl;
-                uint8_t deleted;
-                uint64_t seq;
+            uint8_t *k, *v;
+            size_t k_size, v_size;
+            int64_t ttl;
+            uint8_t deleted;
+            uint64_t seq;
 
-                if (skip_list_cursor_get_with_seq(cursor, &k, &k_size, &v, &v_size, &ttl, &deleted,
-                                                  &seq) == 0)
-                {
-                    tidesdb_memtable_source_set_inline_borrowed(source, k, k_size, v, v_size, ttl,
-                                                                seq, deleted);
-                }
+            if (skip_list_cursor_get_with_seq(cursor, &k, &k_size, &v, &v_size, &ttl, &deleted,
+                                              &seq) == 0)
+            {
+                tidesdb_memtable_source_set_inline_borrowed(source, k, k_size, v, v_size, ttl, seq,
+                                                            deleted);
             }
         }
     }
@@ -28604,8 +28601,7 @@ int tidesdb_iter_seek(tidesdb_iter_t *iter, const uint8_t *key, const size_t key
             {
                 tdb_build_prefixed_key(source->source.unified.cf_index, key, key_size, pk);
                 skip_list_cursor_t *cursor = source->source.unified.cursor;
-                if (skip_list_cursor_seek(cursor, pk, pk_total) == 0 &&
-                    skip_list_cursor_next(cursor) == 0)
+                if (skip_list_cursor_seek_ge(cursor, pk, pk_total) == 0)
                 {
                     tidesdb_unified_source_advance_to_cf(source, 1);
                 }

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -807,6 +807,8 @@ struct tidesdb_t
         int cf_index_map_count;
         int cf_index_map_capacity;
         pthread_mutex_t cf_index_map_lock;
+        pthread_mutex_t wal_group_sync_lock; /* coordinates group-commit fsync on the unified WAL */
+        pthread_cond_t wal_group_sync_cond;
     } unified_mt;
 
     /* object store mode runtime state */

--- a/test/bloom_filter__tests.c
+++ b/test/bloom_filter__tests.c
@@ -752,12 +752,83 @@ void test_bloom_filter_deserialize_overflow_m(void)
     ASSERT_TRUE(bf == NULL);
 }
 
+/* exercises the hash-version logic: new filters are v2 and carry the sentinel;
+ * a legacy v1 filter (no sentinel) round-trips back as v1 and stays correct,
+ * proving a filter is always queried with the hash that built it (no FN). */
+void test_bloom_filter_hash_versioning()
+{
+    const char *keys[] = {"alpha", "beta", "gamma", "delta", "epsilon"};
+
+    /* v2: a freshly built filter uses the current hash and serializes with the
+     * 0x00 version sentinel */
+    bloom_filter_t *v2;
+    (void)bloom_filter_new(&v2, 0.01, 1000);
+    ASSERT_EQ(v2->hash_version, 2);
+    for (int i = 0; i < 5; i++)
+        (void)bloom_filter_add(v2, (const uint8_t *)keys[i], strlen(keys[i]));
+
+    size_t v2_size;
+    uint8_t *v2_blob = bloom_filter_serialize(v2, &v2_size);
+    ASSERT_TRUE(v2_blob != NULL);
+    ASSERT_EQ(v2_blob[0], 0x00); /* v2 leads with the version sentinel */
+
+    bloom_filter_t *v2_rt = bloom_filter_deserialize(v2_blob);
+    ASSERT_TRUE(v2_rt != NULL);
+    ASSERT_EQ(v2_rt->hash_version, 2);
+    ASSERT_EQ(v2_rt->m, v2->m);
+    ASSERT_EQ(v2_rt->h, v2->h);
+    for (int i = 0; i < 5; i++)
+        ASSERT_EQ(bloom_filter_contains(v2_rt, (const uint8_t *)keys[i], strlen(keys[i])), 1);
+
+    /* legacy v1: simulate an on-disk filter built with the old hash. force the
+     * version to 1 BEFORE adding so the bits are set with the v1 hash. */
+    bloom_filter_t *v1;
+    (void)bloom_filter_new(&v1, 0.01, 1000);
+    v1->hash_version = 1;
+    for (int i = 0; i < 5; i++)
+        (void)bloom_filter_add(v1, (const uint8_t *)keys[i], strlen(keys[i]));
+
+    size_t v1_size;
+    uint8_t *v1_blob = bloom_filter_serialize(v1, &v1_size);
+    ASSERT_TRUE(v1_blob != NULL);
+    ASSERT_TRUE(v1_blob[0] != 0x00); /* legacy format: first byte is varint(m), never 0 */
+
+    /* the legacy blob must come back as v1 and still find every key -- a
+     * regression that queried v1 bits with the v2 hash would false-negative here */
+    bloom_filter_t *v1_rt = bloom_filter_deserialize(v1_blob);
+    ASSERT_TRUE(v1_rt != NULL);
+    ASSERT_EQ(v1_rt->hash_version, 1);
+    for (int i = 0; i < 5; i++)
+        ASSERT_EQ(bloom_filter_contains(v1_rt, (const uint8_t *)keys[i], strlen(keys[i])), 1);
+
+    /* v1 round-trip must answer identically to the original v1 filter on a probe
+     * set, proving consistent hash routing across serialize */
+    int mismatch = 0;
+    char probe[32];
+    for (int i = 0; i < 5000; i++)
+    {
+        int n = snprintf(probe, sizeof(probe), "probe-%d", i);
+        if (bloom_filter_contains(v1, (const uint8_t *)probe, (size_t)n) !=
+            bloom_filter_contains(v1_rt, (const uint8_t *)probe, (size_t)n))
+            mismatch++;
+    }
+    ASSERT_EQ(mismatch, 0);
+
+    free(v2_blob);
+    free(v1_blob);
+    (void)bloom_filter_free(v2);
+    (void)bloom_filter_free(v2_rt);
+    (void)bloom_filter_free(v1);
+    (void)bloom_filter_free(v1_rt);
+}
+
 int main(int argc, char **argv)
 {
     INIT_TEST_FILTER(argc, argv);
     RUN_TEST(test_bloom_filter_new, tests_passed);
     RUN_TEST(test_bloom_filter_add_and_contains, tests_passed);
     RUN_TEST(test_bloom_filter_serialize_deserialize, tests_passed);
+    RUN_TEST(test_bloom_filter_hash_versioning, tests_passed);
     RUN_TEST(test_false_positive_rate, tests_passed);
     RUN_TEST(test_boundary_conditions, tests_passed);
     RUN_TEST(test_bloom_filter_edge_cases, tests_passed);

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tidesdb",
-  "version-string": "9.2.4",
+  "version-string": "9.2.5",
   "description": "TidesDB is a high-performance durable, transactional embeddable storage engine designed for flash and RAM optimization with optional object storage support for unlimited data scaling.",
   "dependencies": ["zstd", "snappy", "lz4", "pthreads"],
   "features": {


### PR DESCRIPTION
version the bloom filter index hash so short keys avalanche without breaking existing filters

the index positions were derived by kirsch mitzenmacher double hashing over two seeds of a
single round mix, which for short keys left the two derived hashes correlated and pushed the
measured false positive rate well above the configured rate for small integer keys while
finalizer so even a four byte key fully avalanches, which decorrelates the derived hashes and
brings the measured rate back to the configured rate across key shapes.

bloom filters are persisted in sstables and must be queried with the hash that built them, so
swapping the hash outright would make old filters return false negatives. instead a filter
carries a hash version, new filters use the finalized hash and serialize a leading sentinel
byte a legacy filter can never produce, and deserialize routes a filter back to the hash that
built it. old sstables keep querying with the old hash and stay correct, new sstables get the
better rate, and the improvement spreads as compaction rewrites old files.
 
skip list doc--
correct the skip list snapshot_seq doc to match the uint64_max latest sentinel

the get_with_seq and get_with_seq_ref headers described snapshot_seq as 0 meaning latest, but
the implementation treats uint64_max as the see everything sentinel and a value of 0 filters
to versions with seq at or below 0 which matches nothing since sequence numbers start at 1.
the comments now state the real behavior.

klog arena--
pool a klog block's per entry key and value copies in a reusable bump arena

building an sstable klog block copied every entry's key and inline value into its own malloc
and freed them when the block was sealed, so a flush or merge ran on the order of two thousand
allocations per 64KB block across thousands of blocks. those copies now come from a small per
block bump arena, and finishing a block resets the arena and entry count instead of freeing and
recreating the block, so the write path does no per entry allocation. the on disk format and
the public api are unchanged.

flush/compaction is ~14% faster on the test (HDD), with the per-block allocation churn 
eliminated (malloc/free in the path dropped from ~10% to under 2% of CPU)

group commit the unified WAL fsync so concurrent durable commits scale

with SYNC_FULL every commit fdatasync'd its own write, so on slow storage one fsync round
trip capped throughput and concurrent committers gained nothing because each waited on its
own flush. the unified WAL is now opened without block manager self sync and the commit path
coalesces the fdatasync instead. one committer becomes the leader, fdatasyncs the WAL once and
publishes how far the file is durable, while the rest wait for it rather than each issuing
their own flush, so a batch of concurrent committers costs one fsync instead of N. durable
progress is tracked per WAL on the block manager so a memtable rotation that swaps the active
WAL cannot let a new wal committer see old wal durability, and a lone committer takes an atomic
fast path that skips the coordinator entirely so the low concurrency case is unchanged. the
fsync still completes before the commit is made visible, so durability is preserved. only the
unified WAL benefits, since per cf mode fragments commits across separate WALs. measured around
two times more durable commits per second at high concurrency in unified mode versus per cf,
with parity at low concurrency.