### PR TITLE
a long debug pass on the spooky paper alignment turned up a small clu…

### DIFF
--- a/.github/workflows/build_and_test_tidesdb.yml
+++ b/.github/workflows/build_and_test_tidesdb.yml
@@ -410,9 +410,22 @@ jobs:
         run: |
           cd build
           if [ "${{ matrix.arch }}" == "ppc" ]; then
-            echo "**Linux PowerPC 32-bit: build verified, runtime tests skipped (QEMU usermode PPC emulation segfaults on pthreads/atomics)"
+            # Linux PowerPC 32-bit: attempt qemu-user-static execution. older qemu
+            # versions segfaulted on PowerPC pthread mutex internals and lwsync
+            # barrier translation; modern qemu (8.x+) has improved this. trailing
+            # || true keeps the workflow green on emulation regressions while still
+            # logging the segfault for diagnosis. wrap in `timeout` so a hung qemu
+            # cannot burn the full ctest budget.
+            echo "**Linux PowerPC 32-bit: running tests via qemu-user-static (best effort)"
+            timeout 1800 qemu-ppc-static -L /usr/powerpc-linux-gnu ./tidesdb_tests \
+              || echo "**qemu-ppc-static exit non-zero -- see log above; build verification still valid"
           elif [ "${{ matrix.arch }}" == "ppc-macos" ]; then
-            echo "**macOS PowerPC (G5): build verified, runtime tests skipped (QEMU usermode PPC emulation segfaults on pthreads/atomics)"
+            # macOS PowerPC (G5): the cross-build emits Mach-O PowerPC binaries
+            # targeting Mac OS X 10.6.8 which Linux has no way to execute --
+            # Darling does not support PowerPC, and qemu-system-ppc booting an
+            # actual OS X PowerPC VM is impractical (licensed installer ISO +
+            # 10+ min boot per CI). build verification is the realistic ceiling.
+            echo "**macOS PowerPC (G5): build verified, runtime tests not possible on a Linux runner (Mach-O PPC has no Linux execution path)"
           elif [ "${{ matrix.arch }}" == "riscv64" ]; then
             CTEST_OUTPUT_ON_FAILURE=1 qemu-riscv64-static -L /usr/riscv64-linux-gnu ./tidesdb_tests || true
             echo "**Linux RISC-V 64-bit tests run via QEMU emulation"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ if(TIDESDB_WITH_MIMALLOC)
 endif()
 
 project(tidesdb
-	VERSION 9.2.6
+	VERSION 9.3.0
 	LANGUAGES C)
 
 set(CMAKE_C_STANDARD 11)

--- a/src/db.h
+++ b/src/db.h
@@ -161,6 +161,7 @@ typedef enum
 #define TDB_ERR_UNKNOWN      -11
 #define TDB_ERR_LOCKED       -12
 #define TDB_ERR_READONLY     -13
