### PR TITLE
add write amplification byte counters and stats

### DIFF
--- a/src/block_manager.c
+++ b/src/block_manager.c
@@ -339,7 +339,7 @@ static int get_file_size(const int fd, uint64_t *size)
 /**
  * reopen_fd
  * closes and reopens the block manager file descriptor with the same flags.
- * NOT safe against concurrent readers: a reader that already captured bm->fd will
+ * NOT safe against concurrent readers, a reader that already captured bm->fd will
  * pread on a closed (possibly recycled) descriptor. callers (truncate, permissive
  * validation) must hold the bm exclusively / quiesce readers first.
  * @param bm the block manager
@@ -1445,6 +1445,11 @@ int block_manager_get_size(block_manager_t *bm, uint64_t *size)
     if (!bm || !size) return -1;
     *size = atomic_load(&bm->current_file_size);
     return 0;
+}
+
+uint64_t block_manager_framed_size(const uint32_t payload_size)
+{
+    return BLOCK_MANAGER_BLOCK_HEADER_SIZE + (uint64_t)payload_size + BLOCK_MANAGER_FOOTER_SIZE;
 }
 
 int block_manager_cursor_goto(block_manager_cursor_t *cursor, const uint64_t pos)

--- a/src/block_manager.h
+++ b/src/block_manager.h
@@ -428,6 +428,16 @@ int block_manager_cursor_goto_first(block_manager_cursor_t *cursor);
 int block_manager_get_size(block_manager_t *bm, uint64_t *size);
 
 /**
+ * block_manager_framed_size
+ * on-disk footprint of a payload once framed (header + payload + footer), i.e. the bytes a
+ * block_manager_write_raw/block_write of this payload appends to the file. lets callers count
+ * framed write volume without depending on the framing layout.
+ * @param payload_size size of the payload in bytes
+ * @return framed size in bytes
+ */
+uint64_t block_manager_framed_size(uint32_t payload_size);
+
+/**
  * block_manager_escalate_fsync
  * escalates an fsync syscall to the underlying block manager file
  * @param bm the block manager to fsync

--- a/src/db.h
+++ b/src/db.h
@@ -363,6 +363,13 @@ typedef struct tidesdb_config_t
  * @param level_tombstone_counts tombstone count per level (parallels level_key_counts)
  * @param max_sst_density worst per-sstable tombstone density observed in the cf
  * @param max_sst_density_level 1-based level where max_sst_density was observed (0 if none)
+ * @param wal_bytes_written framed bytes appended to this cf's WAL (0 in unified mode)
+ * @param flush_bytes_written on-disk bytes this cf's flushes wrote to L0 sstables
+ * @param compaction_bytes_written on-disk bytes this cf's compactions wrote
+ * @param compaction_bytes_read on-disk bytes this cf's compactions read as input
+ * @param user_bytes_written logical key+value bytes committed to this cf (WA denominator)
+ * @param flush_count flushed sstables produced by this cf
+ * @param compaction_count compaction output sstables produced by this cf
  */
 typedef struct tidesdb_stats_t
 {
@@ -387,6 +394,17 @@ typedef struct tidesdb_stats_t
     uint64_t *level_tombstone_counts;
     double max_sst_density;
     int max_sst_density_level;
+    /* write-amplification counters (lifetime since open, on-disk framed bytes). divide the
+     * write totals by user_bytes_written for this cf's write amplification. wal_bytes_written
+     * is zero in unified mode -- the shared WAL volume is reported db-wide in
+     * tidesdb_db_stats_t.uwal_bytes_written. the *_count fields count output sstables. */
+    uint64_t wal_bytes_written;
+    uint64_t flush_bytes_written;
+    uint64_t compaction_bytes_written;
+    uint64_t compaction_bytes_read;
+    uint64_t user_bytes_written;
+    uint64_t flush_count;
+    uint64_t compaction_count;
 } tidesdb_stats_t;
 
 /**
@@ -446,6 +464,14 @@ typedef struct tidesdb_cache_stats_t
  * @param total_uploads lifetime count of objects uploaded to object store
  * @param total_upload_failures lifetime count of permanently failed uploads (after all retries)
  * @param replica_mode whether running in read-only replica mode
+ * @param uwal_bytes_written framed bytes appended to the shared unified WAL (0 if unified off)
+ * @param wal_bytes_written per-cf WAL bytes summed across all column families
+ * @param flush_bytes_written flush output bytes summed across all column families
+ * @param compaction_bytes_written compaction output bytes summed across all column families
+ * @param compaction_bytes_read compaction input bytes summed across all column families
+ * @param user_bytes_written logical committed bytes summed across all column families
+ * @param flush_count flushed sstables summed across all column families
+ * @param compaction_count compaction output sstables summed across all column families
  */
 typedef struct tidesdb_db_stats_t
 {
@@ -480,6 +506,18 @@ typedef struct tidesdb_db_stats_t
     uint64_t total_uploads;
     uint64_t total_upload_failures;
     int replica_mode;
+    /* write-amplification counters (lifetime since open, on-disk framed bytes). uwal is the
+     * shared unified WAL volume (zero when unified mode is off); the remaining fields are
+     * summed across all column families. db-wide WA = (uwal + wal + flush + compaction) /
+     * user bytes. the *_count fields count output sstables, not logical runs. */
+    uint64_t uwal_bytes_written;
+    uint64_t wal_bytes_written;
+    uint64_t flush_bytes_written;
+    uint64_t compaction_bytes_written;
+    uint64_t compaction_bytes_read;
+    uint64_t user_bytes_written;
+    uint64_t flush_count;
+    uint64_t compaction_count;
 } tidesdb_db_stats_t;
 
 /**** system default configuration functions */
@@ -490,7 +528,7 @@ tidesdb_config_t tidesdb_default_config(void);
  * tidesdb_raise_open_file_limit
  * raise this process's open-file ceiling toward `desired` descriptors so a database can keep more
  * sstables open -- the engine sizes max_open_sstables to fit this at open time, so call it BEFORE
