### PR TITLE
fix: harden code formatter script

### DIFF
--- a/code_formatter.ps1
+++ b/code_formatter.ps1
@@ -1,4 +1,7 @@
 # Before submitting a PR, run this script to format the source code.
+# Usage: .\code_formatter.ps1
+
+$ErrorActionPreference = 'Stop'
 
 $EXCLUDE_DIRS = @('external', 'cmake-build-debug', '.idea', 'build', 'cmake', 'vcpkg_installed')
 

--- a/code_formatter.sh
+++ b/code_formatter.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 # Before submitting a PR, run this script to format the source code.
+# Usage: ./code_formatter.sh
 
 find . \
   \( -path "./external" \


### PR DESCRIPTION
Adds '$ErrorActionPreference = "Stop"' to code_formatter.ps1 so PowerShell aborts on the first failed clang-format invocation instead of silently continuing. Also adds a 'Usage:' comment line to both code_formatter.sh and code_formatter.ps1 to make the invocation form discoverable from the script header. No behavioral changes to the .sh logic (set -euo pipefail was already present).