+#define TDB_ERR_BUSY         -14
 
 /** configuration limits */
 #define TDB_MAX_COMPARATOR_NAME 64

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -383,7 +383,7 @@ static inline size_t tdb_build_prefixed_key(const uint32_t cf_index, const uint8
 
 /* default L0/L1 management configuration */
 #define TDB_DEFAULT_L1_FILE_COUNT_TRIGGER    4
-#define TDB_DEFAULT_L0_QUEUE_STALL_THRESHOLD 20
+#define TDB_DEFAULT_L0_QUEUE_STALL_THRESHOLD 10
 
 /* default tombstone density trigger configuration -- 0.0 disables the check, an sstable
  * must hold at least TDB_DEFAULT_TOMBSTONE_DENSITY_MIN_ENTRIES entries before its density
@@ -18840,6 +18840,27 @@ int tidesdb_open(const tidesdb_config_t *config, tidesdb_t **db)
 
     memcpy(&(*db)->config, config, sizeof(tidesdb_config_t));
 
+    /* normalize the flush pool sizing. num_flush_threads must be positive
+     * and max_concurrent_flushes is pinned 1:1 to it -- a higher cap is
+     * meaningless because the pool is the upper bound, a lower cap leaves
+     * workers idle, so any deviation gets a warning and is corrected.
+     * subsequent code reads from the owned copy via the rebind below */
+    if ((*db)->config.num_flush_threads <= 0)
+        (*db)->config.num_flush_threads = TDB_DEFAULT_FLUSH_THREAD_POOL_SIZE;
+    if ((*db)->config.max_concurrent_flushes <= 0)
+        (*db)->config.max_concurrent_flushes = (*db)->config.num_flush_threads;
+    else if ((*db)->config.max_concurrent_flushes != (*db)->config.num_flush_threads)
+    {
+        TDB_DEBUG_LOG(TDB_LOG_WARN,
+                      "max_concurrent_flushes (%d) does not match num_flush_threads (%d) -- "
+                      "pinning to num_flush_threads",
+                      (*db)->config.max_concurrent_flushes, (*db)->config.num_flush_threads);
+        (*db)->config.max_concurrent_flushes = (*db)->config.num_flush_threads;
+    }
+    /* subsequent reads in tidesdb_open should see the normalized values, so
+     * rebind the input config alias to point at the owned copy */
+    config = &(*db)->config;
+
     /* object_store_config is a caller-owned pointer the user typically passes
      * from a stack variable -- deep-copy it so the db keeps a stable view
      * even after the caller's frame is gone */
@@ -23013,7 +23034,7 @@ static int tidesdb_apply_backpressure(tidesdb_column_family_t *cf)
                               "flush engine appears wedged",
                               cf->name,
                               no_progress * (TDB_BACKPRESSURE_STALL_CHECK_INTERVAL_US / 1000));
-                return TDB_ERR_IO; /* flush engine genuinely stuck, not merely slow */
+                return TDB_ERR_BUSY;
             }
         }
 
@@ -23087,7 +23108,7 @@ static int tidesdb_apply_backpressure(tidesdb_column_family_t *cf)
                                   "%dms - flush engine appears wedged",
                                   cf->name,
                                   no_progress * (TDB_BACKPRESSURE_STALL_CHECK_INTERVAL_US / 1000));
-                    return TDB_ERR_IO;
+                    return TDB_ERR_BUSY;
                 }
             }
 
@@ -23167,7 +23188,7 @@ static int tidesdb_apply_backpressure(tidesdb_column_family_t *cf)
                                   "unified active memtable ceiling stall: no rotate progress for "
                                   "%dms - flush engine appears wedged",
                                   no_progress * (TDB_BACKPRESSURE_STALL_CHECK_INTERVAL_US / 1000));
-                    return TDB_ERR_IO;
+                    return TDB_ERR_BUSY;
                 }
             }
 
@@ -23237,7 +23258,7 @@ static int tidesdb_apply_backpressure(tidesdb_column_family_t *cf)
                         TDB_LOG_ERROR,
                         "CF '%s' global memory pressure stall timeout after %d iterations",
                         cf->name, wait);
-                    return TDB_ERR_MEMORY_LIMIT;
+                    return TDB_ERR_BUSY;
                 }
             }
             TDB_DEBUG_LOG(TDB_LOG_INFO,
@@ -32738,10 +32759,16 @@ int tidesdb_checkpoint(tidesdb_t *db, const char *checkpoint_dir)
                 usleep(TDB_CLOSE_FLUSH_WAIT_SLEEP_US);
             }
 
-            /* we check if memtable is already empty (flushed by another thread) */
-            tidesdb_memtable_t *mt =
-                atomic_load_explicit(&cf->active_memtable, memory_order_acquire);
-            if (!mt || !mt->skip_list || skip_list_count_entries(mt->skip_list) == 0) break;
+            /* we check if memtable is already empty (flushed by another thread).
+             * pin the active under cf->active_mt_readers so a concurrent flush
+             * worker draining a just-rotated immutable cannot free the struct
+             * between our load and the skip_list deref */
+            tidesdb_memtable_t *mt = NULL;
+            int mt_pinned =
+                tidesdb_active_memtable_try_ref(&cf->active_mt_readers, &cf->active_memtable, &mt);
+            int empty = !mt_pinned || !mt->skip_list || skip_list_count_entries(mt->skip_list) == 0;
+            if (mt_pinned) tidesdb_immutable_memtable_unref(mt);
+            if (empty) break;
 
             result = tidesdb_flush_memtable_internal(cf, 0, 1);
             if (result != TDB_SUCCESS && result != TDB_ERR_MEMORY)

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -138,6 +138,9 @@ typedef enum
 #define TDB_ERR_UNKNOWN      -11
 #define TDB_ERR_LOCKED       -12
 #define TDB_ERR_READONLY     -13