- * tidesdb_open. an explicit, opt-in operator action: tidesdb never raises the limit itself. POSIX
+ * tidesdb_open. an explicit, opt-in operator action, tidesdb never raises the limit itself. POSIX
  * (Linux, macOS, the BSDs, illumos) raises the RLIMIT_NOFILE soft limit toward the hard limit;
  * Windows raises the CRT stdio cap (max 8192). a failed or partial raise is non-fatal.
  * @param desired target descriptor count; <= 0 just reports the current ceiling

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -65,7 +65,7 @@ typedef tidesdb_memtable_t tidesdb_immutable_memtable_t;
 #define TDB_KV_FLAG_HAS_TTL   0x02
 #define TDB_KV_FLAG_HAS_VLOG  0x04
 #define TDB_KV_FLAG_DELTA_SEQ                                          \
-    0x08 /* serialization-only: seq is delta-encoded, stripped on read \
+    0x08 /* serialization-only, seq is delta-encoded, stripped on read \
           */
 #define TDB_KV_FLAG_SINGLE_DELETE                                \
     0x10 /* tombstone subtype -- caller promises the key was put \
@@ -8210,6 +8210,17 @@ static int tidesdb_sstable_write_from_heap_btree(tidesdb_column_family_t *cf,
     if (klog_bm) block_manager_escalate_fsync(klog_bm);
     if (vlog_bm) block_manager_escalate_fsync(vlog_bm);
 
+    /* write-amplification -- on-disk bytes this merge output produced. read the managers
+     * directly, the metadata block above lands after sst->klog_size was snapshotted, so a
+     * fresh size also counts framing, bloom and metadata. covers the btree output of every
+     * merge method (full preemptive, targeted, dividing, partitioned) */
+    uint64_t klog_final = 0, vlog_final = 0;
+    block_manager_get_size(klog_bm, &klog_final);
+    block_manager_get_size(vlog_bm, &vlog_final);
+    atomic_fetch_add_explicit(&cf->compaction_bytes_written, klog_final + vlog_final,
+                              memory_order_relaxed);
+    atomic_fetch_add_explicit(&cf->compaction_count, 1, memory_order_relaxed);
+
     return TDB_SUCCESS;
 }
 
@@ -13412,6 +13423,13 @@ static void tidesdb_add_ssts_to_merge_heap(tidesdb_t *db, tidesdb_column_family_
                                   sst->id);
                     tidesdb_merge_source_free(source);
                 }
+                else if (cf)
+                {
+                    /* write-amplification -- on-disk bytes this merge reads as input */
+                    atomic_fetch_add_explicit(&cf->compaction_bytes_read,
+                                              sst->klog_size + sst->vlog_size,
+                                              memory_order_relaxed);
+                }
             }
             else
             {
@@ -13965,7 +13983,13 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
                 {
                     if (source->current_kv &&
                         tidesdb_merge_heap_add_source(heap, source) == TDB_SUCCESS)
+                    {
                         estimated_entries += sst->num_entries;
+                        /* write-amplification -- on-disk bytes this merge reads as input */
+                        atomic_fetch_add_explicit(&cf->compaction_bytes_read,
+                                                  sst->klog_size + sst->vlog_size,
+                                                  memory_order_relaxed);
+                    }
                     else
                         tidesdb_merge_source_free(source);
                 }
@@ -14451,6 +14475,11 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
 
         block_manager_get_size(klog_bm, &new_sst->klog_size);
         block_manager_get_size(vlog_bm, &new_sst->vlog_size);
+
+        /* write-amplification -- on-disk bytes this preemptive-merge output produced */
+        atomic_fetch_add_explicit(&cf->compaction_bytes_written,
+                                  new_sst->klog_size + new_sst->vlog_size, memory_order_relaxed);
+        atomic_fetch_add_explicit(&cf->compaction_count, 1, memory_order_relaxed);
 
         tidesdb_merge_heap_free(heap);
 
@@ -15057,6 +15086,11 @@ static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t
     block_manager_get_size(klog_bm, &new_sst->klog_size);
     block_manager_get_size(vlog_bm, &new_sst->vlog_size);
 
+    /* write-amplification -- on-disk bytes this targeted-merge output produced */
+    atomic_fetch_add_explicit(&cf->compaction_bytes_written,
+                              new_sst->klog_size + new_sst->vlog_size, memory_order_relaxed);
+    atomic_fetch_add_explicit(&cf->compaction_count, 1, memory_order_relaxed);
+
     tidesdb_merge_heap_free(heap);
 
     block_manager_escalate_fsync(klog_bm);
@@ -15504,6 +15538,10 @@ static int tidesdb_dividing_merge_partition(void *vctx, int partition)
                         if (tidesdb_merge_heap_add_source(partition_heap, source) == TDB_SUCCESS)
                         {
                             partition_entries += sst->num_entries;
+                            /* write-amplification -- on-disk bytes this merge reads as input */
+                            atomic_fetch_add_explicit(&cf->compaction_bytes_read,
+                                                      sst->klog_size + sst->vlog_size,
+                                                      memory_order_relaxed);
                         }
                         else
                         {
@@ -16004,6 +16042,11 @@ static int tidesdb_dividing_merge_partition(void *vctx, int partition)
         block_manager_get_size(klog_bm, &new_sst->klog_size);
         block_manager_get_size(vlog_bm, &new_sst->vlog_size);
 
+        /* write-amplification -- on-disk bytes this dividing-merge partition output produced */
+        atomic_fetch_add_explicit(&cf->compaction_bytes_written,
+                                  new_sst->klog_size + new_sst->vlog_size, memory_order_relaxed);
+        atomic_fetch_add_explicit(&cf->compaction_count, 1, memory_order_relaxed);
+
         /* we keep block managers open for immediate reads, reaper will close if needed once it's
          * evicted */
         new_sst->klog_bm = klog_bm;
@@ -16172,6 +16215,11 @@ static int tdb_partitioned_merge_finalize_sst(
 
     block_manager_get_size(klog_bm, &sst->klog_size);
     block_manager_get_size(vlog_bm, &sst->vlog_size);
+
+    /* write-amplification -- on-disk bytes this partitioned-merge output produced */
+    atomic_fetch_add_explicit(&cf->compaction_bytes_written, sst->klog_size + sst->vlog_size,
+                              memory_order_relaxed);
+    atomic_fetch_add_explicit(&cf->compaction_count, 1, memory_order_relaxed);
 
     block_manager_close(klog_bm);
     block_manager_close(vlog_bm);
@@ -16640,6 +16688,10 @@ static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
                         if (tidesdb_merge_heap_add_source(heap, source) == TDB_SUCCESS)
                         {
                             estimated_entries += sst->num_entries;
+                            /* write-amplification -- on-disk bytes this merge reads as input */
+                            atomic_fetch_add_explicit(&cf->compaction_bytes_read,
+                                                      sst->klog_size + sst->vlog_size,
+                                                      memory_order_relaxed);
                         }
                         else
                         {
@@ -17930,6 +17982,12 @@ static int tidesdb_wal_replay_into(tidesdb_column_family_t *cf, block_manager_t 
                     skip_list_put_with_seq(target, key, entry.key_size, value, entry.value_size,
                                            entry.ttl, entry.seq, 0);
                 }
+
+                /* replayed entries re-enter the memtable, so they count toward the
+                 * write-amplification denominator the same as a live commit -- otherwise a
+                 * post-restart flush of recovered data would have no matching ingest bytes */
+                atomic_fetch_add_explicit(&cf->user_bytes_written,
+                                          entry.key_size + entry.value_size, memory_order_relaxed);
             }
 
             block_manager_block_release(block);
@@ -18279,6 +18337,13 @@ static void *tidesdb_flush_worker_thread(void *arg)
              * flush_pending counter in place, the retry will release them */
             continue;
         }
+
+        /* write-amplification -- on-disk bytes this flush produced (klog + vlog, framing,
+         * index and bloom blobs included). klog_size/vlog_size are finalized by the footer
+         * write inside the writer above. one flushed L0 sstable per flush on the per-cf path */
+        atomic_fetch_add_explicit(&cf->flush_bytes_written, sst->klog_size + sst->vlog_size,
+                                  memory_order_relaxed);
+        atomic_fetch_add_explicit(&cf->flush_count, 1, memory_order_relaxed);
 
         /* we must always sync sstable files regardless of sync_mode
          * sstable durability is required before we can delete WAL */
@@ -27435,6 +27500,13 @@ static int tidesdb_unified_write_cf_sstable(tidesdb_t *db, tidesdb_column_family
         return TDB_SUCCESS;
     }
 
+    /* write-amplification -- this unified split produced one L0 sstable for this CF.
+     * count its on-disk bytes against the CF the segment belongs to (not db-wide) so
+     * per-cf flush volume stays correct in unified mode */
+    atomic_fetch_add_explicit(&cf->flush_bytes_written, sst->klog_size + sst->vlog_size,
+                              memory_order_relaxed);
+    atomic_fetch_add_explicit(&cf->flush_count, 1, memory_order_relaxed);
+
     tidesdb_level_add_sstable(cf->levels[0], sst);
     tidesdb_bump_sstable_layout_version(cf);
 
@@ -28029,6 +28101,9 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
                 atomic_fetch_sub_explicit(&umt->refcount, 1, memory_order_release);
                 return TDB_ERR_IO;
             }
+            atomic_fetch_add_explicit(&txn->db->uwal_bytes_written,
+                                      block_manager_framed_size((uint32_t)uwal_size),
+                                      memory_order_relaxed);
         }
 
         if (uwal_batch && uwal_batch != uwal_stack_buf) free(uwal_batch);
