### PR TITLE
TidesDB 9 PATCH (v9.3.1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ if(TIDESDB_WITH_MIMALLOC)
 endif()
 
 project(tidesdb
-	VERSION 9.3.0
+	VERSION 9.3.1
 	LANGUAGES C)
 
 set(CMAKE_C_STANDARD 11)

--- a/src/block_manager.c
+++ b/src/block_manager.c
@@ -403,8 +403,12 @@ static int block_manager_open_internal(block_manager_t **bm, const char *file_pa
     new_bm->fd = open(file_path, flags, mode);
     if (new_bm->fd == -1)
     {
+        /* preserve the open() errno across free() so the caller can report the real cause
+         * (EMFILE/ENFILE = fd exhaustion, ENOSPC = disk full, EACCES, ...) */
+        const int open_errno = errno;
         free(new_bm);
         *bm = NULL;
+        errno = open_errno;
         return -1;
     }
 
@@ -415,9 +419,11 @@ static int block_manager_open_internal(block_manager_t **bm, const char *file_pa
     {
         if (read_header(new_bm->fd) != 0)
         {
+            const int hdr_errno = errno;
             close(new_bm->fd);
             free(new_bm);
             *bm = NULL;
+            errno = hdr_errno;
             return -1;
         }
     }
@@ -425,9 +431,11 @@ static int block_manager_open_internal(block_manager_t **bm, const char *file_pa
     {
         if (write_header(new_bm->fd) != 0)
         {
+            const int hdr_errno = errno;
             close(new_bm->fd);
             free(new_bm);
             *bm = NULL;
+            errno = hdr_errno;
             return -1;
         }
         /* if O_DSYNC is available, pwrite already synced the header
@@ -436,9 +444,11 @@ static int block_manager_open_internal(block_manager_t **bm, const char *file_pa
         {
             if (fdatasync(new_bm->fd) != 0)
             {
+                const int sync_errno = errno;
                 close(new_bm->fd);
                 free(new_bm);
                 *bm = NULL;
+                errno = sync_errno;
                 return -1;
             }
         }

--- a/src/btree.c
+++ b/src/btree.c
@@ -395,11 +395,17 @@ int btree_comparator_memcmp(const uint8_t *key1, size_t key1_size, const uint8_t
 int btree_comparator_string(const uint8_t *key1, size_t key1_size, const uint8_t *key2,
                             size_t key2_size, void *ctx)
 {
-    (void)key1_size;
-    (void)key2_size;
     (void)ctx;
-    int cmp = strcmp((const char *)key1, (const char *)key2);
-    return cmp == 0 ? 0 : (cmp < 0 ? -1 : 1);
+    /* length-bounded compare, keys are byte buffers, not guaranteed NUL-terminated.
+     * strcmp here would read past the buffer on a non-terminated key. memcmp over the
+     * shorter length plus a length tie-break gives the same order as strcmp for
+     * well-formed C-string keys while staying in bounds. */
+    const size_t min_size = key1_size < key2_size ? key1_size : key2_size;
+    const int cmp = memcmp(key1, key2, min_size);
+    if (cmp != 0) return cmp < 0 ? -1 : 1;
+    if (key1_size < key2_size) return -1;
+    if (key1_size > key2_size) return 1;
+    return 0;
 }
 
 int btree_comparator_numeric(const uint8_t *key1, size_t key1_size, const uint8_t *key2,

--- a/src/clock_cache.c
+++ b/src/clock_cache.c
@@ -26,9 +26,13 @@
 #define CLOCK_CACHE_READER_INC               2u
 #define CLOCK_CACHE_REF_MASK                 ((uint8_t)(~1u & 0xFFu))
 #define CLOCK_CACHE_HAS_READERS(ref)         (((ref)&CLOCK_CACHE_REF_MASK) != 0)
-#define CLOCK_CACHE_PAYLOAD_ALIGN            8 /* align payload for safe typed access */
-#define CLOCK_CACHE_ALIGN_UP(x, a)           (((x) + ((a)-1)) & ~((size_t)(a)-1))
-#define CLOCK_CACHE_MAX_CPUS                 1024
+/* reader field (bits 1-7) is saturated, all reader bits set == 127 concurrent readers.
+ * one more READER_INC would carry out of the byte and wrap the field to 0, which would make
+ * HAS_READERS read false while readers are live -- free_entry would then free under them. */
+#define CLOCK_CACHE_READERS_SATURATED(ref) (((ref)&CLOCK_CACHE_REF_MASK) == CLOCK_CACHE_REF_MASK)
+#define CLOCK_CACHE_PAYLOAD_ALIGN          8 /* align payload for safe typed access */
+#define CLOCK_CACHE_ALIGN_UP(x, a)         (((x) + ((a)-1)) & ~((size_t)(a)-1))
+#define CLOCK_CACHE_MAX_CPUS               1024
 
 /* upper bound on the number of distinct L3 groups detect_l3_groups will track and the
  * sysfs path buffer used to read each cpu's shared-cache id */
@@ -319,8 +323,24 @@ static clock_cache_entry_t *try_match_entry(clock_cache_entry_t *entry, const ch
     size_t entry_key_len = atomic_load_explicit(&entry->key_len, memory_order_relaxed);
     if (entry_key_len != key_len) return NULL;
 
-    /* acquire reader ref -- prevents free_entry from freeing key/payload while we memcmp */
-    atomic_fetch_add_explicit(&entry->ref_bit, CLOCK_CACHE_READER_INC, memory_order_acq_rel);
+    /* acquire reader ref -- prevents free_entry from freeing key/payload while we memcmp.
+     * saturating CAS rather than an unconditional fetch_add the reader field is 7 bits, so the
+     * 128th concurrent pin would wrap it to 0 and let free_entry reclaim the entry under live
+     * readers (use-after-free). at saturation we refuse the pin and report a miss instead -- the
+     * caller falls back to a fresh read, which is correct for a single entry held by 127 readers.
+     */
+    {
+        uint8_t cur = atomic_load_explicit(&entry->ref_bit, memory_order_relaxed);
+        for (;;)
+        {
+            if (CLOCK_CACHE_READERS_SATURATED(cur)) return NULL;
+            const uint8_t desired = (uint8_t)(cur + CLOCK_CACHE_READER_INC);
+            if (atomic_compare_exchange_weak_explicit(&entry->ref_bit, &cur, desired,
+                                                      memory_order_acq_rel, memory_order_relaxed))
+                break;
+            /* cur was reloaded with the current value on CAS failure -- retry */
+        }
+    }
 
     /* we re-validate state after acquiring ref (entry may have been evicted between
      * our pre-checks and the ref acquisition) */

--- a/src/compat.h
+++ b/src/compat.h
@@ -518,7 +518,7 @@ typedef atomic_uint_fast64_t atomic_uint64_t;
 #if defined(__GNUC__) || defined(__clang__)
 /* __builtin_prefetch(addr, rw, locality)
  * rw -- 0 = read, 1 = write
- * locality: 0 = no temporal locality, 3 = high temporal locality */
+ * locality-- 0 = no temporal locality, 3 = high temporal locality */
 #define PREFETCH_READ(addr)  __builtin_prefetch((addr), 0, 3)
 #define PREFETCH_WRITE(addr) __builtin_prefetch((addr), 1, 3)
 #elif defined(_MSC_VER)
@@ -550,7 +550,7 @@ static inline int tdb_ctz64_msvc(uint64_t x)
         return (int)index;
     }
 #else
-    /* 32-bit MSVC: check low and high 32-bit halves */
+    /* 32-bit MSVC-- check low and high 32-bit halves */
     if (_BitScanForward(&index, (unsigned long)x))
     {
         return (int)index;
@@ -644,7 +644,7 @@ static inline int tdb_spawn_wait(const char *cmd, char *const argv[])
 #if defined(_MSC_VER)
 #pragma warning(disable : 4996) /* disable deprecated warning for windows */
 #pragma warning(disable : 4029) /* declared formal parameter list different from definition */
-#pragma warning(disable : 4211) /* nonstandard extension used: redefined extern to static */
+#pragma warning(disable : 4211) /* nonstandard extension used-- redefined extern to static */
 #endif
 
 #if defined(__MINGW32__) || defined(__MINGW64__)
@@ -769,6 +769,12 @@ typedef volatile LONGLONG atomic_uint64_t;
         {                                                                                 \
             InterlockedExchangePointer((PVOID volatile *)(ptr), (PVOID)(uintptr_t)(val)); \
         }                                                                                 \
+        else if (sizeof(*(ptr)) == 8)                                                     \
+        {                                                                                 \
+            /* 64-bit value on a 32-bit target cast straight to LONGLONG, NOT via         \
+             * uintptr_t (4 bytes here) which would truncate the input */                 \
+            InterlockedExchange64((LONGLONG volatile *)(ptr), (LONGLONG)(val));           \
+        }                                                                                 \
         else if (sizeof(*(ptr)) == 4)                                                     \
         {                                                                                 \
             InterlockedExchange((LONG volatile *)(ptr), (LONG)(uintptr_t)(val));          \
@@ -791,8 +797,8 @@ static inline void *_atomic_load_ptr(volatile void *const *ptr)
     return (void *)InterlockedCompareExchangePointer((PVOID volatile *)ptr, NULL, NULL);
 }
 
-#ifdef _WIN64
-/* atomic load */
+/* atomic load -- available on both _WIN64 and 32-bit (InterlockedCompareExchange64
+ * is provided on 32-bit Windows too, so 64-bit atomics work on a 32-bit target) */
 /*
  * _atomic_load_i64
  * @param ptr the pointer to load the value from
@@ -802,7 +808,6 @@ static inline LONGLONG _atomic_load_i64(volatile LONGLONG *ptr)
 {
     return InterlockedCompareExchange64((LONGLONG volatile *)ptr, 0, 0);
 }
-#endif
 
 /* atomic load */
 /*
@@ -847,10 +852,19 @@ static inline unsigned char _atomic_load_u8(volatile unsigned char *ptr)
  * @param order the memory order (unused)
  * @return the value loaded from the pointer
  */
-#define atomic_load_explicit(ptr, order)                                                            \
-    (sizeof(*(ptr)) == sizeof(void *) ? _atomic_load_ptr((volatile void *const *)(ptr))             \
-     : sizeof(*(ptr)) == 4            ? (void *)(uintptr_t)_atomic_load_i32((volatile LONG *)(ptr)) \
-                           : (void *)(uintptr_t)_atomic_load_u8((volatile unsigned char *)(ptr)))
+/* NOTE (32-bit MSVC < 2022) this path returns unsigned long long, not void*, so a
+ * 64-bit atomic (sizeof==8, e.g. atomic_uint64_t / atomic_size_t) is loaded at full
+ * width -- routing it through (void*)(uintptr_t) as the _WIN64 path does would truncate
+ * to 32 bits here. Pointer and 32-bit values widen losslessly. A caller assigning the
+ * result to a pointer gets an integer->pointer conversion (cast as needed).
+ * This whole 32-bit MSVC<2022 atomics path MUST be compiled and tested on the target. */
+#define atomic_load_explicit(ptr, order)                                                      \
+    (sizeof(*(ptr)) == sizeof(void *)                                                         \
+         ? (unsigned long long)(uintptr_t)_atomic_load_ptr((volatile void *const *)(ptr))     \
+     : sizeof(*(ptr)) == 8 ? (unsigned long long)_atomic_load_i64((volatile LONGLONG *)(ptr)) \
+     : sizeof(*(ptr)) == 4                                                                    \
+         ? (unsigned long long)(uintptr_t)_atomic_load_i32((volatile LONG *)(ptr))            \
+         : (unsigned long long)_atomic_load_u8((volatile unsigned char *)(ptr)))
 #endif
 
 /* atomic exchange */
@@ -879,10 +893,15 @@ static inline unsigned char _atomic_load_u8(volatile unsigned char *ptr)
  * @param order the memory order (unused)
  * @return the value exchanged from the pointer
  */
-#define atomic_exchange_explicit(ptr, val, order)                                       \
-    (sizeof(*(ptr)) == sizeof(void *)                                                   \
-         ? InterlockedExchangePointer((PVOID volatile *)(ptr), (PVOID)(uintptr_t)(val)) \
-         : (void *)(uintptr_t)InterlockedExchange((LONG volatile *)(ptr), (LONG)(uintptr_t)(val)))
+/* NOTE (32-bit MSVC < 2022) returns unsigned long long for the same reason as
+ * atomic_load_explicit above -- the 8-byte arm must not truncate. Verify on target. */
+#define atomic_exchange_explicit(ptr, val, order)                                                  \
+    (sizeof(*(ptr)) == sizeof(void *) ? (unsigned long long)(uintptr_t)InterlockedExchangePointer( \
+                                            (PVOID volatile *)(ptr), (PVOID)(uintptr_t)(val))      \
+     : sizeof(*(ptr)) == 8                                                                         \
+         ? (unsigned long long)InterlockedExchange64((LONGLONG volatile *)(ptr), (LONGLONG)(val))  \
+         : (unsigned long long)(uintptr_t)InterlockedExchange((LONG volatile *)(ptr),              \
+                                                              (LONG)(uintptr_t)(val)))
 #endif
 
 #ifdef _WIN64
@@ -903,7 +922,13 @@ static inline unsigned char _atomic_load_u8(volatile unsigned char *ptr)
  * @param val the value to add
  * @return the value before the addition
  */
-#define atomic_fetch_add(ptr, val) InterlockedExchangeAdd((LONG volatile *)(ptr), (LONG)(val))
+/* 32-bit dispatch on width so an 8-byte counter (atomic_uint64_t / atomic_size_t)
+ * uses the 64-bit intrinsic instead of truncating to LONG. Returns unsigned long long. */
+#define atomic_fetch_add(ptr, val)                                                    \
+    (sizeof(*(ptr)) == 8 ? (unsigned long long)InterlockedExchangeAdd64(              \
+                               (LONGLONG volatile *)(ptr), (LONGLONG)(val))           \
+                         : (unsigned long long)(unsigned long)InterlockedExchangeAdd( \
+                               (LONG volatile *)(ptr), (LONG)(val)))
 #endif
 
 /* atomic store */
@@ -1733,7 +1758,7 @@ static inline int sem_post(sem_t *sem)
 }
 #else
 /* for macOS < 10.6 (e.g., 10.5 PPC64), use POSIX semaphores
- * note: POSIX semaphores are deprecated on modern macOS but work on older versions */
+ * note-- POSIX semaphores are deprecated on modern macOS but work on older versions */
 /* sem_t, sem_init, sem_destroy, sem_wait, sem_post are provided by semaphore.h */
 #endif
 
@@ -2466,7 +2491,7 @@ static inline const uint8_t *decode_varint64(const uint8_t *ptr, uint64_t *value
 /*
  * serialize_kv_varint
  * serialize key-value pair with varint length prefixes
- * format: varint(key_size) + key + varint(value_size) + value
+ * format-- varint(key_size) + key + varint(value_size) + value
  * @param ptr output buffer (must have enough space)
  * @param key key data
  * @param key_size key size
@@ -2535,7 +2560,7 @@ static inline uint8_t *serialize_kv_varint_ex(uint8_t *ptr, uint8_t flags, const
 /*
  * serialize_kv_varint_full
  * serialize key-value pair with all metadata (for WAL)
- * format: flags(1) + varint(key_size) + key + varint(value_size) + value + varint(ttl) +
+ * format-- flags(1) + varint(key_size) + key + varint(value_size) + value + varint(ttl) +
  * varint(seq)
  * @param ptr output buffer (must have enough space)
  * @param flags flags byte
@@ -2723,7 +2748,7 @@ static inline const uint8_t *deserialize_kv_varint_full(const uint8_t *ptr, cons
  * avoids the per-inode i_rwsem write lock; equivalent locks exist on macOS APFS
  * (vnode write lock) and Windows NTFS (file-extension lock).
  *
- * critical detail: the logical EOF (i_size) MUST advance, not just the on-disk
+ * critical detail the logical EOF (i_size) MUST advance, not just the on-disk
  * extent allocation. on Linux, fallocate(KEEP_SIZE) reserves blocks but leaves
  * i_size unchanged, and the kernel still treats writes past i_size as extending
  * writes -- delivering no speedup. mode 0 advances i_size and initializes the
@@ -2735,12 +2760,12 @@ static inline const uint8_t *deserialize_kv_varint_full(const uint8_t *ptr, cons
  * tail (size_field == 0 marks the boundary between data and preallocated region).
  *
  * platform behavior:
- *   linux:   fallocate(fd, 0, off, len) -- advances i_size, initializes extents
- *   macos:   fcntl(F_PREALLOCATE) reserves, then ftruncate advances logical EOF
- *   windows: SetFileInformationByHandle(FileAllocationInfo) reserves, then
- *            FileEndOfFileInfo advances EOF
- *   other posix: posix_fallocate -- already advances EOF
- *   fallback: returns -1, caller falls back to extending writes
+ *   linux           fallocate(fd, 0, off, len) -- advances i_size, initializes extents
+ *   macos           fcntl(F_PREALLOCATE) reserves, then ftruncate advances logical EOF
+ *   windows         SetFileInformationByHandle(FileAllocationInfo) reserves, then
+ *                   FileEndOfFileInfo advances EOF
+ *   other posix     posix_fallocate -- already advances EOF
+ *   fallback        returns -1, caller falls back to extending writes
  *
  * @param fd the file descriptor
  * @param offset start of the region to preallocate (typically current EOF)

--- a/src/compat.h
+++ b/src/compat.h
@@ -3500,4 +3500,37 @@ static inline FILE *tdb_fmemopen(void *buf, size_t size, const char *mode)
 #endif
 }
 
+#ifndef _WIN32
+#include <sys/resource.h> /* getrlimit / RLIMIT_NOFILE for tdb_max_open_files */
+#endif
+
+/* fallback open-file ceilings used when the OS limit cannot be queried */
+#define TDB_FALLBACK_MAX_OPEN_FILES_POSIX 1024 /* POSIX-typical default RLIMIT_NOFILE soft cap */
+#define TDB_FALLBACK_MAX_OPEN_FILES_WIN \
+    2048 /* conservative floor for the Windows CRT low-IO layer */
+
+/**
+ * tdb_max_open_files
+ * report the process's maximum number of simultaneously open file descriptors, so callers can
+ * size their fd budgets (e.g. max_open_sstables) to fit the OS limit. returns a conservative
+ * fallback when the limit cannot be determined or is unlimited.
+ * @return the open-file ceiling as a long
+ */
+static inline long tdb_max_open_files(void)
+{
+#if defined(_WIN32)
+    /* windows has no RLIMIT_NOFILE. the CRT low-IO layer permits a large but not directly
+     * queryable number of _open handles; _getmaxstdio reports the (smaller) stdio stream cap.
+     * use the larger of that and a conservative floor so we neither over- nor under-budget. */
+    const int stdio_cap = _getmaxstdio();
+    const long win_floor = TDB_FALLBACK_MAX_OPEN_FILES_WIN;
+    return (stdio_cap > win_floor) ? (long)stdio_cap : win_floor;
+#else
+    struct rlimit rl;
+    if (getrlimit(RLIMIT_NOFILE, &rl) == 0 && rl.rlim_cur != RLIM_INFINITY && rl.rlim_cur > 0)
+        return (long)rl.rlim_cur;
+    return TDB_FALLBACK_MAX_OPEN_FILES_POSIX;
+#endif
+}
+
 #endif /* __COMPAT_H__ */

--- a/src/compress.c
+++ b/src/compress.c
@@ -19,6 +19,21 @@
 
 #include "compress.h"
 
+/* the compression_algorithm enum values are an on-disk + ABI contract, they are written into
+ * sstable/vlog metadata, so they must never change, and the duplicate enum in db.h (the
+ * standalone FFI header, which cannot include this header) MUST hold identical values. pin them
+ * at compile time so any drift in compress.h fails the build; db.h carries the matching contract
+ * comment. guarded on C11 so older/non-conforming C front-ends still compile. */
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+_Static_assert(TDB_COMPRESS_NONE == 0, "compression_algorithm wire drift: NONE must be 0");
+#ifndef __sun
+_Static_assert(TDB_COMPRESS_SNAPPY == 1, "compression_algorithm wire drift: SNAPPY must be 1");
+#endif
+_Static_assert(TDB_COMPRESS_LZ4 == 2, "compression_algorithm wire drift: LZ4 must be 2");
+_Static_assert(TDB_COMPRESS_ZSTD == 3, "compression_algorithm wire drift: ZSTD must be 3");
+_Static_assert(TDB_COMPRESS_LZ4_FAST == 4, "compression_algorithm wire drift: LZ4_FAST must be 4");
+#endif
+
 uint8_t *compress_data(const uint8_t *data, const size_t data_size, size_t *compressed_size,
                        const compression_algorithm type)
 {
@@ -65,7 +80,7 @@ uint8_t *compress_data(const uint8_t *data, const size_t data_size, size_t *comp
 
             encode_uint64_le_compat(compressed_data, data_size);
 
-            /* unified LZ4 path: acceleration=1 for default, acceleration=2 for fast */
+            /* unified LZ4 path-- acceleration=1 for default, acceleration=2 for fast */
             const int acceleration = (type == TDB_COMPRESS_LZ4_FAST) ? 2 : 1;
             const int lz4_result =
                 LZ4_compress_fast((const char *)data, (char *)(compressed_data + sizeof(uint64_t)),
@@ -152,6 +167,14 @@ uint8_t *decompress_data(const uint8_t *data, const size_t data_size, size_t *de
                                                data_size - sizeof(uint64_t),
                                                (char *)decompressed_data,
                                                decompressed_size) != SNAPPY_OK))
+            {
+                free(decompressed_data);
+                return NULL;
+            }
+            /* verify produced length matches the size prefix, mirroring the LZ4/ZSTD branches.
+             * snappy_uncompress can succeed with a shorter output that still fits the buffer,
+             * which would otherwise pass silently. */
+            if (TDB_UNLIKELY(*decompressed_size != (size_t)original_size))
             {
                 free(decompressed_data);
                 return NULL;

--- a/src/compress.h
+++ b/src/compress.h
@@ -26,12 +26,11 @@
 
 #include "compat.h"
 
-#ifndef _WIN32
-#include <signal.h>
-#endif
-
 /* snappy, lz4, zstd supported to use for compression purposes */
 /* snappy is not available on SunOS/OmniOS/Illumos */
+/* ABI/on-disk contract, these numeric values are persisted in sstable/vlog metadata and are
+ * duplicated in db.h (the standalone FFI header). the two copies MUST stay identical; compress.c
+ * pins these values with _Static_assert to catch drift at build time. */
 typedef enum
 {
     TDB_COMPRESS_NONE = 0,

--- a/src/db.h
+++ b/src/db.h
@@ -127,6 +127,9 @@ typedef enum
 } tidesdb_isolation_level_t;
 
 /** compression algorithms */
+/* ABI/on-disk contract, these numeric values are persisted in sstable/vlog metadata and are
+ * duplicated in compress.h. the two copies MUST stay identical -- compress.c _Static_asserts the
+ * compress.h copy; keep this copy in lockstep. */
 typedef enum
 {
     TDB_COMPRESS_NONE = 0,
@@ -752,6 +755,51 @@ tidesdb_objstore_t *tidesdb_objstore_s3_create(const char *endpoint, const char 
                                                const char *prefix, const char *access_key,
                                                const char *secret_key, const char *region,
                                                int use_ssl, int use_path_style);
+
+/**
+ * tidesdb_objstore_s3_config_t
+ * full S3 connector configuration, including TLS and multipart tuning the positional
+ * tidesdb_objstore_s3_create cannot express. zero-initialize and set what you need; the
+ * all-zero defaults are secure (TLS verify on, no custom CA) and use the built-in multipart
+ * sizes.
+ * @param endpoint S3 endpoint (required)
+ * @param bucket bucket name (required)
+ * @param prefix key prefix, or NULL
+ * @param access_key AWS access key ID (required)
+ * @param secret_key AWS secret access key (required)
+ * @param region AWS region, or NULL for the default
+ * @param use_ssl 1 for HTTPS, 0 for HTTP
+ * @param use_path_style 1 for path-style URLs (MinIO), 0 for virtual-hosted (AWS)
+ * @param tls_ca_path custom CA bundle file path, or NULL for the system bundle
+ * @param tls_insecure_skip_verify 1 disables TLS peer+host verification (test only, insecure);
+ *                                 0 keeps verification on (default)
+ * @param multipart_threshold object size at/above which multipart upload is used; 0 = default
+ * @param multipart_part_size multipart chunk size in bytes; 0 = default
+ */
+typedef struct
+{
+    const char *endpoint;
+    const char *bucket;
+    const char *prefix;
+    const char *access_key;
+    const char *secret_key;
+    const char *region;
+    int use_ssl;
+    int use_path_style;
+    const char *tls_ca_path;
+    int tls_insecure_skip_verify;
+    size_t multipart_threshold;
+    size_t multipart_part_size;
+} tidesdb_objstore_s3_config_t;
+
+/**
+ * tidesdb_objstore_s3_create_config
+ * create an S3-compatible connector from a full configuration struct (TLS + multipart).
+ * tidesdb_objstore_s3_create is a thin wrapper over this with secure/default settings.
+ * @param config connector configuration (fields are copied; need not outlive the call)
+ * @return connector handle, or NULL on error
+ */
+tidesdb_objstore_t *tidesdb_objstore_s3_create_config(const tidesdb_objstore_s3_config_t *config);
 
 /**
  * tidesdb_promote_to_primary

--- a/src/local_cache.c
+++ b/src/local_cache.c
@@ -208,11 +208,17 @@ static void cache_remove_entry(tdb_local_cache_t *cache, tdb_cache_entry_t *entr
 
     if (delete_file)
     {
-#ifdef _WIN32
-        _unlink(entry->path);
-#else
-        unlink(entry->path);
-#endif
+        /* tdb_unlink clears the Windows read-only attribute that can otherwise block
+         * deletion. surface a failure, a swallowed unlink error leaks the file on disk
+         * while the byte counter below is decremented as if reclaimed. this leaf module has
+         * no db log, so stderr is the available channel. the counter is still decremented
+         * because the entry is being untracked regardless -- the leak is an OS-level issue
+         * the operator must clear, not a tracker-accounting one. */
+        if (tdb_unlink(entry->path) != 0)
+        {
+            fprintf(stderr, "tidesdb local_cache: failed to unlink %s; file leaked on disk\n",
+                    entry->path);
+        }
     }
 
     *current -= entry->size;

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -169,9 +169,24 @@ tidesdb_manifest_t *tidesdb_manifest_open(const char *path)
 
     if (fgets(line, sizeof(line), fp))
     {
-        atomic_store(&manifest->sequence, strtoull(line, NULL, 10));
+        char *seq_endptr;
+        const unsigned long long seq = strtoull(line, &seq_endptr, 10);
+        /* the sequence line must be a number terminated by end-of-line. reject junk
+         * (e.g. "123abc") rather than silently truncating it -- an under-parsed
+         * sequence under-seeds next_sstable_id on recovery and risks id collisions */
+        if (seq_endptr == line ||
+            (*seq_endptr != '\0' && *seq_endptr != '\n' && *seq_endptr != '\r'))
+        {
+            fclose(fp);
+            pthread_rwlock_destroy(&manifest->lock);
+            free(manifest->entries);
+            free(manifest);
+            return NULL;
+        }
+        atomic_store(&manifest->sequence, seq);
     }
 
+    int skipped_lines = 0;
     while (fgets(line, sizeof(line), fp))
     {
         const char *ptr = line;
@@ -179,25 +194,49 @@ tidesdb_manifest_t *tidesdb_manifest_open(const char *path)
 
         /* parse level */
         const long level_val = strtol(ptr, &endptr, 10);
-        if (endptr == ptr || *endptr != ',') continue;
+        if (endptr == ptr || *endptr != ',')
+        {
+            skipped_lines++;
+            continue;
+        }
         const int level = (int)level_val;
         ptr = endptr + 1;
 
         /* parse id */
         const uint64_t id = strtoull(ptr, &endptr, 10);
-        if (endptr == ptr || *endptr != ',') continue;
+        if (endptr == ptr || *endptr != ',')
+        {
+            skipped_lines++;
+            continue;
+        }
         ptr = endptr + 1;
 
         /* parse num_entries */
         const uint64_t num_entries = strtoull(ptr, &endptr, 10);
-        if (endptr == ptr || *endptr != ',') continue;
+        if (endptr == ptr || *endptr != ',')
+        {
+            skipped_lines++;
+            continue;
+        }
         ptr = endptr + 1;
 
         /* parse size_bytes */
         const uint64_t size_bytes = strtoull(ptr, &endptr, 10);
-        if (endptr == ptr) continue;
+        if (endptr == ptr)
+        {
+            skipped_lines++;
+            continue;
+        }
 
         tidesdb_manifest_add_sstable_unlocked(manifest, level, id, num_entries, size_bytes);
+    }
+
+    /* surface silent data loss, malformed entry lines were dropped. this leaf module has
+     * no access to the db log, so a single stderr line is the best signal available. */
+    if (skipped_lines > 0)
+    {
+        fprintf(stderr, "tidesdb manifest: skipped %d malformed entry line(s) while loading %s\n",
+                skipped_lines, manifest->path ? manifest->path : "(unknown)");
     }
 
     /* we keep file open for future use */
@@ -319,8 +358,11 @@ void tidesdb_manifest_update_sequence(tidesdb_manifest_t *manifest, uint64_t seq
 {
     if (!manifest) return;
 
-    /* sequence is atomic, no lock needed for simple store */
-    atomic_store(&manifest->sequence, sequence);
+    /* monotonic guard, the sequence seeds next_sstable_id on recovery, so it must never
+     * regress or recovery would re-hand-out live sstable ids and collide. only advance.
+     * (best-effort under concurrency; this API is not on a hot path.) */
+    const uint64_t cur = atomic_load(&manifest->sequence);
+    if (sequence > cur) atomic_store(&manifest->sequence, sequence);
 }
 
 int tidesdb_manifest_commit(tidesdb_manifest_t *manifest, const char *path)
@@ -402,7 +444,9 @@ int tidesdb_manifest_commit(tidesdb_manifest_t *manifest, const char *path)
      * without this, a crash after rename could lose the directory entry
      * on POSIX systems that don't flush directory metadata automatically. */
     {
-        char dir_buf[1024];
+        /* sized to the full manifest path length -- a 1024-byte buffer silently truncated
+         * paths > 1023 chars and synced the wrong directory */
+        char dir_buf[MANIFEST_PATH_LEN];
         strncpy(dir_buf, path, sizeof(dir_buf) - 1);
         dir_buf[sizeof(dir_buf) - 1] = '\0';
         char *last_sep = strrchr(dir_buf, '/');

--- a/src/objstore_fs.c
+++ b/src/objstore_fs.c
@@ -34,6 +34,8 @@
 #define TDB_FS_MAX_PATH 4096
 #define TDB_FS_COPY_BUF 65536
 #define TDB_FS_DIR_MODE 0755
+/* extra bytes reserved for the ".tmp.<pid>.<tid>" suffix on the atomic-put temp path */
+#define TDB_FS_TMP_SUFFIX_MAX 64
 
 /* default object store config values */
 #define TDB_OBJSTORE_DEFAULT_CACHE_ON_READ         1
@@ -175,7 +177,22 @@ static int fs_put(void *ctx, const char *key, const char *local_path)
     fs_ctx_t *fs = (fs_ctx_t *)ctx;
     char full[TDB_FS_MAX_PATH * 2];
     fs_full_path(fs, key, full, sizeof(full));
-    return fs_copy_file(local_path, full);
+
+    /* copy to a unique temp file then atomically rename into place, so a concurrent
+     * reader/list never observes a partially-written object -- the objstore put contract
+     * (objstore.h) is "atomic object". the temp lives in the same directory as the target
+     * so the rename stays within one filesystem. */
+    char tmp[TDB_FS_MAX_PATH * 2 + TDB_FS_TMP_SUFFIX_MAX];
+    snprintf(tmp, sizeof(tmp), "%s.tmp.%ld.%lu", full, (long)TDB_GETPID(), TDB_THREAD_ID());
+
+    if (fs_copy_file(local_path, tmp) != 0) return -1;
+
+    if (atomic_rename_file(tmp, full) != 0)
+    {
+        unlink(tmp);
+        return -1;
+    }
+    return 0;
 }
 
 /**
@@ -401,7 +418,7 @@ static int fs_list_walk(const char *abs_dir, const char *rel_dir, size_t rel_dir
 /**
  * fs_list
  * enumerate all objects whose key starts with prefix. matches S3
- * ListObjectsV2(prefix=...) semantics: the prefix is matched byte-wise
+ * ListObjectsV2(prefix=...) semantics, the prefix is matched byte-wise
  * against the key and need not align to a directory boundary.
  * @param ctx opaque connector context
  * @param prefix key prefix to list (e.g. "cf_name/" or "uwal_")

--- a/src/objstore_s3.c
+++ b/src/objstore_s3.c
@@ -47,9 +47,10 @@
 #define TDB_S3_REGION_MAX   64
 
 /* HTTP status codes */
-#define TDB_S3_HTTP_OK       200
-#define TDB_S3_HTTP_PARTIAL  206
-#define TDB_S3_HTTP_REDIRECT 300
+#define TDB_S3_HTTP_OK        200
+#define TDB_S3_HTTP_PARTIAL   206
+#define TDB_S3_HTTP_REDIRECT  300
+#define TDB_S3_HTTP_NOT_FOUND 404
 
 /* signing and response buffers. host and key_date buffers must be large
  * enough for concatenated bucket+endpoint or "AWS4"+secret_key strings. */
@@ -76,9 +77,13 @@
 /* multipart upload -- objects at or above the threshold are uploaded in
  * parts so the connector never buffers a whole large file in memory and is
  * not bound by S3's 5 GiB single-PUT limit. S3 requires parts of at least
- * 5 MiB (the final part may be smaller) and at most 10000 parts. */
+ * 5 MiB (the final part may be smaller) and at most 10000 parts.
+ * these match the documented objstore_config defaults (threshold 64 MiB,
+ * part size 8 MiB); honoring per-config overrides at runtime additionally
+ * requires plumbing multipart_threshold / multipart_part_size through the
+ * public tidesdb_objstore_s3_create signature (deferred -- API change). */
 #define TDB_S3_MULTIPART_THRESHOLD ((size_t)64 * 1024 * 1024)
-#define TDB_S3_MULTIPART_PART_SIZE ((size_t)16 * 1024 * 1024)
+#define TDB_S3_MULTIPART_PART_SIZE ((size_t)8 * 1024 * 1024)
 #define TDB_S3_MAX_PARTS           10000
 #define TDB_S3_ETAG_MAX            128
 #define TDB_S3_UPLOAD_ID_MAX       512
@@ -113,26 +118,42 @@ static void s3_uri_encode(const char *src, char *dst, size_t dst_size)
 }
 
 /**
- * s3_curl_new
- * create a curl easy handle with the connector's common options applied --
- * a connection timeout and a stalled-transfer timeout so a dead endpoint
- * cannot hang a worker, and NOSIGNAL for safe use from multiple threads.
- * @return a configured handle, or NULL on allocation failure
+ * s3_uri_encode_path
+ * URI-encode an object key for use as a request path / SigV4 canonical URI. like
+ * s3_uri_encode but leaves '/' unencoded so path segments are preserved. the request
+ * URL (s3_build_url) and the canonical URI (s3_sign_request) MUST apply the exact same
+ * encoding or the SigV4 signature will not match the request. for keys made only of
+ * unreserved characters and '/' (which is what tidesdb cf/sstable keys are) this is a
+ * passthrough, so normal operation is unchanged; it only matters for keys containing
+ * spaces, '+', '?', '#', '&', etc.
+ * @param src input key
+ * @param dst output buffer
+ * @param dst_size size of output buffer
  */
-static CURL *s3_curl_new(void)
+static void s3_uri_encode_path(const char *src, char *dst, size_t dst_size)
 {
-    CURL *curl = curl_easy_init();
-    if (!curl) return NULL;
-    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
-    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, (long)TDB_S3_CONNECT_TIMEOUT_S);
-    curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, (long)TDB_S3_LOW_SPEED_LIMIT);
-    curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, (long)TDB_S3_LOW_SPEED_TIME_S);
-    return curl;
+    static const char *unreserved =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~/";
+    size_t pos = 0;
+    for (; *src && pos + 3 < dst_size; src++)
+    {
+        if (strchr(unreserved, *src))
+        {
+            dst[pos++] = *src;
+        }
+        else
+        {
+            snprintf(dst + pos, dst_size - pos, "%%%02X", (unsigned char)*src);
+            pos += 3;
+        }
+    }
+    dst[pos] = '\0';
 }
 
 /**
  * s3_ctx_t
- * internal context for the S3 connector, holding credentials and endpoint config
+ * internal context for the S3 connector, credentials, endpoint, TLS, and multipart config.
+ * defined before s3_curl_new so that helper can apply the per-connector TLS options.
  * @param endpoint S3 endpoint hostname
  * @param bucket S3 bucket name
  * @param prefix key prefix prepended to all object keys
@@ -141,6 +162,10 @@ static CURL *s3_curl_new(void)
  * @param region AWS region string
  * @param use_ssl 1 for HTTPS, 0 for HTTP
  * @param use_path_style 1 for path-style URLs, 0 for virtual-hosted
+ * @param tls_ca_path custom CA bundle file path (empty = libcurl default bundle)
+ * @param tls_insecure_skip_verify 1 disables peer+host verification (test endpoints only)
+ * @param multipart_threshold object size at/above which multipart upload is used
+ * @param multipart_part_size multipart chunk size
  */
 typedef struct
 {
@@ -152,7 +177,43 @@ typedef struct
     char region[TDB_S3_REGION_MAX];
     int use_ssl;
     int use_path_style;
+    char tls_ca_path[TDB_S3_MAX_PATH];
+    int tls_insecure_skip_verify;
+    size_t multipart_threshold;
+    size_t multipart_part_size;
 } s3_ctx_t;
+
+/**
+ * s3_curl_new
+ * create a curl easy handle with the connector's common options applied -- a connection
+ * timeout and a stalled-transfer timeout so a dead endpoint cannot hang a worker, NOSIGNAL
+ * for safe use from multiple threads, and (over https) the connector's TLS settings, a custom
+ * CA bundle when configured, and an opt-in insecure skip-verify for test endpoints.
+ * @param s3 connector context (for TLS settings)
+ * @return a configured handle, or NULL on allocation failure
+ */
+static CURL *s3_curl_new(const s3_ctx_t *s3)
+{
+    CURL *curl = curl_easy_init();
+    if (!curl) return NULL;
+    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, (long)TDB_S3_CONNECT_TIMEOUT_S);
+    curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, (long)TDB_S3_LOW_SPEED_LIMIT);
+    curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, (long)TDB_S3_LOW_SPEED_TIME_S);
+
+    /* TLS only matters over https. leaving both branches untouched keeps libcurl's secure
+     * defaults (verify peer + host against the system CA bundle). */
+    if (s3 && s3->use_ssl)
+    {
+        if (s3->tls_ca_path[0]) curl_easy_setopt(curl, CURLOPT_CAINFO, s3->tls_ca_path);
+        if (s3->tls_insecure_skip_verify)
+        {
+            curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
+            curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+        }
+    }
+    return curl;
+}
 
 /**
  * sha256_hex
@@ -206,7 +267,7 @@ static void s3_get_timestamp(char *date8, char *timestamp16)
 
 /**
  * s3_signing_key
- * derive the SigV4 signing key via HMAC chain: date -> region -> service -> request
+ * derive the SigV4 signing key via HMAC chain date -> region -> service -> request
  * @param secret_key AWS secret access key
  * @param date8 date string YYYYMMDD
  * @param region AWS region
@@ -248,10 +309,14 @@ static void s3_build_url(const s3_ctx_t *ctx, const char *key, char *url, size_t
     else
         snprintf(full_key, sizeof(full_key), "%s", key);
 
+    /* must match the canonical-URI encoding in s3_sign_request exactly */
+    char enc_key[TDB_S3_MAX_PATH * 3];
+    s3_uri_encode_path(full_key, enc_key, sizeof(enc_key));
+
     if (ctx->use_path_style)
-        snprintf(url, url_size, "%s://%s/%s/%s", scheme, ctx->endpoint, ctx->bucket, full_key);
+        snprintf(url, url_size, "%s://%s/%s/%s", scheme, ctx->endpoint, ctx->bucket, enc_key);
     else
-        snprintf(url, url_size, "%s://%s.%s/%s", scheme, ctx->bucket, ctx->endpoint, full_key);
+        snprintf(url, url_size, "%s://%s.%s/%s", scheme, ctx->bucket, ctx->endpoint, enc_key);
 }
 #ifndef _MSC_VER
 #pragma GCC diagnostic pop
@@ -389,11 +454,16 @@ static struct curl_slist *s3_sign_request(const s3_ctx_t *ctx, const char *metho
     else
         snprintf(full_key, sizeof(full_key), "%s", key);
 
-    char canonical_uri[TDB_S3_MAX_PATH + 256];
+    /* URI-encode the key path exactly as s3_build_url does, or the signature will not
+     * match the request for keys containing characters outside [A-Za-z0-9-._~/] */
+    char enc_key[TDB_S3_MAX_PATH * 3];
+    s3_uri_encode_path(full_key, enc_key, sizeof(enc_key));
+
+    char canonical_uri[TDB_S3_MAX_PATH * 3 + 256];
     if (ctx->use_path_style)
-        snprintf(canonical_uri, sizeof(canonical_uri), "/%s/%s", ctx->bucket, full_key);
+        snprintf(canonical_uri, sizeof(canonical_uri), "/%s/%s", ctx->bucket, enc_key);
     else
-        snprintf(canonical_uri, sizeof(canonical_uri), "/%s", full_key);
+        snprintf(canonical_uri, sizeof(canonical_uri), "/%s", enc_key);
 
     return s3_sign_raw(ctx, method, canonical_uri, "", content_sha256, extra_headers_canonical,
                        extra_signed_headers);
@@ -518,7 +588,7 @@ static int s3_get(void *ctx, const char *key, const char *local_path)
 
     s3_write_ctx_t wctx = {.fp = fp};
 
-    CURL *curl = s3_curl_new();
+    CURL *curl = s3_curl_new(s3);
     if (!curl)
     {
         fclose(fp);
@@ -577,7 +647,7 @@ static ssize_t s3_range_get(void *ctx, const char *key, uint64_t offset, void *b
 
     s3_write_ctx_t wctx = {.buf = (char *)buf, .buf_size = size, .written = 0};
 
-    CURL *curl = s3_curl_new();
+    CURL *curl = s3_curl_new(s3);
     if (!curl)
     {
         curl_slist_free_all(headers);
@@ -619,7 +689,7 @@ static int s3_delete_object(void *ctx, const char *key)
     char url[TDB_S3_MAX_PATH];
     s3_build_url(s3, key, url, sizeof(url));
 
-    CURL *curl = s3_curl_new();
+    CURL *curl = s3_curl_new(s3);
     if (!curl)
     {
         curl_slist_free_all(headers);
@@ -632,11 +702,20 @@ static int s3_delete_object(void *ctx, const char *key)
 
     CURLcode res = curl_easy_perform(curl);
 
+    long http_code = 0;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+
     curl_slist_free_all(headers);
     curl_easy_cleanup(curl);
 
-    /* 204 No Content or 404 Not Found are both success for delete */
-    return (res == CURLE_OK) ? 0 : -1;
+    if (res != CURLE_OK) return -1;
+    /* 2xx (200/204 No Content) = deleted, 404 Not Found = already absent; both are success.
+     * any other status (403, 5xx, ...) is a real failure that must NOT be masked, or the
+     * integration layer's retry/cleanup is silently defeated. */
+    if ((http_code >= TDB_S3_HTTP_OK && http_code < TDB_S3_HTTP_REDIRECT) ||
+        http_code == TDB_S3_HTTP_NOT_FOUND)
+        return 0;
+    return -1;
 }
 
 /**
@@ -659,7 +738,7 @@ static int s3_exists(void *ctx, const char *key, size_t *size_out)
     char url[TDB_S3_MAX_PATH];
     s3_build_url(s3, key, url, sizeof(url));
 
-    CURL *curl = s3_curl_new();
+    CURL *curl = s3_curl_new(s3);
     if (!curl)
     {
         curl_slist_free_all(headers);
@@ -880,7 +959,7 @@ static int s3_multipart_create(s3_ctx_t *s3, const char *key, char *upload_id_ou
         return -1;
     }
 
-    CURL *curl = s3_curl_new();
+    CURL *curl = s3_curl_new(s3);
     if (!curl)
     {
         free(resp.data);
@@ -965,7 +1044,7 @@ static int s3_upload_part(s3_ctx_t *s3, const char *key, const char *upload_id, 
     }
 
     s3_header_ctx_t hctx = {.found = 0};
-    CURL *curl = s3_curl_new();
+    CURL *curl = s3_curl_new(s3);
     if (!curl)
     {
         fclose(mem_fp);
@@ -1053,7 +1132,7 @@ static int s3_multipart_complete(s3_ctx_t *s3, const char *key, const char *uplo
         return -1;
     }
 
-    CURL *curl = s3_curl_new();
+    CURL *curl = s3_curl_new(s3);
     if (!curl)
     {
         free(body);
@@ -1121,7 +1200,7 @@ static int s3_multipart_abort(s3_ctx_t *s3, const char *key, const char *upload_
     char full_url[TDB_S3_MAX_PATH + TDB_S3_UPLOAD_ID_MAX * 4 + 32];
     snprintf(full_url, sizeof(full_url), "%s?uploadId=%s", url, enc_id);
 
-    CURL *curl = s3_curl_new();
+    CURL *curl = s3_curl_new(s3);
     if (!curl)
     {
         curl_slist_free_all(headers);
@@ -1158,7 +1237,7 @@ static int s3_put_single(s3_ctx_t *s3, const char *key, FILE *fp, long file_size
     char url[TDB_S3_MAX_PATH];
     s3_build_url(s3, key, url, sizeof(url));
 
-    CURL *curl = s3_curl_new();
+    CURL *curl = s3_curl_new(s3);
     if (!curl)
     {
         curl_slist_free_all(headers);
@@ -1196,15 +1275,16 @@ static int s3_put_single(s3_ctx_t *s3, const char *key, FILE *fp, long file_size
  */
 static int s3_put_multipart(s3_ctx_t *s3, const char *key, FILE *fp, long file_size)
 {
-    long parts_needed =
-        (long)(((size_t)file_size + TDB_S3_MULTIPART_PART_SIZE - 1) / TDB_S3_MULTIPART_PART_SIZE);
+    const size_t part_size = s3->multipart_part_size; /* resolved to a default at create time */
+
+    long parts_needed = (long)(((size_t)file_size + part_size - 1) / part_size);
     if (parts_needed < 1) parts_needed = 1;
     if (parts_needed > TDB_S3_MAX_PARTS) return -1; /* file too large for the part size */
 
     char upload_id[TDB_S3_UPLOAD_ID_MAX];
     if (s3_multipart_create(s3, key, upload_id, sizeof(upload_id)) != 0) return -1;
 
-    char *part_buf = malloc(TDB_S3_MULTIPART_PART_SIZE);
+    char *part_buf = malloc(part_size);
     char *etags = malloc((size_t)parts_needed * TDB_S3_ETAG_MAX);
     if (!part_buf || !etags)
     {
@@ -1218,7 +1298,7 @@ static int s3_put_multipart(s3_ctx_t *s3, const char *key, FILE *fp, long file_s
     int failed = 0;
     for (;;)
     {
-        size_t got = fread(part_buf, 1, TDB_S3_MULTIPART_PART_SIZE, fp);
+        size_t got = fread(part_buf, 1, part_size, fp);
         if (got == 0)
         {
             if (ferror(fp)) failed = 1;
@@ -1236,7 +1316,7 @@ static int s3_put_multipart(s3_ctx_t *s3, const char *key, FILE *fp, long file_s
             break;
         }
         part_count++;
-        if (got < TDB_S3_MULTIPART_PART_SIZE) break; /* short read -- last part */
+        if (got < part_size) break; /* short read -- last part */
     }
 
     int rc = -1;
@@ -1283,7 +1363,7 @@ static int s3_put(void *ctx, const char *key, const char *local_path)
     rewind(fp);
 
     int rc;
-    if ((size_t)file_size >= TDB_S3_MULTIPART_THRESHOLD)
+    if ((size_t)file_size >= s3->multipart_threshold)
         rc = s3_put_multipart(s3, key, fp, file_size);
     else
         rc = s3_put_single(s3, key, fp, file_size);
@@ -1380,7 +1460,7 @@ static int s3_list(void *ctx, const char *prefix,
             return count > 0 ? count : -1;
         }
 
-        CURL *curl = s3_curl_new();
+        CURL *curl = s3_curl_new(s3);
         if (!curl)
         {
             free(resp.data);
@@ -1484,26 +1564,38 @@ static void s3_destroy(void *ctx)
     free(ctx);
 }
 
-tidesdb_objstore_t *tidesdb_objstore_s3_create(const char *endpoint, const char *bucket,
-                                               const char *prefix, const char *access_key,
-                                               const char *secret_key, const char *region,
-                                               int use_ssl, int use_path_style)
+tidesdb_objstore_t *tidesdb_objstore_s3_create_config(const tidesdb_objstore_s3_config_t *config)
 {
-    if (!endpoint || !bucket || !access_key || !secret_key) return NULL;
+    if (!config || !config->endpoint || !config->bucket || !config->access_key ||
+        !config->secret_key)
+        return NULL;
 
     curl_global_init(CURL_GLOBAL_DEFAULT);
 
     s3_ctx_t *s3 = calloc(1, sizeof(s3_ctx_t));
     if (!s3) return NULL;
 
-    snprintf(s3->endpoint, sizeof(s3->endpoint), "%s", endpoint);
-    snprintf(s3->bucket, sizeof(s3->bucket), "%s", bucket);
-    if (prefix) snprintf(s3->prefix, sizeof(s3->prefix), "%s", prefix);
-    snprintf(s3->access_key, sizeof(s3->access_key), "%s", access_key);
-    snprintf(s3->secret_key, sizeof(s3->secret_key), "%s", secret_key);
-    snprintf(s3->region, sizeof(s3->region), "%s", region ? region : TDB_S3_DEFAULT_REGION);
-    s3->use_ssl = use_ssl;
-    s3->use_path_style = use_path_style;
+    snprintf(s3->endpoint, sizeof(s3->endpoint), "%s", config->endpoint);
+    snprintf(s3->bucket, sizeof(s3->bucket), "%s", config->bucket);
+    if (config->prefix) snprintf(s3->prefix, sizeof(s3->prefix), "%s", config->prefix);
+    snprintf(s3->access_key, sizeof(s3->access_key), "%s", config->access_key);
+    snprintf(s3->secret_key, sizeof(s3->secret_key), "%s", config->secret_key);
+    snprintf(s3->region, sizeof(s3->region), "%s",
+             config->region ? config->region : TDB_S3_DEFAULT_REGION);
+    s3->use_ssl = config->use_ssl;
+    s3->use_path_style = config->use_path_style;
+
+    /* TLS copy a custom CA bundle path if given; the secure default (empty path +
+     * skip_verify 0) leaves libcurl verifying peer+host against the system CA bundle. */
+    if (config->tls_ca_path)
+        snprintf(s3->tls_ca_path, sizeof(s3->tls_ca_path), "%s", config->tls_ca_path);
+    s3->tls_insecure_skip_verify = config->tls_insecure_skip_verify;
+
+    /* multipart honor the caller's tuning, falling back to the documented defaults */
+    s3->multipart_threshold =
+        config->multipart_threshold ? config->multipart_threshold : TDB_S3_MULTIPART_THRESHOLD;
+    s3->multipart_part_size =
+        config->multipart_part_size ? config->multipart_part_size : TDB_S3_MULTIPART_PART_SIZE;
 
     tidesdb_objstore_t *store = calloc(1, sizeof(tidesdb_objstore_t));
     if (!store)
@@ -1523,6 +1615,29 @@ tidesdb_objstore_t *tidesdb_objstore_s3_create(const char *endpoint, const char 
     store->ctx = s3;
 
     return store;
+}
+
+tidesdb_objstore_t *tidesdb_objstore_s3_create(const char *endpoint, const char *bucket,
+                                               const char *prefix, const char *access_key,
+                                               const char *secret_key, const char *region,
+                                               int use_ssl, int use_path_style)
+{
+    /* thin wrapper preserving the original signature, secure TLS defaults (verify peer+host
+     * against the system CA bundle) and default multipart tuning -- identical behavior to
+     * before this entry point existed. */
+    const tidesdb_objstore_s3_config_t config = {.endpoint = endpoint,
+                                                 .bucket = bucket,
+                                                 .prefix = prefix,
+                                                 .access_key = access_key,
+                                                 .secret_key = secret_key,
+                                                 .region = region,
+                                                 .use_ssl = use_ssl,
+                                                 .use_path_style = use_path_style,
+                                                 .tls_ca_path = NULL,
+                                                 .tls_insecure_skip_verify = 0,
+                                                 .multipart_threshold = 0,
+                                                 .multipart_part_size = 0};
+    return tidesdb_objstore_s3_create_config(&config);
 }
 
 #endif /* TIDESDB_WITH_S3 */

--- a/src/objstore_s3.h
+++ b/src/objstore_s3.h
@@ -41,4 +41,49 @@ tidesdb_objstore_t *tidesdb_objstore_s3_create(const char *endpoint, const char 
                                                const char *secret_key, const char *region,
                                                int use_ssl, int use_path_style);
 
+/**
+ * tidesdb_objstore_s3_config_t
+ * full configuration for an S3 connector, including TLS and multipart tuning that the
+ * positional tidesdb_objstore_s3_create cannot express. zero-initialize and set the fields
+ * you need the all-zero defaults are secure (TLS verify on, no custom CA) and use the
+ * built-in multipart sizes.
+ * @param endpoint S3 endpoint (required)
+ * @param bucket bucket name (required)
+ * @param prefix key prefix, or NULL
+ * @param access_key AWS access key ID (required)
+ * @param secret_key AWS secret access key (required)
+ * @param region AWS region, or NULL for the default
+ * @param use_ssl 1 for HTTPS, 0 for HTTP
+ * @param use_path_style 1 for path-style URLs (MinIO), 0 for virtual-hosted (AWS)
+ * @param tls_ca_path custom CA bundle file path, or NULL for the system bundle
+ * @param tls_insecure_skip_verify 1 disables TLS peer+host verification (test endpoints
+ *                                 ONLY -- insecure); 0 keeps verification on (default)
+ * @param multipart_threshold object size at/above which multipart upload is used; 0 = default
+ * @param multipart_part_size multipart chunk size in bytes; 0 = default
+ */
+typedef struct
+{
+    const char *endpoint;
+    const char *bucket;
+    const char *prefix;
+    const char *access_key;
+    const char *secret_key;
+    const char *region;
+    int use_ssl;
+    int use_path_style;
+    const char *tls_ca_path;
+    int tls_insecure_skip_verify;
+    size_t multipart_threshold;
+    size_t multipart_part_size;
+} tidesdb_objstore_s3_config_t;
+
+/**
+ * tidesdb_objstore_s3_create_config
+ * create an S3-compatible connector from a full configuration struct (TLS + multipart).
+ * tidesdb_objstore_s3_create is a thin wrapper over this with secure/default settings.
+ * @param config connector configuration (fields are copied; need not outlive the call)
+ * @return connector handle, or NULL on error
+ */
+tidesdb_objstore_t *tidesdb_objstore_s3_create_config(const tidesdb_objstore_s3_config_t *config);
+
 #endif /* __OBJSTORE_S3_H__ */

--- a/src/skip_list.c
+++ b/src/skip_list.c
@@ -298,6 +298,10 @@ static inline uint64_t SKIP_LIST_BSWAP64(uint64_t x)
 #define SKIP_LIST_IS_BIG_ENDIAN 0
 #endif
 
+/* stack-allocated update array size for the batch/put paths; lists taller than this
+ * fall back to a heap update array. file-scope so it is defined exactly once. */
+#define SKIP_LIST_STACK_UPDATE_SIZE 64
+
 /**
  * skip_list_compare_keys_4_inline
  * fast inline lexicographic comparison for 4-byte keys
@@ -638,11 +642,17 @@ int skip_list_comparator_memcmp(const uint8_t *key1, size_t key1_size, const uin
 int skip_list_comparator_string(const uint8_t *key1, size_t key1_size, const uint8_t *key2,
                                 size_t key2_size, void *ctx)
 {
-    (void)key1_size;
-    (void)key2_size;
     (void)ctx;
-    int cmp = strcmp((const char *)key1, (const char *)key2);
-    return cmp == 0 ? 0 : (cmp < 0 ? -1 : 1);
+    /* length-bounded compare keys are byte buffers, not guaranteed NUL-terminated.
+     * strcmp here would read past the buffer on a non-terminated key. memcmp over the
+     * shorter length plus a length tie-break gives the same order as strcmp for
+     * well-formed C-string keys while staying in bounds. */
+    const size_t min_size = key1_size < key2_size ? key1_size : key2_size;
+    const int cmp = memcmp(key1, key2, min_size);
+    if (cmp != 0) return cmp < 0 ? -1 : 1;
+    if (key1_size < key2_size) return -1;
+    if (key1_size > key2_size) return 1;
+    return 0;
 }
 
 int skip_list_comparator_numeric(const uint8_t *key1, size_t key1_size, const uint8_t *key2,
@@ -1863,8 +1873,7 @@ int skip_list_put_with_seq(skip_list_t *list, const uint8_t *key, size_t key_siz
     const int max_level = atomic_load_explicit(&list->level, memory_order_acquire);
     const skip_list_cmp_type_t cmp_type = list->cmp_type;
 
-    /* we use stack allocation for update array */
-#define SKIP_LIST_STACK_UPDATE_SIZE 64
+    /* we use stack allocation for update array (SKIP_LIST_STACK_UPDATE_SIZE is file-scope) */
     skip_list_node_t *stack_update[SKIP_LIST_STACK_UPDATE_SIZE];
     skip_list_node_t **update;
     const int use_stack = (list->max_level < SKIP_LIST_STACK_UPDATE_SIZE);
@@ -2190,7 +2199,6 @@ int skip_list_put_batch(skip_list_t *list, const skip_list_batch_entry_t *entrie
      * this avoids repeated allocation/deallocation per entry */
     skip_list_node_t *header = atomic_load_explicit(&list->header, memory_order_acquire);
 
-#define SKIP_LIST_STACK_UPDATE_SIZE 64
     skip_list_node_t *stack_update[SKIP_LIST_STACK_UPDATE_SIZE];
     skip_list_node_t **update;
     const int use_stack = (list->max_level < SKIP_LIST_STACK_UPDATE_SIZE);

--- a/src/skip_list.h
+++ b/src/skip_list.h
@@ -431,7 +431,11 @@ typedef struct
  * @param list skip list
  * @param entries array of batch entries
  * @param count number of entries
- * @return number of successfully inserted entries, -1 on critical failure
+ * @return number of successfully inserted entries; this MAY be less than count when
+ *         individual entries are skipped (e.g. duplicate (key,seq) or a per-entry
+ *         allocation failure) -- compare the result against count to detect a partial
+ *         batch. returns -1 only on a critical failure that inserts nothing, NULL list/
+ *         entries, count == 0, or the update-array allocation failing.
  */
 int skip_list_put_batch(skip_list_t *list, const skip_list_batch_entry_t *entries, size_t count);
 

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -438,7 +438,7 @@ static inline size_t tdb_build_prefixed_key(const uint32_t cf_index, const uint8
 
 /* file-open descriptor-pressure handling. block_manager_open can fail with EMFILE/ENFILE when the
  * process is momentarily at its open-fd ceiling (many sstables open under heavy flush+compaction).
- * tidesdb_bm_open treats that as transient backpressure: it wakes the reaper to close idle sstables
+ * tidesdb_bm_open treats that as transient backpressure, it wakes the reaper to close idle sstables
  * and retries a bounded number of times before failing, so an fd spike does not permanently wedge
  * flush or compaction. all other errors (and success) return immediately. */
 #define TDB_BM_OPEN_EMFILE_MAX_RETRIES 5
@@ -531,11 +531,11 @@ static void tidesdb_wake_reaper(tidesdb_t *db)
 /**
  * tidesdb_bm_open
  * open a block manager, treating file-descriptor exhaustion (EMFILE/ENFILE) as transient
- * backpressure rather than a hard failure: wake the reaper to close idle sstables and retry a
+ * backpressure rather than a hard failure, wake the reaper to close idle sstables and retry a
  * bounded number of times. every other errno (and success) returns immediately. errno is preserved
  * by block_manager_open across its own cleanup, so the EMFILE/ENFILE check sees the real cause.
  * @param db database instance (for waking the reaper)
- * @param bm out: opened block manager
+ * @param bm out-- opened block manager
  * @param path file path
  * @param sync_mode block-manager sync mode (already converted)
  * @return 0 on success, -1 on failure (errno set)
@@ -15817,14 +15817,31 @@ static int tidesdb_partitioned_merge(tidesdb_column_family_t *cf, int start_leve
             block_manager_t *klog_bm = NULL;
             block_manager_t *vlog_bm = NULL;
 
-            block_manager_open(&klog_bm, new_sst->klog_path,
-                               convert_sync_mode(cf->config.sync_mode == TDB_SYNC_INTERVAL
-                                                     ? TDB_SYNC_FULL
-                                                     : cf->config.sync_mode));
-            block_manager_open(&vlog_bm, new_sst->vlog_path,
-                               convert_sync_mode(cf->config.sync_mode == TDB_SYNC_INTERVAL
-                                                     ? TDB_SYNC_FULL
-                                                     : cf->config.sync_mode));
+            /* open the partition's output sstable. on failure (e.g. EMFILE under fd pressure) we
+             * MUST NOT proceed -- the merge loop below writes through klog_bm/vlog_bm and would
+             * dereference a NULL block manager. abort the merge instead; the aborted path preserves
+             * the source sstables, so no data is lost and compaction retries later. routed through
+             * tidesdb_bm_open so a transient fd spike gets a reaper-assisted retry first. */
+            if (tidesdb_bm_open(cf->db, &klog_bm, new_sst->klog_path,
+                                convert_sync_mode(cf->config.sync_mode == TDB_SYNC_INTERVAL
+                                                      ? TDB_SYNC_FULL
+                                                      : cf->config.sync_mode)) != 0 ||
+                tidesdb_bm_open(cf->db, &vlog_bm, new_sst->vlog_path,
+                                convert_sync_mode(cf->config.sync_mode == TDB_SYNC_INTERVAL
+                                                      ? TDB_SYNC_FULL
+                                                      : cf->config.sync_mode)) != 0)
+            {
+                TDB_DEBUG_LOG(TDB_LOG_ERROR,
+                              "CF '%s' partitioned merge: failed to open output sstable for "
+                              "partition %d: %s -- aborting (sources preserved)",
+                              cf->name, partition, strerror(errno));
+                if (klog_bm) block_manager_close(klog_bm);
+                if (vlog_bm) block_manager_close(vlog_bm);
+                tidesdb_sstable_unref(cf->db, new_sst);
+                tidesdb_merge_heap_free(heap);
+                aborted = 1;
+                break;
+            }
 
             bloom_filter_t *bloom = NULL;
             tidesdb_block_index_t *block_indexes = NULL;
@@ -16193,21 +16210,54 @@ static int tidesdb_partitioned_merge(tidesdb_column_family_t *cf, int start_leve
                                     else
                                         break;
                                 }
+                                /* the prior split was already finalized (it consumed klog_bm,
+                                 * vlog_bm, bloom, block_indexes), so NULL them before the post-loop
+                                 * finalize guard runs -- otherwise it would double-free/close them.
+                                 * abort so the sources are preserved (no data loss; retried). */
+                                klog_bm = NULL;
+                                vlog_bm = NULL;
+                                bloom = NULL;
+                                block_indexes = NULL;
+                                aborted = 1;
                                 break;
                             }
 
                             klog_bm = NULL;
                             vlog_bm = NULL;
-                            block_manager_open(
-                                &klog_bm, new_sst->klog_path,
-                                convert_sync_mode(cf->config.sync_mode == TDB_SYNC_INTERVAL
-                                                      ? TDB_SYNC_FULL
-                                                      : cf->config.sync_mode));
-                            block_manager_open(
-                                &vlog_bm, new_sst->vlog_path,
-                                convert_sync_mode(cf->config.sync_mode == TDB_SYNC_INTERVAL
-                                                      ? TDB_SYNC_FULL
-                                                      : cf->config.sync_mode));
+                            /* open the split (continuation) output. same hazard as the partition's
+                             * first output, on failure we must not write through a NULL block
+                             * manager. abort cleanly -- the previous split was already finalized,
+                             * and the aborted path preserves the sources, so reads still find every
+                             * key (dedup by seq) and compaction retries. the post-loop finalize is
+                             * guarded on new_sst/klog_bm so the NULL'd state below is never used.
+                             */
+                            if (tidesdb_bm_open(
+                                    cf->db, &klog_bm, new_sst->klog_path,
+                                    convert_sync_mode(cf->config.sync_mode == TDB_SYNC_INTERVAL
+                                                          ? TDB_SYNC_FULL
+                                                          : cf->config.sync_mode)) != 0 ||
+                                tidesdb_bm_open(
+                                    cf->db, &vlog_bm, new_sst->vlog_path,
+                                    convert_sync_mode(cf->config.sync_mode == TDB_SYNC_INTERVAL
+                                                          ? TDB_SYNC_FULL
+                                                          : cf->config.sync_mode)) != 0)
+                            {
+                                TDB_DEBUG_LOG(TDB_LOG_ERROR,
+                                              "CF '%s' partitioned merge: failed to open split "
+                                              "output for partition %d: %s -- aborting",
+                                              cf->name, partition, strerror(errno));
+                                if (klog_bm) block_manager_close(klog_bm);
+                                if (vlog_bm) block_manager_close(vlog_bm);
+                                tidesdb_sstable_unref(cf->db, new_sst);
+                                new_sst = NULL;
+                                klog_bm = NULL;
+                                vlog_bm = NULL;
+                                bloom =
+                                    NULL; /* consumed by the prior finalize -- don't reuse/free */
+                                block_indexes = NULL;
+                                aborted = 1;
+                                break;
+                            }
 
                             bloom = NULL;
                             block_indexes = NULL;
@@ -16255,8 +16305,10 @@ static int tidesdb_partitioned_merge(tidesdb_column_family_t *cf, int start_leve
             /* we clean up duplicate detection tracking */
             free(last_seen_key);
 
-            /* we write remaining block */
-            if (klog_block->num_entries > 0)
+            /* we write remaining block -- skipped when an output open aborted the merge (new_sst or
+             * klog_bm NULL), since writing through a NULL block manager would crash and the sources
+             * are being preserved anyway */
+            if (klog_block->num_entries > 0 && new_sst && klog_bm)
             {
                 uint8_t *klog_data;
                 size_t klog_size;
@@ -16306,18 +16358,36 @@ static int tidesdb_partitioned_merge(tidesdb_column_family_t *cf, int start_leve
             free(block_first_key);
             free(block_last_key);
 
-            /* we assign min/max keys and finalize via helper */
-            new_sst->min_key = first_key;
-            new_sst->min_key_size = first_key_size;
-            new_sst->max_key = last_key;
-            new_sst->max_key_size = last_key_size;
+            /* we assign min/max keys and finalize via helper -- unless an output open aborted the
+             * merge, in which case we must not finalize through a NULL block manager. release this
+             * partition's still-owned resources and leave the sources intact (aborted path below).
+             */
+            if (new_sst && klog_bm && vlog_bm)
+            {
+                new_sst->min_key = first_key;
+                new_sst->min_key_size = first_key_size;
+                new_sst->max_key = last_key;
+                new_sst->max_key_size = last_key_size;
 
-            tdb_partitioned_merge_finalize_sst(cf, new_sst, klog_bm, vlog_bm, bloom, block_indexes,
-                                               entry_count, tombstone_count, klog_block_num,
-                                               vlog_block_num, max_seq, end_level, partition);
+                tdb_partitioned_merge_finalize_sst(
+                    cf, new_sst, klog_bm, vlog_bm, bloom, block_indexes, entry_count,
+                    tombstone_count, klog_block_num, vlog_block_num, max_seq, end_level, partition);
+            }
+            else
+            {
+                free(first_key);
+                free(last_key);
+                if (bloom) bloom_filter_free(bloom);
+                if (block_indexes) compact_block_index_free(block_indexes);
+                if (klog_bm) block_manager_close(klog_bm);
+                if (vlog_bm) block_manager_close(vlog_bm);
+                if (new_sst) tidesdb_sstable_unref(cf->db, new_sst);
+                aborted = 1;
+            }
         }
 
         tidesdb_merge_heap_free(heap);
+        if (aborted) break;
     }
 
     if (aborted)
@@ -17470,7 +17540,7 @@ static void *tidesdb_flush_worker_thread(void *arg)
         }
 
         /* out-of-order L0 insertion check. concurrent flush threads finish out of id order, so a
-         * lower-max_seq sstable can land after a higher one. this is benign: both point reads and
+         * lower-max_seq sstable can land after a higher one. this is benign, both point reads and
          * the merge-heap iterators resolve versions by per-entry seq, never by L0 array position
          * (the array is append-only and unsorted). logged at DEBUG as a flush-concurrency signal
          * only -- it is not a correctness violation. one line per out-of-order add (not per pair)
@@ -17719,9 +17789,9 @@ static void *tidesdb_flush_worker_thread(void *arg)
                     /* we try to claim the last reference atomically. this is a single,
                      * NON-BLOCKING attempt -- it succeeds only when refcount==1 (no reader holds a
                      * merge-source ref). a pinned immutable is left in the queue and reclaimed on a
-                     * later pass once its readers drain. we must NOT spin-wait here: a flushed
+                     * later pass once its readers drain. we must not spin-wait here, a flushed
                      * immutable is now excluded from the reader snapshot (see
-                     * tidesdb_imm_snap_publish_locked), so no NEW reader can pin it and its
+                     * tidesdb_imm_snap_publish_locked), so no new reader can pin it and its
                      * refcount will fall to 1 on its own -- blocking the flush worker to wait for
                      * that is what collapsed flush throughput and wedged writes under reader load.
                      */

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -410,6 +410,12 @@ static inline size_t tdb_build_prefixed_key(const uint32_t cf_index, const uint8
  * stalls the writer until rotation completes */
 #define TDB_BACKPRESSURE_ACTIVE_MT_CEILING_MULT 2
 
+/* backpressure stall warnings (ceiling stall, immutable-queue-critical) are emitted from the
+ * write/flush hot paths -- a per-event log floods under sustained backpressure (every stalling
+ * writer, every flush completion). throttle each to at most one line per CF per this many seconds
+ * so the condition stays visible without drowning the log. see tdb_log_throttle. */
+#define TDB_BACKPRESSURE_STALL_LOG_INTERVAL_SEC 1
+
 /* global memory pressure configuration (computed by reaper, consumed by write path)
  * graduated response based on ratio of used memory to resolved_memory_limit */
 #define TDB_MEMORY_PRESSURE_NORMAL         0    /* < 60% -- no action */
@@ -469,6 +475,26 @@ static inline size_t tdb_build_prefixed_key(const uint32_t cf_index, const uint8
 #define TDB_BLOCK_INDEX_PREFIX_MIN 4
 #define TDB_BLOCK_INDEX_PREFIX_MAX 256
 #define TDB_BLOCK_INDEX_MAX_COUNT  1000000
+
+/**
+ * tdb_log_throttle
+ * rate-limit a hot-path log line. returns 1 at most once per interval_sec for a given
+ * last_log_sec slot, 0 otherwise. a CAS picks a single winner among concurrent callers so the
+ * line is emitted once per window even under many simultaneous writers/flushers.
+ * uses db->cached_current_time (maintained by the reaper) to avoid a clock syscall on the hot path.
+ * @param db database (source of cached time)
+ * @param last_log_sec per-CF / per-mode atomic holding the last emit time in seconds
+ * @param interval_sec minimum seconds between emissions
+ * @return 1 if the caller should emit now, 0 to suppress
+ */
+static int tdb_log_throttle(tidesdb_t *db, _Atomic(time_t) *last_log_sec, int interval_sec)
+{
+    const time_t now = atomic_load_explicit(&db->cached_current_time, memory_order_relaxed);
+    time_t last = atomic_load_explicit(last_log_sec, memory_order_relaxed);
+    if (now - last < interval_sec) return 0;
+    return atomic_compare_exchange_strong_explicit(last_log_sec, &last, now, memory_order_relaxed,
+                                                   memory_order_relaxed);
+}
 
 /* empty block index placeholder ( 4 byte LE count (0) followed by 1 byte prefix_len ) */
 #define TDB_EMPTY_BLOCK_INDEX_SIZE 5
@@ -5836,6 +5862,8 @@ static int tidesdb_sstable_ensure_open(tidesdb_t *db, tidesdb_sstable_t *sst)
                                                      ? TDB_SYNC_FULL
                                                      : sst->config->sync_mode)) != 0)
         {
+            TDB_DEBUG_LOG(TDB_LOG_ERROR, "failed to open klog '%s': %s", sst->klog_path,
+                          strerror(errno));
             return -1;
         }
         /* CAS to set klog_bm -- if another thread already set it, close ours */
@@ -5854,6 +5882,8 @@ static int tidesdb_sstable_ensure_open(tidesdb_t *db, tidesdb_sstable_t *sst)
                                convert_sync_mode(sst->config->sync_mode)) != 0)
         {
             /* we dont close klog_bm here -- it may be used by another thread */
+            TDB_DEBUG_LOG(TDB_LOG_ERROR, "failed to open vlog '%s': %s", sst->vlog_path,
+                          strerror(errno));
             return -1;
         }
 
@@ -17363,8 +17393,12 @@ static void *tidesdb_flush_worker_thread(void *arg)
             continue;
         }
 
-        /* we validate flush ordering -- new sst should have higher sequence than existing ones
-         * this maintains LSM invariant that newer data has higher sequence numbers */
+        /* out-of-order L0 insertion check. concurrent flush threads finish out of id order, so a
+         * lower-max_seq sstable can land after a higher one. this is benign: both point reads and
+         * the merge-heap iterators resolve versions by per-entry seq, never by L0 array position
+         * (the array is append-only and unsorted). logged at DEBUG as a flush-concurrency signal
+         * only -- it is not a correctness violation. one line per out-of-order add (not per pair)
+         * to avoid an O(n) burst when an old sstable lands behind many newer ones. */
         int num_existing = atomic_load_explicit(&cf->levels[0]->num_sstables, memory_order_acquire);
         if (num_existing > 0)
         {
@@ -17374,13 +17408,13 @@ static void *tidesdb_flush_worker_thread(void *arg)
             {
                 if (existing_ssts[i] && existing_ssts[i]->max_seq >= sst->max_seq)
                 {
-                    TDB_DEBUG_LOG(TDB_LOG_WARN,
-                                  "CF '%s' flush ordering violation - SSTable %" PRIu64
-                                  " (max_seq=%" PRIu64
-                                  ") "
-                                  "added after SSTable %" PRIu64 " (max_seq=%" PRIu64 ")",
+                    TDB_DEBUG_LOG(TDB_LOG_DEBUG,
+                                  "CF '%s' SSTable %" PRIu64 " (max_seq=%" PRIu64
+                                  ") added to L0 out of seq order behind SSTable %" PRIu64
+                                  " (max_seq=%" PRIu64 ") -- benign, reads resolve by seq",
                                   cf->name, work->sst_id, sst->max_seq, existing_ssts[i]->id,
                                   existing_ssts[i]->max_seq);
+                    break;
                 }
             }
         }
@@ -17558,7 +17592,8 @@ static void *tidesdb_flush_worker_thread(void *arg)
             (counter % cleanup_threshold == 0) || (current_queue_size > max_queue_size);
         int force_cleanup = (current_queue_size >= force_cleanup_size);
 
-        if (force_cleanup)
+        if (force_cleanup && tdb_log_throttle(cf->db, &cf->last_imm_critical_log_sec,
+                                              TDB_BACKPRESSURE_STALL_LOG_INTERVAL_SEC))
         {
             TDB_DEBUG_LOG(
                 TDB_LOG_WARN,
@@ -22518,7 +22553,8 @@ static int tidesdb_flush_memtable_internal(tidesdb_column_family_t *cf,
 
         if (block_manager_open(&new_wal, wal_path, convert_sync_mode(cf->config.sync_mode)) != 0)
         {
-            TDB_DEBUG_LOG(TDB_LOG_WARN, "CF '%s' failed to open new WAL: %s", cf->name, wal_path);
+            TDB_DEBUG_LOG(TDB_LOG_WARN, "CF '%s' failed to open new WAL '%s': %s", cf->name,
+                          wal_path, strerror(errno));
             skip_list_free(new_memtable);
             atomic_fetch_sub_explicit(&cf->db->active_flushes, 1, memory_order_release);
             atomic_store_explicit(&cf->is_flushing, 0, memory_order_release);
@@ -23187,9 +23223,12 @@ static int tidesdb_apply_backpressure(tidesdb_column_family_t *cf)
         }
         if (active_size >= ceiling)
         {
-            TDB_DEBUG_LOG(TDB_LOG_WARN,
-                          "CF '%s' active memtable ceiling stall: %zu bytes >= %zu (%dx wbuf)",
-                          cf->name, active_size, ceiling, TDB_BACKPRESSURE_ACTIVE_MT_CEILING_MULT);
+            if (tdb_log_throttle(cf->db, &cf->last_ceiling_stall_log_sec,
+                                 TDB_BACKPRESSURE_STALL_LOG_INTERVAL_SEC))
+                TDB_DEBUG_LOG(TDB_LOG_WARN,
+                              "CF '%s' active memtable ceiling stall: %zu bytes >= %zu (%dx wbuf)",
+                              cf->name, active_size, ceiling,
+                              TDB_BACKPRESSURE_ACTIVE_MT_CEILING_MULT);
 
             /* kick a force-flush so rotation runs as soon as a slot frees, instead
              * of waiting for the reaper's deferred-flush retry cycle. if the slot
@@ -23265,9 +23304,11 @@ static int tidesdb_apply_backpressure(tidesdb_column_family_t *cf)
         }
         if (u_size >= u_ceiling)
         {
-            TDB_DEBUG_LOG(TDB_LOG_WARN,
-                          "unified active memtable ceiling stall: %zu bytes >= %zu (%dx wbuf)",
-                          u_size, u_ceiling, TDB_BACKPRESSURE_ACTIVE_MT_CEILING_MULT);
+            if (tdb_log_throttle(cf->db, &cf->db->unified_mt.last_ceiling_stall_log_sec,
+                                 TDB_BACKPRESSURE_STALL_LOG_INTERVAL_SEC))
+                TDB_DEBUG_LOG(TDB_LOG_WARN,
+                              "unified active memtable ceiling stall: %zu bytes >= %zu (%dx wbuf)",
+                              u_size, u_ceiling, TDB_BACKPRESSURE_ACTIVE_MT_CEILING_MULT);
 
             int expected = 0;
             if (atomic_compare_exchange_strong_explicit(&cf->db->unified_mt.is_flushing, &expected,

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -580,8 +580,8 @@ static int tidesdb_bm_open(tidesdb_t *db, block_manager_t **bm, const char *path
  */
 /**
  * tidesdb_sstable_open_budget
- * the descriptor budget for resident open sstables: max_open_sstables minus the reserve held for
- * flush/compaction. BOTH the reader admission check and the reaper's eviction trigger use this, so
+ * the descriptor budget for resident open sstables, max_open_sstables minus the reserve held for
+ * flush/compaction. both the reader admission check and the reaper's eviction trigger use this, so
  * the reaper keeps num_open_sstables at or below the budget the readers stop at -- otherwise reads
  * would back off in the [budget, max_open) gap while the reaper (triggering only at max_open) frees
  * nothing, starving reads with no relief on fd-constrained hosts.
@@ -605,15 +605,23 @@ static int tidesdb_reader_fd_budget_ok(tidesdb_t *db, tidesdb_sstable_t *sst)
      * needs no new tracked descriptor and is never blocked (the lazy vlog rides along) */
     if (atomic_load_explicit(&sst->klog_bm, memory_order_acquire)) return 1;
 
-    const int budget = tidesdb_sstable_open_budget(db);
+    /* reads may open up to max_open_sstables -- the open-file clamp keeps that descriptor-safe, and
+     * respecting it (rather than opening every source unbounded) is what prevents the original
+     * full-scan fd-exhaustion wedge. the reaper evicts IDLE sstables down to the smaller
+     * open-budget (max_open - reserve), so [open_budget, max_open) is burst headroom for active
+     * reads and compaction; a read only backs off with a retryable error at the hard cap. a
+     * k-way-merge iterator needs its whole source set open at once, so it must use this full cap
+     * too -- a smaller per-read reserve would make any scan over more than (budget) sstables
+     * impossible. */
+    const int max_open = (int)db->config.max_open_sstables;
 
-    if (atomic_load_explicit(&db->num_open_sstables, memory_order_relaxed) < budget) return 1;
+    if (atomic_load_explicit(&db->num_open_sstables, memory_order_relaxed) < max_open) return 1;
 
     /* over budget for a new open -- give the reaper a chance to reclaim idle sstables, then recheck
      */
     tidesdb_wake_reaper(db);
     usleep(TDB_BACKPRESSURE_STALL_CHECK_INTERVAL_US);
-    return atomic_load_explicit(&db->num_open_sstables, memory_order_relaxed) < budget;
+    return atomic_load_explicit(&db->num_open_sstables, memory_order_relaxed) < max_open;
 }
 
 /* empty block index placeholder ( 4 byte LE count (0) followed by 1 byte prefix_len ) */
@@ -19290,8 +19298,8 @@ static void *tidesdb_sstable_reaper_thread(void *arg)
 
         int current_open = atomic_load(&db->num_open_sstables);
         int max_open = (int)db->config.max_open_sstables;
-        /* evict down to the reader budget, not max_open: keeping num_open at/below the budget
-         * leaves the reserve free for flush/compaction AND gives readers headroom to open, closing
+        /* evict down to the reader budget, not max_open, keeping num_open at/below the budget
+         * leaves the reserve free for flush/compaction and gives readers headroom to open, closing
          * the [budget, max_open) starvation gap where reads back off but eviction never fired. */
         const int reap_target = tidesdb_sstable_open_budget(db);
 
@@ -22733,6 +22741,10 @@ int tidesdb_rename_column_family(tidesdb_t *db, const char *old_name, const char
             tidesdb_sstable_t *sst = sstables[s];
             if (!sst) continue;
 
+            /* num_open_sstables is keyed on the klog; a klog-open sstable counts one, so dropping
+             * its handle here must decrement or the rename leaks the count for every open sstable
+             */
+            const int had_open_klog = (sst->klog_bm != NULL);
             if (sst->klog_bm)
             {
                 block_manager_close(sst->klog_bm);
@@ -22743,6 +22755,7 @@ int tidesdb_rename_column_family(tidesdb_t *db, const char *old_name, const char
                 block_manager_close(sst->vlog_bm);
                 sst->vlog_bm = NULL;
             }
+            if (had_open_klog) atomic_fetch_sub(&cf->db->num_open_sstables, 1);
         }
     }
 
@@ -25277,9 +25290,10 @@ unified_sst_search:;
                 continue;
             }
 
-            /* reader fd budget, don't open a new sstable for this read if doing so would eat into
-             * the flush/compaction reserve. back off with a retryable error rather than starving
-             * the write path; an already-open sstable is never blocked (see helper). */
+            /* reader fd budget -- don't open past the max_open cap; back off with a retryable error
+             * rather than starving the write path. an already-open sstable is never blocked, and
+             * the reaper keeps idle sstables below the cap so a point-get normally has headroom
+             * (see helper). */
             if (!tidesdb_reader_fd_budget_ok(cf->db, sst))
             {
                 tidesdb_sstable_unref(cf->db, sst);
@@ -26999,6 +27013,12 @@ static int tidesdb_unified_write_cf_sstable(tidesdb_t *db, tidesdb_column_family
         if (bms.klog_bm) block_manager_escalate_fsync(bms.klog_bm);
         if (bms.vlog_bm) block_manager_escalate_fsync(bms.vlog_bm);
     }
+    /* the write opened the klog via tidesdb_sstable_ensure_open, which counted it in
+     * num_open_sstables (the count is keyed on the klog). closing it here must drop that count or
+     * num_open leaks one per flush -- the published sstable carries klog_bm == NULL, so the reaper,
+     * which only reclaims klog-open in-level sstables, can never bring the count back down and it
+     * climbs until it pegs max_open_sstables and reads start backing off with TDB_ERR_BUSY */
+    const int had_open_klog = (sst->klog_bm != NULL);
     if (sst->klog_bm)
     {
         block_manager_close(sst->klog_bm);
@@ -27009,6 +27029,7 @@ static int tidesdb_unified_write_cf_sstable(tidesdb_t *db, tidesdb_column_family
         block_manager_close(sst->vlog_bm);
         sst->vlog_bm = NULL;
     }
+    if (had_open_klog) atomic_fetch_sub(&db->num_open_sstables, 1);
 
     /* drop may have fired during the fsync/close above; check once more before publishing
      * to the level so we do not leave a fresh sstable behind for remove_directory to race */
@@ -28735,9 +28756,9 @@ int tidesdb_iter_new(tidesdb_txn_t *txn, tidesdb_column_family_t *cf, tidesdb_it
         {
             tidesdb_sstable_t *sst = ssts_array[i];
 
-            /* reader fd budget--a full-scan iterator opens every source; refuse to exceed the
-             * reader budget (reserve held for flush/compaction). fail creation with a retryable
-             * error rather than starving the write path -- the caller retries once fds free. */
+            /* reader fd budget -- a full-scan iterator opens its entire source set at once, bounded
+             * by the max_open cap (clamp keeps it descriptor-safe); only a source set larger than
+             * max_open fails (a real fd limit). */
             if (!tidesdb_reader_fd_budget_ok(cf->db, sst))
             {
                 for (int k = i; k < sst_count; k++) tidesdb_sstable_unref(cf->db, ssts_array[k]);
@@ -28963,7 +28984,8 @@ static int tidesdb_iter_rebuild_sst_cache(tidesdb_iter_t *iter)
     {
         tidesdb_sstable_t *sst = ssts_array[i];
 
-        /* reader fd budget (see helper) -- back off rather than starving flush/compaction */
+        /* reader fd budget -- iterator source-cache rebuild also opens the whole set at once,
+         * bounded by the max_open cap, same as iter_new */
         if (!tidesdb_reader_fd_budget_ok(cf->db, sst))
         {
             for (int k = i; k < sst_count; k++) tidesdb_sstable_unref(cf->db, ssts_array[k]);

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -1370,8 +1370,8 @@ static int tidesdb_level_add_sstable(tidesdb_level_t *level, tidesdb_sstable_t *
 static int tidesdb_level_remove_sstable(const tidesdb_t *db, tidesdb_level_t *level,
                                         tidesdb_sstable_t *sst);
 static int tidesdb_level_update_boundaries(tidesdb_level_t *level, tidesdb_level_t *largest_level);
-static void tidesdb_level_sort_by_min_key(tidesdb_t *db, tidesdb_level_t *level,
-                                          skip_list_comparator_fn cmp, void *cmp_ctx);
+static int tidesdb_level_sort_by_min_key(tidesdb_t *db, tidesdb_level_t *level,
+                                         skip_list_comparator_fn cmp, void *cmp_ctx);
 static tidesdb_merge_heap_t *tidesdb_merge_heap_create(skip_list_comparator_fn comparator,
                                                        void *comparator_ctx);
 static void tidesdb_merge_heap_free(tidesdb_merge_heap_t *heap);
@@ -1389,7 +1389,8 @@ static tidesdb_merge_source_t *tidesdb_merge_source_from_btree(tidesdb_t *db,
                                                                tidesdb_sstable_t *sst);
 static int tidesdb_btree_read_vlog_value(block_manager_cursor_t *vlog_cursor, uint64_t vlog_offset,
                                          const tidesdb_column_family_config_t *config,
-                                         uint8_t **value_out, size_t *value_size_out);
+                                         uint8_t **value_out, size_t *value_size_out,
+                                         size_t expected_value_size);
 static void tidesdb_iter_clear_block_stash(tidesdb_merge_source_t *source);
 static void tidesdb_iter_clear_lazy(tidesdb_merge_source_t *source);
 static tidesdb_column_family_t *tidesdb_get_column_family_internal(tidesdb_t *db, const char *name);
@@ -2063,42 +2064,11 @@ static int tidesdb_validate_kv_size(tidesdb_t *db, const size_t key_size, const 
     return 0;
 }
 
-/**
- * sstable_metadata_header_t
- * @param magic magic number for validation
- * @param num_entries total number of entries
- * @param num_klog_blocks number of klog blocks
- * @param num_vlog_blocks number of vlog blocks
- * @param klog_size size of klog file
- * @param vlog_size size of vlog file
- * @param min_key_size size of min key
- * @param max_key_size size of max key
- * @param compression_algorithm compression algorithm used (0=none, 1=snappy, 2=lz4, 3=zstd,
- * 4=lz4_fast)
- * @param flags metadata flags (bit 0 = use_btree, bits 1-31 reserved)
- * @param checksum xxHash64 checksum of all fields except checksum itself
- *
- * if flags & SSTABLE_FLAG_BTREE is set, additional btree metadata follows after max_key:
- *   -- int64_t btree_root_offset
- *   -- int64_t btree_first_leaf
- *   -- int64_t btree_last_leaf
- *   -- uint64_t btree_node_count
- *   -- uint32_t btree_height
- */
-typedef struct
-{
-    uint32_t magic;
-    uint64_t num_entries;
-    uint64_t num_klog_blocks;
-    uint64_t num_vlog_blocks;
-    uint64_t klog_size;
-    uint64_t vlog_size;
-    uint64_t min_key_size;
-    uint64_t max_key_size;
-    uint32_t compression_algorithm;
-    uint32_t flags;
-    uint64_t checksum;
-} sstable_metadata_header_t;
+/* the on-disk sstable metadata header is serialized/deserialized field-by-field with the
+ * encode_*_le_compat helpers in sstable_metadata_serialize / sstable_metadata_deserialize --
+ * see those functions (and design/tidesdb_sstable_format.md S7.4) for the authoritative wire
+ * layout. a stale `sstable_metadata_header_t` struct used to live here but was never
+ * referenced and omitted two serialized fields (klog_data_end_offset, max_seq); removed. */
 
 /* sstable metadata flags */
 #define SSTABLE_FLAG_BTREE 0x01 /* sstable uses btree format instead of klog blocks */
@@ -4485,38 +4455,41 @@ static void *tdb_upload_worker_thread(void *arg)
             for (int attempt = 0; attempt < TDB_UPLOAD_MAX_RETRIES; attempt++)
             {
                 rc = db->object_store->put(db->object_store->ctx, job->object_key, job->local_path);
-                if (rc == 0) break;
+                if (rc != 0)
+                {
+                    TDB_DEBUG_LOG(TDB_LOG_WARN, "Upload attempt %d/%d failed: %s", attempt + 1,
+                                  TDB_UPLOAD_MAX_RETRIES, job->object_key);
+                }
+                else if (!strstr(job->object_key, TDB_COLUMN_FAMILY_MANIFEST_NAME))
+                {
+                    /* verify the upload landed with the correct size. MANIFEST is skipped --
+                     * it is mutable and may grow between upload and the exists check due to
+                     * concurrent flushes. a verify mismatch now retries the put (rc=-1 below)
+                     * instead of being a permanent failure with no re-upload. */
+                    struct stat local_st;
+                    if (stat(job->local_path, &local_st) == 0)
+                    {
+                        size_t remote_size = 0;
+                        const int verify = db->object_store->exists(db->object_store->ctx,
+                                                                    job->object_key, &remote_size);
+                        if (verify != 1 || remote_size != (size_t)local_st.st_size)
+                        {
+                            TDB_DEBUG_LOG(
+                                TDB_LOG_ERROR,
+                                "Upload verification failed for %s (local=%zu, remote=%zu, "
+                                "exists=%d)",
+                                job->object_key, (size_t)local_st.st_size, remote_size, verify);
+                            rc = -1;
+                        }
+                    }
+                }
 
-                TDB_DEBUG_LOG(TDB_LOG_WARN, "Upload attempt %d/%d failed: %s", attempt + 1,
-                              TDB_UPLOAD_MAX_RETRIES, job->object_key);
+                if (rc == 0) break;
 
                 if (attempt + 1 < TDB_UPLOAD_MAX_RETRIES)
                 {
                     usleep(backoff_us);
                     backoff_us *= TDB_UPLOAD_BACKOFF_MULTIPLIER;
-                }
-            }
-
-            /* we verify upload landed by checking the object exists with correct size.
-             * skip size verification for MANIFEST files since they are mutable and
-             * may grow between upload and the exists check due to concurrent flushes. */
-            if (rc == 0 && !strstr(job->object_key, TDB_COLUMN_FAMILY_MANIFEST_NAME))
-            {
-                struct stat local_st;
-                if (stat(job->local_path, &local_st) == 0)
-                {
-                    size_t remote_size = 0;
-                    const int verify = db->object_store->exists(db->object_store->ctx,
-                                                                job->object_key, &remote_size);
-                    if (verify != 1 || remote_size != (size_t)local_st.st_size)
-                    {
-                        TDB_DEBUG_LOG(TDB_LOG_ERROR,
-                                      "Upload verification failed for %s (local=%zu, remote=%zu, "
-                                      "exists=%d)",
-                                      job->object_key, (size_t)local_st.st_size, remote_size,
-                                      verify);
-                        rc = -1;
-                    }
                 }
             }
 
@@ -5354,9 +5327,14 @@ static int tdb_replica_replay_single_wal(tidesdb_t *db, const char *wal_local,
                 memcpy(prefixed + TDB_UNIFIED_CF_PREFIX_SIZE, key, key_size_u64);
 
                 const int is_delete = (flags & TDB_KV_FLAG_TOMBSTONE) ? 1 : 0;
+                /* preserve the single-delete subtype across replay (mirrors per-CF WAL
+                 * replay) so compaction can still pair-cancel put+single-delete */
+                int sl_flags = is_delete ? SKIP_LIST_FLAG_DELETED : 0;
+                if (is_delete && (flags & TDB_KV_FLAG_SINGLE_DELETE))
+                    sl_flags |= SKIP_LIST_FLAG_SINGLE_DELETE;
                 skip_list_put_with_seq(
                     umt->skip_list, prefixed, pk_total, is_delete ? NULL : (uint8_t *)value,
-                    is_delete ? 0 : (size_t)value_size_u64, ttl, seq_value, is_delete);
+                    is_delete ? 0 : (size_t)value_size_u64, ttl, seq_value, sl_flags);
                 TDB_PREFIXED_KEY_FREE(prefixed, _pk_stack_r);
 
                 if (seq_value > max_seq) max_seq = seq_value;
@@ -5419,10 +5397,31 @@ static void tdb_objstore_replay_remote_wals(tidesdb_t *db)
         return;
     }
 
-    /* we list all available WAL objects in the object store */
+    /* we list all available WAL objects in the object store, with retry -- a transient list
+     * failure must not be mistaken for "no WALs" and silently skip WAL recovery (mirrors the
+     * retry in tdb_replica_discover_new_cfs) */
     tdb_wal_discovery_ctx_t discovery = {.count = 0};
-    db->object_store->list(db->object_store->ctx, TDB_UNIFIED_WAL_PREFIX, tdb_wal_discovery_cb,
-                           &discovery);
+    int list_rc = -1;
+    unsigned int backoff_us = TDB_LIST_INITIAL_BACKOFF_US;
+    for (int attempt = 0; attempt < TDB_LIST_MAX_RETRIES; attempt++)
+    {
+        discovery.count = 0;
+        list_rc = db->object_store->list(db->object_store->ctx, TDB_UNIFIED_WAL_PREFIX,
+                                         tdb_wal_discovery_cb, &discovery);
+        if (list_rc >= 0) break;
+        TDB_DEBUG_LOG(TDB_LOG_WARN, "Replica WAL replay: object store list attempt %d/%d failed",
+                      attempt + 1, TDB_LIST_MAX_RETRIES);
+        if (attempt + 1 < TDB_LIST_MAX_RETRIES) usleep(backoff_us);
+        backoff_us *= 2;
+    }
+
+    if (list_rc < 0)
+    {
+        TDB_DEBUG_LOG(TDB_LOG_WARN,
+                      "Replica WAL replay: object store list failed after %d attempts, skipping",
+                      TDB_LIST_MAX_RETRIES);
+        return;
+    }
 
     if (discovery.count == 0)
     {
@@ -5782,7 +5781,21 @@ static void tdb_objstore_delete_listed_cb(const char *key, const size_t size, vo
 {
     (void)size;
     const tidesdb_objstore_t *store = (tidesdb_objstore_t *)cb_ctx;
-    store->delete_object(store->ctx, key);
+
+    /* retry with backoff and log on exhaustion, mirroring tdb_objstore_delete_file -- a
+     * single ignored delete during CF drop silently leaves orphaned remote objects */
+    unsigned int delay_us = TDB_UPLOAD_INITIAL_BACKOFF_US;
+    for (int attempt = 0; attempt < TDB_UPLOAD_MAX_RETRIES; attempt++)
+    {
+        if (store->delete_object(store->ctx, key) == 0) return;
+
+        TDB_DEBUG_LOG(TDB_LOG_WARN, "Object store delete attempt %d/%d failed during drop: %s",
+                      attempt + 1, TDB_UPLOAD_MAX_RETRIES, key);
+        if (attempt + 1 < TDB_UPLOAD_MAX_RETRIES) usleep(delay_us);
+        delay_us *= TDB_UPLOAD_BACKOFF_MULTIPLIER;
+    }
+    TDB_DEBUG_LOG(TDB_LOG_ERROR, "Object store delete failed after %d attempts during drop: %s",
+                  TDB_UPLOAD_MAX_RETRIES, key);
 }
 
 /**
@@ -8001,9 +8014,16 @@ static int tidesdb_sstable_get_btree(tidesdb_t *db, tidesdb_sstable_t *sst, cons
     const int max_cmp =
         comparator_fn(key, key_size, sst->max_key, sst->max_key_size, comparator_ctx);
 
-    if (min_cmp < 0 || max_cmp > 0)
+    /* mirror the klog get path, a reverse comparator stores min_key/max_key in reverse
+     * user order, so the range gate must invert or a reverse-sorted btree sstable
+     * rejects every in-range key */
+    if (sst->is_reverse)
     {
-        return TDB_ERR_NOT_FOUND;
+        if (min_cmp > 0 || max_cmp < 0) return TDB_ERR_NOT_FOUND;
+    }
+    else
+    {
+        if (min_cmp < 0 || max_cmp > 0) return TDB_ERR_NOT_FOUND;
     }
 
     if (sst->bloom_filter)
@@ -8080,7 +8100,7 @@ static int tidesdb_sstable_get_btree(tidesdb_t *db, tidesdb_sstable_t *sst, cons
         uint8_t *vlog_value = NULL;
         size_t vlog_value_size = 0;
         if (tidesdb_btree_read_vlog_value(&vlog_cursor, vlog_offset, sst->config, &vlog_value,
-                                          &vlog_value_size) != 0)
+                                          &vlog_value_size, value_size) != 0)
         {
             return TDB_ERR_IO;
         }
@@ -9725,8 +9745,8 @@ static int tidesdb_level_remove_sstables_batch(const tidesdb_t *db, tidesdb_leve
  * @param cmp resolved comparator
  * @param cmp_ctx resolved comparator context
  */
-static void tidesdb_level_sort_by_min_key(tidesdb_t *db, tidesdb_level_t *level,
-                                          skip_list_comparator_fn cmp, void *cmp_ctx)
+static int tidesdb_level_sort_by_min_key(tidesdb_t *db, tidesdb_level_t *level,
+                                         skip_list_comparator_fn cmp, void *cmp_ctx)
 {
     while (1)
     {
@@ -9748,14 +9768,14 @@ static void tidesdb_level_sort_by_min_key(tidesdb_t *db, tidesdb_level_t *level,
         if (num < 2)
         {
             atomic_fetch_sub_explicit(&level->array_readers, 1, memory_order_release);
-            return;
+            return TDB_SUCCESS;
         }
 
         tidesdb_sstable_t **new_arr = calloc(capacity + 1, sizeof(tidesdb_sstable_t *));
         if (!new_arr)
         {
             atomic_fetch_sub_explicit(&level->array_readers, 1, memory_order_release);
-            return;
+            return TDB_ERR_MEMORY;
         }
         memcpy(new_arr, old_arr, num * sizeof(tidesdb_sstable_t *));
 
@@ -9789,7 +9809,7 @@ static void tidesdb_level_sort_by_min_key(tidesdb_t *db, tidesdb_level_t *level,
             tidesdb_sstable_t **prev_retired = atomic_exchange_explicit(
                 &level->retired_sstables_arr, old_arr, memory_order_acq_rel);
             tidesdb_retire_array(db, prev_retired, level);
-            return;
+            return TDB_SUCCESS;
         }
 
         atomic_fetch_sub_explicit(&level->array_readers, 1, memory_order_release);
@@ -10409,18 +10429,32 @@ static int tidesdb_iter_skip_tombstone_versions(tidesdb_iter_t *iter, const tide
 {
     uint8_t tombstone_key_stack[TDB_PREFIXED_KEY_STACK_MAX];
     uint8_t *tombstone_key;
+    uint8_t *tombstone_key_heap = NULL; /* set only when we snapshot via malloc */
     const size_t tombstone_key_size = kv->entry.key_size;
 
-    if (tombstone_key_size <= sizeof(tombstone_key_stack))
+    if (direction > 0)
+    {
+        /* forward skip pops via pop_discard, which never rewrites the pop_buf slot backing
+         * kv, so kv->key stays valid for the whole loop -- compare against it directly with
+         * no copy, and thus no allocation that could fail on a >256-byte tombstone key.
+         * (the previous unconditional copy made forward iteration able to OOM here and then
+         * silently surface a stale superseded version.) */
+        tombstone_key = (uint8_t *)kv->key;
+    }
+    else if (tombstone_key_size <= sizeof(tombstone_key_stack))
     {
         memcpy(tombstone_key_stack, kv->key, tombstone_key_size);
         tombstone_key = tombstone_key_stack;
     }
     else
     {
-        tombstone_key = malloc(tombstone_key_size);
-        if (!tombstone_key) return TDB_ERR_MEMORY;
-        memcpy(tombstone_key, kv->key, tombstone_key_size);
+        /* backward skip pops via pop_max, which rewrites the pop_buf slot backing kv, so the
+         * key must be snapshotted first. this malloc can still fail for a >256-byte tombstone
+         * key under memory pressure (rare); callers treat a non-success return as "stop". */
+        tombstone_key_heap = malloc(tombstone_key_size);
+        if (!tombstone_key_heap) return TDB_ERR_MEMORY;
+        memcpy(tombstone_key_heap, kv->key, tombstone_key_size);
+        tombstone_key = tombstone_key_heap;
     }
 
     while (!tidesdb_merge_heap_empty(iter->heap))
@@ -10443,7 +10477,7 @@ static int tidesdb_iter_skip_tombstone_versions(tidesdb_iter_t *iter, const tide
         }
     }
 
-    if (tombstone_key != tombstone_key_stack) free(tombstone_key);
+    free(tombstone_key_heap); /* NULL-safe; only the backward large-key path allocates */
     return TDB_SUCCESS;
 }
 
@@ -10971,7 +11005,8 @@ static tidesdb_merge_source_t *tidesdb_merge_source_from_sstable_klog(tidesdb_t 
 static int tidesdb_btree_read_vlog_value(block_manager_cursor_t *vlog_cursor,
                                          const uint64_t vlog_offset,
                                          const tidesdb_column_family_config_t *config,
-                                         uint8_t **value_out, size_t *value_size_out)
+                                         uint8_t **value_out, size_t *value_size_out,
+                                         const size_t expected_value_size)
 {
     block_manager_cursor_goto(vlog_cursor, vlog_offset);
     block_manager_block_t *vlog_block = block_manager_cursor_read(vlog_cursor);
@@ -10989,12 +11024,26 @@ static int tidesdb_btree_read_vlog_value(block_manager_cursor_t *vlog_cursor,
         block_manager_block_free(vlog_block);
         if (!decompressed) return -1;
 
+        /* verify the produced size matches the klog entry's recorded value_size, mirroring
+         * tidesdb_vlog_read_value -- a truncated/corrupt vlog block must not silently return
+         * surviving bytes (expected_value_size == 0 means the caller opts out of the check) */
+        if (expected_value_size != 0 && decompressed_size != expected_value_size)
+        {
+            free(decompressed);
+            return -1;
+        }
+
         *value_out = decompressed;
         *value_size_out = decompressed_size;
         return 0;
     }
 
-    /* uncompressed, we copy raw block data */
+    /* uncompressed, we copy raw block data -- same size verification as the compressed path */
+    if (expected_value_size != 0 && data_size != expected_value_size)
+    {
+        block_manager_block_free(vlog_block);
+        return -1;
+    }
     uint8_t *copy = malloc(data_size);
     if (!copy)
     {
@@ -11128,7 +11177,8 @@ static tidesdb_merge_source_t *tidesdb_merge_source_from_btree(tidesdb_t *db,
     if (vlog_offset > 0)
     {
         if (tidesdb_btree_read_vlog_value(source->source.btree.vlog_cursor, vlog_offset,
-                                          source->config, &vlog_value, &actual_value_size) == 0)
+                                          source->config, &vlog_value, &actual_value_size,
+                                          value_size) == 0)
         {
             actual_value = vlog_value;
         }
@@ -11425,12 +11475,19 @@ static int tidesdb_merge_source_advance(tidesdb_merge_source_t *source)
                 {
                     if (tidesdb_btree_read_vlog_value(source->source.btree.vlog_cursor, vlog_offset,
                                                       source->config, &vlog_value,
-                                                      &actual_value_size) == 0)
+                                                      &actual_value_size, value_size) == 0)
                     {
                         actual_value = vlog_value;
                     }
                     else
                     {
+                        /* surface the silent data-integrity event, a failed vlog read here
+                         * writes an empty value into the merge output. with F6 this also
+                         * fires on a value-size mismatch. */
+                        TDB_DEBUG_LOG(TDB_LOG_WARN,
+                                      "merge: btree vlog read failed (offset=%" PRIu64
+                                      "), value treated as empty in merged output",
+                                      vlog_offset);
                         actual_value = NULL;
                         actual_value_size = 0;
                     }
@@ -12009,12 +12066,19 @@ static int tidesdb_merge_source_retreat(tidesdb_merge_source_t *source)
                 {
                     if (tidesdb_btree_read_vlog_value(source->source.btree.vlog_cursor, vlog_offset,
                                                       source->config, &vlog_value,
-                                                      &actual_value_size) == 0)
+                                                      &actual_value_size, value_size) == 0)
                     {
                         actual_value = vlog_value;
                     }
                     else
                     {
+                        /* surface the silent data-integrity event, a failed vlog read here
+                         * writes an empty value into the merge output. with F6 this also
+                         * fires on a value-size mismatch. */
+                        TDB_DEBUG_LOG(TDB_LOG_WARN,
+                                      "merge: btree vlog read failed (offset=%" PRIu64
+                                      "), value treated as empty in merged output",
+                                      vlog_offset);
                         actual_value = NULL;
                         actual_value_size = 0;
                     }
@@ -12441,14 +12505,26 @@ static int tidesdb_apply_dca(tidesdb_column_family_t *cf)
     for (int i = 0; i < num_levels - 1; i++)
     {
         size_t power = num_levels - 1 - i; /* L - 1 - i (adjusted for 0-based indexing) */
+        const size_t ratio = cf->config.level_size_ratio;
         size_t divisor = 1;
-        for (size_t p = 0; p < power; p++)
+        int divisor_overflow = 0;
+        /* ratio <= 1 leaves divisor == 1 (no leveling, and avoids a divide-by-zero when
+         * ratio == 0); otherwise guard the running product against size_t overflow -- with
+         * ratio 10 and a deep tree, T^power exceeds size_t past ~19 levels and would wrap. */
+        for (size_t p = 0; p < power && ratio > 1; p++)
         {
-            divisor *= cf->config.level_size_ratio;
+            if (divisor > SIZE_MAX / ratio)
+            {
+                divisor_overflow = 1;
+                break;
+            }
+            divisor *= ratio;
         }
 
         size_t old_capacity = atomic_load_explicit(&cf->levels[i]->capacity, memory_order_acquire);
-        size_t new_capacity = N_L / divisor;
+        /* an overflowed divisor means N_L / divisor underflows toward 0; floor to the write
+         * buffer size, same as the normal small-capacity case below */
+        size_t new_capacity = divisor_overflow ? cf->config.write_buffer_size : N_L / divisor;
 
         if (new_capacity < cf->config.write_buffer_size)
         {
@@ -14572,15 +14648,18 @@ static int tidesdb_dividing_merge(tidesdb_column_family_t *cf, int target_level)
                                            comparator_fn, comparator_ctx);
         }
 
-        /* we branch to btree output if use_btree is enabled
-         * dividing merge never goes to largest level (it adds a level first) */
+        /* we branch to btree output if use_btree is enabled.
+         * is_largest_level mirrors the non-btree branch below, a small-tree
+         * dividing merge whose deeper levels are all empty is the effective
+         * bottom, so regular tombstones must drop here or they accumulate
+         * forever (the same reclamation bug fixed for partitioned merge). */
         if (cf->config.use_btree)
         {
             tidesdb_klog_block_free(klog_block);
             klog_block = NULL;
 
             int btree_result = tidesdb_sstable_write_from_heap_btree(
-                cf, new_sst, partition_heap, klog_bm, vlog_bm, bloom, NULL, 0);
+                cf, new_sst, partition_heap, klog_bm, vlog_bm, bloom, NULL, is_largest_level);
             block_manager_close(klog_bm);
             block_manager_close(vlog_bm);
             tidesdb_merge_heap_free(partition_heap);
@@ -16168,8 +16247,17 @@ static int tidesdb_partitioned_merge(tidesdb_column_family_t *cf, int start_leve
         skip_list_comparator_fn sort_cmp = NULL;
         void *sort_cmp_ctx = NULL;
         tidesdb_resolve_comparator(cf->db, &cf->config, &sort_cmp, &sort_cmp_ctx);
-        if (sort_cmp)
-            tidesdb_level_sort_by_min_key(cf->db, cf->levels[end_idx], sort_cmp, sort_cmp_ctx);
+        if (sort_cmp && tidesdb_level_sort_by_min_key(cf->db, cf->levels[end_idx], sort_cmp,
+                                                      sort_cmp_ctx) != TDB_SUCCESS)
+        {
+            /* the largest level is left unsorted -- the next partitioned merge will derive
+             * boundaries from an out-of-order array. not fatal to this merge (sstables are
+             * already committed), but surface it. */
+            TDB_DEBUG_LOG(TDB_LOG_WARN,
+                          "CF '%s' failed to re-sort level %d by min_key after partitioned merge "
+                          "(out of memory); next merge's partition boundaries may be skewed",
+                          cf->name, cf->levels[end_idx]->level_num);
+        }
     }
 
     for (int i = 0; i < num_partitions; i++)
@@ -17324,7 +17412,13 @@ static void *tidesdb_flush_worker_thread(void *arg)
                           "CF '%s' failed to commit manifest for SSTable %" PRIu64 " (error: %d)",
                           cf->name, work->sst_id, manifest_result);
         }
-        tdb_objstore_upload_manifest(db, cf);
+        else
+        {
+            /* only mirror to the object store when the local commit succeeded -- uploading
+             * after a failed commit could push a manifest inconsistent with local on-disk
+             * state that recovery would then have to reconcile */
+            tdb_objstore_upload_manifest(db, cf);
+        }
 
         /* we check file count in addition to size
          * cf->levels[0] (level_num=1) is TidesDB's first disk level, equivalent to
@@ -17555,15 +17649,16 @@ static void *tidesdb_flush_worker_thread(void *arg)
                     if (to_free_count < TDB_IMM_SNAP_MAX_ITEMS)
                     {
                         to_free[to_free_count++] = queued_imm;
+                        cleaned++;
                     }
                     else
                     {
-                        /* overflow, we free immediately (shouldnt happen with bounded queue) */
-                        if (queued_imm->skip_list) skip_list_free(queued_imm->skip_list);
-                        if (queued_imm->wal) block_manager_close(queued_imm->wal);
-                        free(queued_imm);
+                        /* to_free is full -- re-enqueue rather than free immediately. an
+                         * immediate free here would bypass the publish+drain barrier below
+                         * and could free a memtable a concurrent reader still references via
+                         * the immutable snapshot (UAF). the next cleanup pass reclaims it. */
+                        queue_enqueue(cf->immutable_memtables, queued_imm);
                     }
-                    cleaned++;
                 }
                 else
                 {
@@ -18876,6 +18971,17 @@ int tidesdb_open(const tidesdb_config_t *config, tidesdb_t **db)
         }
         memcpy(owned, config->object_store_config, sizeof(tidesdb_objstore_config_t));
         (*db)->config.object_store_config = owned;
+
+        /* wal_upload_sync only takes effect when replicate_wal is on -- the WAL-close path
+         * checks replicate_wal first, so the sync flag is silently ignored otherwise. warn
+         * rather than fail so an over-specified config still opens. */
+        if (owned->wal_upload_sync && !owned->replicate_wal)
+        {
+            TDB_DEBUG_LOG(
+                TDB_LOG_WARN,
+                "object store config: wal_upload_sync=1 has no effect because "
+                "replicate_wal=0 (WAL is not replicated); enable replicate_wal to use it");
+        }
     }
 
     /* object store mode requires unified memtable!! */
@@ -20894,6 +21000,12 @@ int tidesdb_create_column_family(tidesdb_t *db, const char *name,
 {
     if (!db || !name || !config) return TDB_ERR_INVALID_ARGS;
 
+    /* reject names that would truncate into cf->config.name (TDB_MAX_CF_NAME_LEN)
+     * -- mirrors the guard in tidesdb_rename_column_family so cf->name, the
+     * registry key, and cf->config.name can never disagree */
+    const size_t name_len = strlen(name);
+    if (name_len == 0 || name_len >= TDB_MAX_CF_NAME_LEN) return TDB_ERR_INVALID_ARGS;
+
     if (!atomic_load(&db->is_recovering))
     {
         int wait_result = wait_for_open(db);
@@ -21381,6 +21493,19 @@ int tidesdb_create_column_family(tidesdb_t *db, const char *name,
     }
 
     pthread_rwlock_wrlock(&db->cf_list_lock);
+
+    /* the earlier duplicate scan ran under a read lock; re-check under the write
+     * lock so two concurrent creates of the same name cannot both append */
+    for (int i = 0; i < db->num_column_families; i++)
+    {
+        if (db->column_families[i] && strcmp(db->column_families[i]->name, name) == 0)
+        {
+            pthread_rwlock_unlock(&db->cf_list_lock);
+            tidesdb_column_family_free(cf);
+            TDB_DEBUG_LOG(TDB_LOG_WARN, "Column family %s already exists (lost create race)", name);
+            return TDB_ERR_EXISTS;
+        }
+    }
 
     if (db->num_column_families >= db->cf_capacity)
     {
@@ -24638,8 +24763,12 @@ int tidesdb_txn_reset(tidesdb_txn_t *txn, const tidesdb_isolation_level_t isolat
         return wait_result;
     }
 
-    /* we remove from SERIALIZABLE active list if the old isolation was SERIALIZABLE */
-    if (txn->isolation_level == TDB_ISOLATION_SERIALIZABLE)
+    /* remove from the active list if the OLD isolation had registered it. registration
+     * happens for any isolation >= REPEATABLE_READ (see txn create / re-register), so the
+     * removal condition must match -- a == SERIALIZABLE guard here leaves a stale entry
+     * for an RR/SNAPSHOT txn that re-registration then duplicates (later a dangling ptr).
+     * tidesdb_txn_remove_from_active_list self-guards on < REPEATABLE_READ. */
+    if (txn->isolation_level >= TDB_ISOLATION_REPEATABLE_READ)
     {
         tidesdb_txn_remove_from_active_list(txn);
     }
@@ -28398,7 +28527,8 @@ static void tidesdb_iter_seek_btree_source_forward(tidesdb_merge_source_t *sourc
     if (vlog_offset > 0)
     {
         if (tidesdb_btree_read_vlog_value(source->source.btree.vlog_cursor, vlog_offset,
-                                          source->config, &vlog_value, &actual_value_size) == 0)
+                                          source->config, &vlog_value, &actual_value_size,
+                                          value_size) == 0)
         {
             actual_value = vlog_value;
         }
@@ -28469,7 +28599,8 @@ static void tidesdb_iter_seek_btree_source_backward(tidesdb_merge_source_t *sour
     if (vlog_offset > 0)
     {
         if (tidesdb_btree_read_vlog_value(source->source.btree.vlog_cursor, vlog_offset,
-                                          source->config, &vlog_value, &actual_value_size) == 0)
+                                          source->config, &vlog_value, &actual_value_size,
+                                          value_size) == 0)
         {
             actual_value = vlog_value;
         }
@@ -29906,7 +30037,7 @@ int tidesdb_iter_seek_to_last(tidesdb_iter_t *iter)
                     {
                         if (tidesdb_btree_read_vlog_value(source->source.btree.vlog_cursor,
                                                           vlog_offset, source->config, &vlog_value,
-                                                          &actual_value_size) == 0)
+                                                          &actual_value_size, value_size) == 0)
                         {
                             actual_value = vlog_value;
                         }
@@ -31167,9 +31298,14 @@ static int tidesdb_unified_wal_replay_into(tidesdb_t *db, block_manager_t *wal, 
                 const size_t pk_size = TDB_UNIFIED_CF_PREFIX_SIZE + key_size_u64;
 
                 const int is_delete = (flags & TDB_KV_FLAG_TOMBSTONE) ? 1 : 0;
+                /* preserve the single-delete subtype across replay (mirrors per-CF WAL
+                 * replay) so compaction can still pair-cancel put+single-delete */
+                int sl_flags = is_delete ? SKIP_LIST_FLAG_DELETED : 0;
+                if (is_delete && (flags & TDB_KV_FLAG_SINGLE_DELETE))
+                    sl_flags |= SKIP_LIST_FLAG_SINGLE_DELETE;
                 skip_list_put_with_seq(
                     target, prefixed, pk_size, is_delete ? NULL : (uint8_t *)value,
-                    is_delete ? 0 : (size_t)value_size_u64, ttl, seq_value, is_delete);
+                    is_delete ? 0 : (size_t)value_size_u64, ttl, seq_value, sl_flags);
                 TDB_PREFIXED_KEY_FREE(prefixed, _pk_stack4);
 
                 if (seq_value > *max_seq) *max_seq = seq_value;

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -578,12 +578,16 @@ static int tidesdb_bm_open(tidesdb_t *db, block_manager_t **bm, const char *path
  * @param sst sstable the reader is about to open
  * @return 1 if ok to open (or already open), 0 if over the reader budget
  */
-static int tidesdb_reader_fd_budget_ok(tidesdb_t *db, tidesdb_sstable_t *sst)
+/**
+ * tidesdb_sstable_open_budget
+ * the descriptor budget for resident open sstables: max_open_sstables minus the reserve held for
+ * flush/compaction. BOTH the reader admission check and the reaper's eviction trigger use this, so
+ * the reaper keeps num_open_sstables at or below the budget the readers stop at -- otherwise reads
+ * would back off in the [budget, max_open) gap while the reaper (triggering only at max_open) frees
+ * nothing, starving reads with no relief on fd-constrained hosts.
+ */
+static int tidesdb_sstable_open_budget(const tidesdb_t *db)
 {
-    /* already counted -- num_open_sstables is keyed on the klog, so a klog-open sstable
-     * needs no new tracked descriptor and is never blocked (the lazy vlog rides along) */
-    if (atomic_load_explicit(&sst->klog_bm, memory_order_acquire)) return 1;
-
     const int max_open = (int)db->config.max_open_sstables;
     int reserve = max_open / TDB_FD_READER_RESERVE_DIVISOR;
     if (reserve < TDB_FD_READER_RESERVE_MIN) reserve = TDB_FD_READER_RESERVE_MIN;
@@ -592,6 +596,16 @@ static int tidesdb_reader_fd_budget_ok(tidesdb_t *db, tidesdb_sstable_t *sst)
     if (reserve > reserve_cap) reserve = reserve_cap;
     int budget = max_open - reserve;
     if (budget < 1) budget = 1;
+    return budget;
+}
+
+static int tidesdb_reader_fd_budget_ok(tidesdb_t *db, tidesdb_sstable_t *sst)
+{
+    /* already counted -- num_open_sstables is keyed on the klog, so a klog-open sstable
+     * needs no new tracked descriptor and is never blocked (the lazy vlog rides along) */
+    if (atomic_load_explicit(&sst->klog_bm, memory_order_acquire)) return 1;
+
+    const int budget = tidesdb_sstable_open_budget(db);
 
     if (atomic_load_explicit(&db->num_open_sstables, memory_order_relaxed) < budget) return 1;
 
@@ -13100,8 +13114,8 @@ static void *tidesdb_subcompaction_worker(void *arg)
         if (rc != TDB_SUCCESS)
         {
             int expected = TDB_SUCCESS;
-            atomic_compare_exchange_strong_explicit(&sc->error, &expected, rc,
-                                                    memory_order_acq_rel, memory_order_relaxed);
+            atomic_compare_exchange_strong_explicit(&sc->error, &expected, rc, memory_order_acq_rel,
+                                                    memory_order_relaxed);
         }
     }
     return NULL;
@@ -13178,7 +13192,8 @@ static int tidesdb_run_subcompactions(tidesdb_t *db, void *merge_ctx,
  * sampled from the input sstables' min keys; each shard builds its own heap from overlapping
  * inputs, range-filters the merge, and writes its own output sstable at output_level. the commit
  * is serialized on cf->compaction_commit_lock; per-merge teardown (input cleanup) runs once after
- * the shards join. the btree branch writes the shard heap unfiltered, matching dividing/partitioned.
+ * the shards join. the btree branch writes the shard heap unfiltered, matching
+ * dividing/partitioned.
  */
 typedef struct
 {
@@ -13321,20 +13336,30 @@ static int tidesdb_full_preemptive_merge(tidesdb_column_family_t *cf, int start_
         }
         if (fp_boundaries && fp_boundary_sizes)
         {
-            /* shard boundaries are the output sstables' min keys; the first sstable's min key is
-             * skipped so keys below it land in shard 0 (range_start = NULL) */
+            /* boundaries are the output sstables' min keys, skipping the first so keys below it
+             * land in shard 0 (range_start = NULL). they MUST be strictly increasing to form a
+             * valid key-range partition -- the first disk level holds overlapping runs added in
+             * flush-completion order, not key order, so the array is not sorted. accept a min key
+             * only when it exceeds the last accepted boundary; the resulting monotonic subset is a
+             * coarser-but-always-correct tiling (shard 0's NULL start and the last shard's NULL end
+             * guarantee full coverage, so no key range is ever dropped). */
+            uint8_t *last_b = NULL;
+            size_t last_bsz = 0;
             for (int i = 1; i < out_n; i++)
             {
                 tidesdb_sstable_t *s = out_ssts[i];
-                if (s && s->min_key && s->min_key_size > 0)
+                if (!s || !s->min_key || s->min_key_size == 0) continue;
+                if (last_b && comparator_fn(s->min_key, s->min_key_size, last_b, last_bsz,
+                                            comparator_ctx) <= 0)
+                    continue;
+                fp_boundaries[fp_num_boundaries] = malloc(s->min_key_size);
+                if (fp_boundaries[fp_num_boundaries])
                 {
-                    fp_boundaries[fp_num_boundaries] = malloc(s->min_key_size);
-                    if (fp_boundaries[fp_num_boundaries])
-                    {
-                        memcpy(fp_boundaries[fp_num_boundaries], s->min_key, s->min_key_size);
-                        fp_boundary_sizes[fp_num_boundaries] = s->min_key_size;
-                        fp_num_boundaries++;
-                    }
+                    memcpy(fp_boundaries[fp_num_boundaries], s->min_key, s->min_key_size);
+                    fp_boundary_sizes[fp_num_boundaries] = s->min_key_size;
+                    last_b = fp_boundaries[fp_num_boundaries];
+                    last_bsz = s->min_key_size;
+                    fp_num_boundaries++;
                 }
             }
         }
@@ -13500,620 +13525,627 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
             break;
         }
 
-    bloom_filter_t *bloom = NULL;
-    tidesdb_block_index_t *block_indexes = NULL;
+        bloom_filter_t *bloom = NULL;
+        tidesdb_block_index_t *block_indexes = NULL;
 
-    if (new_sst->config->enable_bloom_filter)
-    {
-        if (bloom_filter_new(&bloom, new_sst->config->bloom_fpr, (int)estimated_entries) == 0)
+        if (new_sst->config->enable_bloom_filter)
         {
-            TDB_DEBUG_LOG(TDB_LOG_INFO, "Bloom filter created (estimated entries: %" PRIu64 ")",
-                          estimated_entries);
+            if (bloom_filter_new(&bloom, new_sst->config->bloom_fpr, (int)estimated_entries) == 0)
+            {
+                TDB_DEBUG_LOG(TDB_LOG_INFO, "Bloom filter created (estimated entries: %" PRIu64 ")",
+                              estimated_entries);
+            }
+            else
+            {
+                TDB_DEBUG_LOG(TDB_LOG_ERROR, "Bloom filter creation failed");
+                bloom = NULL;
+            }
         }
         else
         {
-            TDB_DEBUG_LOG(TDB_LOG_ERROR, "Bloom filter creation failed");
+            TDB_DEBUG_LOG(TDB_LOG_INFO, "Bloom filter disabled");
+        }
+
+        if (new_sst->config->enable_block_indexes && !cf->config.use_btree)
+        {
+            block_indexes = compact_block_index_create(estimated_entries,
+                                                       new_sst->config->block_index_prefix_len,
+                                                       comparator_fn, comparator_ctx);
+            if (block_indexes)
+            {
+                TDB_DEBUG_LOG(TDB_LOG_INFO, "Block indexes created");
+            }
+            else
+            {
+                TDB_DEBUG_LOG(TDB_LOG_ERROR, "Block indexes builder creation failed");
+            }
+        }
+        else
+        {
+            TDB_DEBUG_LOG(TDB_LOG_INFO, "Block indexes disabled");
+        }
+
+        /* we branch to btree output if use_btree is enabled */
+        if (cf->config.use_btree)
+        {
+            int btree_result = tidesdb_sstable_write_from_heap_btree(
+                cf, new_sst, heap, klog_bm, vlog_bm, bloom, sstables_to_delete, is_largest_level);
+            block_manager_close(klog_bm);
+            block_manager_close(vlog_bm);
+            tidesdb_merge_heap_free(heap);
+
+            if (btree_result != TDB_SUCCESS)
+            {
+                /* mark so sstable_free unlinks the partial klog/vlog files */
+                atomic_store_explicit(&new_sst->marked_for_deletion, 1, memory_order_release);
+                tidesdb_sstable_unref(cf->db, new_sst);
+                aborted = 1;
+                break;
+            }
+
             bloom = NULL;
-        }
-    }
-    else
-    {
-        TDB_DEBUG_LOG(TDB_LOG_INFO, "Bloom filter disabled");
-    }
-
-    if (new_sst->config->enable_block_indexes && !cf->config.use_btree)
-    {
-        block_indexes =
-            compact_block_index_create(estimated_entries, new_sst->config->block_index_prefix_len,
-                                       comparator_fn, comparator_ctx);
-        if (block_indexes)
-        {
-            TDB_DEBUG_LOG(TDB_LOG_INFO, "Block indexes created");
-        }
-        else
-        {
-            TDB_DEBUG_LOG(TDB_LOG_ERROR, "Block indexes builder creation failed");
-        }
-    }
-    else
-    {
-        TDB_DEBUG_LOG(TDB_LOG_INFO, "Block indexes disabled");
-    }
-
-    /* we branch to btree output if use_btree is enabled */
-    if (cf->config.use_btree)
-    {
-        int btree_result = tidesdb_sstable_write_from_heap_btree(
-            cf, new_sst, heap, klog_bm, vlog_bm, bloom, sstables_to_delete, is_largest_level);
-        block_manager_close(klog_bm);
-        block_manager_close(vlog_bm);
-        tidesdb_merge_heap_free(heap);
-
-        if (btree_result != TDB_SUCCESS)
-        {
-            /* mark so sstable_free unlinks the partial klog/vlog files */
-            atomic_store_explicit(&new_sst->marked_for_deletion, 1, memory_order_release);
-            tidesdb_sstable_unref(cf->db, new_sst);
-            aborted = 1;
-            break;
+            goto merge_complete;
         }
 
-        bloom = NULL;
-        goto merge_complete;
-    }
+        tidesdb_klog_block_t *current_klog_block = tidesdb_klog_block_create();
 
-    tidesdb_klog_block_t *current_klog_block = tidesdb_klog_block_create();
+        uint64_t klog_block_num = 0;
+        uint64_t vlog_block_num = 0;
+        uint64_t max_seq = 0;
 
-    uint64_t klog_block_num = 0;
-    uint64_t vlog_block_num = 0;
-    uint64_t max_seq = 0;
+        /* we track first and last key of current block for block index */
+        uint8_t *block_first_key = NULL;
+        size_t block_first_key_size = 0;
+        uint8_t *block_last_key = NULL;
+        size_t block_last_key_size = 0;
 
-    /* we track first and last key of current block for block index */
-    uint8_t *block_first_key = NULL;
-    size_t block_first_key_size = 0;
-    uint8_t *block_last_key = NULL;
-    size_t block_last_key_size = 0;
+        /* snapshot floor -- see tidesdb_sstable_write_from_heap_btree for rationale */
+        const uint64_t min_snapshot_seq = tidesdb_min_active_snapshot_seq(cf->db);
 
-    /* snapshot floor -- see tidesdb_sstable_write_from_heap_btree for rationale */
-    const uint64_t min_snapshot_seq = tidesdb_min_active_snapshot_seq(cf->db);
+        /**** single-step lookahead in which we buffer the pending first-for-key entry so a
+         ***  put+single-delete pair detected in the same merge input cancels together
+         **   at any level instead of carrying the tombstone forward. same-key dedup,
+         *    largest-level tombstone drop, and ttl drop fire when pending resolves. */
+        tidesdb_kv_pair_t *pending = NULL;
+        int pending_is_single_delete = 0;
+        int pending_sd_paired_with_put = 0;
 
-    /**** single-step lookahead in which we buffer the pending first-for-key entry so a
-     ***  put+single-delete pair detected in the same merge input cancels together
-     **   at any level instead of carrying the tombstone forward. same-key dedup,
-     *    largest-level tombstone drop, and ttl drop fire when pending resolves. */
-    tidesdb_kv_pair_t *pending = NULL;
-    int pending_is_single_delete = 0;
-    int pending_sd_paired_with_put = 0;
-
-    /* merge using heap */
-    while (!tidesdb_merge_heap_empty(heap) || pending != NULL)
-    {
-        if (tidesdb_cf_abort_requested(cf))
+        /* merge using heap */
+        while (!tidesdb_merge_heap_empty(heap) || pending != NULL)
         {
-            aborted = 1;
-            break;
-        }
-
-        tidesdb_kv_pair_t *kv = NULL;
-
-        if (!tidesdb_merge_heap_empty(heap))
-        {
-            tidesdb_sstable_t *corrupted_sst = NULL;
-            kv = tidesdb_merge_heap_pop(heap, &corrupted_sst);
-
-            /* if corruption detected, add to deletion queue */
-            if (corrupted_sst)
+            if (tidesdb_cf_abort_requested(cf))
             {
-                TDB_DEBUG_LOG(TDB_LOG_ERROR,
-                              "Detected corrupted SSTable %" PRIu64 ", marking for deletion",
-                              corrupted_sst->id);
-                /* shared cleanup queue -- guard against concurrent shards */
-                pthread_mutex_lock(&cf->compaction_commit_lock);
-                queue_enqueue(sstables_to_delete, corrupted_sst);
-                pthread_mutex_unlock(&cf->compaction_commit_lock);
+                aborted = 1;
+                break;
             }
-        }
 
-        /* range filter -- this shard only writes keys in [range_start, range_end). a filtered
-         * key cannot pair with pending (pending is in range), matching dividing_merge. */
-        if (kv)
-        {
-            if (range_start && comparator_fn(kv->key, kv->entry.key_size, range_start,
-                                             range_start_size, comparator_ctx) < 0)
+            tidesdb_kv_pair_t *kv = NULL;
+
+            if (!tidesdb_merge_heap_empty(heap))
             {
+                tidesdb_sstable_t *corrupted_sst = NULL;
+                kv = tidesdb_merge_heap_pop(heap, &corrupted_sst);
+
+                /* if corruption detected, add to deletion queue */
+                if (corrupted_sst)
+                {
+                    TDB_DEBUG_LOG(TDB_LOG_ERROR,
+                                  "Detected corrupted SSTable %" PRIu64 ", marking for deletion",
+                                  corrupted_sst->id);
+                    /* shared cleanup queue -- guard against concurrent shards */
+                    pthread_mutex_lock(&cf->compaction_commit_lock);
+                    queue_enqueue(sstables_to_delete, corrupted_sst);
+                    pthread_mutex_unlock(&cf->compaction_commit_lock);
+                }
+            }
+
+            /* range filter -- this shard only writes keys in [range_start, range_end). a filtered
+             * key cannot pair with pending (pending is in range), matching dividing_merge. */
+            if (kv)
+            {
+                if (range_start && comparator_fn(kv->key, kv->entry.key_size, range_start,
+                                                 range_start_size, comparator_ctx) < 0)
+                {
+                    tidesdb_kv_pair_free(kv);
+                    continue;
+                }
+                if (range_end && comparator_fn(kv->key, kv->entry.key_size, range_end,
+                                               range_end_size, comparator_ctx) >= 0)
+                {
+                    tidesdb_kv_pair_free(kv);
+                    continue;
+                }
+            }
+
+            if (kv && pending && pending->entry.key_size == kv->entry.key_size &&
+                memcmp(pending->key, kv->key, pending->entry.key_size) == 0 &&
+                pending->entry.seq <= min_snapshot_seq)
+            {
+                /* older same-key version -- drop silently.  we record whether the
+                 * trailing version is a live put so a pending single-delete can
+                 * pair-cancel with it when we resolve pending. */
+                if (pending_is_single_delete && !(kv->entry.flags & TDB_KV_FLAG_TOMBSTONE))
+                {
+                    pending_sd_paired_with_put = 1;
+                }
                 tidesdb_kv_pair_free(kv);
                 continue;
             }
-            if (range_end && comparator_fn(kv->key, kv->entry.key_size, range_end, range_end_size,
-                                           comparator_ctx) >= 0)
+
+            /* new key arrived (or heap exhausted) -- decide the fate of pending */
+            if (pending)
             {
-                tidesdb_kv_pair_free(kv);
-                continue;
-            }
-        }
+                const int sd_pair_drop = pending_is_single_delete && pending_sd_paired_with_put;
+                const int tombstone_drop =
+                    (pending->entry.flags & TDB_KV_FLAG_TOMBSTONE) && is_largest_level;
+                const int ttl_drop =
+                    pending->entry.ttl > 0 &&
+                    pending->entry.ttl <
+                        atomic_load_explicit(&cf->db->cached_current_time, memory_order_relaxed);
 
-        if (kv && pending && pending->entry.key_size == kv->entry.key_size &&
-            memcmp(pending->key, kv->key, pending->entry.key_size) == 0 &&
-            pending->entry.seq <= min_snapshot_seq)
-        {
-            /* older same-key version -- drop silently.  we record whether the
-             * trailing version is a live put so a pending single-delete can
-             * pair-cancel with it when we resolve pending. */
-            if (pending_is_single_delete && !(kv->entry.flags & TDB_KV_FLAG_TOMBSTONE))
-            {
-                pending_sd_paired_with_put = 1;
-            }
-            tidesdb_kv_pair_free(kv);
-            continue;
-        }
-
-        /* new key arrived (or heap exhausted) -- decide the fate of pending */
-        if (pending)
-        {
-            const int sd_pair_drop = pending_is_single_delete && pending_sd_paired_with_put;
-            const int tombstone_drop =
-                (pending->entry.flags & TDB_KV_FLAG_TOMBSTONE) && is_largest_level;
-            const int ttl_drop =
-                pending->entry.ttl > 0 &&
-                pending->entry.ttl <
-                    atomic_load_explicit(&cf->db->cached_current_time, memory_order_relaxed);
-
-            if (!sd_pair_drop && !tombstone_drop && !ttl_drop)
-            {
-                if (pending->entry.value_size >= cf->config.klog_value_threshold && pending->value)
+                if (!sd_pair_drop && !tombstone_drop && !ttl_drop)
                 {
-                    /* we write value directly to vlog */
-                    uint8_t *final_data = pending->value;
-                    size_t final_size = pending->entry.value_size;
-                    uint8_t *compressed = NULL;
-
-                    if (new_sst->config->compression_algorithm != TDB_COMPRESS_NONE)
+                    if (pending->entry.value_size >= cf->config.klog_value_threshold &&
+                        pending->value)
                     {
-                        size_t compressed_size;
-                        compressed =
-                            compress_data(pending->value, pending->entry.value_size,
-                                          &compressed_size, new_sst->config->compression_algorithm);
-                        if (compressed)
-                        {
-                            final_data = compressed;
-                            final_size = compressed_size;
-                        }
-                    }
+                        /* we write value directly to vlog */
+                        uint8_t *final_data = pending->value;
+                        size_t final_size = pending->entry.value_size;
+                        uint8_t *compressed = NULL;
 
-                    block_manager_block_t *vlog_block =
-                        block_manager_block_create(final_size, final_data);
-                    if (vlog_block)
-                    {
-                        int64_t block_offset = block_manager_block_write(vlog_bm, vlog_block);
-                        if (block_offset >= 0)
-                        {
-                            pending->entry.vlog_offset = (uint64_t)block_offset;
-                            vlog_block_num++;
-                        }
-                        block_manager_block_release(vlog_block);
-                    }
-                    free(compressed);
-                }
-
-                /* we check if this is the first entry in a new block */
-                int is_first_entry_in_block = (current_klog_block->num_entries == 0);
-
-                tidesdb_klog_block_add_entry(current_klog_block, pending, &cf->config,
-                                             comparator_fn, comparator_ctx);
-
-                /* we track first key of block */
-                if (is_first_entry_in_block)
-                {
-                    free(block_first_key);
-                    block_first_key = malloc(pending->entry.key_size);
-                    if (block_first_key)
-                    {
-                        memcpy(block_first_key, pending->key, pending->entry.key_size);
-                        block_first_key_size = pending->entry.key_size;
-                    }
-                }
-
-                /* we always update last key of block */
-                free(block_last_key);
-                block_last_key = malloc(pending->entry.key_size);
-                if (block_last_key)
-                {
-                    memcpy(block_last_key, pending->key, pending->entry.key_size);
-                    block_last_key_size = pending->entry.key_size;
-                }
-
-                if (tidesdb_klog_block_is_full(current_klog_block, TDB_KLOG_BLOCK_SIZE))
-                {
-                    uint8_t *klog_data;
-                    size_t klog_size;
-                    if (tidesdb_klog_block_serialize(current_klog_block, &klog_data, &klog_size) ==
-                        0)
-                    {
-                        uint8_t *final_data = klog_data;
-                        size_t final_size = klog_size;
-
-                        if (cf->config.compression_algorithm != TDB_COMPRESS_NONE)
+                        if (new_sst->config->compression_algorithm != TDB_COMPRESS_NONE)
                         {
                             size_t compressed_size;
-                            uint8_t *compressed =
-                                compress_data(klog_data, klog_size, &compressed_size,
-                                              cf->config.compression_algorithm);
+                            compressed = compress_data(pending->value, pending->entry.value_size,
+                                                       &compressed_size,
+                                                       new_sst->config->compression_algorithm);
                             if (compressed)
                             {
-                                free(klog_data);
                                 final_data = compressed;
                                 final_size = compressed_size;
                             }
                         }
 
-                        block_manager_block_t *klog_block =
+                        block_manager_block_t *vlog_block =
                             block_manager_block_create(final_size, final_data);
-                        if (klog_block)
+                        if (vlog_block)
                         {
-                            uint64_t block_file_position = atomic_load(&klog_bm->current_file_size);
-                            block_manager_block_write(klog_bm, klog_block);
-                            block_manager_block_release(klog_block);
-
-                            if (block_indexes && block_first_key && block_last_key)
+                            int64_t block_offset = block_manager_block_write(vlog_bm, vlog_block);
+                            if (block_offset >= 0)
                             {
-                                if (klog_block_num % cf->config.index_sample_ratio == 0)
+                                pending->entry.vlog_offset = (uint64_t)block_offset;
+                                vlog_block_num++;
+                            }
+                            block_manager_block_release(vlog_block);
+                        }
+                        free(compressed);
+                    }
+
+                    /* we check if this is the first entry in a new block */
+                    int is_first_entry_in_block = (current_klog_block->num_entries == 0);
+
+                    tidesdb_klog_block_add_entry(current_klog_block, pending, &cf->config,
+                                                 comparator_fn, comparator_ctx);
+
+                    /* we track first key of block */
+                    if (is_first_entry_in_block)
+                    {
+                        free(block_first_key);
+                        block_first_key = malloc(pending->entry.key_size);
+                        if (block_first_key)
+                        {
+                            memcpy(block_first_key, pending->key, pending->entry.key_size);
+                            block_first_key_size = pending->entry.key_size;
+                        }
+                    }
+
+                    /* we always update last key of block */
+                    free(block_last_key);
+                    block_last_key = malloc(pending->entry.key_size);
+                    if (block_last_key)
+                    {
+                        memcpy(block_last_key, pending->key, pending->entry.key_size);
+                        block_last_key_size = pending->entry.key_size;
+                    }
+
+                    if (tidesdb_klog_block_is_full(current_klog_block, TDB_KLOG_BLOCK_SIZE))
+                    {
+                        uint8_t *klog_data;
+                        size_t klog_size;
+                        if (tidesdb_klog_block_serialize(current_klog_block, &klog_data,
+                                                         &klog_size) == 0)
+                        {
+                            uint8_t *final_data = klog_data;
+                            size_t final_size = klog_size;
+
+                            if (cf->config.compression_algorithm != TDB_COMPRESS_NONE)
+                            {
+                                size_t compressed_size;
+                                uint8_t *compressed =
+                                    compress_data(klog_data, klog_size, &compressed_size,
+                                                  cf->config.compression_algorithm);
+                                if (compressed)
                                 {
-                                    compact_block_index_add(
-                                        block_indexes, block_first_key, block_first_key_size,
-                                        block_last_key, block_last_key_size, block_file_position);
+                                    free(klog_data);
+                                    final_data = compressed;
+                                    final_size = compressed_size;
                                 }
                             }
 
-                            klog_block_num++;
+                            block_manager_block_t *klog_block =
+                                block_manager_block_create(final_size, final_data);
+                            if (klog_block)
+                            {
+                                uint64_t block_file_position =
+                                    atomic_load(&klog_bm->current_file_size);
+                                block_manager_block_write(klog_bm, klog_block);
+                                block_manager_block_release(klog_block);
+
+                                if (block_indexes && block_first_key && block_last_key)
+                                {
+                                    if (klog_block_num % cf->config.index_sample_ratio == 0)
+                                    {
+                                        compact_block_index_add(block_indexes, block_first_key,
+                                                                block_first_key_size,
+                                                                block_last_key, block_last_key_size,
+                                                                block_file_position);
+                                    }
+                                }
+
+                                klog_block_num++;
+                            }
+                            free(final_data);
                         }
-                        free(final_data);
+
+                        tidesdb_klog_block_reset(current_klog_block);
+
+                        free(block_first_key);
+                        free(block_last_key);
+                        block_first_key = NULL;
+                        block_last_key = NULL;
                     }
 
-                    tidesdb_klog_block_reset(current_klog_block);
-
-                    free(block_first_key);
-                    free(block_last_key);
-                    block_first_key = NULL;
-                    block_last_key = NULL;
-                }
-
-                if (pending->entry.seq > max_seq)
-                {
-                    max_seq = pending->entry.seq;
-                }
-
-                if (bloom)
-                {
-                    bloom_filter_add(bloom, pending->key, pending->entry.key_size);
-                }
-
-                if (!new_sst->min_key)
-                {
-                    new_sst->min_key = malloc(pending->entry.key_size);
-                    if (new_sst->min_key)
+                    if (pending->entry.seq > max_seq)
                     {
-                        memcpy(new_sst->min_key, pending->key, pending->entry.key_size);
-                        new_sst->min_key_size = pending->entry.key_size;
+                        max_seq = pending->entry.seq;
                     }
+
+                    if (bloom)
+                    {
+                        bloom_filter_add(bloom, pending->key, pending->entry.key_size);
+                    }
+
+                    if (!new_sst->min_key)
+                    {
+                        new_sst->min_key = malloc(pending->entry.key_size);
+                        if (new_sst->min_key)
+                        {
+                            memcpy(new_sst->min_key, pending->key, pending->entry.key_size);
+                            new_sst->min_key_size = pending->entry.key_size;
+                        }
+                    }
+
+                    free(new_sst->max_key);
+                    new_sst->max_key = malloc(pending->entry.key_size);
+                    if (new_sst->max_key)
+                    {
+                        memcpy(new_sst->max_key, pending->key, pending->entry.key_size);
+                        new_sst->max_key_size = pending->entry.key_size;
+                    }
+
+                    new_sst->num_entries++;
+                    if (pending->entry.flags & TDB_KV_FLAG_TOMBSTONE) new_sst->tombstone_count++;
                 }
 
-                free(new_sst->max_key);
-                new_sst->max_key = malloc(pending->entry.key_size);
-                if (new_sst->max_key)
-                {
-                    memcpy(new_sst->max_key, pending->key, pending->entry.key_size);
-                    new_sst->max_key_size = pending->entry.key_size;
-                }
-
-                new_sst->num_entries++;
-                if (pending->entry.flags & TDB_KV_FLAG_TOMBSTONE) new_sst->tombstone_count++;
+                tidesdb_kv_pair_free(pending);
+                pending = NULL;
             }
 
-            tidesdb_kv_pair_free(pending);
-            pending = NULL;
+            if (!kv) break;
+
+            pending = kv;
+            pending_is_single_delete = (kv->entry.flags & TDB_KV_FLAG_SINGLE_DELETE) != 0;
+            pending_sd_paired_with_put = 0;
         }
 
-        if (!kv) break;
+        if (aborted)
+        {
+            TDB_DEBUG_LOG(TDB_LOG_INFO,
+                          "CF '%s' aborting full preemptive merge for SSTable %" PRIu64, cf->name,
+                          new_sst->id);
+            if (pending) tidesdb_kv_pair_free(pending);
+            tidesdb_klog_block_free(current_klog_block);
+            free(block_first_key);
+            free(block_last_key);
+            if (bloom) bloom_filter_free(bloom);
+            if (block_indexes) compact_block_index_free(block_indexes);
+            tidesdb_merge_heap_free(heap);
+            if (klog_bm) block_manager_close(klog_bm);
+            if (vlog_bm) block_manager_close(vlog_bm);
+            remove(new_sst->klog_path);
+            remove(new_sst->vlog_path);
+            tidesdb_sstable_unref(cf->db, new_sst);
+            break; /* per-merge teardown happens once after the shards join */
+        }
 
-        pending = kv;
-        pending_is_single_delete = (kv->entry.flags & TDB_KV_FLAG_SINGLE_DELETE) != 0;
-        pending_sd_paired_with_put = 0;
-    }
+        new_sst->max_seq = max_seq;
 
-    if (aborted)
-    {
-        TDB_DEBUG_LOG(TDB_LOG_INFO, "CF '%s' aborting full preemptive merge for SSTable %" PRIu64,
-                      cf->name, new_sst->id);
-        if (pending) tidesdb_kv_pair_free(pending);
-        tidesdb_klog_block_free(current_klog_block);
+        if (current_klog_block->num_entries > 0)
+        {
+            uint8_t *klog_data;
+            size_t klog_size;
+            if (tidesdb_klog_block_serialize(current_klog_block, &klog_data, &klog_size) == 0)
+            {
+                uint8_t *final_data = klog_data;
+                size_t final_size = klog_size;
+
+                if (cf->config.compression_algorithm != TDB_COMPRESS_NONE)
+                {
+                    size_t compressed_size;
+                    uint8_t *compressed = compress_data(klog_data, klog_size, &compressed_size,
+                                                        cf->config.compression_algorithm);
+                    if (compressed)
+                    {
+                        free(klog_data);
+                        final_data = compressed;
+                        final_size = compressed_size;
+                    }
+                }
+
+                block_manager_block_t *klog_block =
+                    block_manager_block_create(final_size, final_data);
+                if (klog_block)
+                {
+                    uint64_t block_file_position = atomic_load(&klog_bm->current_file_size);
+                    block_manager_block_write(klog_bm, klog_block);
+                    block_manager_block_release(klog_block);
+
+                    if (block_indexes && block_first_key && block_last_key)
+                    {
+                        if (klog_block_num % cf->config.index_sample_ratio == 0)
+                        {
+                            compact_block_index_add(block_indexes, block_first_key,
+                                                    block_first_key_size, block_last_key,
+                                                    block_last_key_size, block_file_position);
+                        }
+                    }
+
+                    klog_block_num++;
+                }
+                free(final_data);
+            }
+        }
+
         free(block_first_key);
         free(block_last_key);
-        if (bloom) bloom_filter_free(bloom);
-        if (block_indexes) compact_block_index_free(block_indexes);
-        tidesdb_merge_heap_free(heap);
-        if (klog_bm) block_manager_close(klog_bm);
-        if (vlog_bm) block_manager_close(vlog_bm);
-        remove(new_sst->klog_path);
-        remove(new_sst->vlog_path);
-        tidesdb_sstable_unref(cf->db, new_sst);
-        break; /* per-merge teardown happens once after the shards join */
-    }
 
-    new_sst->max_seq = max_seq;
+        tidesdb_klog_block_free(current_klog_block);
 
-    if (current_klog_block->num_entries > 0)
-    {
-        uint8_t *klog_data;
-        size_t klog_size;
-        if (tidesdb_klog_block_serialize(current_klog_block, &klog_data, &klog_size) == 0)
+        new_sst->num_klog_blocks = klog_block_num;
+        new_sst->num_vlog_blocks = vlog_block_num;
+
+        block_manager_get_size(klog_bm, &new_sst->klog_data_end_offset);
+
+        /* we write auxiliary structures (always write, even if empty, to maintain consistent file
+         * structure) */
+        if (new_sst->num_entries > 0)
         {
-            uint8_t *final_data = klog_data;
-            size_t final_size = klog_size;
-
-            if (cf->config.compression_algorithm != TDB_COMPRESS_NONE)
+            /* write index block */
+            if (block_indexes)
             {
-                size_t compressed_size;
-                uint8_t *compressed = compress_data(klog_data, klog_size, &compressed_size,
-                                                    cf->config.compression_algorithm);
-                if (compressed)
-                {
-                    free(klog_data);
-                    final_data = compressed;
-                    final_size = compressed_size;
-                }
-            }
+                /* we assign the built index to the sstable */
+                new_sst->block_indexes = block_indexes;
+                block_indexes =
+                    NULL; /* ownership transferred; local must not double-free on abort */
 
-            block_manager_block_t *klog_block = block_manager_block_create(final_size, final_data);
-            if (klog_block)
-            {
-                uint64_t block_file_position = atomic_load(&klog_bm->current_file_size);
-                block_manager_block_write(klog_bm, klog_block);
-                block_manager_block_release(klog_block);
-
-                if (block_indexes && block_first_key && block_last_key)
+                TDB_DEBUG_LOG(TDB_LOG_INFO, "Block index built with %u samples",
+                              new_sst->block_indexes->count);
+                size_t index_size;
+                uint8_t *index_data =
+                    compact_block_index_serialize(new_sst->block_indexes, &index_size);
+                if (index_data)
                 {
-                    if (klog_block_num % cf->config.index_sample_ratio == 0)
+                    block_manager_block_t *index_block =
+                        block_manager_block_create(index_size, index_data);
+                    if (index_block)
                     {
-                        compact_block_index_add(block_indexes, block_first_key,
-                                                block_first_key_size, block_last_key,
-                                                block_last_key_size, block_file_position);
+                        block_manager_block_write(klog_bm, index_block);
+                        block_manager_block_release(index_block);
                     }
+                    free(index_data);
                 }
-
-                klog_block_num++;
-            }
-            free(final_data);
-        }
-    }
-
-    free(block_first_key);
-    free(block_last_key);
-
-    tidesdb_klog_block_free(current_klog_block);
-
-    new_sst->num_klog_blocks = klog_block_num;
-    new_sst->num_vlog_blocks = vlog_block_num;
-
-    block_manager_get_size(klog_bm, &new_sst->klog_data_end_offset);
-
-    /* we write auxiliary structures (always write, even if empty, to maintain consistent file
-     * structure) */
-    if (new_sst->num_entries > 0)
-    {
-        /* write index block */
-        if (block_indexes)
-        {
-            /* we assign the built index to the sstable */
-            new_sst->block_indexes = block_indexes;
-            block_indexes = NULL; /* ownership transferred; local must not double-free on abort */
-
-            TDB_DEBUG_LOG(TDB_LOG_INFO, "Block index built with %u samples",
-                          new_sst->block_indexes->count);
-            size_t index_size;
-            uint8_t *index_data =
-                compact_block_index_serialize(new_sst->block_indexes, &index_size);
-            if (index_data)
-            {
-                block_manager_block_t *index_block =
-                    block_manager_block_create(index_size, index_data);
-                if (index_block)
-                {
-                    block_manager_block_write(klog_bm, index_block);
-                    block_manager_block_release(index_block);
-                }
-                free(index_data);
-            }
-        }
-        else
-        {
-            /* we write empty index block as placeholder */
-            block_manager_block_t *empty_index = block_manager_block_create(0, NULL);
-            if (empty_index)
-            {
-                block_manager_block_write(klog_bm, empty_index);
-                block_manager_block_release(empty_index);
-            }
-        }
-
-        if (bloom)
-        {
-            size_t bloom_size;
-            uint8_t *bloom_data = bloom_filter_serialize(bloom, &bloom_size);
-            if (bloom_data)
-            {
-                TDB_DEBUG_LOG(TDB_LOG_INFO, "Bloom filter serialized to %zu bytes", bloom_size);
-                block_manager_block_t *bloom_block =
-                    block_manager_block_create(bloom_size, bloom_data);
-                if (bloom_block)
-                {
-                    block_manager_block_write(klog_bm, bloom_block);
-                    block_manager_block_release(bloom_block);
-                }
-                free(bloom_data);
             }
             else
             {
-                TDB_DEBUG_LOG(TDB_LOG_ERROR, "Bloom filter serialization failed");
+                /* we write empty index block as placeholder */
+                block_manager_block_t *empty_index = block_manager_block_create(0, NULL);
+                if (empty_index)
+                {
+                    block_manager_block_write(klog_bm, empty_index);
+                    block_manager_block_release(empty_index);
+                }
             }
-            new_sst->bloom_filter = bloom;
-            bloom = NULL; /* ownership transferred; local must not double-free on abort */
+
+            if (bloom)
+            {
+                size_t bloom_size;
+                uint8_t *bloom_data = bloom_filter_serialize(bloom, &bloom_size);
+                if (bloom_data)
+                {
+                    TDB_DEBUG_LOG(TDB_LOG_INFO, "Bloom filter serialized to %zu bytes", bloom_size);
+                    block_manager_block_t *bloom_block =
+                        block_manager_block_create(bloom_size, bloom_data);
+                    if (bloom_block)
+                    {
+                        block_manager_block_write(klog_bm, bloom_block);
+                        block_manager_block_release(bloom_block);
+                    }
+                    free(bloom_data);
+                }
+                else
+                {
+                    TDB_DEBUG_LOG(TDB_LOG_ERROR, "Bloom filter serialization failed");
+                }
+                new_sst->bloom_filter = bloom;
+                bloom = NULL; /* ownership transferred; local must not double-free on abort */
+            }
+            else
+            {
+                /* we write empty bloom block as placeholder */
+                block_manager_block_t *empty_bloom = block_manager_block_create(0, NULL);
+                if (empty_bloom)
+                {
+                    block_manager_block_write(klog_bm, empty_bloom);
+                    block_manager_block_release(empty_bloom);
+                }
+            }
+        }
+
+        /* we get file sizes before metadata write for serialization */
+        uint64_t klog_size_before_metadata;
+        uint64_t vlog_size_before_metadata;
+        block_manager_get_size(klog_bm, &klog_size_before_metadata);
+        block_manager_get_size(vlog_bm, &vlog_size_before_metadata);
+
+        new_sst->klog_size = klog_size_before_metadata;
+        new_sst->vlog_size = vlog_size_before_metadata;
+
+        /* we write metadata block as the last block -- only if we have entries */
+        uint8_t *metadata_data = NULL;
+        size_t metadata_size = 0;
+        if (new_sst->num_entries > 0 &&
+            sstable_metadata_serialize(new_sst, &metadata_data, &metadata_size) == 0)
+        {
+            block_manager_block_t *metadata_block =
+                block_manager_block_create(metadata_size, metadata_data);
+            if (metadata_block)
+            {
+                block_manager_block_write(klog_bm, metadata_block);
+                block_manager_block_release(metadata_block);
+            }
+            free(metadata_data);
+        }
+
+        block_manager_get_size(klog_bm, &new_sst->klog_size);
+        block_manager_get_size(vlog_bm, &new_sst->vlog_size);
+
+        tidesdb_merge_heap_free(heap);
+
+        block_manager_escalate_fsync(klog_bm);
+        block_manager_escalate_fsync(vlog_bm);
+
+        new_sst->klog_bm = klog_bm;
+        new_sst->vlog_bm = vlog_bm;
+        atomic_store(&new_sst->last_access_time,
+                     atomic_load_explicit(&cf->db->cached_current_time, memory_order_relaxed));
+
+        /* we ensure all writes are visible before making sstable discoverable */
+        atomic_thread_fence(memory_order_seq_cst);
+
+        /******     we close write handles before adding to level
+         *****      readers will reopen files on-demand through tidesdb_sstable_ensure_open
+         ****       this prevents file locking issues where readers try to open files
+         ***        that are still open for writing
+         **         note -- we do not increment num_open_sstables here because we close
+         *          immediately -- ensure_open will increment when a reader reopens */
+        if (klog_bm)
+        {
+            block_manager_close(klog_bm);
+            new_sst->klog_bm = NULL;
+        }
+        if (vlog_bm)
+        {
+            block_manager_close(vlog_bm);
+            new_sst->vlog_bm = NULL;
+        }
+
+    merge_complete:;
+        /* we save metadata for logging before potentially freeing sstable */
+        const uint64_t sst_id = new_sst->id;
+        const uint64_t num_entries = new_sst->num_entries;
+
+        /* drop_column_family marked us after the inner loop finished -- skip publishing the
+         * merged sstable; remove() drops the half-written files we already created on disk and the
+         * post-join teardown unrefs inputs without touching the manifest */
+        if (tidesdb_cf_abort_requested(cf))
+        {
+            if (bloom) bloom_filter_free(bloom);
+            if (block_indexes) compact_block_index_free(block_indexes);
+            remove(new_sst->klog_path);
+            remove(new_sst->vlog_path);
+            tidesdb_sstable_unref(cf->db, new_sst);
+            aborted = 1;
+            break;
+        }
+
+        /* we only add sstable if it has entries -- empty sstables cause corruption */
+        if (num_entries > 0)
+        {
+            /* we reload num_levels as DCA may have changed it */
+            int num_levels = atomic_load_explicit(&cf->num_active_levels, memory_order_acquire);
+
+            /* we find the output level by level_num, not by stale array index */
+            int target_level_num = output_level + 1;
+            int target_idx = -1;
+            for (int i = 0; i < num_levels; i++)
+            {
+                if (cf->levels[i]->level_num == target_level_num)
+                {
+                    target_idx = i;
+                    break;
+                }
+            }
+
+            if (target_idx < 0 || target_idx >= num_levels)
+            {
+                TDB_DEBUG_LOG(TDB_LOG_ERROR, "Target level %d not found (current_num_levels=%d)",
+                              target_level_num, num_levels);
+                /* the merge output cannot be published -- mark it so sstable_free
+                 * unlinks the klog/vlog files instead of orphaning them on disk for
+                 * recovery to find as an sstable that is not in the manifest */
+                atomic_store_explicit(&new_sst->marked_for_deletion, 1, memory_order_release);
+                tidesdb_sstable_unref(cf->db, new_sst);
+            }
+            else
+            {
+                TDB_DEBUG_LOG(TDB_LOG_INFO,
+                              "Adding merged SSTable %" PRIu64 " to level %d (array index %d)",
+                              new_sst->id, cf->levels[target_idx]->level_num, target_idx);
+                /* commit serialized across shards (shared level array + manifest) */
+                pthread_mutex_lock(&cf->compaction_commit_lock);
+                tidesdb_level_add_sstable(cf->levels[target_idx], new_sst);
+                tidesdb_bump_sstable_layout_version(cf);
+
+                tidesdb_manifest_add_sstable(cf->manifest, cf->levels[target_idx]->level_num,
+                                             new_sst->id, new_sst->num_entries,
+                                             new_sst->klog_size + new_sst->vlog_size);
+                atomic_store(&cf->manifest->sequence, atomic_load(&cf->next_sstable_id));
+                int manifest_result = tidesdb_manifest_commit(cf->manifest, cf->manifest->path);
+                if (manifest_result != 0)
+                {
+                    TDB_DEBUG_LOG(TDB_LOG_ERROR,
+                                  "Failed to commit manifest for new SSTable %" PRIu64
+                                  " (error: %d)",
+                                  new_sst->id, manifest_result);
+                }
+
+                /** we upload manifest to object store so replicas and cold-start nodes
+                 *  can see the new sstable before old inputs are cleaned up */
+                tdb_objstore_upload_manifest(cf->db, cf);
+                pthread_mutex_unlock(&cf->compaction_commit_lock);
+
+                tidesdb_sstable_unref(cf->db, new_sst);
+            }
         }
         else
         {
-            /* we write empty bloom block as placeholder */
-            block_manager_block_t *empty_bloom = block_manager_block_create(0, NULL);
-            if (empty_bloom)
-            {
-                block_manager_block_write(klog_bm, empty_bloom);
-                block_manager_block_release(empty_bloom);
-            }
-        }
-    }
-
-    /* we get file sizes before metadata write for serialization */
-    uint64_t klog_size_before_metadata;
-    uint64_t vlog_size_before_metadata;
-    block_manager_get_size(klog_bm, &klog_size_before_metadata);
-    block_manager_get_size(vlog_bm, &vlog_size_before_metadata);
-
-    new_sst->klog_size = klog_size_before_metadata;
-    new_sst->vlog_size = vlog_size_before_metadata;
-
-    /* we write metadata block as the last block -- only if we have entries */
-    uint8_t *metadata_data = NULL;
-    size_t metadata_size = 0;
-    if (new_sst->num_entries > 0 &&
-        sstable_metadata_serialize(new_sst, &metadata_data, &metadata_size) == 0)
-    {
-        block_manager_block_t *metadata_block =
-            block_manager_block_create(metadata_size, metadata_data);
-        if (metadata_block)
-        {
-            block_manager_block_write(klog_bm, metadata_block);
-            block_manager_block_release(metadata_block);
-        }
-        free(metadata_data);
-    }
-
-    block_manager_get_size(klog_bm, &new_sst->klog_size);
-    block_manager_get_size(vlog_bm, &new_sst->vlog_size);
-
-    tidesdb_merge_heap_free(heap);
-
-    block_manager_escalate_fsync(klog_bm);
-    block_manager_escalate_fsync(vlog_bm);
-
-    new_sst->klog_bm = klog_bm;
-    new_sst->vlog_bm = vlog_bm;
-    atomic_store(&new_sst->last_access_time,
-                 atomic_load_explicit(&cf->db->cached_current_time, memory_order_relaxed));
-
-    /* we ensure all writes are visible before making sstable discoverable */
-    atomic_thread_fence(memory_order_seq_cst);
-
-    /******     we close write handles before adding to level
-     *****      readers will reopen files on-demand through tidesdb_sstable_ensure_open
-     ****       this prevents file locking issues where readers try to open files
-     ***        that are still open for writing
-     **         note -- we do not increment num_open_sstables here because we close
-     *          immediately -- ensure_open will increment when a reader reopens */
-    if (klog_bm)
-    {
-        block_manager_close(klog_bm);
-        new_sst->klog_bm = NULL;
-    }
-    if (vlog_bm)
-    {
-        block_manager_close(vlog_bm);
-        new_sst->vlog_bm = NULL;
-    }
-
-merge_complete:;
-    /* we save metadata for logging before potentially freeing sstable */
-    const uint64_t sst_id = new_sst->id;
-    const uint64_t num_entries = new_sst->num_entries;
-
-    /* drop_column_family marked us after the inner loop finished -- skip publishing the
-     * merged sstable; remove() drops the half-written files we already created on disk and the
-     * post-join teardown unrefs inputs without touching the manifest */
-    if (tidesdb_cf_abort_requested(cf))
-    {
-        if (bloom) bloom_filter_free(bloom);
-        if (block_indexes) compact_block_index_free(block_indexes);
-        remove(new_sst->klog_path);
-        remove(new_sst->vlog_path);
-        tidesdb_sstable_unref(cf->db, new_sst);
-        aborted = 1;
-        break;
-    }
-
-    /* we only add sstable if it has entries -- empty sstables cause corruption */
-    if (num_entries > 0)
-    {
-        /* we reload num_levels as DCA may have changed it */
-        int num_levels = atomic_load_explicit(&cf->num_active_levels, memory_order_acquire);
-
-        /* we find the output level by level_num, not by stale array index */
-        int target_level_num = output_level + 1;
-        int target_idx = -1;
-        for (int i = 0; i < num_levels; i++)
-        {
-            if (cf->levels[i]->level_num == target_level_num)
-            {
-                target_idx = i;
-                break;
-            }
-        }
-
-        if (target_idx < 0 || target_idx >= num_levels)
-        {
-            TDB_DEBUG_LOG(TDB_LOG_ERROR, "Target level %d not found (current_num_levels=%d)",
-                          target_level_num, num_levels);
-            /* the merge output cannot be published -- mark it so sstable_free
-             * unlinks the klog/vlog files instead of orphaning them on disk for
-             * recovery to find as an sstable that is not in the manifest */
-            atomic_store_explicit(&new_sst->marked_for_deletion, 1, memory_order_release);
+            TDB_DEBUG_LOG(TDB_LOG_INFO, "Skipping empty SSTable %" PRIu64 " (0 entries)", sst_id);
+            if (bloom) bloom_filter_free(bloom);
+            if (block_indexes) compact_block_index_free(block_indexes);
+            remove(new_sst->klog_path);
+            remove(new_sst->vlog_path);
             tidesdb_sstable_unref(cf->db, new_sst);
         }
-        else
-        {
-            TDB_DEBUG_LOG(TDB_LOG_INFO,
-                          "Adding merged SSTable %" PRIu64 " to level %d (array index %d)",
-                          new_sst->id, cf->levels[target_idx]->level_num, target_idx);
-            /* commit serialized across shards (shared level array + manifest) */
-            pthread_mutex_lock(&cf->compaction_commit_lock);
-            tidesdb_level_add_sstable(cf->levels[target_idx], new_sst);
-            tidesdb_bump_sstable_layout_version(cf);
-
-            tidesdb_manifest_add_sstable(cf->manifest, cf->levels[target_idx]->level_num,
-                                         new_sst->id, new_sst->num_entries,
-                                         new_sst->klog_size + new_sst->vlog_size);
-            atomic_store(&cf->manifest->sequence, atomic_load(&cf->next_sstable_id));
-            int manifest_result = tidesdb_manifest_commit(cf->manifest, cf->manifest->path);
-            if (manifest_result != 0)
-            {
-                TDB_DEBUG_LOG(TDB_LOG_ERROR,
-                              "Failed to commit manifest for new SSTable %" PRIu64 " (error: %d)",
-                              new_sst->id, manifest_result);
-            }
-
-            /** we upload manifest to object store so replicas and cold-start nodes
-             *  can see the new sstable before old inputs are cleaned up */
-            tdb_objstore_upload_manifest(cf->db, cf);
-            pthread_mutex_unlock(&cf->compaction_commit_lock);
-
-            tidesdb_sstable_unref(cf->db, new_sst);
-        }
-    }
-    else
-    {
-        TDB_DEBUG_LOG(TDB_LOG_INFO, "Skipping empty SSTable %" PRIu64 " (0 entries)", sst_id);
-        if (bloom) bloom_filter_free(bloom);
-        if (block_indexes) compact_block_index_free(block_indexes);
-        remove(new_sst->klog_path);
-        remove(new_sst->vlog_path);
-        tidesdb_sstable_unref(cf->db, new_sst);
-    }
     } while (0);
 
     if (aborted) atomic_store_explicit(&c->aborted, 1, memory_order_release);
@@ -19258,14 +19290,18 @@ static void *tidesdb_sstable_reaper_thread(void *arg)
 
         int current_open = atomic_load(&db->num_open_sstables);
         int max_open = (int)db->config.max_open_sstables;
+        /* evict down to the reader budget, not max_open: keeping num_open at/below the budget
+         * leaves the reserve free for flush/compaction AND gives readers headroom to open, closing
+         * the [budget, max_open) starvation gap where reads back off but eviction never fired. */
+        const int reap_target = tidesdb_sstable_open_budget(db);
 
-        if (current_open < max_open)
+        if (current_open < reap_target)
         {
-            continue; /* under limit, nothing to do */
+            continue; /* under budget, nothing to do */
         }
 
-        TDB_DEBUG_LOG(TDB_LOG_INFO, "Reaper triggered: %d/%d open SSTables", current_open,
-                      max_open);
+        TDB_DEBUG_LOG(TDB_LOG_INFO, "Reaper triggered: %d open SSTables (budget %d, max %d)",
+                      current_open, reap_target, max_open);
 
         /**
          * sstable_candidate_t

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -402,6 +402,11 @@ static inline size_t tdb_build_prefixed_key(const uint32_t cf_index, const uint8
 #define TDB_BACKPRESSURE_MODERATE_THRESHOLD_RATIO 0.5 /* 50% of stall threshold */
 #define TDB_BACKPRESSURE_L1_HIGH_MULTIPLIER       4   /* 4x L1 trigger = high  */
 #define TDB_BACKPRESSURE_L1_MODERATE_MULTIPLIER   3   /* 3x L1 trigger = moderate */
+/* hard write-stop, once the first disk level holds this many x the trigger, compaction has fallen
+ * so far behind that the on-disk file count (and thus open fds + aux memory) would grow without
+ * bound. block writers here until compaction drains it, instead of only delaying. ~2x the HIGH
+ * slowdown band, mirroring the slowdown/stop split of leveled LSMs. */
+#define TDB_BACKPRESSURE_L1_STOP_MULTIPLIER 8
 /* active memtable hard ceiling as a multiple of write_buffer_size. the
  * commit-time threshold check allows up to 1.5x for batching headroom; this
  * leaves a small overshoot margin above that before apply_backpressure
@@ -452,6 +457,17 @@ static inline size_t tdb_build_prefixed_key(const uint32_t cf_index, const uint8
 #define TDB_FDS_PER_SSTABLE        2
 #define TDB_FD_RESERVE_NON_SSTABLE 64 /* descriptors reserved for WALs/manifest/objstore/stdio */
 #define TDB_MIN_OPEN_SSTABLES      4  /* never clamp the sstable budget below this */
+
+/* reader fd reservation. point reads and iterators may open NEW sstables only while
+ * num_open_sstables stays under max_open_sstables minus this reserve, which is held for the
+ * flush / compaction / commit-conflict-check paths -- those MUST make progress to relieve fd
+ * pressure, whereas a read can degrade to a retryable error (see the scan / iter open-failure
+ * paths). this bounds reader-induced opens so writes never starve, preventing the fd wedge. */
+#define TDB_FD_READER_RESERVE_DIVISOR 8  /* reserve = max_open_sstables / this ... */
+#define TDB_FD_READER_RESERVE_MIN     16 /* ... but at least this many sstables ... */
+#define TDB_FD_READER_RESERVE_MAX_DIVISOR                                                  \
+    2 /* ... and never more than max_open_sstables / this, so reads keep at least half the \
+       * fd budget even when max_open_sstables is smaller than the reserve floor */
 
 /* sstable reaper eviction sentinel -- set on refcount during block manager close
  * to prevent concurrent try_ref from acquiring a reference on an evicting sstable */
@@ -552,6 +568,43 @@ static int tidesdb_bm_open(tidesdb_t *db, block_manager_t **bm, const char *path
         tidesdb_wake_reaper(db);
         usleep(TDB_BM_OPEN_EMFILE_BACKOFF_US);
     }
+}
+
+/**
+ * tidesdb_reader_fd_budget_ok
+ * gate a reader (point-get / iterator) about to open a NOT-yet-open sstable against the reader fd
+ * budget = max_open_sstables - reserve, the reserve being held for flush / compaction /
+ * conflict-check (the priority paths that must progress to relieve fd pressure). an already-open
+ * sstable needs no new descriptor, so re-reads are never blocked. when over budget, wake the reaper
+ * to reclaim idle sstables and recheck; if still over, the caller fails the read with a retryable
+ * error rather than starving the write path or returning wrong data (the scan/iter open-failure
+ * paths surface it). returns 1 if the reader may open, 0 if it must back off.
+ * @param db database instance
+ * @param sst sstable the reader is about to open
+ * @return 1 if ok to open (or already open), 0 if over the reader budget
+ */
+static int tidesdb_reader_fd_budget_ok(tidesdb_t *db, tidesdb_sstable_t *sst)
+{
+    /* already counted -- num_open_sstables is keyed on the klog, so a klog-open sstable
+     * needs no new tracked descriptor and is never blocked (the lazy vlog rides along) */
+    if (atomic_load_explicit(&sst->klog_bm, memory_order_acquire)) return 1;
+
+    const int max_open = (int)db->config.max_open_sstables;
+    int reserve = max_open / TDB_FD_READER_RESERVE_DIVISOR;
+    if (reserve < TDB_FD_READER_RESERVE_MIN) reserve = TDB_FD_READER_RESERVE_MIN;
+    /* cap the reserve so it never starves reads when max_open_sstables is below the floor */
+    const int reserve_cap = max_open / TDB_FD_READER_RESERVE_MAX_DIVISOR;
+    if (reserve > reserve_cap) reserve = reserve_cap;
+    int budget = max_open - reserve;
+    if (budget < 1) budget = 1;
+
+    if (atomic_load_explicit(&db->num_open_sstables, memory_order_relaxed) < budget) return 1;
+
+    /* over budget for a new open -- give the reaper a chance to reclaim idle sstables, then recheck
+     */
+    tidesdb_wake_reaper(db);
+    usleep(TDB_BACKPRESSURE_STALL_CHECK_INTERVAL_US);
+    return atomic_load_explicit(&db->num_open_sstables, memory_order_relaxed) < budget;
 }
 
 /* empty block index placeholder ( 4 byte LE count (0) followed by 1 byte prefix_len ) */
@@ -1563,6 +1616,8 @@ static tidesdb_kv_pair_t *tidesdb_kv_pair_create(const uint8_t *key, size_t key_
 static void tidesdb_kv_pair_free(tidesdb_kv_pair_t *kv);
 static int tidesdb_iter_kv_visible(tidesdb_iter_t *iter, tidesdb_kv_pair_t *kv);
 static int tidesdb_sstable_ensure_open(tidesdb_t *db, tidesdb_sstable_t *sst);
+static int tidesdb_sstable_ensure_klog_open(tidesdb_t *db, tidesdb_sstable_t *sst);
+static int tidesdb_sstable_ensure_vlog_open(tidesdb_t *db, tidesdb_sstable_t *sst);
 static int wait_for_open(tidesdb_t *db);
 
 /**
@@ -4383,6 +4438,14 @@ static int tidesdb_vlog_read_value(const tidesdb_t *db, tidesdb_sstable_t *sst,
 {
     if (!db || !sst || !value) return TDB_ERR_INVALID_ARGS;
 
+    /* the vlog is opened lazily on first non-inline value read. the const cast is safe:
+     * opening the vlog mutates sst (not db's logical state) and does not touch
+     * num_open_sstables, which is keyed on the klog. */
+    if (tidesdb_sstable_ensure_vlog_open((tidesdb_t *)db, sst) != 0)
+    {
+        return TDB_ERR_IO;
+    }
+
     tidesdb_block_managers_t bms;
     if (tidesdb_sstable_get_block_managers(db, sst, &bms) != TDB_SUCCESS)
     {
@@ -4467,7 +4530,10 @@ static int tidesdb_sstable_get_block_managers(const tidesdb_t *db, tidesdb_sstab
     bms->klog_bm = sst->klog_bm;
     bms->vlog_bm = sst->vlog_bm;
 
-    if (!bms->klog_bm || !bms->vlog_bm)
+    /* the vlog is opened lazily, so it may legitimately be NULL here; only the klog is
+     * guaranteed open. callers that read values must first call
+     * tidesdb_sstable_ensure_vlog_open (tidesdb_vlog_read_value does so at its top). */
+    if (!bms->klog_bm)
     {
         return TDB_ERR_IO;
     }
@@ -5883,90 +5949,124 @@ static void tdb_objstore_delete_listed_cb(const char *key, const size_t size, vo
 }
 
 /**
- * tidesdb_sstable_ensure_open
- * ensures an sstable's block managers are open, using the cache
+ * tidesdb_sstable_ensure_klog_open
+ * ensures an sstable's klog block manager is open. num_open_sstables is keyed on the
+ * klog, it is incremented here when the klog transitions closed->open and decremented
+ * when the reaper (or a cleanup path) closes the klog. the vlog is opened lazily and is
+ * not separately counted, so a scan that touches only inline values holds one fd per
+ * pinned sstable instead of two.
  * @param db database instance
- * @param sst sstable to ensure is open
+ * @param sst sstable whose klog to ensure open
  * @return 0 on success, -1 on error
  */
-static int tidesdb_sstable_ensure_open(tidesdb_t *db, tidesdb_sstable_t *sst)
+static int tidesdb_sstable_ensure_klog_open(tidesdb_t *db, tidesdb_sstable_t *sst)
 {
     if (!db || !sst) return -1;
-    if (!sst->config || !sst->klog_path || !sst->vlog_path) return -1;
+    if (!sst->config || !sst->klog_path) return -1;
 
-    /* we only open block managers if not already open */
-    if (sst->klog_bm && sst->vlog_bm)
+    if (sst->klog_bm)
     {
+        atomic_store(&sst->last_access_time, atomic_load(&db->cached_current_time));
         return 0; /* already open */
     }
 
     if (db->object_store)
     {
         if (tdb_objstore_download_if_missing(db, sst->klog_path) != 0) return -1;
-        if (tdb_objstore_download_if_missing(db, sst->vlog_path) != 0) return -1;
     }
 
-    /* we track whether the sstable was fully closed (evicted by reaper) so we can
-     * update num_open_sstables after reopening */
-    const int was_fully_closed = (!sst->klog_bm && !sst->vlog_bm);
-
-    /* we open block managers if needed, using CAS to prevent race conditions
-     * where two threads both try to open the same sstable simultaneously */
-    if (!sst->klog_bm)
+    block_manager_t *new_klog_bm = NULL;
+    if (tidesdb_bm_open(db, &new_klog_bm, sst->klog_path,
+                        convert_sync_mode(sst->config->sync_mode == TDB_SYNC_INTERVAL
+                                              ? TDB_SYNC_FULL
+                                              : sst->config->sync_mode)) != 0)
     {
-        block_manager_t *new_klog_bm = NULL;
-        if (tidesdb_bm_open(db, &new_klog_bm, sst->klog_path,
-                            convert_sync_mode(sst->config->sync_mode == TDB_SYNC_INTERVAL
-                                                  ? TDB_SYNC_FULL
-                                                  : sst->config->sync_mode)) != 0)
-        {
-            TDB_DEBUG_LOG(TDB_LOG_ERROR, "failed to open klog '%s': %s", sst->klog_path,
-                          strerror(errno));
-            return -1;
-        }
-        /* CAS to set klog_bm -- if another thread already set it, close ours */
-        block_manager_t *expected = NULL;
-        if (!atomic_compare_exchange_strong(&sst->klog_bm, &expected, new_klog_bm))
-        {
-            /* another thread already opened it,we  close our duplicate */
-            block_manager_close(new_klog_bm);
-        }
+        if (tdb_log_throttle(db, &db->last_open_fail_log_sec,
+                             TDB_BACKPRESSURE_STALL_LOG_INTERVAL_SEC))
+            TDB_DEBUG_LOG(TDB_LOG_ERROR, "failed to open sstable klog '%s': %s%s", sst->klog_path,
+                          strerror(errno),
+                          (errno == EMFILE || errno == ENFILE)
+                              ? " -- open-file limit reached; raise ulimit -n"
+                              : "");
+        return -1;
     }
 
-    if (!sst->vlog_bm)
+    /* CAS to set klog_bm -- if another thread already set it, close ours and let that
+     * thread's CAS win own the num_open_sstables increment (exactly one inc per open) */
+    block_manager_t *expected = NULL;
+    if (!atomic_compare_exchange_strong(&sst->klog_bm, &expected, new_klog_bm))
     {
-        block_manager_t *new_vlog_bm = NULL;
-        if (tidesdb_bm_open(db, &new_vlog_bm, sst->vlog_path,
-                            convert_sync_mode(sst->config->sync_mode)) != 0)
-        {
-            /* we dont close klog_bm here -- it may be used by another thread */
-            TDB_DEBUG_LOG(TDB_LOG_ERROR, "failed to open vlog '%s': %s", sst->vlog_path,
-                          strerror(errno));
-            return -1;
-        }
-
-        /* we hint that vlog access is random (point lookups by offset)
-         * this disables read-ahead which would waste I/O for random access */
-        set_file_random_hint(new_vlog_bm->fd);
-
-        /* CAS to set vlog_bm -- if another thread already set it, we close ours */
-        block_manager_t *expected = NULL;
-        if (!atomic_compare_exchange_strong(&sst->vlog_bm, &expected, new_vlog_bm))
-        {
-            /* another thread already opened it, we close our duplicate */
-            block_manager_close(new_vlog_bm);
-        }
+        block_manager_close(new_klog_bm);
+        return 0;
     }
 
     atomic_store(&sst->last_access_time, atomic_load(&db->cached_current_time));
+    atomic_fetch_add(&db->num_open_sstables, 1);
+    return 0;
+}
 
-    /* if we transitioned from fully-closed to fully-open, track it
-     * this balances the reaper's decrement when it evicts the sstable */
-    if (was_fully_closed && sst->klog_bm && sst->vlog_bm)
+/**
+ * tidesdb_sstable_ensure_vlog_open
+ * ensures an sstable's vlog block manager is open. the vlog is opened lazily on the first
+ * value read that misses the inline klog payload; it is not counted in num_open_sstables
+ * (see tidesdb_sstable_ensure_klog_open) and is closed alongside the klog by the reaper.
+ * @param db database instance
+ * @param sst sstable whose vlog to ensure open
+ * @return 0 on success, -1 on error
+ */
+static int tidesdb_sstable_ensure_vlog_open(tidesdb_t *db, tidesdb_sstable_t *sst)
+{
+    if (!db || !sst) return -1;
+    if (!sst->config || !sst->vlog_path) return -1;
+
+    if (sst->vlog_bm) return 0; /* already open */
+
+    if (db->object_store)
     {
-        atomic_fetch_add(&db->num_open_sstables, 1);
+        if (tdb_objstore_download_if_missing(db, sst->vlog_path) != 0) return -1;
     }
 
+    block_manager_t *new_vlog_bm = NULL;
+    if (tidesdb_bm_open(db, &new_vlog_bm, sst->vlog_path,
+                        convert_sync_mode(sst->config->sync_mode)) != 0)
+    {
+        if (tdb_log_throttle(db, &db->last_open_fail_log_sec,
+                             TDB_BACKPRESSURE_STALL_LOG_INTERVAL_SEC))
+            TDB_DEBUG_LOG(TDB_LOG_ERROR, "failed to open sstable vlog '%s': %s%s", sst->vlog_path,
+                          strerror(errno),
+                          (errno == EMFILE || errno == ENFILE)
+                              ? " -- open-file limit reached; raise ulimit -n"
+                              : "");
+        return -1;
+    }
+
+    /* we hint that vlog access is random (point lookups by offset)
+     * this disables read-ahead which would waste I/O for random access */
+    set_file_random_hint(new_vlog_bm->fd);
+
+    /* CAS to set vlog_bm -- if another thread already set it, we close ours */
+    block_manager_t *expected = NULL;
+    if (!atomic_compare_exchange_strong(&sst->vlog_bm, &expected, new_vlog_bm))
+    {
+        block_manager_close(new_vlog_bm);
+    }
+
+    return 0;
+}
+
+/**
+ * tidesdb_sstable_ensure_open
+ * ensures both block managers are open. used by write/flush/compaction/btree paths that
+ * need the vlog eagerly; scan sources open the klog only (tidesdb_sstable_ensure_klog_open)
+ * and let tidesdb_vlog_read_value open the vlog on demand.
+ * @param db database instance
+ * @param sst sstable to ensure is open
+ * @return 0 on success, -1 on error
+ */
+static int tidesdb_sstable_ensure_open(tidesdb_t *db, tidesdb_sstable_t *sst)
+{
+    if (tidesdb_sstable_ensure_klog_open(db, sst) != 0) return -1;
+    if (tidesdb_sstable_ensure_vlog_open(db, sst) != 0) return -1;
     return 0;
 }
 
@@ -6127,7 +6227,9 @@ static void tidesdb_sstable_free(tidesdb_sstable_t *sst)
     }
 
     {
-        const int had_open_bms = (sst->klog_bm != NULL || sst->vlog_bm != NULL);
+        /* num_open_sstables is keyed on the klog (the vlog is opened lazily and not
+         * separately counted), so the decrement fires iff the klog was open */
+        const int had_open_bms = (sst->klog_bm != NULL);
         if (sst->klog_bm)
         {
             block_manager_close(sst->klog_bm);
@@ -10947,7 +11049,9 @@ static tidesdb_merge_source_t *tidesdb_merge_source_from_sstable_klog(tidesdb_t 
 
     tidesdb_sstable_ref(sst);
 
-    if (tidesdb_sstable_ensure_open(db, sst) != 0)
+    /* scan sources open the klog only; the vlog is opened on demand by
+     * tidesdb_vlog_read_value when a value misses the inline klog payload */
+    if (tidesdb_sstable_ensure_klog_open(db, sst) != 0)
     {
         tidesdb_sstable_unref(db, sst);
         free(source);
@@ -10969,18 +11073,13 @@ static tidesdb_merge_source_t *tidesdb_merge_source_from_sstable_klog(tidesdb_t 
         return NULL;
     }
 
-    if (block_manager_cursor_init(&source->source.sstable.vlog_cursor, bms.vlog_bm) != 0)
-    {
-        tidesdb_sstable_unref(db, sst);
-        block_manager_cursor_free(source->source.sstable.klog_cursor);
-        free(source);
-        return NULL;
-    }
+    /* the klog source reads values via tidesdb_vlog_read_value (sst->vlog_bm), never via a
+     * source-held vlog cursor; leave it NULL so cleanup's cursor_free is a no-op */
+    source->source.sstable.vlog_cursor = NULL;
 
     /* we hint to OS that this is streaming read (data will be accessed only once)
      * this helps prevent cache pollution during compaction * * */
     set_file_noreuse_hint(bms.klog_bm->fd, 0, 0);
-    set_file_noreuse_hint(bms.vlog_bm->fd, 0, 0);
 
     source->source.sstable.current_block_data = NULL; /* no block data yet */
     source->source.sstable.current_rc_block = NULL;   /* no ref-counted block yet */
@@ -11358,7 +11457,9 @@ static tidesdb_merge_source_t *tidesdb_merge_source_from_sstable_lazy(tidesdb_t 
 
     tidesdb_sstable_ref(sst);
 
-    if (tidesdb_sstable_ensure_open(db, sst) != 0)
+    /* scan sources open the klog only; the vlog is opened on demand by
+     * tidesdb_vlog_read_value when a value misses the inline klog payload */
+    if (tidesdb_sstable_ensure_klog_open(db, sst) != 0)
     {
         tidesdb_sstable_unref(db, sst);
         free(source);
@@ -11380,13 +11481,9 @@ static tidesdb_merge_source_t *tidesdb_merge_source_from_sstable_lazy(tidesdb_t 
         return NULL;
     }
 
-    if (block_manager_cursor_init(&source->source.sstable.vlog_cursor, bms.vlog_bm) != 0)
-    {
-        tidesdb_sstable_unref(db, sst);
-        block_manager_cursor_free(source->source.sstable.klog_cursor);
-        free(source);
-        return NULL;
-    }
+    /* the klog source reads values via tidesdb_vlog_read_value (sst->vlog_bm), never via a
+     * source-held vlog cursor; leave it NULL so cleanup's cursor_free is a no-op */
+    source->source.sstable.vlog_cursor = NULL;
 
     source->source.sstable.current_block_data = NULL;
     source->source.sstable.current_rc_block = NULL;
@@ -17497,7 +17594,9 @@ static void *tidesdb_flush_worker_thread(void *arg)
          * this prevents file locking issues where readers cannot open files
          * that are still held open by the flush worker */
         {
-            const int had_open_bms = (sst->klog_bm != NULL || sst->vlog_bm != NULL);
+            /* num_open_sstables is keyed on the klog (the vlog is opened lazily and not
+             * separately counted), so the decrement fires iff the klog was open */
+            const int had_open_bms = (sst->klog_bm != NULL);
             if (sst->klog_bm)
             {
                 block_manager_close(sst->klog_bm);
@@ -18851,8 +18950,9 @@ static void *tidesdb_sstable_reaper_thread(void *arg)
                     /* we only consider ssts that are open and not in use
                      * we use try_ref to safely acquire reference -- if it fails, sstable is being
                      * freed after acquiring ref, check if refcount is now 2 (level ref + our ref)
-                     */
-                    if (sst->klog_bm && sst->vlog_bm)
+                     * num_open_sstables is keyed on the klog, so a klog-open sstable is
+                     * reclaimable even when its vlog was never lazily opened */
+                    if (sst->klog_bm)
                     {
                         if (!tidesdb_sstable_try_ref(sst))
                         {
@@ -18919,13 +19019,17 @@ static void *tidesdb_sstable_reaper_thread(void *arg)
              *** between refcount check and close. the baseline matches the drain path's
              *** "1 original + 1 work ref" semantic, so we reuse the same constant. */
             int expected = TDB_REFCOUNT_DRAIN_BASELINE;
-            if (sst->klog_bm && sst->vlog_bm &&
+            if (sst->klog_bm &&
                 atomic_compare_exchange_strong(&sst->refcount, &expected, TDB_REFCOUNT_EVICTING))
             {
                 block_manager_close(sst->klog_bm);
-                block_manager_close(sst->vlog_bm);
                 sst->klog_bm = NULL;
-                sst->vlog_bm = NULL;
+                /* the vlog is opened lazily, so it may not be open; close it if it is */
+                if (sst->vlog_bm)
+                {
+                    block_manager_close(sst->vlog_bm);
+                    sst->vlog_bm = NULL;
+                }
                 atomic_fetch_sub(&db->num_open_sstables, 1);
                 closed_count++;
 
@@ -23353,6 +23457,63 @@ static int tidesdb_apply_backpressure(tidesdb_column_family_t *cf)
         l0_delayed = 1;
     }
 
+    /* L1 (first disk level) hard write-stop. the graduated delays below only *slow* writes when L1
+     * exceeds a few x the trigger; under sustained ingest that compaction cannot match, the file
+     * count would still grow without bound -- the on-disk working set readers pin, and thus open
+     * fds and per-sstable aux memory, with it (the fd-exhaustion wedge). stop writers once L1
+     * reaches a high multiple of the trigger and hold until compaction drains it. like the L0 queue
+     * stall, we pace while compaction makes progress (file count shrinks or the sstable layout
+     * version advances) and only return BUSY if compaction is genuinely wedged. */
+    const int l1_stop_watermark = effective_l1_trigger * TDB_BACKPRESSURE_L1_STOP_MULTIPLIER;
+    if (l1_file_count >= l1_stop_watermark)
+    {
+        if (tdb_log_throttle(cf->db, &cf->last_l1_stop_log_sec,
+                             TDB_BACKPRESSURE_STALL_LOG_INTERVAL_SEC))
+            TDB_DEBUG_LOG(TDB_LOG_WARN,
+                          "CF '%s' L1 file-count stall: %d >= %d (%dx trigger) -- blocking until "
+                          "compaction drains",
+                          cf->name, l1_file_count, l1_stop_watermark,
+                          TDB_BACKPRESSURE_L1_STOP_MULTIPLIER);
+
+        /* ensure compaction is actually working the backlog down */
+        if (!atomic_load_explicit(&cf->is_compacting, memory_order_relaxed))
+            tidesdb_enqueue_compaction(cf, 0);
+
+        int total_iterations = 0;
+        int no_progress = 0;
+        int best_count = l1_file_count;
+        uint64_t last_layout =
+            atomic_load_explicit(&cf->sstable_layout_version, memory_order_relaxed);
+        while (atomic_load_explicit(&cf->levels[0]->num_sstables, memory_order_acquire) >=
+               l1_stop_watermark)
+        {
+            usleep(TDB_BACKPRESSURE_STALL_CHECK_INTERVAL_US);
+            total_iterations++;
+            const int cur =
+                atomic_load_explicit(&cf->levels[0]->num_sstables, memory_order_acquire);
+            const uint64_t cur_layout =
+                atomic_load_explicit(&cf->sstable_layout_version, memory_order_relaxed);
+            if (cur < best_count || cur_layout != last_layout)
+            {
+                best_count = cur;
+                last_layout = cur_layout;
+                no_progress = 0;
+            }
+            else if (++no_progress >= TDB_BACKPRESSURE_STALL_MAX_ITERATIONS)
+            {
+                TDB_DEBUG_LOG(TDB_LOG_ERROR,
+                              "CF '%s' L1 file-count stall: no compaction progress for %dms -- "
+                              "compaction appears wedged",
+                              cf->name,
+                              no_progress * (TDB_BACKPRESSURE_STALL_CHECK_INTERVAL_US / 1000));
+                return TDB_ERR_BUSY;
+            }
+        }
+        TDB_DEBUG_LOG(TDB_LOG_INFO, "CF '%s' L1 file-count stall resolved after %dms", cf->name,
+                      total_iterations * (TDB_BACKPRESSURE_STALL_CHECK_INTERVAL_US / 1000));
+        l0_delayed = 1;
+    }
+
     /* per-cf active memtable ceiling. tidesdb_flush_memtable_internal silently
      * defers the rotate when the active_flushes slot cap is reached, so the L0
      * queue stall and L1 file-count delays above are not enough to bound the
@@ -24627,6 +24788,7 @@ unified_sst_search:;
         size_t best_value_size = 0;
         int best_is_dead = 0;
         int best_found = 0;
+        int scan_error = 0; /* set if an sstable could not be opened/read (incomplete scan) */
 
         const int scan_start = num_ssts - 1;
         const int scan_end = 0;
@@ -24705,6 +24867,16 @@ unified_sst_search:;
                 continue;
             }
 
+            /* reader fd budget, don't open a new sstable for this read if doing so would eat into
+             * the flush/compaction reserve. back off with a retryable error rather than starving
+             * the write path; an already-open sstable is never blocked (see helper). */
+            if (!tidesdb_reader_fd_budget_ok(cf->db, sst))
+            {
+                tidesdb_sstable_unref(cf->db, sst);
+                scan_error = TDB_ERR_BUSY;
+                break;
+            }
+
             tidesdb_kv_pair_t *candidate_kv = NULL;
             int get_result =
                 tidesdb_sstable_get(cf->db, sst, key, key_size, snapshot_seq, &candidate_kv, 0);
@@ -24747,9 +24919,26 @@ unified_sst_search:;
             }
 
             tidesdb_sstable_unref(cf->db, sst);
+
+            /* a non-found, non-success return means this sstable could not be opened or read
+             * (e.g. EMFILE under fd pressure, or an IO error). the scan is therefore incomplete --
+             * a newer version of the key may live in the sstable we just failed on -- so we must
+             * NOT fall through and treat it as "not present" (which would return a stale version or
+             * a false not-found). surface the error and let the caller retry once fds free. */
+            if (get_result != TDB_SUCCESS && get_result != TDB_ERR_NOT_FOUND)
+            {
+                scan_error = get_result;
+                break;
+            }
         }
 
         atomic_fetch_sub_explicit(&level->array_readers, 1, memory_order_release);
+
+        if (scan_error)
+        {
+            if (best_value) free(best_value);
+            return scan_error;
+        }
 
         if (best_found)
         {
@@ -28136,23 +28325,44 @@ int tidesdb_iter_new(tidesdb_txn_t *txn, tidesdb_column_family_t *cf, tidesdb_it
         {
             tidesdb_sstable_t *sst = ssts_array[i];
 
+            /* reader fd budget--a full-scan iterator opens every source; refuse to exceed the
+             * reader budget (reserve held for flush/compaction). fail creation with a retryable
+             * error rather than starving the write path -- the caller retries once fds free. */
+            if (!tidesdb_reader_fd_budget_ok(cf->db, sst))
+            {
+                for (int k = i; k < sst_count; k++) tidesdb_sstable_unref(cf->db, ssts_array[k]);
+                free(ssts_array);
+                tidesdb_iter_free(*iter);
+                *iter = NULL;
+                return TDB_ERR_BUSY;
+            }
+
             tidesdb_merge_source_t *sst_source =
                 tidesdb_merge_source_from_sstable_lazy(cf->db, sst);
-            if (sst_source)
+            if (!sst_source)
             {
-                /* we mark as cached so it wont be freed when popped from heap */
-                sst_source->is_cached = 1;
+                /* could not open/build a source for this sstable (e.g. EMFILE under fd pressure).
+                 * an iterator that silently omits an sstable returns wrong/incomplete results, so
+                 * fail creation and let the caller retry once descriptors free. */
+                for (int k = i; k < sst_count; k++) tidesdb_sstable_unref(cf->db, ssts_array[k]);
+                free(ssts_array);
+                tidesdb_iter_free(*iter);
+                *iter = NULL;
+                return TDB_ERR_IO;
+            }
 
-                /* we cache the source for reuse */
-                (*iter)->cached_sources[(*iter)->num_cached_sources++] = sst_source;
+            /* we mark as cached so it wont be freed when popped from heap */
+            sst_source->is_cached = 1;
 
-                /* we add to heap if it has initial data */
-                if (sst_source->current_kv != NULL)
+            /* we cache the source for reuse */
+            (*iter)->cached_sources[(*iter)->num_cached_sources++] = sst_source;
+
+            /* we add to heap if it has initial data */
+            if (sst_source->current_kv != NULL)
+            {
+                if (tidesdb_merge_heap_add_source((*iter)->heap, sst_source) != TDB_SUCCESS)
                 {
-                    if (tidesdb_merge_heap_add_source((*iter)->heap, sst_source) != TDB_SUCCESS)
-                    {
-                        /* source is still cached, just not in heap initially */
-                    }
+                    /* source is still cached, just not in heap initially */
                 }
             }
 
@@ -28342,12 +28552,26 @@ static int tidesdb_iter_rebuild_sst_cache(tidesdb_iter_t *iter)
     for (int i = 0; i < sst_count; i++)
     {
         tidesdb_sstable_t *sst = ssts_array[i];
-        tidesdb_merge_source_t *sst_source = tidesdb_merge_source_from_sstable_lazy(cf->db, sst);
-        if (sst_source)
+
+        /* reader fd budget (see helper) -- back off rather than starving flush/compaction */
+        if (!tidesdb_reader_fd_budget_ok(cf->db, sst))
         {
-            sst_source->is_cached = 1;
-            iter->cached_sources[iter->num_cached_sources++] = sst_source;
+            for (int k = i; k < sst_count; k++) tidesdb_sstable_unref(cf->db, ssts_array[k]);
+            free(ssts_array);
+            return TDB_ERR_BUSY;
         }
+
+        tidesdb_merge_source_t *sst_source = tidesdb_merge_source_from_sstable_lazy(cf->db, sst);
+        if (!sst_source)
+        {
+            /* could not open/build a source (e.g. EMFILE) -- a rebuilt cache that omits an sstable
+             * would silently drop data from the scan. surface the failure; the caller retries. */
+            for (int k = i; k < sst_count; k++) tidesdb_sstable_unref(cf->db, ssts_array[k]);
+            free(ssts_array);
+            return TDB_ERR_IO;
+        }
+        sst_source->is_cached = 1;
+        iter->cached_sources[iter->num_cached_sources++] = sst_source;
         tidesdb_sstable_unref(cf->db, sst);
     }
     free(ssts_array);

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -402,11 +402,6 @@ static inline size_t tdb_build_prefixed_key(const uint32_t cf_index, const uint8
 #define TDB_BACKPRESSURE_MODERATE_THRESHOLD_RATIO 0.5 /* 50% of stall threshold */
 #define TDB_BACKPRESSURE_L1_HIGH_MULTIPLIER       4   /* 4x L1 trigger = high  */
 #define TDB_BACKPRESSURE_L1_MODERATE_MULTIPLIER   3   /* 3x L1 trigger = moderate */
-/* hard write-stop, once the first disk level holds this many x the trigger, compaction has fallen
- * so far behind that the on-disk file count (and thus open fds + aux memory) would grow without
- * bound. block writers here until compaction drains it, instead of only delaying. ~2x the HIGH
- * slowdown band, mirroring the slowdown/stop split of leveled LSMs. */
-#define TDB_BACKPRESSURE_L1_STOP_MULTIPLIER 8
 /* active memtable hard ceiling as a multiple of write_buffer_size. the
  * commit-time threshold check allows up to 1.5x for batching headroom; this
  * leaves a small overshoot margin above that before apply_backpressure
@@ -13064,6 +13059,149 @@ static void tidesdb_cleanup_merged_sstables(tidesdb_column_family_t *cf, queue_t
 }
 
 /**
+ * tidesdb_subcompaction_t
+ * shared coordination state for running a single compaction round's independent partition
+ * sub-merges across multiple ephemeral helper threads. each partition is a disjoint key range
+ * with its own heap/output; workers steal partitions via next_partition and each calls
+ * run_partition, which performs that partition's commit under cf->compaction_commit_lock.
+ * @param db database (for the helper-thread budget)
+ * @param merge_ctx opaque per-merge context passed to run_partition
+ * @param run_partition per-partition worker; returns TDB_SUCCESS or a hard error
+ * @param num_partitions number of partitions to process
+ * @param next_partition work-stealing cursor
+ * @param aborted set when a partition observes an external abort (e.g. CF drop)
+ * @param error first hard error code observed across partitions (TDB_SUCCESS = none)
+ */
+typedef struct
+{
+    tidesdb_t *db;
+    void *merge_ctx;
+    int (*run_partition)(void *merge_ctx, int partition);
+    int num_partitions;
+    _Atomic(int) next_partition;
+    _Atomic(int) aborted;
+    _Atomic(int) error;
+} tidesdb_subcompaction_t;
+
+/**
+ * tidesdb_subcompaction_worker
+ * helper-thread body-- steal partition indices and run each until exhausted or aborted
+ */
+static void *tidesdb_subcompaction_worker(void *arg)
+{
+    tidesdb_subcompaction_t *sc = (tidesdb_subcompaction_t *)arg;
+    tdb_set_thread_name("tdb-subcompact");
+    for (;;)
+    {
+        if (atomic_load_explicit(&sc->aborted, memory_order_acquire)) break;
+        const int p = atomic_fetch_add_explicit(&sc->next_partition, 1, memory_order_acq_rel);
+        if (p >= sc->num_partitions) break;
+        const int rc = sc->run_partition(sc->merge_ctx, p);
+        if (rc != TDB_SUCCESS)
+        {
+            int expected = TDB_SUCCESS;
+            atomic_compare_exchange_strong_explicit(&sc->error, &expected, rc,
+                                                    memory_order_acq_rel, memory_order_relaxed);
+        }
+    }
+    return NULL;
+}
+
+/**
+ * tidesdb_run_subcompactions
+ * run num_partitions independent partition merges concurrently. borrows up to
+ * (num_partitions - 1) helper threads from db->compaction_helper_budget (bounded so parallel
+ * rounds across CFs never oversubscribe the pool); the calling thread also works, so progress
+ * is guaranteed even when the budget is zero or pthread_create fails (work is stolen, never
+ * dropped). run_partition owns each partition's heap/output and commits under the CF lock.
+ * @return the first hard error from any partition, or TDB_SUCCESS
+ */
+static int tidesdb_run_subcompactions(tidesdb_t *db, void *merge_ctx,
+                                      int (*run_partition)(void *, int), int num_partitions)
+{
+    if (num_partitions <= 0) return TDB_SUCCESS;
+
+    tidesdb_subcompaction_t sc;
+    sc.db = db;
+    sc.merge_ctx = merge_ctx;
+    sc.run_partition = run_partition;
+    sc.num_partitions = num_partitions;
+    atomic_init(&sc.next_partition, 0);
+    atomic_init(&sc.aborted, 0);
+    atomic_init(&sc.error, TDB_SUCCESS);
+
+    /* borrow helpers from the global budget; the calling thread is always an extra worker so we
+     * never need more than num_partitions - 1 helpers. a CAS loop claims whatever is available. */
+    int want = num_partitions - 1;
+    int helpers = 0;
+    if (want > 0)
+    {
+        int avail = atomic_load_explicit(&db->compaction_helper_budget, memory_order_acquire);
+        while (avail > 0)
+        {
+            const int claim = (want < avail) ? want : avail;
+            if (atomic_compare_exchange_weak_explicit(&db->compaction_helper_budget, &avail,
+                                                      avail - claim, memory_order_acq_rel,
+                                                      memory_order_acquire))
+            {
+                helpers = claim;
+                break;
+            }
+        }
+    }
+
+    pthread_t *threads = (helpers > 0) ? malloc((size_t)helpers * sizeof(pthread_t)) : NULL;
+    int launched = 0;
+    for (int i = 0; threads && i < helpers; i++)
+    {
+        if (pthread_create(&threads[launched], NULL, tidesdb_subcompaction_worker, &sc) == 0)
+            launched++;
+    }
+
+    /* the calling thread participates as a worker too -- guarantees forward progress */
+    tidesdb_subcompaction_worker(&sc);
+
+    for (int i = 0; i < launched; i++) pthread_join(threads[i], NULL);
+    free(threads);
+
+    /* return exactly what we claimed (failed pthread_create leaves work to the stealers) */
+    if (helpers > 0)
+        atomic_fetch_add_explicit(&db->compaction_helper_budget, helpers, memory_order_release);
+
+    return atomic_load_explicit(&sc.error, memory_order_acquire);
+}
+
+/**
+ * tidesdb_full_preemptive_ctx_t / _shard
+ * shared read-only context for a full preemptive merge's parallel shards (RocksDB-style
+ * subcompactions). the single-output merge is split into key-range shards whose boundaries are
+ * sampled from the input sstables' min keys; each shard builds its own heap from overlapping
+ * inputs, range-filters the merge, and writes its own output sstable at output_level. the commit
+ * is serialized on cf->compaction_commit_lock; per-merge teardown (input cleanup) runs once after
+ * the shards join. the btree branch writes the shard heap unfiltered, matching dividing/partitioned.
+ */
+typedef struct
+{
+    tidesdb_column_family_t *cf;
+    int start_level;
+    int target_level;
+    int output_level;
+    int is_largest_level;
+    skip_list_comparator_fn comparator_fn;
+    void *comparator_ctx;
+    tidesdb_sstable_t **del_snap;
+    size_t del_snap_count;
+    uint8_t **boundaries;
+    size_t *boundary_sizes;
+    int num_boundaries;
+    uint64_t min_snapshot_seq;
+    queue_t *sstables_to_delete;
+    _Atomic(int) aborted;
+} tidesdb_full_preemptive_ctx_t;
+
+static int tidesdb_full_preemptive_shard(void *vctx, int shard);
+
+/**
  * tidesdb_full_preemptive_merge
  * perform a full preemptive merge on the column family
  * @param cf the column family
@@ -13146,89 +13284,221 @@ static int tidesdb_full_preemptive_merge(tidesdb_column_family_t *cf, int start_
         tdb_objstore_prefetch_sstables(cf->db, ssts_array, sst_count);
     }
 
-    tidesdb_add_ssts_to_merge_heap(cf->db, cf, ssts_array, sst_count, heap, sstables_to_delete);
+    /* sub-compaction sharding, the single output is split into key-range shards,
+     * each merged in parallel. boundaries come from the output level's existing sstable min keys
+     * (already sorted and non-overlapping -- the same source dividing_merge uses). an empty output
+     * level yields one shard, i.e. the original single-output behaviour with no regression. inputs
+     * are enqueued for cleanup and snapshotted into an array each shard reads from. */
+    for (int i = 0; i < sst_count; i++) queue_enqueue(sstables_to_delete, ssts_array[i]);
     free(ssts_array);
+    tidesdb_merge_heap_free(heap); /* setup heap is unused -- each shard builds its own */
 
-    uint64_t new_id = atomic_fetch_add(&cf->next_sstable_id, 1);
-    char path[MAX_FILE_PATH_LENGTH];
-    /* the merged run is written at output_level -- normally the deepest input
-     * level, one shallower for a level-collapse merge */
-    snprintf(path, sizeof(path), "%s" PATH_SEPARATOR TDB_LEVEL_PREFIX "%d", cf->directory,
-             output_level + 1);
-
-    tidesdb_sstable_t *new_sst = tidesdb_sstable_create(cf->db, path, new_id, &cf->config);
-    if (!new_sst)
+    const size_t fp_del_count = queue_size(sstables_to_delete);
+    tidesdb_sstable_t **fp_del_snap =
+        malloc((fp_del_count ? fp_del_count : 1) * sizeof(tidesdb_sstable_t *));
+    if (!fp_del_snap)
     {
-        tidesdb_merge_heap_free(heap);
         tidesdb_cleanup_merged_sstables(cf, sstables_to_delete, start_level, target_level);
         queue_free(sstables_to_delete);
         tidesdb_cleanup_snapshot_ids(sstable_ids_snapshot);
         return TDB_ERR_MEMORY;
     }
+    const size_t fp_del_n = queue_snapshot(sstables_to_delete, (void **)fp_del_snap, fp_del_count);
 
-    block_manager_t *klog_bm = NULL;
-    block_manager_t *vlog_bm = NULL;
-
-    if (block_manager_open(&klog_bm, new_sst->klog_path,
-                           convert_sync_mode(cf->config.sync_mode == TDB_SYNC_INTERVAL
-                                                 ? TDB_SYNC_FULL
-                                                 : cf->config.sync_mode)) != 0)
+    int fp_num_boundaries = 0;
+    uint8_t **fp_boundaries = NULL;
+    size_t *fp_boundary_sizes = NULL;
     {
-        tidesdb_sstable_unref(cf->db, new_sst);
-        tidesdb_merge_heap_free(heap);
-        tidesdb_cleanup_merged_sstables(cf, sstables_to_delete, start_level, target_level);
-        queue_free(sstables_to_delete);
-        tidesdb_cleanup_snapshot_ids(sstable_ids_snapshot);
-        return TDB_ERR_IO;
-    }
-
-    if (block_manager_open(&vlog_bm, new_sst->vlog_path,
-                           convert_sync_mode(cf->config.sync_mode == TDB_SYNC_INTERVAL
-                                                 ? TDB_SYNC_FULL
-                                                 : cf->config.sync_mode)) != 0)
-    {
-        block_manager_close(klog_bm);
-        tidesdb_sstable_unref(cf->db, new_sst);
-        tidesdb_merge_heap_free(heap);
-        tidesdb_cleanup_merged_sstables(cf, sstables_to_delete, start_level, target_level);
-        queue_free(sstables_to_delete);
-        tidesdb_cleanup_snapshot_ids(sstable_ids_snapshot);
-        return TDB_ERR_IO;
-    }
-
-    /* we calc expected number of entries for bloom filter sizing
-     * during merge, duplicates are eliminated and tombstones may be removed,
-     * so the actual count will be lower. we use the sum as an upper bound to ensure
-     * the bloom filter is adequately sized. */
-    uint64_t estimated_entries = 0;
-
-    /* we reload levels for estimated entries calculation */
-    for (int level = start_level; level <= target_level; level++)
-    {
-        tidesdb_level_t *lvl = cf->levels[level];
-
-        /* we hold array_readers to prevent retire_array from freeing the array
-         * while we iterate -- a concurrent flush on L1 can swap the array */
-        atomic_fetch_add_explicit(&lvl->array_readers, 1, memory_order_acq_rel);
-
-        int num_ssts = atomic_load_explicit(&lvl->num_sstables, memory_order_acquire);
-        tidesdb_sstable_t **sstables = atomic_load_explicit(&lvl->sstables, memory_order_acquire);
-
-        for (int i = 0; i < num_ssts; i++)
+        tidesdb_level_t *out_lvl = cf->levels[output_level];
+        atomic_fetch_add_explicit(&out_lvl->array_readers, 1, memory_order_acq_rel);
+        const int out_n = atomic_load_explicit(&out_lvl->num_sstables, memory_order_acquire);
+        tidesdb_sstable_t **out_ssts =
+            atomic_load_explicit(&out_lvl->sstables, memory_order_acquire);
+        if (out_n > 0)
         {
-            tidesdb_sstable_t *sst = sstables[i];
-            /* we check for null as concurrent compactions may have removed sstables */
-            if (sst)
+            fp_boundaries = malloc((size_t)out_n * sizeof(uint8_t *));
+            fp_boundary_sizes = malloc((size_t)out_n * sizeof(size_t));
+        }
+        if (fp_boundaries && fp_boundary_sizes)
+        {
+            /* shard boundaries are the output sstables' min keys; the first sstable's min key is
+             * skipped so keys below it land in shard 0 (range_start = NULL) */
+            for (int i = 1; i < out_n; i++)
             {
-                estimated_entries += sst->num_entries;
+                tidesdb_sstable_t *s = out_ssts[i];
+                if (s && s->min_key && s->min_key_size > 0)
+                {
+                    fp_boundaries[fp_num_boundaries] = malloc(s->min_key_size);
+                    if (fp_boundaries[fp_num_boundaries])
+                    {
+                        memcpy(fp_boundaries[fp_num_boundaries], s->min_key, s->min_key_size);
+                        fp_boundary_sizes[fp_num_boundaries] = s->min_key_size;
+                        fp_num_boundaries++;
+                    }
+                }
             }
         }
-
-        atomic_fetch_sub_explicit(&lvl->array_readers, 1, memory_order_release);
+        atomic_fetch_sub_explicit(&out_lvl->array_readers, 1, memory_order_release);
     }
 
-    if (estimated_entries < TDB_MERGE_MIN_ESTIMATED_ENTRIES)
-        estimated_entries = TDB_MERGE_MIN_ESTIMATED_ENTRIES;
+    tidesdb_full_preemptive_ctx_t fctx;
+    fctx.cf = cf;
+    fctx.start_level = start_level;
+    fctx.target_level = target_level;
+    fctx.output_level = output_level;
+    fctx.is_largest_level = is_largest_level;
+    fctx.comparator_fn = comparator_fn;
+    fctx.comparator_ctx = comparator_ctx;
+    fctx.del_snap = fp_del_snap;
+    fctx.del_snap_count = fp_del_n;
+    fctx.boundaries = fp_boundaries;
+    fctx.boundary_sizes = fp_boundary_sizes;
+    fctx.num_boundaries = fp_num_boundaries;
+    fctx.min_snapshot_seq = 0;
+    fctx.sstables_to_delete = sstables_to_delete;
+    atomic_init(&fctx.aborted, 0);
+
+    /* run the shards across the sub-compaction helper pool (calling thread works too); each shard
+     * commits its own output under cf->compaction_commit_lock */
+    tidesdb_run_subcompactions(cf->db, &fctx, tidesdb_full_preemptive_shard, fp_num_boundaries + 1);
+
+    const int fp_aborted = atomic_load_explicit(&fctx.aborted, memory_order_acquire);
+
+    for (int i = 0; i < fp_num_boundaries; i++) free(fp_boundaries[i]);
+    free(fp_boundaries);
+    free(fp_boundary_sizes);
+    free(fp_del_snap);
+
+    if (fp_aborted)
+    {
+        TDB_DEBUG_LOG(TDB_LOG_INFO, "CF '%s' aborting full preemptive merge", cf->name);
+        while (!queue_is_empty(sstables_to_delete))
+        {
+            tidesdb_sstable_t *sst = queue_dequeue(sstables_to_delete);
+            if (sst) tidesdb_sstable_unref(cf->db, sst);
+        }
+        queue_free(sstables_to_delete);
+        tidesdb_cleanup_snapshot_ids(sstable_ids_snapshot);
+        return TDB_SUCCESS;
+    }
+
+    tidesdb_cleanup_merged_sstables(cf, sstables_to_delete, start_level, target_level);
+    queue_free(sstables_to_delete);
+    tidesdb_cleanup_snapshot_ids(sstable_ids_snapshot);
+
+    TDB_DEBUG_LOG(TDB_LOG_INFO, "Full preemptive merge complete for CF '%s'", cf->name);
+    return TDB_SUCCESS;
+}
+
+/**
+ * tidesdb_full_preemptive_shard
+ * one key-range shard of a full preemptive merge (see ctx doc above). builds a heap from the
+ * inputs overlapping its range, then runs the original single-output merge body range-filtered,
+ * writing one output sstable at output_level. wrapped in do/while(0), a top-level break/continue
+ * skips this shard; the abort paths set the shared aborted flag.
+ */
+static int tidesdb_full_preemptive_shard(void *vctx, int shard)
+{
+    tidesdb_full_preemptive_ctx_t *c = (tidesdb_full_preemptive_ctx_t *)vctx;
+    tidesdb_column_family_t *cf = c->cf;
+    const int start_level = c->start_level;
+    const int target_level = c->target_level;
+    const int output_level = c->output_level;
+    const int is_largest_level = c->is_largest_level;
+    skip_list_comparator_fn comparator_fn = c->comparator_fn;
+    void *comparator_ctx = c->comparator_ctx;
+    tidesdb_sstable_t **del_snap = c->del_snap;
+    const size_t del_snap_count = c->del_snap_count;
+    uint8_t **boundaries = c->boundaries;
+    size_t *boundary_sizes = c->boundary_sizes;
+    const int num_boundaries = c->num_boundaries;
+    queue_t *sstables_to_delete = c->sstables_to_delete;
+    int aborted = 0;
+    (void)start_level;
+    (void)target_level;
+
+    do
+    {
+        if (tidesdb_cf_abort_requested(cf))
+        {
+            aborted = 1;
+            break;
+        }
+
+        uint8_t *range_start = (shard > 0) ? boundaries[shard - 1] : NULL;
+        size_t range_start_size = (shard > 0) ? boundary_sizes[shard - 1] : 0;
+        uint8_t *range_end = (shard < num_boundaries) ? boundaries[shard] : NULL;
+        size_t range_end_size = (shard < num_boundaries) ? boundary_sizes[shard] : 0;
+
+        tidesdb_merge_heap_t *heap = tidesdb_merge_heap_create(comparator_fn, comparator_ctx);
+        if (!heap) break;
+
+        uint64_t estimated_entries = 0;
+        for (size_t i = 0; i < del_snap_count; i++)
+        {
+            tidesdb_sstable_t *sst = del_snap[i];
+            if (!sst) continue;
+            int overlaps = 1;
+            if (range_start && comparator_fn(sst->max_key, sst->max_key_size, range_start,
+                                             range_start_size, comparator_ctx) < 0)
+                overlaps = 0;
+            if (overlaps && range_end &&
+                comparator_fn(sst->min_key, sst->min_key_size, range_end, range_end_size,
+                              comparator_ctx) >= 0)
+                overlaps = 0;
+            if (overlaps)
+            {
+                tidesdb_merge_source_t *source = tidesdb_merge_source_from_sstable(cf->db, sst);
+                if (source)
+                {
+                    if (source->current_kv &&
+                        tidesdb_merge_heap_add_source(heap, source) == TDB_SUCCESS)
+                        estimated_entries += sst->num_entries;
+                    else
+                        tidesdb_merge_source_free(source);
+                }
+            }
+        }
+        if (estimated_entries < TDB_MERGE_MIN_ESTIMATED_ENTRIES)
+            estimated_entries = TDB_MERGE_MIN_ESTIMATED_ENTRIES;
+
+        if (tidesdb_merge_heap_empty(heap))
+        {
+            tidesdb_merge_heap_free(heap);
+            break;
+        }
+
+        uint64_t new_id = atomic_fetch_add(&cf->next_sstable_id, 1);
+        char path[MAX_FILE_PATH_LENGTH];
+        snprintf(path, sizeof(path),
+                 "%s" PATH_SEPARATOR TDB_LEVEL_PREFIX "%d" TDB_LEVEL_PARTITION_PREFIX "%d",
+                 cf->directory, output_level + 1, shard);
+
+        tidesdb_sstable_t *new_sst = tidesdb_sstable_create(cf->db, path, new_id, &cf->config);
+        if (!new_sst)
+        {
+            tidesdb_merge_heap_free(heap);
+            break;
+        }
+
+        block_manager_t *klog_bm = NULL;
+        block_manager_t *vlog_bm = NULL;
+        if (tidesdb_bm_open(cf->db, &klog_bm, new_sst->klog_path,
+                            convert_sync_mode(cf->config.sync_mode == TDB_SYNC_INTERVAL
+                                                  ? TDB_SYNC_FULL
+                                                  : cf->config.sync_mode)) != 0 ||
+            tidesdb_bm_open(cf->db, &vlog_bm, new_sst->vlog_path,
+                            convert_sync_mode(cf->config.sync_mode == TDB_SYNC_INTERVAL
+                                                  ? TDB_SYNC_FULL
+                                                  : cf->config.sync_mode)) != 0)
+        {
+            if (klog_bm) block_manager_close(klog_bm);
+            if (vlog_bm) block_manager_close(vlog_bm);
+            tidesdb_sstable_unref(cf->db, new_sst);
+            tidesdb_merge_heap_free(heap);
+            aborted = 1;
+            break;
+        }
 
     bloom_filter_t *bloom = NULL;
     tidesdb_block_index_t *block_indexes = NULL;
@@ -13284,10 +13554,8 @@ static int tidesdb_full_preemptive_merge(tidesdb_column_family_t *cf, int start_
             /* mark so sstable_free unlinks the partial klog/vlog files */
             atomic_store_explicit(&new_sst->marked_for_deletion, 1, memory_order_release);
             tidesdb_sstable_unref(cf->db, new_sst);
-            tidesdb_cleanup_merged_sstables(cf, sstables_to_delete, start_level, target_level);
-            queue_free(sstables_to_delete);
-            tidesdb_cleanup_snapshot_ids(sstable_ids_snapshot);
-            return btree_result;
+            aborted = 1;
+            break;
         }
 
         bloom = NULL;
@@ -13316,7 +13584,6 @@ static int tidesdb_full_preemptive_merge(tidesdb_column_family_t *cf, int start_
     tidesdb_kv_pair_t *pending = NULL;
     int pending_is_single_delete = 0;
     int pending_sd_paired_with_put = 0;
-    int aborted = 0;
 
     /* merge using heap */
     while (!tidesdb_merge_heap_empty(heap) || pending != NULL)
@@ -13340,7 +13607,28 @@ static int tidesdb_full_preemptive_merge(tidesdb_column_family_t *cf, int start_
                 TDB_DEBUG_LOG(TDB_LOG_ERROR,
                               "Detected corrupted SSTable %" PRIu64 ", marking for deletion",
                               corrupted_sst->id);
+                /* shared cleanup queue -- guard against concurrent shards */
+                pthread_mutex_lock(&cf->compaction_commit_lock);
                 queue_enqueue(sstables_to_delete, corrupted_sst);
+                pthread_mutex_unlock(&cf->compaction_commit_lock);
+            }
+        }
+
+        /* range filter -- this shard only writes keys in [range_start, range_end). a filtered
+         * key cannot pair with pending (pending is in range), matching dividing_merge. */
+        if (kv)
+        {
+            if (range_start && comparator_fn(kv->key, kv->entry.key_size, range_start,
+                                             range_start_size, comparator_ctx) < 0)
+            {
+                tidesdb_kv_pair_free(kv);
+                continue;
+            }
+            if (range_end && comparator_fn(kv->key, kv->entry.key_size, range_end, range_end_size,
+                                           comparator_ctx) >= 0)
+            {
+                tidesdb_kv_pair_free(kv);
+                continue;
             }
         }
 
@@ -13548,14 +13836,7 @@ static int tidesdb_full_preemptive_merge(tidesdb_column_family_t *cf, int start_
         remove(new_sst->klog_path);
         remove(new_sst->vlog_path);
         tidesdb_sstable_unref(cf->db, new_sst);
-        while (!queue_is_empty(sstables_to_delete))
-        {
-            tidesdb_sstable_t *sst = queue_dequeue(sstables_to_delete);
-            if (sst) tidesdb_sstable_unref(cf->db, sst);
-        }
-        queue_free(sstables_to_delete);
-        tidesdb_cleanup_snapshot_ids(sstable_ids_snapshot);
-        return TDB_SUCCESS;
+        break; /* per-merge teardown happens once after the shards join */
     }
 
     new_sst->max_seq = max_seq;
@@ -13751,14 +14032,10 @@ merge_complete:;
     /* we save metadata for logging before potentially freeing sstable */
     const uint64_t sst_id = new_sst->id;
     const uint64_t num_entries = new_sst->num_entries;
-    const uint64_t num_klog_blocks = new_sst->num_klog_blocks;
-    const uint64_t num_vlog_blocks = new_sst->num_vlog_blocks;
 
     /* drop_column_family marked us after the inner loop finished -- skip publishing the
-     * merged sstable into the level/manifest so remove_directory does not race against
-     * new files appearing in the CF directory. remove() drops the half-written files we
-     * already created on disk; cleanup_merged_sstables sees the marked flag and unrefs
-     * inputs without touching the manifest */
+     * merged sstable; remove() drops the half-written files we already created on disk and the
+     * post-join teardown unrefs inputs without touching the manifest */
     if (tidesdb_cf_abort_requested(cf))
     {
         if (bloom) bloom_filter_free(bloom);
@@ -13766,22 +14043,15 @@ merge_complete:;
         remove(new_sst->klog_path);
         remove(new_sst->vlog_path);
         tidesdb_sstable_unref(cf->db, new_sst);
-        while (!queue_is_empty(sstables_to_delete))
-        {
-            tidesdb_sstable_t *sst = queue_dequeue(sstables_to_delete);
-            if (sst) tidesdb_sstable_unref(cf->db, sst);
-        }
-        queue_free(sstables_to_delete);
-        tidesdb_cleanup_snapshot_ids(sstable_ids_snapshot);
-        return TDB_SUCCESS;
+        aborted = 1;
+        break;
     }
 
     /* we only add sstable if it has entries -- empty sstables cause corruption */
     if (num_entries > 0)
     {
-        /* we reload levels and num_levels as DCA may have changed them
-         * we load num_levels first to match store order */
-        num_levels = atomic_load_explicit(&cf->num_active_levels, memory_order_acquire);
+        /* we reload num_levels as DCA may have changed it */
+        int num_levels = atomic_load_explicit(&cf->num_active_levels, memory_order_acquire);
 
         /* we find the output level by level_num, not by stale array index */
         int target_level_num = output_level + 1;
@@ -13810,6 +14080,8 @@ merge_complete:;
             TDB_DEBUG_LOG(TDB_LOG_INFO,
                           "Adding merged SSTable %" PRIu64 " to level %d (array index %d)",
                           new_sst->id, cf->levels[target_idx]->level_num, target_idx);
+            /* commit serialized across shards (shared level array + manifest) */
+            pthread_mutex_lock(&cf->compaction_commit_lock);
             tidesdb_level_add_sstable(cf->levels[target_idx], new_sst);
             tidesdb_bump_sstable_layout_version(cf);
 
@@ -13828,6 +14100,7 @@ merge_complete:;
             /** we upload manifest to object store so replicas and cold-start nodes
              *  can see the new sstable before old inputs are cleaned up */
             tdb_objstore_upload_manifest(cf->db, cf);
+            pthread_mutex_unlock(&cf->compaction_commit_lock);
 
             tidesdb_sstable_unref(cf->db, new_sst);
         }
@@ -13841,16 +14114,9 @@ merge_complete:;
         remove(new_sst->vlog_path);
         tidesdb_sstable_unref(cf->db, new_sst);
     }
+    } while (0);
 
-    tidesdb_cleanup_merged_sstables(cf, sstables_to_delete, start_level, target_level);
-    queue_free(sstables_to_delete);
-    tidesdb_cleanup_snapshot_ids(sstable_ids_snapshot);
-
-    TDB_DEBUG_LOG(TDB_LOG_INFO,
-                  "Full preemptive merge completed for CF '%s', created SSTable %" PRIu64
-                  " with %" PRIu64 " entries, %" PRIu64 " klog blocks, %" PRIu64 " vlog blocks",
-                  cf->name, sst_id, num_entries, num_klog_blocks, num_vlog_blocks);
-
+    if (aborted) atomic_store_explicit(&c->aborted, 1, memory_order_release);
     return TDB_SUCCESS;
 }
 
@@ -14491,6 +14757,31 @@ merge_complete:;
 }
 
 /**
+ * tidesdb_dividing_merge_ctx_t
+ * shared read-only context for a dividing merge's parallel partition sub-merges. each partition
+ * is a disjoint key range with its own heap and output sstable, so the only shared mutation is the
+ * commit (level add + manifest), which the worker serializes on cf->compaction_commit_lock.
+ */
+typedef struct
+{
+    tidesdb_column_family_t *cf;
+    int target_level;
+    int is_largest_level;
+    int num_boundaries;
+    uint8_t **file_boundaries;
+    size_t *boundary_sizes;
+    tidesdb_sstable_t **del_snap;
+    size_t del_snap_count;
+    skip_list_comparator_fn comparator_fn;
+    void *comparator_ctx;
+    uint64_t partition_estimated_entries;
+    uint64_t min_snapshot_seq;
+    _Atomic(int) aborted;
+} tidesdb_dividing_merge_ctx_t;
+
+static int tidesdb_dividing_merge_partition(void *vctx, int partition);
+
+/**
  * tidesdb_dividing_merge
  * dividing merge into level X and partition based on largest level boundaries
  * @param cf column family
@@ -14679,7 +14970,75 @@ static int tidesdb_dividing_merge(tidesdb_column_family_t *cf, int target_level)
 
     int aborted = 0;
 
-    for (int partition = 0; partition < num_partitions; partition++)
+    tidesdb_dividing_merge_ctx_t dctx;
+    dctx.cf = cf;
+    dctx.target_level = target_level;
+    dctx.is_largest_level = is_largest_level;
+    dctx.num_boundaries = num_boundaries;
+    dctx.file_boundaries = file_boundaries;
+    dctx.boundary_sizes = boundary_sizes;
+    dctx.del_snap = del_snap;
+    dctx.del_snap_count = del_snap_count;
+    dctx.comparator_fn = comparator_fn;
+    dctx.comparator_ctx = comparator_ctx;
+    dctx.partition_estimated_entries = partition_estimated_entries;
+    dctx.min_snapshot_seq = min_snapshot_seq;
+    atomic_init(&dctx.aborted, 0);
+
+    /* run the partition sub-merges across the sub-compaction helper pool (the calling thread
+     * participates too); each partition commits its own output under cf->compaction_commit_lock */
+    tidesdb_run_subcompactions(cf->db, &dctx, tidesdb_dividing_merge_partition, num_partitions);
+
+    if (atomic_load_explicit(&dctx.aborted, memory_order_acquire)) aborted = 1;
+
+    free(del_snap);
+
+    if (aborted)
+    {
+        TDB_DEBUG_LOG(TDB_LOG_INFO, "CF '%s' aborting dividing merge", cf->name);
+        while (!queue_is_empty(sstables_to_delete))
+        {
+            tidesdb_sstable_t *sst = queue_dequeue(sstables_to_delete);
+            if (sst) tidesdb_sstable_unref(cf->db, sst);
+        }
+        queue_free(sstables_to_delete);
+        tidesdb_cleanup_snapshot_ids(sstable_ids_snapshot);
+        return TDB_SUCCESS;
+    }
+
+    tidesdb_cleanup_merged_sstables(cf, sstables_to_delete, 0, target_level);
+    queue_free(sstables_to_delete);
+    tidesdb_cleanup_snapshot_ids(sstable_ids_snapshot);
+
+    TDB_DEBUG_LOG(TDB_LOG_INFO, "Completed dividing merge for CF '%s'", cf->name);
+    return TDB_SUCCESS;
+}
+
+/**
+ * tidesdb_dividing_merge_partition
+ * one partition's sub-merge for tidesdb_dividing_merge. body is the original serial partition
+ * loop iteration, wrapped in do/while(0)-- a top-level continue still skips this partition and the
+ * abort break still bails. shared context arrives via vctx; the commit section is serialized on
+ * cf->compaction_commit_lock.
+ */
+static int tidesdb_dividing_merge_partition(void *vctx, int partition)
+{
+    tidesdb_dividing_merge_ctx_t *c = (tidesdb_dividing_merge_ctx_t *)vctx;
+    tidesdb_column_family_t *cf = c->cf;
+    const int target_level = c->target_level;
+    const int is_largest_level = c->is_largest_level;
+    const int num_boundaries = c->num_boundaries;
+    uint8_t **file_boundaries = c->file_boundaries;
+    size_t *boundary_sizes = c->boundary_sizes;
+    tidesdb_sstable_t **del_snap = c->del_snap;
+    const size_t del_snap_count = c->del_snap_count;
+    skip_list_comparator_fn comparator_fn = c->comparator_fn;
+    void *comparator_ctx = c->comparator_ctx;
+    uint64_t partition_estimated_entries = c->partition_estimated_entries;
+    const uint64_t min_snapshot_seq = c->min_snapshot_seq;
+    int aborted = 0;
+
+    do
     {
         if (tidesdb_cf_abort_requested(cf))
         {
@@ -14880,12 +15239,14 @@ static int tidesdb_dividing_merge(tidesdb_column_family_t *cf, int target_level)
                 continue;
             }
 
-            /* we add the btree sstable to target level */
+            /* we add the btree sstable to target level (commit serialized across partitions) */
+            pthread_mutex_lock(&cf->compaction_commit_lock);
             tidesdb_level_add_sstable(cf->levels[target_level], new_sst);
             tidesdb_bump_sstable_layout_version(cf);
             tidesdb_manifest_add_sstable(cf->manifest, cf->levels[target_level]->level_num,
                                          new_sst->id, new_sst->num_entries,
                                          new_sst->klog_size + new_sst->vlog_size);
+            pthread_mutex_unlock(&cf->compaction_commit_lock);
             tidesdb_sstable_unref(cf->db, new_sst);
             continue;
         }
@@ -15362,6 +15723,8 @@ static int tidesdb_dividing_merge(tidesdb_column_family_t *cf, int target_level)
                     TDB_LOG_INFO,
                     "Partition %d: Adding merged SSTable %" PRIu64 " to level %d (array index %d)",
                     partition, new_sst->id, cf->levels[target_idx]->level_num, target_idx);
+                /* commit serialized across partitions (shared level array + manifest) */
+                pthread_mutex_lock(&cf->compaction_commit_lock);
                 tidesdb_level_add_sstable(cf->levels[target_idx], new_sst);
                 tidesdb_bump_sstable_layout_version(cf);
 
@@ -15379,6 +15742,7 @@ static int tidesdb_dividing_merge(tidesdb_column_family_t *cf, int target_level)
                 }
 
                 tdb_objstore_upload_manifest(cf->db, cf);
+                pthread_mutex_unlock(&cf->compaction_commit_lock);
 
                 tidesdb_sstable_unref(cf->db, new_sst);
             }
@@ -15396,28 +15760,9 @@ static int tidesdb_dividing_merge(tidesdb_column_family_t *cf, int target_level)
             remove(new_sst->vlog_path);
             tidesdb_sstable_unref(cf->db, new_sst);
         }
-    }
+    } while (0);
 
-    free(del_snap);
-
-    if (aborted)
-    {
-        TDB_DEBUG_LOG(TDB_LOG_INFO, "CF '%s' aborting dividing merge", cf->name);
-        while (!queue_is_empty(sstables_to_delete))
-        {
-            tidesdb_sstable_t *sst = queue_dequeue(sstables_to_delete);
-            if (sst) tidesdb_sstable_unref(cf->db, sst);
-        }
-        queue_free(sstables_to_delete);
-        tidesdb_cleanup_snapshot_ids(sstable_ids_snapshot);
-        return TDB_SUCCESS;
-    }
-
-    tidesdb_cleanup_merged_sstables(cf, sstables_to_delete, 0, target_level);
-    queue_free(sstables_to_delete);
-    tidesdb_cleanup_snapshot_ids(sstable_ids_snapshot);
-
-    TDB_DEBUG_LOG(TDB_LOG_INFO, "Completed dividing merge for CF '%s'", cf->name);
+    if (aborted) atomic_store_explicit(&c->aborted, 1, memory_order_release);
     return TDB_SUCCESS;
 }
 
@@ -15579,6 +15924,10 @@ static int tdb_partitioned_merge_finalize_sst(
             return -1;
         }
 
+        /* commit serialized across partitions (shared level array + manifest); finalize is
+         * called from each partition sub-merge, possibly concurrently, and also mid-partition
+         * on a file_max split, so the lock guards every output's publish */
+        pthread_mutex_lock(&cf->compaction_commit_lock);
         tidesdb_level_add_sstable(cf->levels[target_idx], sst);
         tidesdb_bump_sstable_layout_version(cf);
 
@@ -15595,6 +15944,7 @@ static int tdb_partitioned_merge_finalize_sst(
         }
 
         tdb_objstore_upload_manifest(cf->db, cf);
+        pthread_mutex_unlock(&cf->compaction_commit_lock);
 
         TDB_DEBUG_LOG(TDB_LOG_INFO,
                       "Partitioned merge partition %d finalized SSTable %" PRIu64 " with %" PRIu64
@@ -15613,6 +15963,31 @@ static int tdb_partitioned_merge_finalize_sst(
 
     return 0;
 }
+
+/**
+ * tidesdb_partitioned_merge_ctx_t / _partition
+ * shared read-only context for a partitioned merge's parallel partition sub-merges. each partition
+ * is a disjoint key range with its own heap and output sstable(s); commits go through
+ * tdb_partitioned_merge_finalize_sst (or the inline btree path), both serialized on
+ * cf->compaction_commit_lock. the per-partition body is the original serial iteration wrapped in
+ * do/while(0) so top-level continue/break keep their meaning.
+ */
+typedef struct
+{
+    tidesdb_column_family_t *cf;
+    int start_idx;
+    int end_idx;
+    int end_level;
+    int num_partitions;
+    uint8_t **boundaries;
+    size_t *boundary_sizes;
+    int *partition_skipped;
+    size_t file_max;
+    int targeting_largest;
+    _Atomic(int) aborted;
+} tidesdb_partitioned_merge_ctx_t;
+
+static int tidesdb_partitioned_merge_partition(void *vctx, int partition);
 
 static int tidesdb_partitioned_merge(tidesdb_column_family_t *cf, int start_level, int end_level)
 {
@@ -15792,8 +16167,106 @@ static int tidesdb_partitioned_merge(tidesdb_column_family_t *cf, int start_leve
 
     int aborted = 0;
 
-    /* we merge one partition at a time */
-    for (int partition = 0; partition < num_partitions; partition++)
+    tidesdb_partitioned_merge_ctx_t pctx;
+    pctx.cf = cf;
+    pctx.start_idx = start_idx;
+    pctx.end_idx = end_idx;
+    pctx.end_level = end_level;
+    pctx.num_partitions = num_partitions;
+    pctx.boundaries = boundaries;
+    pctx.boundary_sizes = boundary_sizes;
+    pctx.partition_skipped = partition_skipped;
+    pctx.file_max = file_max;
+    pctx.targeting_largest = targeting_largest;
+    atomic_init(&pctx.aborted, 0);
+
+    /* run the partition sub-merges across the sub-compaction helper pool (calling thread works
+     * too); each partition commits its output(s) under cf->compaction_commit_lock */
+    tidesdb_run_subcompactions(cf->db, &pctx, tidesdb_partitioned_merge_partition, num_partitions);
+
+    if (atomic_load_explicit(&pctx.aborted, memory_order_acquire)) aborted = 1;
+
+    if (aborted)
+    {
+        TDB_DEBUG_LOG(TDB_LOG_INFO, "CF '%s' aborting partitioned merge", cf->name);
+        while (!queue_is_empty(sstables_to_delete))
+        {
+            tidesdb_sstable_t *sst = queue_dequeue(sstables_to_delete);
+            if (sst) tidesdb_sstable_unref(cf->db, sst);
+        }
+        queue_free(sstables_to_delete);
+        tidesdb_cleanup_snapshot_ids(sstable_ids_snapshot);
+        for (int i = 0; i < num_partitions; i++)
+        {
+            free(boundaries[i]);
+        }
+        free(boundaries);
+        free(boundary_sizes);
+        free(partition_skipped);
+        return TDB_SUCCESS;
+    }
+
+    tidesdb_cleanup_merged_sstables(cf, sstables_to_delete, start_idx, end_idx);
+    queue_free(sstables_to_delete);
+    tidesdb_cleanup_snapshot_ids(sstable_ids_snapshot);
+
+    /* the skew optimization can leave the largest level out of key order
+     * (skipped files keep their old slots while merged partitions append) --
+     * restore the ascending-min_key order the next partitioned merge relies on
+     * when it derives partition boundaries from this level */
+    if (skipped_any)
+    {
+        skip_list_comparator_fn sort_cmp = NULL;
+        void *sort_cmp_ctx = NULL;
+        tidesdb_resolve_comparator(cf->db, &cf->config, &sort_cmp, &sort_cmp_ctx);
+        if (sort_cmp && tidesdb_level_sort_by_min_key(cf->db, cf->levels[end_idx], sort_cmp,
+                                                      sort_cmp_ctx) != TDB_SUCCESS)
+        {
+            /* the largest level is left unsorted -- the next partitioned merge will derive
+             * boundaries from an out-of-order array. not fatal to this merge (sstables are
+             * already committed), but surface it. */
+            TDB_DEBUG_LOG(TDB_LOG_WARN,
+                          "CF '%s' failed to re-sort level %d by min_key after partitioned merge "
+                          "(out of memory); next merge's partition boundaries may be skewed",
+                          cf->name, cf->levels[end_idx]->level_num);
+        }
+    }
+
+    for (int i = 0; i < num_partitions; i++)
+    {
+        free(boundaries[i]);
+    }
+    free(boundaries);
+    free(boundary_sizes);
+    free(partition_skipped);
+
+    TDB_DEBUG_LOG(TDB_LOG_INFO, "Partitioned merge complete for CF '%s', processed %d partitions",
+                  cf->name, num_partitions);
+
+    return TDB_SUCCESS;
+}
+
+/**
+ * tidesdb_partitioned_merge_partition
+ * one partition's sub-merge for tidesdb_partitioned_merge (see ctx doc above). body is the
+ * original serial iteration wrapped in do/while(0).
+ */
+static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
+{
+    tidesdb_partitioned_merge_ctx_t *c = (tidesdb_partitioned_merge_ctx_t *)vctx;
+    tidesdb_column_family_t *cf = c->cf;
+    const int start_idx = c->start_idx;
+    const int end_idx = c->end_idx;
+    const int end_level = c->end_level;
+    const int num_partitions = c->num_partitions;
+    uint8_t **boundaries = c->boundaries;
+    size_t *boundary_sizes = c->boundary_sizes;
+    int *partition_skipped = c->partition_skipped;
+    const size_t file_max = c->file_max;
+    const int targeting_largest = c->targeting_largest;
+    int aborted = 0;
+
+    do
     {
         if (tidesdb_cf_abort_requested(cf))
         {
@@ -15993,12 +16466,14 @@ static int tidesdb_partitioned_merge(tidesdb_column_family_t *cf, int start_leve
                     continue;
                 }
 
-                /* we add the btree sstable to target level */
+                /* we add the btree sstable to target level (commit serialized across partitions) */
+                pthread_mutex_lock(&cf->compaction_commit_lock);
                 tidesdb_level_add_sstable(cf->levels[end_idx], new_sst);
                 tidesdb_bump_sstable_layout_version(cf);
                 tidesdb_manifest_add_sstable(cf->manifest, cf->levels[end_idx]->level_num,
                                              new_sst->id, new_sst->num_entries,
                                              new_sst->klog_size + new_sst->vlog_size);
+                pthread_mutex_unlock(&cf->compaction_commit_lock);
                 tidesdb_sstable_unref(cf->db, new_sst);
                 continue;
             }
@@ -16484,66 +16959,9 @@ static int tidesdb_partitioned_merge(tidesdb_column_family_t *cf, int start_leve
         }
 
         tidesdb_merge_heap_free(heap);
-        if (aborted) break;
-    }
+    } while (0);
 
-    if (aborted)
-    {
-        TDB_DEBUG_LOG(TDB_LOG_INFO, "CF '%s' aborting partitioned merge", cf->name);
-        while (!queue_is_empty(sstables_to_delete))
-        {
-            tidesdb_sstable_t *sst = queue_dequeue(sstables_to_delete);
-            if (sst) tidesdb_sstable_unref(cf->db, sst);
-        }
-        queue_free(sstables_to_delete);
-        tidesdb_cleanup_snapshot_ids(sstable_ids_snapshot);
-        for (int i = 0; i < num_partitions; i++)
-        {
-            free(boundaries[i]);
-        }
-        free(boundaries);
-        free(boundary_sizes);
-        free(partition_skipped);
-        return TDB_SUCCESS;
-    }
-
-    tidesdb_cleanup_merged_sstables(cf, sstables_to_delete, start_idx, end_idx);
-    queue_free(sstables_to_delete);
-    tidesdb_cleanup_snapshot_ids(sstable_ids_snapshot);
-
-    /* the skew optimization can leave the largest level out of key order
-     * (skipped files keep their old slots while merged partitions append) --
-     * restore the ascending-min_key order the next partitioned merge relies on
-     * when it derives partition boundaries from this level */
-    if (skipped_any)
-    {
-        skip_list_comparator_fn sort_cmp = NULL;
-        void *sort_cmp_ctx = NULL;
-        tidesdb_resolve_comparator(cf->db, &cf->config, &sort_cmp, &sort_cmp_ctx);
-        if (sort_cmp && tidesdb_level_sort_by_min_key(cf->db, cf->levels[end_idx], sort_cmp,
-                                                      sort_cmp_ctx) != TDB_SUCCESS)
-        {
-            /* the largest level is left unsorted -- the next partitioned merge will derive
-             * boundaries from an out-of-order array. not fatal to this merge (sstables are
-             * already committed), but surface it. */
-            TDB_DEBUG_LOG(TDB_LOG_WARN,
-                          "CF '%s' failed to re-sort level %d by min_key after partitioned merge "
-                          "(out of memory); next merge's partition boundaries may be skewed",
-                          cf->name, cf->levels[end_idx]->level_num);
-        }
-    }
-
-    for (int i = 0; i < num_partitions; i++)
-    {
-        free(boundaries[i]);
-    }
-    free(boundaries);
-    free(boundary_sizes);
-    free(partition_skipped);
-
-    TDB_DEBUG_LOG(TDB_LOG_INFO, "Partitioned merge complete for CF '%s', processed %d partitions",
-                  cf->name, num_partitions);
-
+    if (aborted) atomic_store_explicit(&c->aborted, 1, memory_order_release);
     return TDB_SUCCESS;
 }
 
@@ -17298,6 +17716,7 @@ static void tidesdb_column_family_free(tidesdb_column_family_t *cf)
     }
 
     pthread_mutex_destroy(&cf->imm_snap_publish_lock);
+    pthread_mutex_destroy(&cf->compaction_commit_lock);
     free(cf->name);
     free(cf->directory);
     free(cf);
@@ -19459,6 +19878,9 @@ int tidesdb_open(const tidesdb_config_t *config, tidesdb_t **db)
 
     (*db)->flush_queue = queue_new();
     (*db)->compaction_queue = queue_new();
+    /* sub-compaction helper-thread budget-- a parallel compaction round borrows up to this
+     * many ephemeral helpers, so total sub-merge threads across CFs stay within the pool */
+    atomic_init(&(*db)->compaction_helper_budget, config->num_compaction_threads);
 
     if (!(*db)->flush_queue || !(*db)->compaction_queue)
     {
@@ -21516,6 +21938,7 @@ int tidesdb_create_column_family(tidesdb_t *db, const char *name,
     atomic_init(&cf->imm_snap_active, 0);
     atomic_init(&cf->active_mt_readers, 0);
     pthread_mutex_init(&cf->imm_snap_publish_lock, NULL);
+    pthread_mutex_init(&cf->compaction_commit_lock, NULL);
 
     /*** in unified memtable mode, writes go through the unified WAL so
      **  per-CF WAL files are not needed. skip creation to avoid wasted
@@ -23457,62 +23880,13 @@ static int tidesdb_apply_backpressure(tidesdb_column_family_t *cf)
         l0_delayed = 1;
     }
 
-    /* L1 (first disk level) hard write-stop. the graduated delays below only *slow* writes when L1
-     * exceeds a few x the trigger; under sustained ingest that compaction cannot match, the file
-     * count would still grow without bound -- the on-disk working set readers pin, and thus open
-     * fds and per-sstable aux memory, with it (the fd-exhaustion wedge). stop writers once L1
-     * reaches a high multiple of the trigger and hold until compaction drains it. like the L0 queue
-     * stall, we pace while compaction makes progress (file count shrinks or the sstable layout
-     * version advances) and only return BUSY if compaction is genuinely wedged. */
-    const int l1_stop_watermark = effective_l1_trigger * TDB_BACKPRESSURE_L1_STOP_MULTIPLIER;
-    if (l1_file_count >= l1_stop_watermark)
-    {
-        if (tdb_log_throttle(cf->db, &cf->last_l1_stop_log_sec,
-                             TDB_BACKPRESSURE_STALL_LOG_INTERVAL_SEC))
-            TDB_DEBUG_LOG(TDB_LOG_WARN,
-                          "CF '%s' L1 file-count stall: %d >= %d (%dx trigger) -- blocking until "
-                          "compaction drains",
-                          cf->name, l1_file_count, l1_stop_watermark,
-                          TDB_BACKPRESSURE_L1_STOP_MULTIPLIER);
-
-        /* ensure compaction is actually working the backlog down */
-        if (!atomic_load_explicit(&cf->is_compacting, memory_order_relaxed))
-            tidesdb_enqueue_compaction(cf, 0);
-
-        int total_iterations = 0;
-        int no_progress = 0;
-        int best_count = l1_file_count;
-        uint64_t last_layout =
-            atomic_load_explicit(&cf->sstable_layout_version, memory_order_relaxed);
-        while (atomic_load_explicit(&cf->levels[0]->num_sstables, memory_order_acquire) >=
-               l1_stop_watermark)
-        {
-            usleep(TDB_BACKPRESSURE_STALL_CHECK_INTERVAL_US);
-            total_iterations++;
-            const int cur =
-                atomic_load_explicit(&cf->levels[0]->num_sstables, memory_order_acquire);
-            const uint64_t cur_layout =
-                atomic_load_explicit(&cf->sstable_layout_version, memory_order_relaxed);
-            if (cur < best_count || cur_layout != last_layout)
-            {
-                best_count = cur;
-                last_layout = cur_layout;
-                no_progress = 0;
-            }
-            else if (++no_progress >= TDB_BACKPRESSURE_STALL_MAX_ITERATIONS)
-            {
-                TDB_DEBUG_LOG(TDB_LOG_ERROR,
-                              "CF '%s' L1 file-count stall: no compaction progress for %dms -- "
-                              "compaction appears wedged",
-                              cf->name,
-                              no_progress * (TDB_BACKPRESSURE_STALL_CHECK_INTERVAL_US / 1000));
-                return TDB_ERR_BUSY;
-            }
-        }
-        TDB_DEBUG_LOG(TDB_LOG_INFO, "CF '%s' L1 file-count stall resolved after %dms", cf->name,
-                      total_iterations * (TDB_BACKPRESSURE_STALL_CHECK_INTERVAL_US / 1000));
-        l0_delayed = 1;
-    }
+    /* L1 file count does NOT gate writes. compaction (L1->L2+) is serialized per CF and is
+     * structurally slower than flush inflow, so L1 settles at a workload-dependent count; blocking
+     * the write/flush pipeline on it only converts a compaction-throughput limit into a stop-start
+     * stall and starves flushing (which is independent of compaction). the L1 graduated *delays*
+     * below pace writes gently without stopping them, memtable memory is bounded by the L0 queue
+     * stall and the active-memtable ceiling, and the open-fd working set is bounded by the reader
+     * fd reserve plus the reaper -- none of which need L1 file count as a write gate. */
 
     /* per-cf active memtable ceiling. tidesdb_flush_memtable_internal silently
      * defers the rotate when the active_flushes slot cap is reached, so the L0

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -362,14 +362,12 @@ static inline size_t tdb_build_prefixed_key(const uint32_t cf_index, const uint8
 /* immutable memtable cleanup configuration
  * cleanup runs frequently to prevent memory exhaustion from old immutables
  * only flushed immutables with no active readers are removed (safe cleanup) */
-#define TDB_IMMUTABLE_CLEANUP_THRESHOLD      2    /* check every 2 flushes */
-#define TDB_IMMUTABLE_MAX_QUEUE_SIZE         4    /* trigger cleanup when queue > 4 */
-#define TDB_IMMUTABLE_FORCE_CLEANUP_SIZE     8    /* force blocking cleanup at this size */
-#define TDB_IMMUTABLE_HARD_CAP               16   /* hard cap on immutable queue -- block enqueue */
-#define TDB_IMMUTABLE_HARD_CAP_WAIT_US       1000 /* 1ms poll interval when blocked at hard cap */
-#define TDB_IMMUTABLE_HARD_CAP_MAX_WAIT      5000 /* max 5s wait (5000 iterations * 1ms) */
-#define TDB_IMMUTABLE_FORCE_CLEANUP_SPIN_US  100  /* spin interval when waiting for readers */
-#define TDB_IMMUTABLE_FORCE_CLEANUP_MAX_WAIT 1000000 /* max 1 second wait per immutable */
+#define TDB_IMMUTABLE_CLEANUP_THRESHOLD  2    /* check every 2 flushes */
+#define TDB_IMMUTABLE_MAX_QUEUE_SIZE     4    /* trigger cleanup when queue > 4 */
+#define TDB_IMMUTABLE_FORCE_CLEANUP_SIZE 8    /* run a cleanup pass once the queue reaches this */
+#define TDB_IMMUTABLE_HARD_CAP           16   /* hard cap on immutable queue -- block enqueue */
+#define TDB_IMMUTABLE_HARD_CAP_WAIT_US   1000 /* 1ms poll interval when blocked at hard cap */
+#define TDB_IMMUTABLE_HARD_CAP_MAX_WAIT  5000 /* max 5s wait (5000 iterations * 1ms) */
 
 /* refcount drain configuration for flush worker
  * used when waiting for in-flight writers to finish before flushing memtable */
@@ -6748,8 +6746,26 @@ static void tidesdb_imm_snap_publish_locked(tidesdb_column_family_t *cf)
     /* we rebuild snapshot in the inactive slot from the queue
      * no refs needed -- the RCU mechanism guarantees items are valid while any
      * reader holds the slot. the queue itself holds the base ref on each item */
-    size_t count =
+    size_t raw =
         queue_snapshot(cf->immutable_memtables, (void **)next->items, TDB_IMM_SNAP_MAX_ITEMS);
+
+    /* drop already-flushed immutables from the READER snapshot. once an immutable is flushed its
+     * data is durable in an L1 sstable that was added to the level (with release) BEFORE `flushed`
+     * was set (also release), so any reader that observes this republished slot -- via the
+     * release/acquire pair on imm_snap_active below -- is guaranteed to also observe that sstable.
+     * excluding flushed immutables stops new iterators from taking a long-lived merge-source ref on
+     * them (tidesdb_merge_source_from_memtable), which is the only way their refcount can fall back
+     * to 1 so cleanup can reclaim them. without this, a steady stream of readers keeps re-pinning a
+     * flushed immutable, its refcount never reaches 1, the immutable queue cannot drain, and the
+     * flush worker wedges. the immutable stays in the queue until reclaimed -- only the snapshot
+     * drops it early. */
+    size_t count = 0;
+    for (size_t i = 0; i < raw; i++)
+    {
+        tidesdb_memtable_t *m = next->items[i];
+        if (m && atomic_load_explicit(&m->flushed, memory_order_acquire)) continue;
+        next->items[count++] = m;
+    }
     atomic_store_explicit(&next->count, count, memory_order_release);
 
     /* we ensure the new slot contents are visible before swapping active index */
@@ -17657,7 +17673,8 @@ static void *tidesdb_flush_worker_thread(void *arg)
         {
             TDB_DEBUG_LOG(
                 TDB_LOG_WARN,
-                "CF '%s' immutable queue critical size %zu >= %zu, forcing blocking cleanup",
+                "CF '%s' immutable queue at %zu >= %zu, running cleanup (reader-pinned immutables "
+                "are left for a later pass)",
                 cf->name, current_queue_size, force_cleanup_size);
         }
 
@@ -17673,7 +17690,6 @@ static void *tidesdb_flush_worker_thread(void *arg)
         if (should_cleanup || force_cleanup)
         {
             int cleaned = 0;
-            int force_cleaned = 0;
             size_t items_to_process = queue_size(cf->immutable_memtables);
 
             /* we collect items to free -- we must publish snapshot (draining old readers)
@@ -17700,41 +17716,20 @@ static void *tidesdb_flush_worker_thread(void *arg)
 
                 if (is_flushed)
                 {
-                    /* we try to claim the last reference atomically */
+                    /* we try to claim the last reference atomically. this is a single,
+                     * NON-BLOCKING attempt -- it succeeds only when refcount==1 (no reader holds a
+                     * merge-source ref). a pinned immutable is left in the queue and reclaimed on a
+                     * later pass once its readers drain. we must NOT spin-wait here: a flushed
+                     * immutable is now excluded from the reader snapshot (see
+                     * tidesdb_imm_snap_publish_locked), so no NEW reader can pin it and its
+                     * refcount will fall to 1 on its own -- blocking the flush worker to wait for
+                     * that is what collapsed flush throughput and wedged writes under reader load.
+                     */
                     if (atomic_compare_exchange_strong_explicit(
                             &queued_imm->refcount, &expected_refcount, 0, memory_order_acquire,
                             memory_order_relaxed))
                     {
                         can_cleanup = 1;
-                    }
-                    else if (force_cleanup)
-                    {
-                        /* we force cleanup, spin waiting for readers to finish */
-                        int64_t waited_us = 0;
-                        while (waited_us < TDB_IMMUTABLE_FORCE_CLEANUP_MAX_WAIT)
-                        {
-                            expected_refcount = 1;
-                            if (atomic_compare_exchange_strong_explicit(
-                                    &queued_imm->refcount, &expected_refcount, 0,
-                                    memory_order_acquire, memory_order_relaxed))
-                            {
-                                can_cleanup = 1;
-                                force_cleaned++;
-                                break;
-                            }
-                            usleep(TDB_IMMUTABLE_FORCE_CLEANUP_SPIN_US);
-                            waited_us += TDB_IMMUTABLE_FORCE_CLEANUP_SPIN_US;
-                        }
-                        if (!can_cleanup)
-                        {
-                            TDB_DEBUG_LOG(
-                                TDB_LOG_WARN,
-                                "CF '%s' force cleanup timed out waiting for "
-                                "immutable refcount "
-                                "(refcount=%d)",
-                                cf->name,
-                                atomic_load_explicit(&queued_imm->refcount, memory_order_acquire));
-                        }
                     }
                 }
 
@@ -17804,11 +17799,9 @@ static void *tidesdb_flush_worker_thread(void *arg)
                     free(to_free[fi]);
                 }
 
-                TDB_DEBUG_LOG(
-                    TDB_LOG_INFO,
-                    "CF '%s' cleaned up %d flushed immutable(s) (%d forced) with no active "
-                    "readers",
-                    cf->name, cleaned, force_cleaned);
+                TDB_DEBUG_LOG(TDB_LOG_INFO,
+                              "CF '%s' cleaned up %d flushed immutable(s) with no active readers",
+                              cf->name, cleaned);
             }
         }
 

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -438,6 +438,23 @@ static inline size_t tdb_build_prefixed_key(const uint32_t cf_index, const uint8
 #define TDB_SST_RETRY_MAX_SPINS         16 /* maximum cpu_pause count per retry */
 #define TDB_SST_RETRY_MAX_LEVEL_RETRIES 4  /* max full level restarts before skipping dead ssts */
 
+/* file-open descriptor-pressure handling. block_manager_open can fail with EMFILE/ENFILE when the
+ * process is momentarily at its open-fd ceiling (many sstables open under heavy flush+compaction).
+ * tidesdb_bm_open treats that as transient backpressure: it wakes the reaper to close idle sstables
+ * and retries a bounded number of times before failing, so an fd spike does not permanently wedge
+ * flush or compaction. all other errors (and success) return immediately. */
+#define TDB_BM_OPEN_EMFILE_MAX_RETRIES 5
+#define TDB_BM_OPEN_EMFILE_BACKOFF_US \
+    20000 /* 20ms between retries -- reaper evicts idle ssts on wake */
+
+/* sstable fd budget. each open sstable holds two descriptors (klog + vlog). at open we bound
+ * max_open_sstables so 2*cap fits under the process open-file limit, reserving headroom for WALs,
+ * the manifest, object-store handles, and stdio. the floor keeps the db usable even on a tiny
+ * descriptor limit (the EMFILE retry in tidesdb_bm_open then absorbs transient overshoot). */
+#define TDB_FDS_PER_SSTABLE        2
+#define TDB_FD_RESERVE_NON_SSTABLE 64 /* descriptors reserved for WALs/manifest/objstore/stdio */
+#define TDB_MIN_OPEN_SSTABLES      4  /* never clamp the sstable budget below this */
+
 /* sstable reaper eviction sentinel -- set on refcount during block manager close
  * to prevent concurrent try_ref from acquiring a reference on an evicting sstable */
 #define TDB_REFCOUNT_EVICTING (-1)
@@ -494,6 +511,49 @@ static int tdb_log_throttle(tidesdb_t *db, _Atomic(time_t) *last_log_sec, int in
     if (now - last < interval_sec) return 0;
     return atomic_compare_exchange_strong_explicit(last_log_sec, &last, now, memory_order_relaxed,
                                                    memory_order_relaxed);
+}
+
+/**
+ * tidesdb_wake_reaper
+ * nudge the sstable reaper to run its eviction pass now so it closes idle (unreferenced) sstable
+ * block managers and reclaims their file descriptors. uses trylock -- if the reaper mutex is held
+ * (reaper mid-cycle, or we are on the reaper thread itself) the signal is skipped, which is safe:
+ * the reaper runs on its own 100ms timer regardless. never blocks the caller.
+ * @param db database instance
+ */
+static void tidesdb_wake_reaper(tidesdb_t *db)
+{
+    if (pthread_mutex_trylock(&db->reaper_thread_mutex) == 0)
+    {
+        pthread_cond_signal(&db->reaper_thread_cond);
+        pthread_mutex_unlock(&db->reaper_thread_mutex);
+    }
+}
+
+/**
+ * tidesdb_bm_open
+ * open a block manager, treating file-descriptor exhaustion (EMFILE/ENFILE) as transient
+ * backpressure rather than a hard failure: wake the reaper to close idle sstables and retry a
+ * bounded number of times. every other errno (and success) returns immediately. errno is preserved
+ * by block_manager_open across its own cleanup, so the EMFILE/ENFILE check sees the real cause.
+ * @param db database instance (for waking the reaper)
+ * @param bm out: opened block manager
+ * @param path file path
+ * @param sync_mode block-manager sync mode (already converted)
+ * @return 0 on success, -1 on failure (errno set)
+ */
+static int tidesdb_bm_open(tidesdb_t *db, block_manager_t **bm, const char *path, int sync_mode)
+{
+    for (int attempt = 0;; attempt++)
+    {
+        if (block_manager_open(bm, path, sync_mode) == 0) return 0;
+        if ((errno != EMFILE && errno != ENFILE) || attempt >= TDB_BM_OPEN_EMFILE_MAX_RETRIES)
+            return -1;
+        /* fd table is full but idle sstables can usually be closed -- wake the reaper and give it
+         * a moment to reclaim descriptors before retrying. */
+        tidesdb_wake_reaper(db);
+        usleep(TDB_BM_OPEN_EMFILE_BACKOFF_US);
+    }
 }
 
 /* empty block index placeholder ( 4 byte LE count (0) followed by 1 byte prefix_len ) */
@@ -5857,10 +5917,10 @@ static int tidesdb_sstable_ensure_open(tidesdb_t *db, tidesdb_sstable_t *sst)
     if (!sst->klog_bm)
     {
         block_manager_t *new_klog_bm = NULL;
-        if (block_manager_open(&new_klog_bm, sst->klog_path,
-                               convert_sync_mode(sst->config->sync_mode == TDB_SYNC_INTERVAL
-                                                     ? TDB_SYNC_FULL
-                                                     : sst->config->sync_mode)) != 0)
+        if (tidesdb_bm_open(db, &new_klog_bm, sst->klog_path,
+                            convert_sync_mode(sst->config->sync_mode == TDB_SYNC_INTERVAL
+                                                  ? TDB_SYNC_FULL
+                                                  : sst->config->sync_mode)) != 0)
         {
             TDB_DEBUG_LOG(TDB_LOG_ERROR, "failed to open klog '%s': %s", sst->klog_path,
                           strerror(errno));
@@ -5878,8 +5938,8 @@ static int tidesdb_sstable_ensure_open(tidesdb_t *db, tidesdb_sstable_t *sst)
     if (!sst->vlog_bm)
     {
         block_manager_t *new_vlog_bm = NULL;
-        if (block_manager_open(&new_vlog_bm, sst->vlog_path,
-                               convert_sync_mode(sst->config->sync_mode)) != 0)
+        if (tidesdb_bm_open(db, &new_vlog_bm, sst->vlog_path,
+                            convert_sync_mode(sst->config->sync_mode)) != 0)
         {
             /* we dont close klog_bm here -- it may be used by another thread */
             TDB_DEBUG_LOG(TDB_LOG_ERROR, "failed to open vlog '%s': %s", sst->vlog_path,
@@ -18987,6 +19047,31 @@ int tidesdb_open(const tidesdb_config_t *config, tidesdb_t **db)
                       (*db)->config.max_concurrent_flushes, (*db)->config.num_flush_threads);
         (*db)->config.max_concurrent_flushes = (*db)->config.num_flush_threads;
     }
+
+    /* bound the sstable fd budget to the OS open-file limit. each open sstable holds two
+     * descriptors; if the configured cap would need more fds than the limit can honor, opens
+     * fail with EMFILE under load, so clamp it down and tell the operator to raise ulimit -n.
+     * the reserve leaves headroom for WALs, the manifest, object-store handles, and stdio. */
+    {
+        const long fd_limit = tdb_max_open_files();
+        long fd_budget_ssts = (fd_limit - TDB_FD_RESERVE_NON_SSTABLE) / TDB_FDS_PER_SSTABLE;
+        if (fd_budget_ssts < TDB_MIN_OPEN_SSTABLES) fd_budget_ssts = TDB_MIN_OPEN_SSTABLES;
+        if ((long)(*db)->config.max_open_sstables > fd_budget_ssts)
+        {
+            TDB_DEBUG_LOG(TDB_LOG_WARN,
+                          "max_open_sstables (%zu) exceeds what the open-file limit can honor "
+                          "(%ld sstables for fd limit %ld) -- clamping. raise the process fd "
+                          "limit (ulimit -n) to keep more sstables open",
+                          (*db)->config.max_open_sstables, fd_budget_ssts, fd_limit);
+            (*db)->config.max_open_sstables = (size_t)fd_budget_ssts;
+        }
+        TDB_DEBUG_LOG(TDB_LOG_INFO,
+                      "sstable fd budget: max_open_sstables=%zu (up to %ld fds), process fd "
+                      "limit=%ld",
+                      (*db)->config.max_open_sstables,
+                      (long)(*db)->config.max_open_sstables * TDB_FDS_PER_SSTABLE, fd_limit);
+    }
+
     /* subsequent reads in tidesdb_open should see the normalized values, so
      * rebind the input config alias to point at the owned copy */
     config = &(*db)->config;
@@ -22551,7 +22636,8 @@ static int tidesdb_flush_memtable_internal(tidesdb_column_family_t *cf,
                  "%s" PATH_SEPARATOR TDB_WAL_PREFIX TDB_U64_FMT TDB_WAL_EXT, cf->directory,
                  TDB_U64_CAST(wal_id));
 
-        if (block_manager_open(&new_wal, wal_path, convert_sync_mode(cf->config.sync_mode)) != 0)
+        if (tidesdb_bm_open(cf->db, &new_wal, wal_path, convert_sync_mode(cf->config.sync_mode)) !=
+            0)
         {
             TDB_DEBUG_LOG(TDB_LOG_WARN, "CF '%s' failed to open new WAL '%s': %s", cf->name,
                           wal_path, strerror(errno));

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -588,6 +588,11 @@ struct tidesdb_column_family_t
 
     /* unified memtable mode -- 4-byte big-endian CF prefix for keys in the shared skip list */
     uint32_t unified_cf_index;
+
+    /* last-emit timestamps (seconds) for throttled backpressure warnings -- see tdb_log_throttle.
+     * zero-initialized by calloc, so the first event in each category logs immediately. */
+    _Atomic(time_t) last_ceiling_stall_log_sec;
+    _Atomic(time_t) last_imm_critical_log_sec;
 };
 
 /**
@@ -864,6 +869,8 @@ struct tidesdb_t
         pthread_mutex_t cf_index_map_lock;
         pthread_mutex_t wal_group_sync_lock; /* coordinates group-commit fsync on the unified WAL */
         pthread_cond_t wal_group_sync_cond;
+        /* last-emit timestamp (seconds) for the throttled unified ceiling-stall warning */
+        _Atomic(time_t) last_ceiling_stall_log_sec;
     } unified_mt;
 
     /* object store mode runtime state */

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -577,6 +577,12 @@ struct tidesdb_column_family_t
      * cleanup vs compaction-triggered flush) must serialize on this lock */
     pthread_mutex_t imm_snap_publish_lock;
 
+    /* a single compaction round (serialized per CF by is_compacting) may run its
+     * partition sub-merges across multiple sub-compaction threads; this serializes the
+     * per-partition commit section (level add + manifest commit + layout bump) so the
+     * heavy merge work parallelizes while shared-state mutation stays single-threaded */
+    pthread_mutex_t compaction_commit_lock;
+
     /* read-side epoch for the active_memtable slot. a reader bumps this before
      * loading active_memtable + try_ref'ing the loaded pointer, drops it once
      * try_ref has finished (success means refcount is now pinned, failure means
@@ -593,7 +599,6 @@ struct tidesdb_column_family_t
      * zero-initialized by calloc, so the first event in each category logs immediately. */
     _Atomic(time_t) last_ceiling_stall_log_sec;
     _Atomic(time_t) last_imm_critical_log_sec;
-    _Atomic(time_t) last_l1_stop_log_sec;
 };
 
 /**
@@ -804,6 +809,10 @@ struct tidesdb_t
     queue_t *flush_queue;
     pthread_t *compaction_threads;
     queue_t *compaction_queue;
+    /* budget of ephemeral sub-compaction helper threads a compaction round may spawn,
+     * initialized to num_compaction_threads at open. bounds total concurrent sub-merge
+     * threads across all CFs so parallel compaction never oversubscribes the pool. */
+    _Atomic(int) compaction_helper_budget;
     pthread_t sync_thread;
     _Atomic(int) sync_thread_active;
     pthread_mutex_t sync_thread_mutex;

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -205,12 +205,15 @@ typedef enum
 #define TDB_DEFAULT_DIVIDING_LEVEL_OFFSET       1
 #define TDB_DEFAULT_COMPACTION_THREAD_POOL_SIZE 2
 #define TDB_DEFAULT_FLUSH_THREAD_POOL_SIZE      2
-#define TDB_DEFAULT_MAX_CONCURRENT_FLUSHES      4
-#define TDB_DEFAULT_BLOOM_FPR                   0.01
-#define TDB_DEFAULT_KLOG_VALUE_THRESHOLD        512
-#define TDB_DEFAULT_INDEX_SAMPLE_RATIO          1
-#define TDB_DEFAULT_BLOCK_INDEX_PREFIX_LEN      16
-#define TDB_DEFAULT_MIN_DISK_SPACE              (100 * 1024 * 1024)
+/* pinned to the flush pool size tidesdb_open clamps max_concurrent_flushes to
+ * num_flush_threads and warns when they differ, so the canonical default open
+ * (default_config + open) must already agree or it warns on every startup */
+#define TDB_DEFAULT_MAX_CONCURRENT_FLUSHES TDB_DEFAULT_FLUSH_THREAD_POOL_SIZE
+#define TDB_DEFAULT_BLOOM_FPR              0.01
+#define TDB_DEFAULT_KLOG_VALUE_THRESHOLD   512
+#define TDB_DEFAULT_INDEX_SAMPLE_RATIO     1
+#define TDB_DEFAULT_BLOCK_INDEX_PREFIX_LEN 16
+#define TDB_DEFAULT_MIN_DISK_SPACE         (100 * 1024 * 1024)
 #if defined(__OpenBSD__)
 #define TDB_DEFAULT_MAX_OPEN_SSTABLES 64 /* x2 OpenBSD has lower default fd limits */
 #else
@@ -342,9 +345,10 @@ typedef struct tidesdb_stats_t tidesdb_stats_t;
  *                              lower compaction write-amp. higher offsets push
  *                              X further up the tree, reducing write-amp again
  *                              but multiplying the number of open files per
- *                              spooky equation 12. default 0 favors ingest
- *                              throughput; set to 1 for write-amp-sensitive
- *                              workloads.
+ *                              spooky equation 12. default is 1 (X=L-2, the paper's
+ *                              generalized tuning, per TDB_DEFAULT_DIVIDING_LEVEL_OFFSET);
+ *                              set to 0 (X=L-1) to favor ingest throughput at higher
+ *                              write-amp.
  * @param klog_value_threshold threshold for klog value
  * @param compression_algorithm compression algorithm
  * @param enable_bloom_filter enable bloom filter
@@ -1414,6 +1418,15 @@ int tidesdb_txn_rollback(tidesdb_txn_t *txn);
 /**
  * tidesdb_txn_commit
  * commits a transaction to the database
+ *
+ * multi-CF atomicity at runtime a transaction is all-or-nothing across all its column
+ * families -- a single commit sequence gates visibility, so nothing is visible until the one
+ * commit point. crash/failure atomicity differs by memtable mode, UNIFIED mode is crash-atomic
+ * across CFs (the whole transaction is one atomic WAL batch), whereas per-CF mode writes a
+ * separate WAL per CF, so a crash or IO/OOM failure mid-commit can leave a partially-applied
+ * prefix (the CFs written before the failure) that recovery treats as committed. use unified
+ * memtable mode when you need crash-atomic multi-CF transactions.
+ *
  * @param txn transaction handle
  * @return 0 on success, -n on failure
  */

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -593,6 +593,7 @@ struct tidesdb_column_family_t
      * zero-initialized by calloc, so the first event in each category logs immediately. */
     _Atomic(time_t) last_ceiling_stall_log_sec;
     _Atomic(time_t) last_imm_critical_log_sec;
+    _Atomic(time_t) last_l1_stop_log_sec;
 };
 
 /**
@@ -818,6 +819,9 @@ struct tidesdb_t
     pthread_mutex_t btree_cache_lock;
     size_t resolved_block_cache_size;
     _Atomic(int) num_open_sstables;
+    /* last-emit timestamp (seconds) for the throttled open-failure (EMFILE) diagnostic, so a
+     * descriptor-exhaustion storm logs one legible line per second instead of flooding */
+    _Atomic(time_t) last_open_fail_log_sec;
     _Atomic(uint64_t) next_txn_id;
     _Atomic(uint64_t) global_seq;
     tidesdb_commit_status_t *commit_status;

--- a/test/clock_cache__tests.c
+++ b/test/clock_cache__tests.c
@@ -1300,7 +1300,7 @@ void test_concurrent_put_delete_same_key(void)
     for (int i = 0; i < num_putters; i++) pthread_join(putters[i], NULL);
     for (int i = 0; i < num_deleters; i++) pthread_join(deleters[i], NULL);
 
-    /* final state: key may or may not exist */
+    /* final state-- key may or may not exist */
     size_t len;
     uint8_t *data = clock_cache_get(cache, key, strlen(key), &len);
     if (data)
@@ -1482,6 +1482,67 @@ void test_zero_copy_get_release(void)
 
     clock_cache_destroy(cache);
     printf("  ✓ Zero-copy get/release test passed\n");
+}
+
+void test_reader_saturation_refuses_pin(void)
+{
+    printf("Testing reader-count saturation refuses pins instead of wrapping...\n");
+
+    /* the ref_bit reader field is 7 bits, so at most this many readers can pin one entry at
+     * once. an unconditional increment would wrap the 128th pin to 0 and let a concurrent
+     * delete/evict free the entry under live readers (use-after-free). the acquire must instead
+     * refuse the over-cap pin and report a miss, leaving earlier pins valid. */
+    const int max_readers = 127;
+
+    cache_config_t config = {
+        .max_bytes = 1024 * 1024, .num_partitions = 4, .slots_per_partition = 256};
+    clock_cache_t *cache = clock_cache_create(&config);
+    ASSERT_TRUE(cache != NULL);
+
+    const char *key = "saturation_key";
+    const uint8_t payload[] = "saturation_payload_data";
+    ASSERT_EQ(clock_cache_put(cache, key, strlen(key), payload, sizeof(payload), 0), 0);
+
+    clock_cache_entry_t *held[128] = {0};
+    const uint8_t *first_data = NULL;
+
+    /* pin up to the reader cap -- all of these must succeed */
+    for (int i = 0; i < max_readers; i++)
+    {
+        size_t len = 0;
+        const uint8_t *data = clock_cache_get_zero_copy(cache, key, strlen(key), &len, &held[i]);
+        ASSERT_TRUE(data != NULL);
+        ASSERT_TRUE(held[i] != NULL);
+        if (i == 0) first_data = data;
+    }
+
+    /* the next pin would overflow the reader field -- it must be refused (reported as a miss) */
+    {
+        size_t len = 0;
+        clock_cache_entry_t *over = NULL;
+        const uint8_t *data = clock_cache_get_zero_copy(cache, key, strlen(key), &len, &over);
+        ASSERT_TRUE(data == NULL);
+        ASSERT_TRUE(over == NULL);
+    }
+
+    /* delete while all readers are held -- free_entry must NOT reclaim the entry (it reverts to
+     * VALID and aborts), so the held payload stays valid and readable; a use-after-free here
+     * would trip ASan, and a wrapped reader field would have let the free through. */
+    clock_cache_delete(cache, key, strlen(key));
+    ASSERT_TRUE(memcmp(first_data, payload, sizeof(payload)) == 0);
+
+    /* release every reader, then delete again -- with no readers held the delete now takes */
+    for (int i = 0; i < max_readers; i++) clock_cache_release(held[i]);
+    clock_cache_delete(cache, key, strlen(key));
+    {
+        size_t len = 0;
+        clock_cache_entry_t *e = NULL;
+        const uint8_t *data = clock_cache_get_zero_copy(cache, key, strlen(key), &len, &e);
+        ASSERT_TRUE(data == NULL);
+    }
+
+    clock_cache_destroy(cache);
+    printf("  ✓ Reader saturation refuses over-cap pins, no wrap, no use-after-free\n");
 }
 
 void test_large_payload(void)
@@ -1889,7 +1950,7 @@ static inline uint32_t xorshift32(uint32_t *state)
     return x;
 }
 
-/* approximate Zipfian: pick index in [0, n) biased toward low indices.
+/* approximate Zipfian, pick index in [0, n) biased toward low indices.
  * models real-world "hot key" patterns -- a few btree root/internal nodes
  * are accessed far more often than deep leaf nodes. */
 static inline int zipf_pick(uint32_t *rng, int n)
@@ -1901,7 +1962,7 @@ static inline int zipf_pick(uint32_t *rng, int n)
     return (idx >= n) ? n - 1 : idx;
 }
 
-/* variable block size: models real btree nodes that range from ~200B (small leaf)
+/* variable block size, models real btree nodes that range from ~200B (small leaf)
  * to ~4KB (large internal node with many keys). returns a size in [lo, hi). */
 static inline size_t variable_block_size(uint32_t *rng, size_t lo, size_t hi)
 {
@@ -1966,7 +2027,7 @@ void test_realistic_block_cache_eviction(void)
     size_t block_sizes[2000];
     for (int i = 0; i < num_blocks; i++) block_sizes[i] = variable_block_size(&rng, 200, 2048);
 
-    /* phase 1: warm-up -- insert all blocks (simulates initial table scan / SST open) */
+    /* warm-up -- insert all blocks (simulates initial table scan / SST open) */
     printf("  Phase 1: inserting %d variable-size blocks (200B-2KB)...\n", num_blocks);
     for (int i = 0; i < num_blocks; i++)
     {
@@ -1994,7 +2055,7 @@ void test_realistic_block_cache_eviction(void)
     printf("    Total data offered: %zu bytes (%.1fx cache size)\n", total_data_inserted,
            (double)total_data_inserted / max_bytes);
 
-    /* phase 2: steady-state Zipfian workload (90% read, 10% new-block writes).
+    /* steady-state Zipfian workload (90% read, 10% new-block writes).
      * on cache miss, we re-insert the block (simulating a real disk read that
      * populates the cache -- this is how btree_node_read_cached works). */
     printf("  Phase 2: 20000 Zipfian accesses (90%% read, 10%% write)...\n");
@@ -2058,13 +2119,13 @@ void test_realistic_block_cache_eviction(void)
     ASSERT_TRUE(hits > 0);
     ASSERT_TRUE(corruptions == 0);
 
-    /* verify byte budget is still respected after steady-state phase */
+    /* we verify byte budget is still respected after steady-state phase */
     clock_cache_stats_t mid_stats;
     clock_cache_get_stats(cache, &mid_stats);
     printf("    Post-steady-state: bytes_used=%zu / %zu\n", mid_stats.total_bytes, max_bytes);
     ASSERT_TRUE(mid_stats.total_bytes <= max_bytes * 2);
 
-    /* phase 3: scan burst -- sequential scan of 500 cold blocks forces eviction
+    /* scan burst -- sequential scan of 500 cold blocks forces eviction
      * of working set, then re-access hot keys to verify cache recovers */
     printf("  Phase 3: sequential scan burst (500 cold blocks)...\n");
     for (int i = 0; i < 500; i++)
@@ -2127,16 +2188,15 @@ void test_realistic_node_cache_external_bytes(void)
     const int num_nodes = 500; /* more nodes than fit in cache */
     uint32_t rng = 12345;
 
-    /* phase 1: populate -- each entry is a small pointer (8B inline) + large external cost */
     printf("  Inserting %d nodes with variable external_bytes (1-8 KB each)...\n", num_nodes);
     size_t total_external_offered = 0;
 
     for (int i = 0; i < num_nodes; i++)
     {
-        /* inline payload: simulates a pointer value */
+        /* inline payload-- simulates a pointer value */
         uint64_t fake_ptr = (uint64_t)(0xCAFE0000 + i);
 
-        /* external_bytes: simulates the real heap cost of the node */
+        /* external_bytes-- simulates the real heap cost of the node */
         size_t ext = variable_block_size(&rng, 1024, 8192);
         total_external_offered += ext;
 
@@ -2156,7 +2216,7 @@ void test_realistic_node_cache_external_bytes(void)
     ASSERT_TRUE(stats.total_entries < (size_t)num_nodes);
     ASSERT_TRUE(stats.total_bytes <= max_bytes * 2);
 
-    /* phase 2: Zipfian reads with miss-fill -- simulates btree_node_read_cached:
+    /* Zipfian reads with miss-fill -- simulates btree_node_read_cached:
      * on miss, read from "disk" and re-populate cache with external_bytes cost.
      * hot root/internal nodes get re-cached and stay cached. */
     printf("  Zipfian reads of %d nodes (with miss-fill)...\n", num_nodes);
@@ -2182,7 +2242,7 @@ void test_realistic_node_cache_external_bytes(void)
         }
         else
         {
-            /* cache miss -- simulate disk read: re-insert with external_bytes */
+            /* cache miss -- simulate disk read re-insert with external_bytes */
             uint64_t fake_ptr = (uint64_t)(0xCAFE0000 + nid);
             size_t ext = variable_block_size(&rng, 1024, 8192);
             clock_cache_put(cache, key, strlen(key), &fake_ptr, sizeof(fake_ptr), ext);
@@ -2194,7 +2254,6 @@ void test_realistic_node_cache_external_bytes(void)
     /* with miss-fill and Zipfian skew, hot nodes get re-cached */
     ASSERT_TRUE(hits > 0);
 
-    /* phase 3: compare with no external_bytes -- should fit far more entries */
     clock_cache_clear(cache);
     for (int i = 0; i < num_nodes; i++)
     {
@@ -2222,7 +2281,7 @@ void test_realistic_node_cache_external_bytes(void)
  *   -- 2 writer threads (insert new blocks + update existing -- simulates INSERT/UPDATE)
  *   -- cache sized to hold ~30% of working set (forces realistic eviction pressure)
  *   -- runs for ~1 second, sampling stats every 200ms
- *   -- verifies: byte budget, data integrity, reasonable hit rates, no crashes
+ *   -- verifies-- byte budget, data integrity, reasonable hit rates, no crashes
  */
 #define OLTP_NUM_BLOCKS    10000 /* total block keyspace */
 #define OLTP_BLOCK_MIN_SZ  256
@@ -2513,9 +2572,9 @@ void test_realistic_working_set_shift(void)
 /**
  * test_realistic_mixed_block_sizes
  * models a column family with mixed SST block sizes:
- *   -- index blocks: small (~128B), frequently accessed
- *   -- data blocks: large (~2-8KB), less frequently accessed
- *   -- filter/bloom blocks: medium (~512B), accessed on every query
+ *   -- index blocks          small (~128B), frequently accessed
+ *   -- data blocks           large (~2-8KB), less frequently accessed
+ *   -- filter/bloom blocks   medium (~512B), accessed on every query
  * verifies that the cache fairly handles mixed sizes and that
  * small hot entries don't get unfairly evicted by large cold entries.
  */
@@ -2580,7 +2639,7 @@ void test_realistic_mixed_block_sizes(void)
     printf("    bytes=%zu/%zu, entries=%zu\n", stats.total_bytes, max_bytes, stats.total_entries);
     ASSERT_TRUE(stats.total_bytes <= max_bytes * 2);
 
-    /* now simulate realistic query pattern: each query reads 1 index + 1 filter + 1 data block
+    /* now simulate realistic query pattern where each query reads 1 index + 1 filter + 1 data block
      * index/filter blocks are Zipfian-hot, data blocks are more uniformly accessed */
     printf("  Simulating 5000 queries (idx + flt + dat per query)...\n");
     int idx_hits = 0, flt_hits = 0, dat_hits = 0;
@@ -2603,7 +2662,7 @@ void test_realistic_mixed_block_sizes(void)
         }
         else
         {
-            /* miss-fill: simulate disk read populating cache */
+            /* miss-fill we simulate disk read populating cache */
             size_t bsz = variable_block_size(&rng, 64, 192);
             uint8_t *block = (uint8_t *)malloc(bsz);
             fill_block_payload(block, bsz, (uint32_t)(10000 + iid));
@@ -2702,6 +2761,7 @@ int main(int argc, char **argv)
     RUN_TEST(test_hash_collision_concurrent, tests_passed);
     RUN_TEST(test_shutdown_during_operations, tests_passed);
     RUN_TEST(test_zero_copy_get_release, tests_passed);
+    RUN_TEST(test_reader_saturation_refuses_pin, tests_passed);
     RUN_TEST(test_large_payload, tests_passed);
     RUN_TEST(test_many_small_entries, tests_passed);
     RUN_TEST(test_foreach_prefix_concurrent, tests_passed);

--- a/test/objstore__tests.c
+++ b/test/objstore__tests.c
@@ -456,6 +456,45 @@ void test_objstore_s3_minio(void)
     free(store);
     remove_directory(TEST_OBJSTORE_DIR2);
 }
+
+/* construct-only coverage for the config-driven S3 constructor, it must build a connector with
+ * TLS + multipart settings without touching the network, reject missing required fields, and the
+ * positional wrapper must still build a connector with secure defaults. network behavior needs a
+ * live endpoint -- see test_objstore_s3_minio. */
+void test_objstore_s3_create_config(void)
+{
+    tidesdb_objstore_s3_config_t cfg = {0};
+    cfg.endpoint = "localhost:9000";
+    cfg.bucket = "testbucket";
+    cfg.access_key = "ak";
+    cfg.secret_key = "sk";
+    cfg.use_ssl = 1;
+    cfg.use_path_style = 1;
+    cfg.tls_ca_path = "/path/to/ca-bundle.crt"; /* stored verbatim; need not exist to construct */
+    cfg.tls_insecure_skip_verify = 1;
+    cfg.multipart_threshold = (size_t)32 * 1024 * 1024; /* non-default, exercises the override */
+    cfg.multipart_part_size = (size_t)16 * 1024 * 1024;
+
+    tidesdb_objstore_t *store = tidesdb_objstore_s3_create_config(&cfg);
+    ASSERT_TRUE(store != NULL);
+    ASSERT_EQ(store->backend, TDB_BACKEND_S3);
+    ASSERT_TRUE(store->put != NULL && store->destroy != NULL && store->ctx != NULL);
+    store->destroy(store->ctx);
+    free(store);
+
+    /* required-field validation */
+    ASSERT_TRUE(tidesdb_objstore_s3_create_config(NULL) == NULL);
+    tidesdb_objstore_s3_config_t missing = {0};
+    missing.endpoint = "localhost:9000"; /* no bucket/keys */
+    ASSERT_TRUE(tidesdb_objstore_s3_create_config(&missing) == NULL);
+
+    /* the positional wrapper must still build a connector (secure defaults) */
+    tidesdb_objstore_t *store2 =
+        tidesdb_objstore_s3_create("localhost:9000", "testbucket", NULL, "ak", "sk", NULL, 0, 1);
+    ASSERT_TRUE(store2 != NULL);
+    store2->destroy(store2->ctx);
+    free(store2);
+}
 #endif
 
 int main(int argc, char **argv)
@@ -474,6 +513,7 @@ int main(int argc, char **argv)
     RUN_TEST(test_objstore_fs_overwrite, tests_passed);
     RUN_TEST(test_objstore_fs_nested_keys, tests_passed);
 #ifdef TIDESDB_WITH_S3
+    RUN_TEST(test_objstore_s3_create_config, tests_passed);
     RUN_TEST(test_objstore_s3_minio, tests_passed);
 #endif
 

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -25147,39 +25147,43 @@ static void test_unified_concurrent_multi_cf_read_write(void)
     ASSERT_EQ(final_fail, 0);
     ASSERT_EQ(final_ok, NUM_WRITERS * W_OPS);
 
-    /* wait for background flushes to settle */
-    usleep(500000);
+    /* wait for flushes AND compaction to settle before verifying. on an fd-constrained host a read
+     * that races active flush/compaction is correctly rejected with the retryable TDB_ERR_BUSY by
+     * the reader fd reserve, which would otherwise be miscounted as a missing key. */
+    for (int c = 0; c < NUM_CFS; c++) wait_for_cf_flush_idle(db, cfs[c]);
+    for (int c = 0; c < NUM_CFS; c++) wait_for_compaction_idle(db, cfs[c]);
 
-    /* verify CF isolation -- each CF should have its own data */
+    /* verify CF isolation -- each CF should have its own data. one txn per get: a long-lived read
+     * txn pins every sstable it touches for its lifetime, so reading all 50 keys in a single txn
+     * would accumulate open sstables past max_open on an fd-constrained host and the rest would
+     * fail with TDB_ERR_BUSY. independent point lookups release each pin, keeping num_open bounded.
+     */
     for (int c = 0; c < NUM_CFS; c++)
     {
-        tidesdb_txn_t *vtxn = NULL;
-        ASSERT_EQ(tidesdb_txn_begin(db, &vtxn), 0);
-
         int found = 0;
         for (int i = 0; i < 50; i++)
         {
+            tidesdb_txn_t *vtxn = NULL;
+            ASSERT_EQ(tidesdb_txn_begin(db, &vtxn), 0);
             char key[64];
             snprintf(key, sizeof(key), "ushared_%06d", i);
             uint8_t *val = NULL;
             size_t vs = 0;
             /* shared keys may have been deleted by interleaved deletes, so some misses are OK */
-            if (tidesdb_txn_get(vtxn, cfs[c], (uint8_t *)key, strlen(key) + 1, &val, &vs) == 0)
+            if (tdb_test_get_with_retry(vtxn, cfs[c], (uint8_t *)key, strlen(key) + 1, &val, &vs) ==
+                0)
             {
                 found++;
                 free(val);
             }
+            tidesdb_txn_free(vtxn);
         }
         printf("  %s: %d/50 shared keys found\n", cf_names[c], found);
         /* at least some shared keys should survive (deletes only hit ~1/11 of ops) */
         ASSERT_TRUE(found > 20);
-
-        tidesdb_txn_free(vtxn);
     }
 
-    /* verify unique keys from each writer are present */
-    tidesdb_txn_t *vtxn = NULL;
-    ASSERT_EQ(tidesdb_txn_begin(db, &vtxn), 0);
+    /* verify unique keys from each writer are present (fresh txn per get, same reasoning) */
     int unique_found = 0;
     for (int t = 0; t < NUM_WRITERS; t++)
     {
@@ -25187,18 +25191,21 @@ static void test_unified_concurrent_multi_cf_read_write(void)
         {
             if (i % 4 == 0) continue; /* shared key pattern, skip */
             int cf_idx = (t + i) % NUM_CFS;
+            tidesdb_txn_t *vtxn = NULL;
+            ASSERT_EQ(tidesdb_txn_begin(db, &vtxn), 0);
             char key[64];
             snprintf(key, sizeof(key), "uuniq_t%d_%06d", t, i);
             uint8_t *val = NULL;
             size_t vs = 0;
-            if (tidesdb_txn_get(vtxn, cfs[cf_idx], (uint8_t *)key, strlen(key) + 1, &val, &vs) == 0)
+            if (tdb_test_get_with_retry(vtxn, cfs[cf_idx], (uint8_t *)key, strlen(key) + 1, &val,
+                                        &vs) == 0)
             {
                 unique_found++;
                 free(val);
             }
+            tidesdb_txn_free(vtxn);
         }
     }
-    tidesdb_txn_free(vtxn);
     printf("  unique keys found: %d\n", unique_found);
     ASSERT_TRUE(unique_found > 0);
 

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -13690,25 +13690,52 @@ static void test_wal_corruption_recovery(void)
         ASSERT_EQ(tidesdb_close(db), 0);
     }
 
-    /* corrupt WAL file (truncate it) */
-    char wal_path[256];
-    snprintf(wal_path, sizeof(wal_path), "%s" PATH_SEPARATOR "wal_cf" PATH_SEPARATOR "wal.log",
-             TEST_DB_PATH);
+    /* corrupt the active WAL by truncating it. real per-CF WAL files are named
+     * wal_<id>.log; the active one (highest id) holds the not-yet-flushed writes. an
+     * earlier version of this test truncated "wal.log", which never exists, so fopen
+     * returned NULL and no corruption was ever applied -- the test passed trivially.
+     * scan for the real highest-id wal_<id>.log and truncate it to half size, leaving a
+     * torn tail that recovery must skip via block_manager_cursor_skip_corrupt while still
+     * recovering the flushed data from the sstable. */
+    char wal_dir[256];
+    snprintf(wal_dir, sizeof(wal_dir), "%s" PATH_SEPARATOR "wal_cf", TEST_DB_PATH);
+
+    const char *wal_prefix = "wal_";
+    const char *wal_suffix = ".log";
+    char wal_path[512];
+    wal_path[0] = '\0';
+    unsigned long long best_wal_id = 0;
+    int found_wal = 0;
+
+    DIR *wal_d = opendir(wal_dir);
+    ASSERT_TRUE(wal_d != NULL);
+    struct dirent *wal_ent;
+    while ((wal_ent = readdir(wal_d)) != NULL)
+    {
+        if (strncmp(wal_ent->d_name, wal_prefix, strlen(wal_prefix)) != 0) continue;
+        if (strstr(wal_ent->d_name, wal_suffix) == NULL) continue;
+        const unsigned long long id = strtoull(wal_ent->d_name + strlen(wal_prefix), NULL, 10);
+        if (!found_wal || id >= best_wal_id)
+        {
+            best_wal_id = id;
+            found_wal = 1;
+            snprintf(wal_path, sizeof(wal_path), "%s" PATH_SEPARATOR "%s", wal_dir,
+                     wal_ent->d_name);
+        }
+    }
+    closedir(wal_d);
+
+    /* the active wal_<id>.log must exist and actually get truncated -- this is what
+     * the test depends on; if it is ever not found, the test must fail, not silently pass */
+    ASSERT_TRUE(found_wal);
 
     FILE *wal_file = fopen(wal_path, "r+b");
-    if (wal_file)
-    {
-        /* truncate WAL to simulate corruption */
-        fseek(wal_file, 0, SEEK_END);
-        long size = ftell(wal_file);
-        if (size > 100)
-        {
-            /* truncate to 50% of original size */
-            int truncate_result = ftruncate(fileno(wal_file), size / 2);
-            (void)truncate_result; /* intentionally ignore for test simulation */
-        }
-        fclose(wal_file);
-    }
+    ASSERT_TRUE(wal_file != NULL);
+    fseek(wal_file, 0, SEEK_END);
+    const long wal_size = ftell(wal_file);
+    ASSERT_TRUE(wal_size > 0);
+    ASSERT_EQ(ftruncate(fileno(wal_file), wal_size / 2), 0);
+    fclose(wal_file);
 
     /* we reopen and verify recovery handles corruption gracefully */
     {
@@ -16777,64 +16804,98 @@ static void test_power_loss_during_sstable_metadata_write(void)
         ASSERT_EQ(tidesdb_close(db), TDB_SUCCESS);
     }
 
-    /* we corrupt the sstable metadata (bloom filter or block index) to simulate power loss */
-    char bloom_path[512];
-    snprintf(bloom_path, sizeof(bloom_path),
-             "%s" PATH_SEPARATOR "powerloss_cf" PATH_SEPARATOR "L1_0.bloom", TEST_DB_PATH);
+    /* corrupt a real sstable footer to simulate an interrupted metadata write. the metadata,
+     * bloom, and block-index live as the trailing blocks INSIDE the klog file -- there is no
+     * separate .bloom file. an earlier version truncated "L1_0.bloom", which never exists, so
+     * fopen returned NULL, no corruption was applied, and the test passed trivially. here we
+     * find a real *.klog and truncate its tail so the metadata block (written last) is torn,
+     * which strict last-block validation must reject on load. */
+    char cf_dir[300];
+    snprintf(cf_dir, sizeof(cf_dir), "%s" PATH_SEPARATOR "powerloss_cf", TEST_DB_PATH);
 
-    FILE *bloom_file = fopen(bloom_path, "r+b");
-    if (bloom_file)
+    const char *klog_suffix = ".klog";
+    char klog_path[512];
+    klog_path[0] = '\0';
+    int found_klog = 0;
+    DIR *cf_d = opendir(cf_dir);
+    ASSERT_TRUE(cf_d != NULL);
+    struct dirent *cf_ent;
+    while ((cf_ent = readdir(cf_d)) != NULL)
     {
-        /* we truncate bloom filter to simulate incomplete write */
-        fseek(bloom_file, 0, SEEK_END);
-        long size = ftell(bloom_file);
-        if (size > 20)
-        {
-            int truncate_result = ftruncate(fileno(bloom_file), size / 3);
-            (void)truncate_result;
-        }
-        fclose(bloom_file);
+        const size_t nlen = strlen(cf_ent->d_name);
+        const size_t slen = strlen(klog_suffix);
+        if (nlen < slen || strcmp(cf_ent->d_name + nlen - slen, klog_suffix) != 0) continue;
+        found_klog = 1;
+        snprintf(klog_path, sizeof(klog_path), "%s" PATH_SEPARATOR "%s", cf_dir, cf_ent->d_name);
+        break; /* corrupt the first sstable we find */
     }
+    closedir(cf_d);
 
-    /* we reopen and verify system handles corrupted metadata gracefully */
+    /* a flushed sstable must exist; the test depends on actually corrupting it */
+    ASSERT_TRUE(found_klog);
+
+    FILE *klog_file = fopen(klog_path, "r+b");
+    ASSERT_TRUE(klog_file != NULL);
+    fseek(klog_file, 0, SEEK_END);
+    const long klog_size = ftell(klog_file);
+    ASSERT_TRUE(klog_size > 0);
+    /* drop the trailing third so the metadata block (the last block) is torn */
+    ASSERT_EQ(ftruncate(fileno(klog_file), klog_size - (klog_size / 3)), 0);
+    fclose(klog_file);
+
+    /* reopen the corrupted sstable must be handled gracefully -- the DB still opens
+     * (recovery skips the unreadable sstable instead of crashing) and stays usable for new
+     * writes/reads. data in the torn sstable may be unrecoverable (the cost of a torn
+     * metadata write), so we do NOT assert it survives; we assert no crash + usability. */
     {
         tidesdb_config_t config = tidesdb_default_config();
         config.db_path = TEST_DB_PATH;
 
         tidesdb_t *db = NULL;
-        int result = tidesdb_open(&config, &db);
+        ASSERT_EQ(tidesdb_open(&config, &db), TDB_SUCCESS);
+        ASSERT_TRUE(db != NULL);
 
-        if (result == TDB_SUCCESS && db != NULL)
+        tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "powerloss_cf");
+        ASSERT_TRUE(cf != NULL);
+
+        /* reads of the possibly-lost keys must not crash, however many survive */
+        tidesdb_txn_t *rtxn = NULL;
+        ASSERT_EQ(tidesdb_txn_begin(db, &rtxn), TDB_SUCCESS);
+        for (int i = 0; i < NUM_KEYS; i++)
         {
-            tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "powerloss_cf");
-            if (cf != NULL)
-            {
-                /* we try to read -- data should still be accessible even without bloom filter */
-                tidesdb_txn_t *txn = NULL;
-                if (tidesdb_txn_begin(db, &txn) == TDB_SUCCESS)
-                {
-                    int found = 0;
-                    for (int i = 0; i < NUM_KEYS; i++)
-                    {
-                        char key[32];
-                        snprintf(key, sizeof(key), "power_key_%03d", i);
-
-                        uint8_t *value = NULL;
-                        size_t value_size = 0;
-                        if (tidesdb_txn_get(txn, cf, (uint8_t *)key, strlen(key) + 1, &value,
-                                            &value_size) == TDB_SUCCESS)
-                        {
-                            found++;
-                            free(value);
-                        }
-                    }
-                    /* we expect data to be recoverable even with corrupted bloom filter */
-                    ASSERT_TRUE(found > 0);
-                    tidesdb_txn_free(txn);
-                }
-            }
-            tidesdb_close(db);
+            char key[32];
+            snprintf(key, sizeof(key), "power_key_%03d", i);
+            uint8_t *value = NULL;
+            size_t value_size = 0;
+            if (tidesdb_txn_get(rtxn, cf, (uint8_t *)key, strlen(key) + 1, &value, &value_size) ==
+                TDB_SUCCESS)
+                free(value);
         }
+        tidesdb_txn_free(rtxn);
+
+        /* the DB must remain usable after recovering past the corruption */
+        tidesdb_txn_t *wtxn = NULL;
+        ASSERT_EQ(tidesdb_txn_begin(db, &wtxn), TDB_SUCCESS);
+        const char *probe_key = "post_recovery_probe";
+        const char *probe_val = "ok";
+        ASSERT_EQ(tidesdb_txn_put(wtxn, cf, (uint8_t *)probe_key, strlen(probe_key) + 1,
+                                  (uint8_t *)probe_val, strlen(probe_val) + 1, -1),
+                  TDB_SUCCESS);
+        ASSERT_EQ(tidesdb_txn_commit(wtxn), TDB_SUCCESS);
+        tidesdb_txn_free(wtxn);
+
+        uint8_t *got = NULL;
+        size_t got_size = 0;
+        tidesdb_txn_t *vtxn = NULL;
+        ASSERT_EQ(tidesdb_txn_begin(db, &vtxn), TDB_SUCCESS);
+        ASSERT_EQ(
+            tidesdb_txn_get(vtxn, cf, (uint8_t *)probe_key, strlen(probe_key) + 1, &got, &got_size),
+            TDB_SUCCESS);
+        ASSERT_TRUE(got != NULL);
+        free(got);
+        tidesdb_txn_free(vtxn);
+
+        tidesdb_close(db);
     }
 
     cleanup_test_dir();
@@ -28478,6 +28539,147 @@ static void crash_recovery_verify(int unified, int num_cfs)
     ASSERT_EQ(tidesdb_close(db), 0);
 }
 
+/* crash + unified-WAL-replay guard for single-delete. a child puts every key and
+ * purges (so the puts are durable in sstables), then single-deletes every key WITHOUT
+ * flushing and _exit()s -- the single-deletes live only in the unified wal, so reopen
+ * must replay them through tidesdb_unified_wal_replay_into (the path that previously
+ * dropped the SINGLE_DELETE subtype, fixed under U-1/U-2). the parent reopens and asserts
+ * every key stays deleted across replay, and that a full compaction keeps them gone and
+ * reclaims the residue.
+ *
+ *** the single-delete *subtype* (vs a plain tombstone) is not uniquely
+ * black-box observable -- both keep the key deleted and both reclaim under a full
+ * compaction -- so this guards the replay path's read-correctness and reclamation, not the
+ * subtype bit itself. a bit-level regression guard would need a white-box assertion on the
+ * replayed skip-list flags. */
+#define CRASH_SD_CHILD_ARG    "__crash_single_delete_child"
+#define CRASH_SD_KEY_COUNT    200
+#define CRASH_SD_WRITE_BUFFER 4096
+#define CRASH_SD_CF_NAME      "sd_crash_cf"
+
+static void crash_single_delete_child_workload(void)
+{
+    tidesdb_config_t config = tidesdb_default_config();
+    config.db_path = (char *)CRASH_RECOVERY_DB_PATH;
+    config.log_level = TDB_LOG_ERROR;
+    config.unified_memtable = 1;
+    config.unified_memtable_write_buffer_size = CRASH_SD_WRITE_BUFFER;
+    config.unified_memtable_sync_mode = TDB_SYNC_FULL;
+
+    tidesdb_t *db = NULL;
+    if (tidesdb_open(&config, &db) != 0) _exit(2);
+
+    tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
+    cf_config.write_buffer_size = CRASH_SD_WRITE_BUFFER;
+    cf_config.compression_algorithm = TDB_COMPRESS_NONE;
+    cf_config.sync_mode = TDB_SYNC_FULL;
+    if (tidesdb_create_column_family(db, CRASH_SD_CF_NAME, &cf_config) != 0) _exit(3);
+    tidesdb_column_family_t *cf = tidesdb_get_column_family(db, CRASH_SD_CF_NAME);
+    if (!cf) _exit(4);
+
+    /* put every key, then purge so the puts are durably on disk in sstables and the
+     * unified memtable/wal is clean before the single-deletes */
+    for (int i = 0; i < CRASH_SD_KEY_COUNT; i++)
+    {
+        char key[32];
+        int klen = snprintf(key, sizeof(key), "sd%08d", i);
+        tidesdb_txn_t *txn = NULL;
+        if (tidesdb_txn_begin(db, &txn) != 0) _exit(5);
+        if (tidesdb_txn_put(txn, cf, (uint8_t *)key, (size_t)klen, (uint8_t *)key, (size_t)klen,
+                            0) != 0)
+            _exit(6);
+        if (tidesdb_txn_commit(txn) != 0) _exit(7);
+        tidesdb_txn_free(txn);
+    }
+    if (tidesdb_purge(db) != 0) _exit(8);
+
+    /* single-delete every key but do NOT flush -- these live only in the unified wal */
+    for (int i = 0; i < CRASH_SD_KEY_COUNT; i++)
+    {
+        char key[32];
+        int klen = snprintf(key, sizeof(key), "sd%08d", i);
+        tidesdb_txn_t *txn = NULL;
+        if (tidesdb_txn_begin(db, &txn) != 0) _exit(9);
+        if (tidesdb_txn_single_delete(txn, cf, (uint8_t *)key, (size_t)klen) != 0) _exit(10);
+        if (tidesdb_txn_commit(txn) != 0) _exit(11);
+        tidesdb_txn_free(txn);
+    }
+
+    /* crash, no tidesdb_close, no final flush -- single-deletes are wal-only */
+    _exit(0);
+}
+
+static int crash_single_delete_spawn_child(void)
+{
+    char *child_argv[] = {(char *)g_test_argv0, (char *)CRASH_SD_CHILD_ARG, NULL};
+    return tdb_spawn_wait(g_test_argv0, child_argv);
+}
+
+static void test_crash_single_delete_replay(void)
+{
+    (void)remove_directory(CRASH_RECOVERY_DB_PATH);
+
+    ASSERT_EQ(crash_single_delete_spawn_child(), 0);
+
+    tidesdb_config_t config = tidesdb_default_config();
+    config.db_path = (char *)CRASH_RECOVERY_DB_PATH;
+    config.log_level = TDB_LOG_ERROR;
+    config.unified_memtable = 1;
+    config.unified_memtable_write_buffer_size = CRASH_SD_WRITE_BUFFER;
+
+    tidesdb_t *db = NULL;
+    ASSERT_EQ(tidesdb_open(&config, &db), 0);
+    ASSERT_TRUE(db != NULL);
+    tidesdb_column_family_t *cf = tidesdb_get_column_family(db, CRASH_SD_CF_NAME);
+    ASSERT_TRUE(cf != NULL);
+
+    /* the single-deletes replayed from the unified wal must keep every key deleted -- a
+     * replay that dropped the delete or resurrected the value would fail here */
+    tidesdb_txn_t *txn = NULL;
+    ASSERT_EQ(tidesdb_txn_begin(db, &txn), 0);
+    for (int i = 0; i < CRASH_SD_KEY_COUNT; i++)
+    {
+        char key[32];
+        int klen = snprintf(key, sizeof(key), "sd%08d", i);
+        uint8_t *value = NULL;
+        size_t value_size = 0;
+        int r = tidesdb_txn_get(txn, cf, (uint8_t *)key, (size_t)klen, &value, &value_size);
+        ASSERT_TRUE(r != 0 || value == NULL);
+        if (value) free(value);
+    }
+    tidesdb_txn_free(txn);
+
+    /* full compaction must keep them gone and reclaim the residue */
+    for (int i = 0; i < 8; i++)
+    {
+        tidesdb_compact(cf);
+        wait_for_compaction_idle(db, cf);
+    }
+
+    tidesdb_txn_t *txn2 = NULL;
+    ASSERT_EQ(tidesdb_txn_begin(db, &txn2), 0);
+    for (int i = 0; i < CRASH_SD_KEY_COUNT; i++)
+    {
+        char key[32];
+        int klen = snprintf(key, sizeof(key), "sd%08d", i);
+        uint8_t *value = NULL;
+        size_t value_size = 0;
+        int r = tidesdb_txn_get(txn2, cf, (uint8_t *)key, (size_t)klen, &value, &value_size);
+        ASSERT_TRUE(r != 0 || value == NULL);
+        if (value) free(value);
+    }
+    tidesdb_txn_free(txn2);
+
+    tidesdb_stats_t *stats = NULL;
+    ASSERT_EQ(tidesdb_get_stats(cf, &stats), 0);
+    ASSERT_TRUE(stats != NULL);
+    ASSERT_TRUE(stats->total_keys < (uint64_t)(2 * CRASH_SD_KEY_COUNT));
+    tidesdb_free_stats(stats);
+
+    ASSERT_EQ(tidesdb_close(db), 0);
+    (void)remove_directory(CRASH_RECOVERY_DB_PATH);
+}
+
 /* per-cf and unified memtable modes, each with one and several column
  * families. for every scenario a child writes fsynced data and crashes, then
  * the parent reopens and verifies nothing committed was lost. */
@@ -28511,6 +28713,13 @@ int main(int argc, char **argv)
         return 1; /* workload _exit()s, this is unreachable */
     }
 
+    /* the single-delete crash-replay test re-execs this binary as its crash child */
+    if (argc >= 2 && strcmp(argv[1], CRASH_SD_CHILD_ARG) == 0)
+    {
+        crash_single_delete_child_workload();
+        return 1; /* workload _exit()s, this is unreachable */
+    }
+
     INIT_TEST_FILTER(argc, argv);
     cleanup_test_dir();
     RUN_TEST(test_custom_allocator, tests_passed);
@@ -28537,6 +28746,7 @@ int main(int argc, char **argv)
     RUN_TEST(test_multi_cf_transaction_atomicity_recovery, tests_passed);
     RUN_TEST(test_multi_cf_transaction_recovery_comprehensive, tests_passed);
     RUN_TEST(test_crash_recovery_no_clean_close, tests_passed);
+    RUN_TEST(test_crash_single_delete_replay, tests_passed);
     RUN_TEST(test_iterator_basic, tests_passed);
     RUN_TEST(test_stats, tests_passed);
     RUN_TEST(test_stats_comprehensive, tests_passed);

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -2250,6 +2250,22 @@ static void wait_for_compaction_idle(tidesdb_t *db, tidesdb_column_family_t *cf)
     }
 }
 
+/* point-get that tolerates the retryable TDB_ERR_BUSY the reader fd reserve returns under fd
+ * pressure (low ulimit -n -> small max_open_sstables -> small reader budget; a scan that must open
+ * more sstables than the budget allows is rejected rather than starving flush/compaction of fds).
+ * the reaper frees idle descriptors between attempts, so a bounded retry succeeds. */
+static int tdb_test_get_with_retry(tidesdb_txn_t *txn, tidesdb_column_family_t *cf,
+                                   const uint8_t *k, size_t ksz, uint8_t **v, size_t *vs)
+{
+    int rc = tidesdb_txn_get(txn, cf, k, ksz, v, vs);
+    for (int a = 0; a < 500 && rc == TDB_ERR_BUSY; a++)
+    {
+        usleep(10000);
+        rc = tidesdb_txn_get(txn, cf, k, ksz, v, vs);
+    }
+    return rc;
+}
+
 /* single-delete + put pair-cancel at compaction.
  *
  * we lay down a sstable of puts and a separate sstable of matching single-
@@ -24806,8 +24822,17 @@ static void test_unified_multi_cf_flush_and_recovery(void)
         tidesdb_txn_free(txn);
     }
 
-    /* let background flushes drain */
-    usleep(500000);
+    /* wait for background flushes AND the parallel compaction to settle before verifying. a fixed
+     * sleep is not enough on a slow / fd-constrained runner: while compaction is still churning,
+     * num_open is elevated and a read that must open another sstable is correctly rejected with
+     * TDB_ERR_BUSY by the reader fd reserve, so the get returns non-zero through no fault of the
+     * data. waiting for idle drops num_open below the reserve so reads always proceed. */
+    wait_for_cf_flush_idle(db, cfa);
+    wait_for_cf_flush_idle(db, cfb);
+    wait_for_cf_flush_idle(db, cfc);
+    wait_for_compaction_idle(db, cfa);
+    wait_for_compaction_idle(db, cfb);
+    wait_for_compaction_idle(db, cfc);
 
     /* we verify before close */
     for (int i = 0; i < N; i++)
@@ -24824,19 +24849,19 @@ static void test_unified_multi_cf_flush_and_recovery(void)
         uint8_t *rv = NULL;
         size_t rs = 0;
 
-        ASSERT_EQ(tidesdb_txn_get(txn, cfa, (uint8_t *)key, strlen(key) + 1, &rv, &rs), 0);
+        ASSERT_EQ(tdb_test_get_with_retry(txn, cfa, (uint8_t *)key, strlen(key) + 1, &rv, &rs), 0);
         ASSERT_EQ(rs, strlen(ea) + 1);
         ASSERT_TRUE(memcmp(rv, ea, rs) == 0);
         free(rv);
         rv = NULL;
 
-        ASSERT_EQ(tidesdb_txn_get(txn, cfb, (uint8_t *)key, strlen(key) + 1, &rv, &rs), 0);
+        ASSERT_EQ(tdb_test_get_with_retry(txn, cfb, (uint8_t *)key, strlen(key) + 1, &rv, &rs), 0);
         ASSERT_EQ(rs, strlen(eb) + 1);
         ASSERT_TRUE(memcmp(rv, eb, rs) == 0);
         free(rv);
         rv = NULL;
 
-        ASSERT_EQ(tidesdb_txn_get(txn, cfc, (uint8_t *)key, strlen(key) + 1, &rv, &rs), 0);
+        ASSERT_EQ(tdb_test_get_with_retry(txn, cfc, (uint8_t *)key, strlen(key) + 1, &rv, &rs), 0);
         ASSERT_EQ(rs, strlen(ec) + 1);
         ASSERT_TRUE(memcmp(rv, ec, rs) == 0);
         free(rv);
@@ -24860,6 +24885,14 @@ static void test_unified_multi_cf_flush_and_recovery(void)
     cfc = tidesdb_get_column_family(db, "ucf_fr_c");
     ASSERT_TRUE(cfa != NULL && cfb != NULL && cfc != NULL);
 
+    /* recovery can re-trigger flush/compaction; settle before verifying (see note above) */
+    wait_for_cf_flush_idle(db, cfa);
+    wait_for_cf_flush_idle(db, cfb);
+    wait_for_cf_flush_idle(db, cfc);
+    wait_for_compaction_idle(db, cfa);
+    wait_for_compaction_idle(db, cfb);
+    wait_for_compaction_idle(db, cfc);
+
     for (int i = 0; i < N; i++)
     {
         tidesdb_txn_t *txn = NULL;
@@ -24874,19 +24907,19 @@ static void test_unified_multi_cf_flush_and_recovery(void)
         uint8_t *rv = NULL;
         size_t rs = 0;
 
-        ASSERT_EQ(tidesdb_txn_get(txn, cfa, (uint8_t *)key, strlen(key) + 1, &rv, &rs), 0);
+        ASSERT_EQ(tdb_test_get_with_retry(txn, cfa, (uint8_t *)key, strlen(key) + 1, &rv, &rs), 0);
         ASSERT_EQ(rs, strlen(ea) + 1);
         ASSERT_TRUE(memcmp(rv, ea, rs) == 0);
         free(rv);
         rv = NULL;
 
-        ASSERT_EQ(tidesdb_txn_get(txn, cfb, (uint8_t *)key, strlen(key) + 1, &rv, &rs), 0);
+        ASSERT_EQ(tdb_test_get_with_retry(txn, cfb, (uint8_t *)key, strlen(key) + 1, &rv, &rs), 0);
         ASSERT_EQ(rs, strlen(eb) + 1);
         ASSERT_TRUE(memcmp(rv, eb, rs) == 0);
         free(rv);
         rv = NULL;
 
-        ASSERT_EQ(tidesdb_txn_get(txn, cfc, (uint8_t *)key, strlen(key) + 1, &rv, &rs), 0);
+        ASSERT_EQ(tdb_test_get_with_retry(txn, cfc, (uint8_t *)key, strlen(key) + 1, &rv, &rs), 0);
         ASSERT_EQ(rs, strlen(ec) + 1);
         ASSERT_TRUE(memcmp(rv, ec, rs) == 0);
         free(rv);

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -2206,6 +2206,27 @@ static void wait_for_flush_queue_drain(tidesdb_t *db)
     }
 }
 
+/* wait until a CF is fully flush-idle. an empty flush_queue is NOT sufficient: a flush deferred by
+ * global-cap backpressure leaves the queue empty with flush_deferred set for the reaper to retry,
+ * and a dequeued flush is still in flight until the sstable is added to its level.
+ * flush_pending_count is incremented at enqueue and decremented only after that level-add, so it
+ * has no TOCTOU gap -- mirroring wait_for_compaction_idle's use of compaction_pending_count.
+ * callers that then compact and assert on reaped state must use this, or the compaction can run
+ * before the tombstones land. */
+static void wait_for_cf_flush_idle(tidesdb_t *db, tidesdb_column_family_t *cf)
+{
+    const int max_wait = 600; /* up to ~6s on a slow runner */
+    for (int i = 0; i < max_wait; i++)
+    {
+        if (queue_size(db->flush_queue) == 0 &&
+            atomic_load_explicit(&cf->flush_pending_count, memory_order_acquire) == 0 &&
+            !atomic_load_explicit(&cf->flush_deferred, memory_order_acquire) &&
+            !tidesdb_is_flushing(cf))
+            break;
+        usleep(10000);
+    }
+}
+
 /* helper used by the single-delete compaction tests -- waits for an in-flight
  * compaction to finish so we can assert on post-compaction state. */
 static void wait_for_compaction_idle(tidesdb_t *db, tidesdb_column_family_t *cf)
@@ -2546,7 +2567,7 @@ static void run_put_then_delete_workload(tidesdb_t *db, tidesdb_column_family_t 
         tidesdb_txn_free(txn);
 
         tidesdb_flush_memtable(cf);
-        wait_for_flush_queue_drain(db);
+        wait_for_cf_flush_idle(db, cf);
     }
 
     for (int b = 0; b < num_batches; b++)
@@ -2576,7 +2597,7 @@ static void run_put_then_delete_workload(tidesdb_t *db, tidesdb_column_family_t 
         tidesdb_txn_free(txn);
 
         tidesdb_flush_memtable(cf);
-        wait_for_flush_queue_drain(db);
+        wait_for_cf_flush_idle(db, cf);
     }
 }
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tidesdb",
-  "version-string": "9.3.0",
+  "version-string": "9.3.1",
   "description": "TidesDB is a high-performance durable, transactional embeddable storage engine designed for flash and RAM optimization with optional object storage support for unlimited data scaling.",
   "dependencies": ["zstd", "snappy", "lz4", "pthreads"],
   "features": {


### PR DESCRIPTION
harden correctness, concurrency, and durability across the engine

this is a broad hardening pass covering memory safety, on disk and read
correctness, object store robustness, and silent failure paths, with the
supporting tests.

memory safety and concurrency.
the clock cache reader pin count is a seven bit field that tops out at
127 readers. the acquire used an unconditional fetch add, so the 128th
concurrent pin wrapped the field to zero, the has readers check then saw
none, and the entry was freed while readers still held zero copy
pointers into it. the acquire is now a saturating compare and swap that
refuses the over cap pin and reports a miss instead of wrapping, so the
caller falls back to a fresh read. the flush cleanup path could free an
immutable memtable outside its publish and drain barrier when more than
sixteen accumulated in one pass, a use after free against a concurrent
reader. overflow items are now re queued and reclaimed on the next pass.
resetting a repeatable read or snapshot transaction left its old active
list entry in place while re registration added a second, leaving a
dangling pointer once the transaction was freed. creating two column
families with the same name could append both because the duplicate
check and the registration ran under different locks. on 32 bit msvc
before 2022 the eight byte atomic fallbacks were missing, so every 64
bit atomic was silently truncated or only partially written. that path
still needs to be built and tested on a real 32 bit msvc target.

on disk and read correctness.
reverse comparator btree lookups applied a forward only range gate and
rejected every in range key as not found. the string comparators used
strcmp and read past the key buffer for keys without a terminator, an
out of bounds read. the btree vlog read path took no expected size and
never checked the returned value length, so a truncated block returned
whatever survived the checksum, it now verifies the recorded value size.
manifest loading now rejects a sequence line with trailing garbage,
makes the sequence update monotonic, sizes the directory sync buffer for
real path lengths, and surfaces dropped malformed lines. unified wal
replay now preserves the single delete subtype across recovery and
replica replay so put and single delete pairs stay cancelable at merge.
the compression algorithm enum is duplicated across two headers that
cannot be co included, so its values are now pinned with static asserts
against the on disk codes to fail the build on drift. the dividing merge
btree branch passed a hardcoded not largest level flag and never reaped
regular tombstones at the effective bottom level, so they accumulated
forever in btree mode.

object store.
added a config struct constructor for the s3 connector that carries a
custom ca bundle path, an insecure verify skip for test endpoints, and
runtime multipart threshold and part size. the positional constructor is
now a secure default wrapper over it with no signature change. the
filesystem backend put is now atomic, writing to a unique temp file and
renaming into place so a concurrent reader never sees a partial object.
s3 delete now checks the http status instead of reporting success
whenever the request ran, and the sigv4 signer uri encodes the key so
keys with reserved characters sign correctly. the upload worker now
verifies inside the retry loop, remote wal list and column family drop
deletes retry with backoff and log on exhaustion.

robustness and silent failures.
snappy decompress now verifies the produced size against the size
prefix. local cache eviction unlinks through the helper that clears the
windows read only attribute and surfaces a failed unlink rather than
leaking the file. compaction guards the divisor loop against overflow
and divide by zero, and the level re sort now returns a status that the
merge caller logs on failure instead of merging an unsorted level. the
forward iterator path no longer allocates and can no longer surface a
stale version under memory pressure. the max concurrent flushes default
is tied to the flush pool size so a default open no longer warns and
clamps on every startup.

tests.
two corruption tests were no ops that truncated files that never existed
and passed against intact data, they now find and tear a real wal and a
real sstable footer and assert graceful recovery. added a crash and
replay test for single delete survival and a clock cache regression test
that drives the reader count to saturation and confirms no wrap and no
use after free.