+/* system is at capacity and the operation gave up after the backpressure
+ * stall hit its no-progress budget. transient; callers should retry */
+#define TDB_ERR_BUSY -14
 
 #ifdef TDB_ENABLE_READ_PROFILING
 /**
@@ -328,7 +331,20 @@ typedef struct tidesdb_stats_t tidesdb_stats_t;
  * @param write_buffer_size size of write buffer
  * @param level_size_ratio ratio of level sizes
  * @param min_levels minimum number of levels
- * @param dividing_level_offset offset for dividing level
+ * @param dividing_level_offset selects spooky's dividing level X via
+ *                              X = num_levels - 1 - offset (X clamped to >= 1).
+ *                              offset=0 means X=L-1 (the second-largest level)
+ *                              and gives the 2L-spooky variant from the paper
+ *                              with transient space-amp bounded by 1/T but the
+ *                              highest write-amp. offset=1 means X=L-2 and is
+ *                              the paper's recommended generalized tuning,
+ *                              trading some ingest throughput for noticeably
+ *                              lower compaction write-amp. higher offsets push
+ *                              X further up the tree, reducing write-amp again
+ *                              but multiplying the number of open files per
+ *                              spooky equation 12. default 0 favors ingest
+ *                              throughput; set to 1 for write-amp-sensitive
+ *                              workloads.
  * @param klog_value_threshold threshold for klog value
  * @param compression_algorithm compression algorithm
  * @param enable_bloom_filter enable bloom filter
@@ -441,7 +457,10 @@ typedef struct tidesdb_comparator_entry_t
  * @param max_concurrent_flushes global semaphore on the number of in-flight memtable flushes
  *                               across all column families. bounds total transient memory and
  *                               work-queue depth when many column families flush at once.
- *                               0 falls back to TDB_DEFAULT_MAX_CONCURRENT_FLUSHES.
+ *                               pinned 1:1 to num_flush_threads at open -- a higher cap is
+ *                               meaningless because the pool size is the upper bound, a lower
+ *                               cap leaves workers idle. 0 means "match num_flush_threads",
+ *                               any other mismatch is corrected with a warning.
  */
 typedef struct tidesdb_config_t
 {

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -23,6 +23,7 @@
 #include <string.h>
 
 #include "../src/compat.h"
+#include "../src/tidesdb.h"
 #include "test_macros.h"
 
 /* global test filter -- set via argv[1] for running specific tests */
@@ -91,6 +92,28 @@ static UNUSED int tests_skipped = 0;
 static inline void cleanup_test_dir(void)
 {
     (void)remove_directory(TEST_DB_PATH);
+}
+
+/*
+ * tdb_test_commit_with_retry
+ * commit a txn, retrying on TDB_ERR_BUSY (backpressure stall timeout) so that
+ * stress tests don't flake on slow CI boxes where the 10s no-progress budget
+ * can be reached under sustained load. caller still observes any real error
+ * (TDB_ERR_IO, TDB_ERR_NOT_FOUND, TDB_ERR_UNKNOWN, ...) as the final return.
+ * @param txn         transaction to commit (caller still owns the txn handle)
+ * @param max_retries upper bound on retry attempts. 0 disables retry
+ * @return 0 on success, or the last commit error code
+ */
+static inline int tdb_test_commit_with_retry(tidesdb_txn_t *txn, int max_retries)
+{
+    int rc;
+    for (int attempt = 0; attempt <= max_retries; attempt++)
+    {
+        rc = tidesdb_txn_commit(txn);
+        if (rc != TDB_ERR_BUSY) return rc;
+        usleep(50000); /* 50ms backoff between attempts */
+    }
+    return rc;
 }
 
 /*

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -24244,7 +24244,17 @@ static void test_perf_txn_put_throughput(void)
     ASSERT_TRUE(db != NULL);
 
     tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
+    /* arena allocates write_buffer_size * 2, on a 32 bit i386 ASan build
+     * the address space is ~1.5 GiB after ASan shadow and a 128 MiB buffer
+     * means a 256 MiB single allocation per memtable plus a second 256 MiB
+     * arena on the close path rotate, intermittently OOMs the process. the
+     * workload only fills ~11 MiB so 16 MiB is enough headroom to never
+     * rotate during the put loop while staying safe on 32 bit */
+#if INTPTR_MAX == INT32_MAX
+    cf_config.write_buffer_size = 16 * 1024 * 1024;
+#else
     cf_config.write_buffer_size = 128 * 1024 * 1024;
+#endif
     cf_config.sync_mode = TDB_SYNC_NONE;
     ASSERT_EQ(tidesdb_create_column_family(db, "put_perf_cf", &cf_config), 0);
     tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "put_perf_cf");

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -11179,7 +11179,11 @@ static void test_cf_drop_during_active_compaction(void)
             ASSERT_EQ(tidesdb_txn_put(txn, cf, (uint8_t *)key, strlen(key) + 1, (uint8_t *)value,
                                       strlen(value) + 1, -1),
                       TDB_SUCCESS);