@@ -28092,6 +28167,17 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
                 }
                 atomic_store_explicit(&txn->db->unified_mt.is_flushing, 0, memory_order_release);
             }
+        }
+
+        /* write-amplification denominator -- logical key+value bytes this commit ingested,
+         * attributed per op to its own CF (unified batches span CFs). counted on the unified
+         * success path; the per-cf path below has its own matching accounting */
+        for (int op_idx = 0; op_idx < txn->num_ops; op_idx++)
+        {
+            const tidesdb_txn_op_t *op = &txn->ops[op_idx];
+            if (!op->cf) continue;
+            atomic_fetch_add_explicit(&op->cf->user_bytes_written, op->key_size + op->value_size,
+                                      memory_order_relaxed);
         }
 
         txn->is_committed = 1;
@@ -28269,6 +28355,9 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
                 if (wal_is_heap) free(wal_batch);
                 goto cleanup_error_io;
             }
+            atomic_fetch_add_explicit(&cf->wal_bytes_written,
+                                      block_manager_framed_size((uint32_t)wal_size),
+                                      memory_order_relaxed);
         }
 
         if (wal_is_heap) free(wal_batch);
@@ -28344,6 +28433,18 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
     {
         free(cf_memtables);
         free(cf_skiplists);
+    }
+
+    /* write-amplification denominator -- logical key+value bytes this commit ingested,
+     * attributed per op to its own CF. this is the per-cf commit path; the unified path
+     * above has its own matching accounting. WAL replay accounts the same way so the ratio
+     * survives restart */
+    for (int op_idx = 0; op_idx < txn->num_ops; op_idx++)
+    {
+        const tidesdb_txn_op_t *op = &txn->ops[op_idx];
+        if (!op->cf) continue;
+        atomic_fetch_add_explicit(&op->cf->user_bytes_written, op->key_size + op->value_size,
+                                  memory_order_relaxed);
     }
 
     txn->is_committed = 1;
@@ -33059,6 +33160,20 @@ int tidesdb_get_stats(tidesdb_column_family_t *cf, tidesdb_stats_t **stats)
         }
     }
 
+    /* write-amplification counters -- relaxed snapshot, observe-only */
+    (*stats)->wal_bytes_written =
+        atomic_load_explicit(&cf->wal_bytes_written, memory_order_relaxed);
+    (*stats)->flush_bytes_written =
+        atomic_load_explicit(&cf->flush_bytes_written, memory_order_relaxed);
+    (*stats)->compaction_bytes_written =
+        atomic_load_explicit(&cf->compaction_bytes_written, memory_order_relaxed);
+    (*stats)->compaction_bytes_read =
+        atomic_load_explicit(&cf->compaction_bytes_read, memory_order_relaxed);
+    (*stats)->user_bytes_written =
+        atomic_load_explicit(&cf->user_bytes_written, memory_order_relaxed);
+    (*stats)->flush_count = atomic_load_explicit(&cf->flush_count, memory_order_relaxed);
+    (*stats)->compaction_count = atomic_load_explicit(&cf->compaction_count, memory_order_relaxed);
+
     return TDB_SUCCESS;
 }
 