-            ASSERT_EQ(tidesdb_txn_commit(txn), TDB_SUCCESS);
+            /* see tdb_test_commit_with_retry -- inline batches with a forced
+             * flush per outer iteration push the L0 queue under load, a slow
+             * runner can reach the backpressure no-progress budget on one of
+             * these commits without any real failure */
+            ASSERT_EQ(tdb_test_commit_with_retry(txn, 20), TDB_SUCCESS);
             tidesdb_txn_free(txn);
         }
 

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -6637,7 +6637,11 @@ static void test_dynamic_capacity_adjustment(void)
         ASSERT_EQ(tidesdb_txn_put(txn, cf, (uint8_t *)key, strlen(key) + 1, (uint8_t *)value,
                                   strlen(value) + 1, 0),
                   0);
-        ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+        /* see tdb_test_commit_with_retry -- with a 1 KiB write buffer every
+         * commit is a flush trigger, so a slow CI box can reach the backpressure
+         * stall budget on one of these 2500 commits without the dca logic
+         * being broken */
+        ASSERT_EQ(tdb_test_commit_with_retry(txn, 20), 0);
         tidesdb_txn_free(txn);
 
         total_keys_written++;
@@ -20272,7 +20276,10 @@ static void *mt_mixed_rw_writer_thread(void *arg)
                         uval_size, 0);
         free(uval);
 
-        int commit_rc = tidesdb_txn_commit(txn);
+        /* retry on TDB_ERR_BUSY -- a slow CI box can reach the backpressure
+         * stall no-progress budget under sustained contention. a real commit
+         * failure still surfaces in the final rc */
+        int commit_rc = tdb_test_commit_with_retry(txn, 20);
         if (commit_rc == 0)
         {
             atomic_fetch_add(data->commit_ok, 1);
@@ -22083,7 +22090,9 @@ static void *iter_direction_writer_thread(void *arg)
             tidesdb_txn_delete(txn, d->cf, (uint8_t *)del_key, strlen(del_key) + 1);
         }
 
-        if (tidesdb_txn_commit(txn) != 0) atomic_fetch_add(d->errors, 1);
+        /* see tdb_test_commit_with_retry -- TDB_ERR_BUSY is a slow-box
+         * artifact, not a test bug, so we retry before counting an error */
+        if (tdb_test_commit_with_retry(txn, 20) != 0) atomic_fetch_add(d->errors, 1);
         tidesdb_txn_free(txn);
     }
     return NULL;
@@ -22597,19 +22606,25 @@ static void test_concurrent_iter_seek_directions_deep_sst(void)
             ASSERT_EQ(tidesdb_txn_put(txn, cf, (uint8_t *)key, strlen(key) + 1, (uint8_t *)value,
                                       vlen, 0),
                       0);
-            ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+            ASSERT_EQ(tdb_test_commit_with_retry(txn, 20), 0);
             tidesdb_txn_free(txn);
         }
 
+        /* the post-flush and post-compact wait budgets are widened to 20s
+         * (1000 x 20ms) from the original 4s because a slow CI box can
+         * legitimately take that long to drain a multi-level compaction
+         * triggered by a 512B write buffer. dropping through with mid-flush
+         * state visible to the concurrent stress phase below is the actual
+         * fragility this test has on constrained runners */
         tidesdb_flush_memtable(cf);
-        for (int w = 0; w < 200; w++)
+        for (int w = 0; w < 1000; w++)
         {
             if (!atomic_load(&cf->is_flushing) && queue_size(db->flush_queue) == 0) break;
             usleep(20000);
         }
 
         tidesdb_compact(cf);
-        for (int w = 0; w < 200; w++)
+        for (int w = 0; w < 1000; w++)
         {
             if (!atomic_load(&cf->is_compacting)) break;
             usleep(20000);
@@ -22889,7 +22904,10 @@ static void *mcf_sat_writer_thread(void *arg)
         tidesdb_txn_put(txn, d->cf, (uint8_t *)key, strlen(key) + 1, (uint8_t *)val,
                         strlen(val) + 1, 0);
 
-        if (tidesdb_txn_commit(txn) != 0) atomic_fetch_add(d->errors, 1);
+        /* see tdb_test_commit_with_retry -- saturating the flush queue is
+         * the whole point of this test, so TDB_ERR_BUSY is expected and we
+         * back off rather than counting it as an error */
+        if (tdb_test_commit_with_retry(txn, 20) != 0) atomic_fetch_add(d->errors, 1);
         tidesdb_txn_free(txn);
     }
     return NULL;

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -15723,7 +15723,11 @@ static void test_seek_large_values_many_sstables(void)
         ASSERT_EQ(
             tidesdb_txn_put(txn, cf, (uint8_t *)key, strlen(key) + 1, large_value, VALUE_SIZE, 0),
             0);
-        ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+        /* see tdb_test_commit_with_retry -- with a 64 KiB write buffer and
+         * VALUE_SIZE large values every commit triggers a flush check, slow
+         * BSD CI runners reach the backpressure budget without anything
+         * actually being broken */
+        ASSERT_EQ(tdb_test_commit_with_retry(txn, 20), 0);
         tidesdb_txn_free(txn);
 
         /* we force flush every KEYS_PER_FLUSH keys to create multiple ssts */
@@ -20544,7 +20548,11 @@ static void *unified_writer_thread(void *arg)
             tidesdb_txn_delete(txn, d->cf, (uint8_t *)del_key, strlen(del_key) + 1);
         }
 
-        if (tidesdb_txn_commit(txn) != 0)
+        /* see tdb_test_commit_with_retry -- 4 KiB write buffer + 6 writers
+         * + 2 flushers + 2 compactors all hammering the same cf can starve
+         * the flush worker enough on slow CI to reach the backpressure
+         * no-progress budget. a real commit bug still surfaces as nonzero */
+        if (tdb_test_commit_with_retry(txn, 20) != 0)
         {
             atomic_fetch_add(d->commit_errors, 1);
         }
@@ -20897,6 +20905,19 @@ static void test_range_cost(void)
 
     wait_count = 0;
     while (tidesdb_is_flushing(cf) && wait_count < 100)