@@ -33142,8 +33257,25 @@ int tidesdb_get_db_stats(tidesdb_t *db, tidesdb_db_stats_t *stats)
             stats->total_data_size_bytes +=
                 (int64_t)atomic_load_explicit(&lvl->current_size, memory_order_relaxed);
         }
+
+        /* write-amplification counters fold across CFs -- uwal is read once below */
+        stats->wal_bytes_written +=
+            atomic_load_explicit(&cf->wal_bytes_written, memory_order_relaxed);
+        stats->flush_bytes_written +=
+            atomic_load_explicit(&cf->flush_bytes_written, memory_order_relaxed);
+        stats->compaction_bytes_written +=
+            atomic_load_explicit(&cf->compaction_bytes_written, memory_order_relaxed);
+        stats->compaction_bytes_read +=
+            atomic_load_explicit(&cf->compaction_bytes_read, memory_order_relaxed);
+        stats->user_bytes_written +=
+            atomic_load_explicit(&cf->user_bytes_written, memory_order_relaxed);
+        stats->flush_count += atomic_load_explicit(&cf->flush_count, memory_order_relaxed);
+        stats->compaction_count +=
+            atomic_load_explicit(&cf->compaction_count, memory_order_relaxed);
     }
     pthread_rwlock_unlock(&db->cf_list_lock);
+
+    stats->uwal_bytes_written = atomic_load_explicit(&db->uwal_bytes_written, memory_order_relaxed);
 
     /* unified memtable stats */
     stats->unified_memtable_enabled = db->unified_mt.enabled;

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -595,6 +595,21 @@ struct tidesdb_column_family_t
     /* unified memtable mode -- 4-byte big-endian CF prefix for keys in the shared skip list */
     uint32_t unified_cf_index;
 
+    /* write-amplification instrumentation -- lifetime, relaxed, observe-only. byte counters
+     * are on-disk (framed) totals-- wal counts framed WAL appends (stays zero in unified mode,
+     * where the shared uwal counter on tidesdb_t carries it), flush and compaction count
+     * finished sstable file sizes (klog_size + vlog_size), user counts logical key+value bytes
+     * committed (incremented on commit apply and on WAL replay so the denominator matches the
+     * data actually flushed). the *_count fields count output sstables, not logical runs -- a
+     * single triggered compaction can produce several. zero-initialized by the cf calloc */
+    _Atomic(uint64_t) wal_bytes_written;
+    _Atomic(uint64_t) flush_bytes_written;
+    _Atomic(uint64_t) compaction_bytes_written;
+    _Atomic(uint64_t) compaction_bytes_read;
+    _Atomic(uint64_t) user_bytes_written;
+    _Atomic(uint64_t) flush_count;
+    _Atomic(uint64_t) compaction_count;
+
     /* last-emit timestamps (seconds) for throttled backpressure warnings -- see tdb_log_throttle.
      * zero-initialized by calloc, so the first event in each category logs immediately. */
     _Atomic(time_t) last_ceiling_stall_log_sec;
@@ -816,7 +831,7 @@ struct tidesdb_t
     _Atomic(int) is_recovering;
     /* set by tidesdb_cancel_background_work -- when non-zero, in-flight compactions
      * bail at their next checkpoint and queued compaction work items are skipped.
-     * compaction-only: flushes are unaffected so durability is preserved. sticky for
+     * compaction-only, flushes are unaffected so durability is preserved. sticky for
      * the db session, reset to 0 on open. */
     _Atomic(int) cancel_compaction;
     _Atomic(tidesdb_comparator_entry_t *) comparators;
@@ -868,6 +883,11 @@ struct tidesdb_t
     _Atomic(int) flush_pending_count;
     _Atomic(int) active_flushes;
     _Atomic(uint64_t) flush_heartbeat;
+    /* write-amplification instrumentation -- lifetime, relaxed, observe-only. uwal is
+     * db-scoped because the unified WAL is shared across CFs; the per-cf flush, compaction
+     * and wal byte counters live on tidesdb_column_family_t and their db-level sums are
+     * folded across CFs in tidesdb_get_db_stats */
+    _Atomic(uint64_t) uwal_bytes_written;
     int os_check_counter;
     pthread_rwlock_t cf_list_lock;
     _Atomic(tidesdb_deferred_free_node_t *) deferred_free_list;
@@ -1085,6 +1105,13 @@ struct tidesdb_iter_t
  * @param level_tombstone_counts tombstone count per level (parallels level_key_counts)
  * @param max_sst_density worst per-sstable tombstone density observed in the cf
  * @param max_sst_density_level 1-based level where max_sst_density was observed (0 if none)