+    {
+        usleep(10000);
+        wait_count++;
+    }
+
+    /* drain auto-compactions too. with a 4 KiB write buffer the 400 commits
+     * generate enough L0 ssts to trip the file-count and size triggers, and
+     * the cost comparisons below need a stable on-disk layout -- otherwise
+     * a compaction completing between the wide_cost and reversed_cost
+     * measurements collapses ssts under the second call and produces a
+     * legitimately different number for the same key range */
+    wait_count = 0;
+    while ((tidesdb_is_compacting(cf) || tidesdb_is_flushing(cf)) && wait_count < 1000)
     {
         usleep(10000);
         wait_count++;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tidesdb",
-  "version-string": "9.2.6",
+  "version-string": "9.3.0",
   "description": "TidesDB is a high-performance durable, transactional embeddable storage engine designed for flash and RAM optimization with optional object storage support for unlimited data scaling.",
   "dependencies": ["zstd", "snappy", "lz4", "pthreads"],
   "features": {


### PR DESCRIPTION
a long debug pass on the spooky paper alignment turned up a small cluster of changes that are best landed together. the
L0 queue stall default of 20 was higher than the paper's stop threshold at 9, and with the active memtable ceiling now
bounding the active to 2x write_buffer_size the L0 queue is the only remaining unbounded growth surface, 20 immutables at
 the 64 MiB default memtable comes out to 1.3 GiB of headroom before the stall fires which is too lenient in practice,
lowering the default to 10 brings tidesdb in range of the paper's value while keeping a small margin over the existing
graduated delay at 0.5x stall = 5 for the throttle band. max_concurrent_flushes was a separate knob from
num_flush_threads with no enforced relationship between the two, a cap above pool size is meaningless because the pool
size is the upper bound, a cap below pool size leaves workers idle, in tidesdb_open the two are now pinned 1 to 1 with a
TDB_LOG_WARN when the caller set them to different values, the const config pointer is rebinded to the owned db copy
after the memcpy so subsequent reads in open see the normalized values. the docstring on max_concurrent_flushes is
rewritten to describe the pin, the prior wording promised the caller's value would be honored which is no longer
accurate.

a separate but related cluster of work hardens four intermittently flaky tests on slow CI runners.
tidesdb_apply_backpressure returned TDB_ERR_IO when its no progress stall budget was exhausted, the same code wal write
failures use, so callers could not distinguish a genuine io error from a backpressure timeout. the four tests treated any
 commit nonzero as a test bug with ASSERT_EQ on a failures counter at the end of the worker loop, so on a slow runner
where the flush worker can be starved enough to hit the 10s no progress budget the test failed without anything actually
being broken. in this work tidesdb.h and db.h gain TDB_ERR_BUSY at value -14 with semantics matching POSIX EBUSY, the
four return sites in tidesdb_apply_backpressure (the L0 queue stall timeout, the active memtable ceiling stall timeout,
the unified active memtable ceiling stall timeout, and the memory pressure critical stall timeout) all return
TDB_ERR_BUSY instead of TDB_ERR_IO or TDB_ERR_MEMORY_LIMIT. test_utils.h gains tdb_test_commit_with_retry which loops
tidesdb_txn_commit up to N times with a 50 ms backoff between attempts, returning early on success or on any code other
than TDB_ERR_BUSY so a genuine commit bug still surfaces unchanged. the four flaky workers mt_mixed_rw_writer_thread,
iter_direction_writer_thread, mcf_sat_writer_thread, and the inline 2500 key loop in test_dynamic_capacity_adjustment all
 switch to the helper. the bounded wait loops at the top of test_concurrent_iter_seek_directions_deep_sst widen from 200
x 20 ms = 4 s to 1000 x 20 ms = 20 s for both is_flushing and is_compacting drains because the prior wait dropped through
 on slow runners and left mid flush state visible to the concurrent stress phase below

 
bumped version minor as new error code busy which is, right for its case.


the full tsan suite caught a heap use after free in tidesdb_checkpoint. the function holds no reference on
cf->active_memtable while reading its skip list, the bare load atomic_load_explicit(&cf->active_memtable) at the empty
memtable check is followed immediately by a deref of mt->skip_list and a skip_list_count_entries call, both without
pinning. between the load and the deref another writer could rotate the active memtable into the immutable queue, the
flush worker could dequeue and flush it, drain its readers, and call skip_list_free plus real_free on the struct, at
which point the checkpoint thread's stale mt pointer references freed memory. tsan reported the race twice in
test_checkpoint_concurrent_writes, once as the skip_list_free write versus the skip_list_count_entries read, once as the
wrapping real_free of the tidesdb_memtable_t struct versus the same read. in this work the empty check is rewritten to
use the existing tidesdb_active_memtable_try_ref helper, mirroring the pattern that all other readers of
cf->active_memtable already use. the helper bumps cf->active_mt_readers under a seq_cst fence, loads the slot, try_refs
the loaded pointer, then drops the counter, so a concurrent flush worker draining a just rotated immutable cannot reclaim
 the struct between the checkpoint's load and its skip_list deref. the count is read while the ref is held, the pinned
memtable is dropped via tidesdb_immutable_memtable_unref before the loop's break decision is taken so the held ref does
not block the next iteration's force flush