+ * @param wal_bytes_written framed bytes appended to this cf's WAL (0 in unified mode)
+ * @param flush_bytes_written on-disk bytes this cf's flushes wrote to L0 sstables
+ * @param compaction_bytes_written on-disk bytes this cf's compactions wrote
+ * @param compaction_bytes_read on-disk bytes this cf's compactions read as input
+ * @param user_bytes_written logical key+value bytes committed to this cf (WA denominator)
+ * @param flush_count flushed sstables produced by this cf
+ * @param compaction_count compaction output sstables produced by this cf
  */
 struct tidesdb_stats_t
 {
@@ -1111,6 +1138,17 @@ struct tidesdb_stats_t
     uint64_t *level_tombstone_counts;
     double max_sst_density;
     int max_sst_density_level;
+    /* write-amplification counters (lifetime since open, on-disk framed bytes). divide the
+     * write totals by user_bytes_written for this cf's write amplification. wal_bytes_written
+     * is zero in unified mode -- the shared WAL volume is reported db-wide in
+     * tidesdb_db_stats_t.uwal_bytes_written. the *_count fields count output sstables. */
+    uint64_t wal_bytes_written;
+    uint64_t flush_bytes_written;
+    uint64_t compaction_bytes_written;
+    uint64_t compaction_bytes_read;
+    uint64_t user_bytes_written;
+    uint64_t flush_count;
+    uint64_t compaction_count;
 };
 
 /**
@@ -1170,6 +1208,14 @@ typedef struct tidesdb_cache_stats_t
  * @param total_uploads lifetime count of objects uploaded to object store
  * @param total_upload_failures lifetime count of permanently failed uploads (after all retries)
  * @param replica_mode whether running in read-only replica mode
+ * @param uwal_bytes_written framed bytes appended to the shared unified WAL (0 if unified off)
+ * @param wal_bytes_written per-cf WAL bytes summed across all column families
+ * @param flush_bytes_written flush output bytes summed across all column families
+ * @param compaction_bytes_written compaction output bytes summed across all column families
+ * @param compaction_bytes_read compaction input bytes summed across all column families
+ * @param user_bytes_written logical committed bytes summed across all column families
+ * @param flush_count flushed sstables summed across all column families
+ * @param compaction_count compaction output sstables summed across all column families
  */
 typedef struct tidesdb_db_stats_t
 {
@@ -1204,6 +1250,18 @@ typedef struct tidesdb_db_stats_t
     uint64_t total_uploads;
     uint64_t total_upload_failures;
     int replica_mode;
+    /* write-amplification counters (lifetime since open, on-disk framed bytes). uwal is the
+     * shared unified WAL volume (zero when unified mode is off); the remaining fields are
+     * summed across all column families. db-wide WA = (uwal + wal + flush + compaction) /
+     * user bytes. the *_count fields count output sstables, not logical runs. */
+    uint64_t uwal_bytes_written;
+    uint64_t wal_bytes_written;
+    uint64_t flush_bytes_written;
+    uint64_t compaction_bytes_written;
+    uint64_t compaction_bytes_read;
+    uint64_t user_bytes_written;
+    uint64_t flush_count;
+    uint64_t compaction_count;
 } tidesdb_db_stats_t;
 
 /**
@@ -1231,7 +1289,7 @@ int tidesdb_open(const tidesdb_config_t *config, tidesdb_t **db);
  * tidesdb_raise_open_file_limit
  * raise this process's open-file ceiling toward `desired` descriptors so a database can keep more
  * sstables open -- the engine sizes max_open_sstables to fit this at open time, so call it BEFORE
- * tidesdb_open. an explicit, opt-in operator action: tidesdb never raises the limit itself. POSIX
+ * tidesdb_open. an explicit, opt-in operator action, tidesdb never raises the limit itself. POSIX
  * raises the RLIMIT_NOFILE soft limit toward the hard limit; Windows raises the CRT stdio cap
  * (max 8192). a failed or partial raise is non-fatal -- the prior ceiling stands.
  * @param desired target descriptor count; <= 0 just reports the current ceiling
@@ -1925,7 +1983,7 @@ int tidesdb_purge(tidesdb_t *db);
 
 /**
  * tidesdb_cancel_background_work
- * cancels background compaction db-wide: in-flight merges bail at their next
+ * cancels background compaction db-wide this means in-flight merges bail at their next
  * checkpoint (uncommitted output is discarded, inputs left intact -- recovery-safe)
  * and queued compaction work is skipped. flushes are unaffected so durability is
  * preserved. blocks (bounded) until compaction is idle. the cancel is sticky for

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -1638,6 +1638,382 @@ static void test_stats_comprehensive(void)
     cleanup_test_dir();
 }
 
+static void test_amplification_counters_classic(void)
+{
+    cleanup_test_dir();
+    tidesdb_t *db = create_test_db(); /* classic per-cf WAL, unified off */
+    tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
+    cf_config.write_buffer_size = 4096; /* small so flushes and compaction happen */
+
+    ASSERT_EQ(tidesdb_create_column_family(db, "amp_cf", &cf_config), 0);
+    tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "amp_cf");
+    ASSERT_TRUE(cf != NULL);
+
+    /* commit unique rows -- drives the wal and user-bytes counters */
+    uint64_t logical_bytes = 0;
+    for (int i = 0; i < 400; i++)
+    {
+        tidesdb_txn_t *txn = NULL;
+        ASSERT_EQ(tidesdb_txn_begin(db, &txn), 0);
+
+        char key[32];
+        char value[128];
+        int klen = snprintf(key, sizeof(key), "amp_key_%05d", i) + 1;
+        int vlen = snprintf(value, sizeof(value), "amp_value_%05d_padding_padding_padding", i) + 1;
+
+        ASSERT_EQ(tidesdb_txn_put(txn, cf, (uint8_t *)key, klen, (uint8_t *)value, vlen, 0), 0);
+        ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+        tidesdb_txn_free(txn);
+        logical_bytes += (uint64_t)(klen + vlen);
+    }
+
+    tidesdb_stats_t *stats = NULL;
+    ASSERT_EQ(tidesdb_get_stats(cf, &stats), TDB_SUCCESS);
+    /* classic mode -- the per-cf WAL carries every commit, user bytes equal logical ingest
+     * (unique keys, no in-txn supersession) and the framed WAL total exceeds it */
+    ASSERT_TRUE(stats->wal_bytes_written > 0);
+    ASSERT_EQ(stats->user_bytes_written, logical_bytes);
+    ASSERT_TRUE(stats->wal_bytes_written > stats->user_bytes_written);
+    tidesdb_free_stats(stats);
+    stats = NULL;
+
+    /* flush -- drives the flush byte and count counters */
+    ASSERT_EQ(tidesdb_flush_memtable(cf), TDB_SUCCESS);
+    int wait = 0;
+    while (tidesdb_is_flushing(cf) && wait < 200)
+    {
+        usleep(10000);
+        wait++;
+    }
+    for (int i = 0; i < 200; i++)
+    {
+        if (queue_size(db->flush_queue) == 0) break;
+        usleep(50000);
+    }
+
+    ASSERT_EQ(tidesdb_get_stats(cf, &stats), TDB_SUCCESS);
+    ASSERT_TRUE(stats->flush_bytes_written > 0);
+    ASSERT_TRUE(stats->flush_count > 0);
+    tidesdb_free_stats(stats);
+    stats = NULL;
+
+    /* full compaction -- drives the compaction write/read byte and count counters */
+    tidesdb_compact(cf);
+    for (int i = 0; i < 200; i++)
+    {
+        int is_compacting = atomic_load_explicit(&cf->is_compacting, memory_order_acquire);
+        if (queue_size(db->compaction_queue) == 0 && !is_compacting)
+        {
+            usleep(100000);
+            break;
+        }
+        usleep(50000);
+    }
+
+    ASSERT_EQ(tidesdb_get_stats(cf, &stats), TDB_SUCCESS);
+    ASSERT_TRUE(stats->compaction_bytes_written > 0);
+    ASSERT_TRUE(stats->compaction_bytes_read > 0);
+    ASSERT_TRUE(stats->compaction_count > 0);
+    tidesdb_free_stats(stats);
+    stats = NULL;
+
+    /* db-level sums fold the single cf; uwal stays zero when unified mode is off */
+    tidesdb_db_stats_t dbs;
+    ASSERT_EQ(tidesdb_get_db_stats(db, &dbs), TDB_SUCCESS);
+    ASSERT_EQ(dbs.uwal_bytes_written, (uint64_t)0);
+    ASSERT_TRUE(dbs.wal_bytes_written > 0);
+    ASSERT_TRUE(dbs.flush_bytes_written > 0);
+    ASSERT_TRUE(dbs.compaction_bytes_written > 0);
+    ASSERT_EQ(dbs.user_bytes_written, logical_bytes);
+
+    tidesdb_close(db);
+    cleanup_test_dir();
+}
+
+static void test_amplification_counters_unified(void)
+{
+    cleanup_test_dir();
+    tidesdb_config_t config = tidesdb_default_config();
+    config.db_path = TEST_DB_PATH;
+    config.unified_memtable = 1;
+    config.unified_memtable_write_buffer_size = 8192; /* small to force unified flushes */
+
+    tidesdb_t *db = NULL;
+    ASSERT_EQ(tidesdb_open(&config, &db), 0);
+    ASSERT_TRUE(db != NULL);
+
+    tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
+    const char *cf_names[] = {"u1", "u2"};
+    tidesdb_column_family_t *cfs[2];
+    for (int c = 0; c < 2; c++)
+    {
+        ASSERT_EQ(tidesdb_create_column_family(db, cf_names[c], &cf_config), 0);
+        cfs[c] = tidesdb_get_column_family(db, cf_names[c]);
+        ASSERT_TRUE(cfs[c] != NULL);
+    }
+
+    /* spread commits across both CFs in the shared unified memtable */
+    for (int i = 0; i < 400; i++)
+    {
+        tidesdb_txn_t *txn = NULL;
+        ASSERT_EQ(tidesdb_txn_begin(db, &txn), 0);
+
+        char key[32];
+        char value[128];
+        int klen = snprintf(key, sizeof(key), "u_key_%05d", i) + 1;
+        int vlen = snprintf(value, sizeof(value), "u_value_%05d_padding_padding", i) + 1;
+
+        ASSERT_EQ(tidesdb_txn_put(txn, cfs[i % 2], (uint8_t *)key, klen, (uint8_t *)value, vlen, 0),
+                  0);
+        ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+        tidesdb_txn_free(txn);
+    }
+
+    /* the unified WAL is shared and db-scoped -- it carries the write volume while the
+     * per-cf WAL counters stay zero */
+    tidesdb_db_stats_t dbs;
+    ASSERT_EQ(tidesdb_get_db_stats(db, &dbs), TDB_SUCCESS);
+    ASSERT_TRUE(dbs.uwal_bytes_written > 0);
+    ASSERT_TRUE(dbs.user_bytes_written > 0);
+    ASSERT_EQ(dbs.wal_bytes_written, (uint64_t)0);
+
+    tidesdb_stats_t *s0 = NULL;
+    ASSERT_EQ(tidesdb_get_stats(cfs[0], &s0), TDB_SUCCESS);
+    ASSERT_EQ(s0->wal_bytes_written, (uint64_t)0);
+    ASSERT_TRUE(s0->user_bytes_written > 0);
+    tidesdb_free_stats(s0);
+
+    /* drain any pending unified flushes, then confirm flush volume landed per-cf */
+    for (int i = 0; i < 200; i++)
+    {
+        if (queue_size(db->flush_queue) == 0) break;
+        usleep(50000);
+    }
+    usleep(200000);
+
+    ASSERT_EQ(tidesdb_get_db_stats(db, &dbs), TDB_SUCCESS);
+    ASSERT_TRUE(dbs.flush_bytes_written > 0);
+
+    tidesdb_close(db);
+    cleanup_test_dir();
+}
+
+/* helper -- bulk-load unique rows into a cf and force a flush to L0, draining the queue */
+static void amp_fill_and_flush(tidesdb_t *db, tidesdb_column_family_t *cf, int start, int count)
+{
+    for (int i = start; i < start + count; i++)
+    {
+        tidesdb_txn_t *txn = NULL;
+        ASSERT_EQ(tidesdb_txn_begin(db, &txn), 0);
+
+        char key[32];
+        char value[128];
+        int klen = snprintf(key, sizeof(key), "amp_key_%06d", i) + 1;
+        int vlen = snprintf(value, sizeof(value), "amp_value_%06d_padding_padding_padding", i) + 1;
+
+        ASSERT_EQ(tidesdb_txn_put(txn, cf, (uint8_t *)key, klen, (uint8_t *)value, vlen, 0), 0);
+        ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+        tidesdb_txn_free(txn);
+    }
+
+    ASSERT_EQ(tidesdb_flush_memtable(cf), TDB_SUCCESS);
+    int wait = 0;
+    while (tidesdb_is_flushing(cf) && wait < 200)
+    {
+        usleep(10000);
+        wait++;
+    }
+    for (int i = 0; i < 200; i++)
+    {
+        if (queue_size(db->flush_queue) == 0) break;
+        usleep(50000);
+    }
+}
+
+/* helper -- block until the cf's compaction queue drains and no merge is in flight */
+static void amp_wait_compaction(tidesdb_t *db, tidesdb_column_family_t *cf)
+{
+    for (int i = 0; i < 300; i++)
+    {
+        int is_compacting = atomic_load_explicit(&cf->is_compacting, memory_order_acquire);
+        if (queue_size(db->compaction_queue) == 0 && !is_compacting)
+        {
+            usleep(100000);
+            break;
+        }
+        usleep(50000);
+    }
+}
+
+static void test_amplification_compaction_btree(void)
+{
+    cleanup_test_dir();
+    tidesdb_t *db = create_test_db();
+    tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
+    cf_config.use_btree = 1; /* exercise the btree merge-output accounting path */
+
+    ASSERT_EQ(tidesdb_create_column_family(db, "amp_btree_cf", &cf_config), 0);
+    tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "amp_btree_cf");
+    ASSERT_TRUE(cf != NULL);
+
+    /* two flushed runs give the full merge overlapping inputs to read and rewrite */
+    amp_fill_and_flush(db, cf, 0, 300);
+    amp_fill_and_flush(db, cf, 300, 300);
+
+    tidesdb_compact(cf);
+    amp_wait_compaction(db, cf);
+
+    tidesdb_stats_t *stats = NULL;
+    ASSERT_EQ(tidesdb_get_stats(cf, &stats), TDB_SUCCESS);
+    ASSERT_TRUE(stats->use_btree == 1);
+    ASSERT_TRUE(stats->compaction_bytes_written > 0);
+    ASSERT_TRUE(stats->compaction_bytes_read > 0);
+    ASSERT_TRUE(stats->compaction_count > 0);
+    tidesdb_free_stats(stats);
+
+    tidesdb_close(db);
+    cleanup_test_dir();
+}
+
+static void test_amplification_compact_range(void)
+{
+    cleanup_test_dir();
+    tidesdb_t *db = create_test_db();
+    tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
+
+    ASSERT_EQ(tidesdb_create_column_family(db, "amp_range_cf", &cf_config), 0);
+    tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "amp_range_cf");
+    ASSERT_TRUE(cf != NULL);
+
+    /* two overlapping flushed runs so a range merge has inputs to read and rewrite */
+    amp_fill_and_flush(db, cf, 0, 300);
+    amp_fill_and_flush(db, cf, 0, 300);
+
+    tidesdb_stats_t *before = NULL;
+    ASSERT_EQ(tidesdb_get_stats(cf, &before), TDB_SUCCESS);
+    uint64_t written_before = before->compaction_bytes_written;
+    uint64_t read_before = before->compaction_bytes_read;
+    uint64_t count_before = before->compaction_count;
+    tidesdb_free_stats(before);
+
+    /* targeted range compaction over the whole key span -- drives tidesdb_targeted_merge */
+    const char *start_key = "amp_key_000000";
+    const char *end_key = "amp_key_999999";
+    ASSERT_EQ(tidesdb_compact_range(cf, (const uint8_t *)start_key, strlen(start_key) + 1,
+                                    (const uint8_t *)end_key, strlen(end_key) + 1),
+              TDB_SUCCESS);
+    amp_wait_compaction(db, cf);
+
+    tidesdb_stats_t *after = NULL;
+    ASSERT_EQ(tidesdb_get_stats(cf, &after), TDB_SUCCESS);
+    ASSERT_TRUE(after->compaction_bytes_written > written_before);
+    ASSERT_TRUE(after->compaction_bytes_read > read_before);
+    ASSERT_TRUE(after->compaction_count > count_before);
+    tidesdb_free_stats(after);
+
+    tidesdb_close(db);
+    cleanup_test_dir();
+}
+
+static void test_amplification_spooky_merges(void)
+{
+    cleanup_test_dir();
+    tidesdb_t *db = create_test_db();
+
+    /* dividing merge -- geometry mirrors test_dividing_merge_strategy */
+    {
+        tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
+        cf_config.write_buffer_size = 256;
+        cf_config.level_size_ratio = 4;
+        cf_config.dividing_level_offset = 1;
+        cf_config.min_levels = 3;
+
+        ASSERT_EQ(tidesdb_create_column_family(db, "amp_div_cf", &cf_config), 0);
+        tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "amp_div_cf");
+        ASSERT_TRUE(cf != NULL);
+
+        for (int i = 0; i < 64; i++)
+        {
+            tidesdb_txn_t *txn = NULL;
+            ASSERT_EQ(tidesdb_txn_begin(db, &txn), 0);
+            char key[32], value[128];
+            int klen = snprintf(key, sizeof(key), "div_key_%04d", i) + 1;
+            int vlen = snprintf(value, sizeof(value), "dividing_value_%04d_with_padding", i) + 1;
+            ASSERT_EQ(tidesdb_txn_put(txn, cf, (uint8_t *)key, klen, (uint8_t *)value, vlen, 0), 0);
+            ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+            tidesdb_txn_free(txn);
+            if (i % 4 == 3)
+            {
+                tidesdb_flush_memtable(cf);
+                usleep(10000);
+            }
+        }
+        for (int i = 0; i < 100; i++)
+        {
+            if (queue_size(db->flush_queue) == 0) break;
+            usleep(10000);
+        }
+
+        tidesdb_compact(cf);
+        amp_wait_compaction(db, cf);
+
+        tidesdb_stats_t *stats = NULL;
+        ASSERT_EQ(tidesdb_get_stats(cf, &stats), TDB_SUCCESS);
+        ASSERT_TRUE(stats->compaction_bytes_written > 0);
+        ASSERT_TRUE(stats->compaction_bytes_read > 0);
+        ASSERT_TRUE(stats->compaction_count > 0);
+        tidesdb_free_stats(stats);
+    }
+
+    /* partitioned merge -- geometry mirrors test_partitioned_merge_strategy */
+    {
+        tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
+        cf_config.write_buffer_size = 150 * 8;
+        cf_config.level_size_ratio = 2;
+        cf_config.dividing_level_offset = 1;
+        cf_config.min_levels = 4;
+
+        ASSERT_EQ(tidesdb_create_column_family(db, "amp_part_cf", &cf_config), 0);
+        tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "amp_part_cf");
+        ASSERT_TRUE(cf != NULL);
+
+        for (int i = 0; i < 150; i++)
+        {
+            tidesdb_txn_t *txn = NULL;
+            ASSERT_EQ(tidesdb_txn_begin(db, &txn), 0);
+            char key[32], value[128];
+            int klen = snprintf(key, sizeof(key), "part_key_%04d", i) + 1;
+            int vlen = snprintf(value, sizeof(value), "partitioned_value_%04d_with_padding", i) + 1;
+            ASSERT_EQ(tidesdb_txn_put(txn, cf, (uint8_t *)key, klen, (uint8_t *)value, vlen, 0), 0);
+            ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+            tidesdb_txn_free(txn);
+            if (i % 5 == 4)
+            {
+                tidesdb_flush_memtable(cf);
+                usleep(10000);
+            }
+        }
+        for (int i = 0; i < 100; i++)
+        {
+            if (queue_size(db->flush_queue) == 0) break;
+            usleep(10000);
+        }
+
+        tidesdb_compact(cf);
+        amp_wait_compaction(db, cf);
+
+        tidesdb_stats_t *stats = NULL;
+        ASSERT_EQ(tidesdb_get_stats(cf, &stats), TDB_SUCCESS);
+        ASSERT_TRUE(stats->compaction_bytes_written > 0);
+        ASSERT_TRUE(stats->compaction_bytes_read > 0);
+        ASSERT_TRUE(stats->compaction_count > 0);
+        tidesdb_free_stats(stats);
+    }
+
+    tidesdb_close(db);
+    cleanup_test_dir();
+}
+
 static void test_cache_stats(void)
 {
     cleanup_test_dir();
@@ -2206,7 +2582,7 @@ static void wait_for_flush_queue_drain(tidesdb_t *db)
     }
 }
 
-/* wait until a CF is fully flush-idle. an empty flush_queue is NOT sufficient: a flush deferred by
+/* wait until a CF is fully flush-idle. an empty flush_queue is NOT sufficient, a flush deferred by
  * global-cap backpressure leaves the queue empty with flush_deferred set for the reaper to retry,
  * and a dequeued flush is still in flight until the sstable is added to its level.
  * flush_pending_count is incremented at enqueue and decremented only after that level-add, so it
@@ -8088,7 +8464,7 @@ static void test_portability_workflow(void)
 
             if (result != 0 || value == NULL)
             {
-                printf("FAILED: Key not found: %s\n", key);
+                printf("FAILED: Key not found (%s)\n", key);
                 ASSERT_EQ(result, 0);
             }
 
@@ -23272,8 +23648,8 @@ static void test_multi_cf_cross_txn_compaction_atomicity(void)
     wait_for_compaction_idle(db, cf_a);
     wait_for_compaction_idle(db, cf_b);
 
-    /* we verify atomicity: every committed pair must be present in BOTH CFs. classify on the exact
-     * return code, not just found-vs-not: a read can return the retryable TDB_ERR_BUSY when
+    /* we verify atomicity every committed pair must be present in BOTH CFs. classify on the exact
+     * return code, not just found-vs-not, a read can return the retryable TDB_ERR_BUSY when
      * background compaction holds the reader fd reserve (common on fd-constrained runners), and
      * BUSY means the key is durably present but momentarily unopenable -- NOT missing. only a
      * definitive TDB_ERR_NOT_FOUND on one side while the other is present is a real cross-CF
@@ -23317,7 +23693,7 @@ static void test_multi_cf_cross_txn_compaction_atomicity(void)
     tidesdb_txn_free(vtxn);
     printf("  atomicity check: both=%d only_a=%d only_b=%d both_absent=%d busy=%d\n", both_present,
            only_a, only_b, both_absent, busy);
-    /* the real invariants: no one-sided loss and no fully-lost committed pair. BUSY pairs are
+    /* the real invariants, no one-sided loss and no fully-lost committed pair. BUSY pairs are
      * present-but-transient, so they count toward the committed total rather than failing. */
     ASSERT_EQ(only_a, 0);
     ASSERT_EQ(only_b, 0);
@@ -25083,7 +25459,7 @@ static void test_unified_multi_cf_flush_and_recovery(void)
     }
 
     /* wait for background flushes AND the parallel compaction to settle before verifying. a fixed
-     * sleep is not enough on a slow / fd-constrained runner: while compaction is still churning,
+     * sleep is not enough on a slow / fd-constrained runner, while compaction is still churning,
      * num_open is elevated and a read that must open another sstable is correctly rejected with
      * TDB_ERR_BUSY by the reader fd reserve, so the get returns non-zero through no fault of the
      * data. waiting for idle drops num_open below the reserve so reads always proceed. */
@@ -25417,7 +25793,7 @@ static void test_unified_concurrent_multi_cf_read_write(void)
     for (int c = 0; c < NUM_CFS; c++) wait_for_cf_flush_idle(db, cfs[c]);
     for (int c = 0; c < NUM_CFS; c++) wait_for_compaction_idle(db, cfs[c]);
 
-    /* verify CF isolation -- each CF should have its own data. one txn per get: a long-lived read
+    /* verify CF isolation -- each CF should have its own data. one txn per get,a long-lived read
      * txn pins every sstable it touches for its lifetime, so reading all 50 keys in a single txn
      * would accumulate open sstables past max_open on an fd-constrained host and the rest would
      * fail with TDB_ERR_BUSY. independent point lookups release each pin, keeping num_open bounded.
@@ -29082,6 +29458,11 @@ int main(int argc, char **argv)
     RUN_TEST(test_iterator_basic, tests_passed);
     RUN_TEST(test_stats, tests_passed);
     RUN_TEST(test_stats_comprehensive, tests_passed);
+    RUN_TEST(test_amplification_counters_classic, tests_passed);
+    RUN_TEST(test_amplification_counters_unified, tests_passed);
+    RUN_TEST(test_amplification_compaction_btree, tests_passed);
+    RUN_TEST(test_amplification_compact_range, tests_passed);
+    RUN_TEST(test_amplification_spooky_merges, tests_passed);
     RUN_TEST(test_cache_stats, tests_passed);
     RUN_TEST(test_cache_stats_disabled, tests_passed);
     RUN_TEST(test_cache_stats_invalid_args, tests_passed);


### PR DESCRIPTION
track on disk byte volume across the write paths so amplification can be measured. all counters are lifetime relaxed atomics counted in framed on disk bytes.

uwal_bytes_written is a db level counter for the shared unified wal. wal_bytes_written, flush_bytes_written, compaction_bytes_written, compaction_bytes_read, user_bytes_written, flush_count and compaction_count live per column family. the db stats fold the per cf counters across all families and read uwal directly.

wal counting happens at the unified and per cf commit writes using a new block_manager_framed_size helper. flush counting reads the finished sstable klog and vlog size at the classic worker and the unified split writer. compaction counting covers every merge output path which is the btree heap writer, full preemptive shard, targeted, dividing and partitioned finalize, plus every merge input add site for the read counter. user bytes are counted on both commit tails attributed per op to its own cf and again on wal replay so the denominator survives restart.

the output fields are appended in lockstep to tidesdb_stats_t and tidesdb_db_stats_t in db.h and tidesdb.h and populated in tidesdb_get_stats and tidesdb_get_db_stats.

adds five tests covering classic and unified modes, btree compaction, range compaction and the spooky dividing and partitioned merges