### PR TITLE
make compression backends optional and tidy the public header docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,16 @@ option(TIDESDB_WITH_S3 "build S3-compatible object store connector (requires lib
 
 # compression backends -- optional, default ON. drop any with -DTIDESDB_WITH_<X>=OFF; a build with
 # all three off has no compression dependencies and supports TDB_COMPRESS_NONE only.
-option(TIDESDB_WITH_SNAPPY "build with Snappy compression support" ON)
+# Snappy has no OmniOS/Illumos package, so its default is OFF on SunOS (still overridable with
+# -DTIDESDB_WITH_SNAPPY=ON). the platform default must be chosen here, before option() creates the
+# cache entry -- option() always seeds the variable, so a post-option "is it set?" test cannot tell
+# a user override from the default and would never disable Snappy on SunOS.
+if(CMAKE_SYSTEM_NAME STREQUAL "SunOS")
+    set(TIDESDB_SNAPPY_DEFAULT OFF)
+else()
+    set(TIDESDB_SNAPPY_DEFAULT ON)
+endif()
+option(TIDESDB_WITH_SNAPPY "build with Snappy compression support" ${TIDESDB_SNAPPY_DEFAULT})
 option(TIDESDB_WITH_LZ4 "build with LZ4 compression support" ON)
 option(TIDESDB_WITH_ZSTD "build with Zstd compression support" ON)
 
@@ -40,11 +49,6 @@ option(TIDESDB_WITH_ZSTD "build with Zstd compression support" ON)
 set(TIDESDB_SNAPPY_TARGET "" CACHE STRING "external Snappy link target/item (empty = autodetect)")
 set(TIDESDB_LZ4_TARGET "" CACHE STRING "external LZ4 link target/item (empty = autodetect)")
 set(TIDESDB_ZSTD_TARGET "" CACHE STRING "external Zstd link target/item (empty = autodetect)")
-
-# Snappy has no OmniOS/Illumos package, so a stock SunOS build drops it by default
-if(CMAKE_SYSTEM_NAME STREQUAL "SunOS" AND NOT DEFINED CACHE{TIDESDB_WITH_SNAPPY})
-    set(TIDESDB_WITH_SNAPPY OFF CACHE BOOL "build with Snappy compression support" FORCE)
-endif()
 
 # mirror TIDESDB_WITH_S3 into TIDESDB_HAS_S3 so configure_file emits the consumer-visible define
 if(TIDESDB_WITH_S3)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ if(TIDESDB_WITH_MIMALLOC)
 endif()
 
 project(tidesdb
-	VERSION 9.3.3
+	VERSION 9.3.4
 	LANGUAGES C)
 
 set(CMAKE_C_STANDARD 11)
@@ -27,9 +27,39 @@ option(TIDESDB_BUILD_TESTS "enable building tests in tidesdb" ON)
 option(ENABLE_READ_PROFILING "Enable read profiling instrumentation" OFF)
 option(TIDESDB_WITH_S3 "build S3-compatible object store connector (requires libcurl + openssl)" OFF)
 
+# compression backends -- optional, default ON. drop any with -DTIDESDB_WITH_<X>=OFF; a build with
+# all three off has no compression dependencies and supports TDB_COMPRESS_NONE only.
+option(TIDESDB_WITH_SNAPPY "build with Snappy compression support" ON)
+option(TIDESDB_WITH_LZ4 "build with LZ4 compression support" ON)
+option(TIDESDB_WITH_ZSTD "build with Zstd compression support" ON)
+
+# explicit link override per backend, for consumers who vendor a compression lib (FetchContent /
+# add_subdirectory) under a target name the auto-probe cannot guess. set to a CMake target or a raw
+# link item, e.g. -DTIDESDB_ZSTD_TARGET=zstd::libzstd_static or -DTIDESDB_ZSTD_TARGET=zstd-neon.
+# empty (default) = probe known target names, then fall back to -l<name>. 
+set(TIDESDB_SNAPPY_TARGET "" CACHE STRING "external Snappy link target/item (empty = autodetect)")
+set(TIDESDB_LZ4_TARGET "" CACHE STRING "external LZ4 link target/item (empty = autodetect)")
+set(TIDESDB_ZSTD_TARGET "" CACHE STRING "external Zstd link target/item (empty = autodetect)")
+
+# Snappy has no OmniOS/Illumos package, so a stock SunOS build drops it by default
+if(CMAKE_SYSTEM_NAME STREQUAL "SunOS" AND NOT DEFINED CACHE{TIDESDB_WITH_SNAPPY})
+    set(TIDESDB_WITH_SNAPPY OFF CACHE BOOL "build with Snappy compression support" FORCE)
+endif()
+
 # mirror TIDESDB_WITH_S3 into TIDESDB_HAS_S3 so configure_file emits the consumer-visible define
 if(TIDESDB_WITH_S3)
     set(TIDESDB_HAS_S3 ON)
+endif()
+
+# mirror the compression options into TIDESDB_HAVE_* for configure_file (consumer-visible defines)
+if(TIDESDB_WITH_SNAPPY)
+    set(TIDESDB_HAVE_SNAPPY ON)
+endif()
+if(TIDESDB_WITH_LZ4)
+    set(TIDESDB_HAVE_LZ4 ON)
+endif()
+if(TIDESDB_WITH_ZSTD)
+    set(TIDESDB_HAVE_ZSTD ON)
 endif()
 
 configure_file(
@@ -130,6 +160,67 @@ set_target_properties(tidesdb PROPERTIES
 
 target_include_directories(tidesdb PRIVATE src)
 
+# private build-time signal that drives the per-backend guards in compress.c
+if(TIDESDB_WITH_SNAPPY)
+    target_compile_definitions(tidesdb PRIVATE TIDESDB_HAVE_SNAPPY)
+endif()
+if(TIDESDB_WITH_LZ4)
+    target_compile_definitions(tidesdb PRIVATE TIDESDB_HAVE_LZ4)
+endif()
+if(TIDESDB_WITH_ZSTD)
+    target_compile_definitions(tidesdb PRIVATE TIDESDB_HAVE_ZSTD)
+endif()
+
+# link one compression backend, resolving its name in three steps so a vendored or system-provided
+# library both work. resolution order:
+#   1. an explicit override in TIDESDB_<X>_TARGET -- a CMake target or raw link item the consumer
+#      passes in. this is the escape hatch for a dependency built under a non-standard target name
+#      (e.g. a FetchContent build named zstd-neon-enabled) where name-probing cannot guess it.
+#   2. a known CMake target already defined in the build (find_package / FetchContent /
+#      add_subdirectory). linking the target carries its include dirs and the in-tree artifact,
+#      which a bare -l<name> cannot -- this is what issue #618 hit on Ubuntu.
+#   3. a bare -l<name> against a system/installed library (the historical fallback).
+# used by every POSIX platform branch below so the behavior is uniform, not Linux-only.
+function(_tidesdb_link_compression libname)
+    string(TOUPPER ${libname} _up)
+    if(TIDESDB_${_up}_TARGET)
+        target_link_libraries(tidesdb PUBLIC ${TIDESDB_${_up}_TARGET})
+        message(STATUS "tidesdb: linking ${libname} via TIDESDB_${_up}_TARGET=${TIDESDB_${_up}_TARGET}")
+        return()
+    endif()
+    set(candidates "")
+    if(libname STREQUAL "zstd")
+        list(APPEND candidates
+                zstd::libzstd_shared zstd::libzstd_static zstd::libzstd
+                libzstd_shared libzstd_static libzstd zstd)
+    elseif(libname STREQUAL "snappy")
+        list(APPEND candidates Snappy::snappy snappy)
+    elseif(libname STREQUAL "lz4")
+        list(APPEND candidates lz4::lz4 LZ4::lz4 lz4)
+    endif()
+    foreach(tgt IN LISTS candidates)
+        if(TARGET ${tgt})
+            target_link_libraries(tidesdb PUBLIC ${tgt})
+            message(STATUS "tidesdb: linking ${libname} via existing target ${tgt}")
+            return()
+        endif()
+    endforeach()
+    target_link_libraries(tidesdb PUBLIC -l${libname})
+endfunction()
+
+# link every compression backend enabled by the -DTIDESDB_WITH_* options through the resolver above
+macro(_tidesdb_link_enabled_compression)
+    if(TIDESDB_WITH_LZ4)
+        _tidesdb_link_compression(lz4)
+    endif()
+    if(TIDESDB_WITH_ZSTD)
+        _tidesdb_link_compression(zstd)
+    endif()
+    if(TIDESDB_WITH_SNAPPY)
+        _tidesdb_link_compression(snappy)
+    endif()
+endmacro()
+
 # find compression libraries.
 # MSVC builds rely on vcpkg, which ships full CMake config packages.
 # MinGW (MSYS2) zstd and lz4 ship only pkg-config (.pc) files, no CMake
@@ -141,13 +232,25 @@ target_include_directories(tidesdb PRIVATE src)
 if(WIN32)
     if(MINGW)
         find_package(PkgConfig REQUIRED)
-        pkg_check_modules(ZSTD REQUIRED IMPORTED_TARGET libzstd)
-        pkg_check_modules(LZ4 REQUIRED IMPORTED_TARGET liblz4)
-        find_package(Snappy CONFIG REQUIRED)
+        if(TIDESDB_WITH_ZSTD)
+            pkg_check_modules(ZSTD REQUIRED IMPORTED_TARGET libzstd)
+        endif()
+        if(TIDESDB_WITH_LZ4)
+            pkg_check_modules(LZ4 REQUIRED IMPORTED_TARGET liblz4)
+        endif()
+        if(TIDESDB_WITH_SNAPPY)
+            find_package(Snappy CONFIG REQUIRED)
+        endif()
     else()
-        find_package(zstd CONFIG REQUIRED)
-        find_package(Snappy CONFIG REQUIRED)
-        find_package(lz4 CONFIG REQUIRED)
+        if(TIDESDB_WITH_ZSTD)
+            find_package(zstd CONFIG REQUIRED)
+        endif()
+        if(TIDESDB_WITH_SNAPPY)
+            find_package(Snappy CONFIG REQUIRED)
+        endif()
+        if(TIDESDB_WITH_LZ4)
+            find_package(lz4 CONFIG REQUIRED)
+        endif()
         find_package(PThreads4W REQUIRED)
     endif()
 endif()
@@ -223,11 +326,10 @@ if(APPLE)
     # Link against compression libraries for macOS
     target_link_libraries(tidesdb PUBLIC
             m           # math library
-            lz4         # lz4 compression
-            zstd        # zstandard compression
-            snappy      # snappy compression
             pthread     # pthread library
     )
+    # resolve compression backends via override -> known target -> -l fallback (issue #618)
+    _tidesdb_link_enabled_compression()
 
     if(CMAKE_SIZEOF_VOID_P EQUAL 4)
         target_link_libraries(tidesdb PUBLIC atomic)
@@ -248,21 +350,30 @@ if(APPLE)
     endif()
 
 elseif(WIN32)
-    # for windows, link against compression libraries and pthreads
+    # for windows, link against the enabled compression libraries and pthreads
     if(MINGW)
-        target_link_libraries(tidesdb PUBLIC
-                PkgConfig::ZSTD
-                PkgConfig::LZ4
-                Snappy::snappy
-                pthread
-        )
+        if(TIDESDB_WITH_ZSTD)
+            target_link_libraries(tidesdb PUBLIC PkgConfig::ZSTD)
+        endif()
+        if(TIDESDB_WITH_LZ4)
+            target_link_libraries(tidesdb PUBLIC PkgConfig::LZ4)
+        endif()
+        if(TIDESDB_WITH_SNAPPY)
+            target_link_libraries(tidesdb PUBLIC Snappy::snappy)
+        endif()
+        target_link_libraries(tidesdb PUBLIC pthread)
     else()
-        target_link_libraries(tidesdb PUBLIC
-                $<IF:$<TARGET_EXISTS:zstd::libzstd_shared>,zstd::libzstd_shared,zstd::libzstd_static>
-                Snappy::snappy
-                lz4::lz4
-                PThreads4W::PThreads4W
-        )
+        if(TIDESDB_WITH_ZSTD)
+            target_link_libraries(tidesdb PUBLIC
+                    $<IF:$<TARGET_EXISTS:zstd::libzstd_shared>,zstd::libzstd_shared,zstd::libzstd_static>)
+        endif()
+        if(TIDESDB_WITH_SNAPPY)
+            target_link_libraries(tidesdb PUBLIC Snappy::snappy)
+        endif()
+        if(TIDESDB_WITH_LZ4)
+            target_link_libraries(tidesdb PUBLIC lz4::lz4)
+        endif()
+        target_link_libraries(tidesdb PUBLIC PThreads4W::PThreads4W)
     endif()
 
     if(TIDESDB_WITH_MIMALLOC)
@@ -277,11 +388,10 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
     target_link_directories(tidesdb PUBLIC /usr/local/lib)
     target_link_libraries(tidesdb PUBLIC
             m           # math library
-            lz4         # lz4 compression
-            zstd        # zstandard compression
-            snappy      # snappy compression
             pthread     # pthread library
     )
+    # resolve compression backends via override -> known target -> -l fallback (issue #618)
+    _tidesdb_link_enabled_compression()
 
     if(TIDESDB_WITH_MIMALLOC)
         target_link_libraries(tidesdb PUBLIC mimalloc)
@@ -302,11 +412,10 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
     target_link_directories(tidesdb PUBLIC /usr/local/lib)
     target_link_libraries(tidesdb PUBLIC
             m           # math library
-            lz4         # lz4 compression
-            zstd        # zstandard compression
-            snappy      # snappy compression
             pthread     # pthread library
     )
+    # resolve compression backends via override -> known target -> -l fallback (issue #618)
+    _tidesdb_link_enabled_compression()
 
     if(TIDESDB_WITH_MIMALLOC)
         target_link_libraries(tidesdb PUBLIC mimalloc)
@@ -327,11 +436,10 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "NetBSD")
     target_link_directories(tidesdb PUBLIC /usr/pkg/lib)
     target_link_libraries(tidesdb PUBLIC
             m           # math library
-            lz4         # lz4 compression
-            zstd        # zstandard compression
-            snappy      # snappy compression
             pthread     # pthread library
     )
+    # resolve compression backends via override -> known target -> -l fallback (issue #618)
+    _tidesdb_link_enabled_compression()
 
     if(TIDESDB_WITH_MIMALLOC)
         target_link_libraries(tidesdb PUBLIC mimalloc)
@@ -352,11 +460,10 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "DragonFly")
     target_link_directories(tidesdb PUBLIC /usr/local/lib)
     target_link_libraries(tidesdb PUBLIC
             m           # math library
-            lz4         # lz4 compression
-            zstd        # zstandard compression
-            snappy      # snappy compression
             pthread     # pthread library
     )
+    # resolve compression backends via override -> known target -> -l fallback (issue #618)
+    _tidesdb_link_enabled_compression()
 
     if(TIDESDB_WITH_MIMALLOC)
         target_link_libraries(tidesdb PUBLIC mimalloc)
@@ -373,15 +480,16 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "DragonFly")
     endif()
 elseif(CMAKE_SYSTEM_NAME STREQUAL "SunOS")
     # OmniOS/Illumos -- OpenIndiana Community Edition packages in /opt/ooce
-    # Note that snappy is not available in OmniOS repos, using only lz4 and zstd
+    # snappy is not packaged for OmniOS, so TIDESDB_WITH_SNAPPY defaults OFF here and the
+    # compression list carries only the backends actually available (lz4/zstd by default)
     target_include_directories(tidesdb PUBLIC /opt/ooce/include /usr/include)
     target_link_directories(tidesdb PUBLIC /opt/ooce/lib/amd64 /usr/lib/amd64)
     target_link_libraries(tidesdb PUBLIC
             m           # math library
-            lz4         # lz4 compression
-            zstd        # zstandard compression
             pthread     # pthread library
     )
+    # resolve compression backends via override -> known target -> -l fallback (snappy off here)
+    _tidesdb_link_enabled_compression()
 
     if(TIDESDB_WITH_MIMALLOC)
         target_link_libraries(tidesdb PUBLIC mimalloc)
@@ -392,46 +500,24 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "SunOS")
         target_include_directories(tidesdb PUBLIC ${TCMALLOC_INCLUDE_DIRS})
     endif()
 else()
-    # for linux and other unix systems
-    # prefer a CMake target if a parent project (FetchContent / add_subdirectory)
-    # has already created one for the compression lib; otherwise fall back to a
-    # bare -l<name> linker flag. the -l fallback exists because some distros
-    # (e.g. Oracle Linux 8, RHEL 8) ship zstd-devel CMake configs that define
-    # zstd::libzstd as a MODULE target and break find_package(zstd CONFIG) for
-    # plain linking. the if(TARGET ...) probe is safe as it only matches when the
-    # parent build has already produced the target, so stand-alone builds on
-    # those distros still take the -l path exactly like before.
-    function(_tidesdb_link_compression libname)
-        set(candidates "")
-        if(libname STREQUAL "zstd")
-            list(APPEND candidates
-                    zstd::libzstd_shared zstd::libzstd_static zstd::libzstd
-                    libzstd_shared libzstd_static libzstd zstd)
-        elseif(libname STREQUAL "snappy")
-            list(APPEND candidates Snappy::snappy snappy)
-        elseif(libname STREQUAL "lz4")
-            list(APPEND candidates lz4::lz4 LZ4::lz4 lz4)
-        endif()
-        foreach(tgt IN LISTS candidates)
-            if(TARGET ${tgt})
-                target_link_libraries(tidesdb PUBLIC ${tgt})
-                message(STATUS "tidesdb: linking ${libname} via existing target ${tgt}")
-                return()
-            endif()
-        endforeach()
-        target_link_libraries(tidesdb PUBLIC -l${libname})
-    endfunction()
-
-    _tidesdb_link_compression(zstd)
-    _tidesdb_link_compression(snappy)
-    _tidesdb_link_compression(lz4)
+    # for linux and other unix systems -- resolve each enabled backend through the shared helper
+    # (override -> known target -> -l fallback). the target probe matters because some distros
+    # (e.g. Oracle Linux 8, RHEL 8) ship zstd-devel CMake configs that define zstd::libzstd as a
+    # MODULE target and break find_package(zstd CONFIG) for plain linking, and a parent build doing
+    # FetchContent / add_subdirectory provides the lib only as a target, never as a system -l.
+    _tidesdb_link_enabled_compression()
 
     target_link_libraries(tidesdb PUBLIC
             pthread
             m           # math library
-            stdc++      # C++ standard library (required by Snappy)
             atomic      # atomic operations library (required for 32-bit architectures like PowerPC)
     )
+
+    # libstdc++ is only pulled in by Snappy's C++ implementation; skip it when Snappy is off so a
+    # no-Snappy build does not acquire a C++ runtime dependency
+    if(TIDESDB_WITH_SNAPPY)
+        target_link_libraries(tidesdb PUBLIC stdc++)
+    endif()
 
     if(TIDESDB_WITH_MIMALLOC)
         target_link_libraries(tidesdb PUBLIC mimalloc)

--- a/src/alloc.h
+++ b/src/alloc.h
@@ -73,7 +73,11 @@ typedef struct tidesdb_allocator_t
     tidesdb_free_fn free_fn;
 } tidesdb_allocator_t;
 
+/* the active allocator backing the tdb_* macros; set by tidesdb_init / tidesdb_ensure_initialized
+ */
 extern tidesdb_allocator_t tidesdb_allocator;
+/* 0 until tidesdb_init (or the lazy tidesdb_ensure_initialized) runs, reset to 0 by
+ * tidesdb_finalize */
 extern _Atomic(int) tidesdb_initialized;
 
 /**
@@ -113,8 +117,11 @@ void tidesdb_ensure_initialized(void);
 #define tdb_free(ptr)           (tidesdb_allocator.free_fn(ptr))
 
 /**
- * override standard allocation functions.
- * this allows existing code using malloc/calloc/realloc/free to automatically
+ * override the standard allocation functions.
+ * past this point malloc/calloc/realloc/free expand to the tdb_* macros above, so existing
+ * code that calls them automatically routes through the configured allocator with no source
+ * changes. this affects every translation unit that includes this header (directly or via
+ * tidesdb.h), which is what keeps all tidesdb allocations and frees on a single allocator.
  */
 #undef malloc
 #undef calloc

--- a/src/block_manager.h
+++ b/src/block_manager.h
@@ -65,8 +65,8 @@
 
 typedef enum
 {
-    BLOCK_MANAGER_SYNC_NONE,
-    BLOCK_MANAGER_SYNC_FULL,
+    BLOCK_MANAGER_SYNC_NONE, /* no per-write fsync; durability left to the caller/group-commit */
+    BLOCK_MANAGER_SYNC_FULL, /* fdatasync each write, unless O_DSYNC already made it durable */
 } block_manager_sync_mode_t;
 
 typedef enum
@@ -109,7 +109,7 @@ typedef struct
 } block_manager_t;
 
 /**
- * block_t
+ * block_manager_block_t
  * block struct
  * used for blocks in TidesDB
  * @param size the size of the data in the block
@@ -126,7 +126,7 @@ typedef struct
 } block_manager_block_t;
 
 /**
- * block_cursor_t
+ * block_manager_cursor_t
  * block cursor struct
  * used for block cursors in TidesDB
  * @param bm the block manager

--- a/src/bloom_filter.h
+++ b/src/bloom_filter.h
@@ -96,6 +96,10 @@ unsigned int bloom_filter_hash(const uint8_t *entry, size_t size, int seed);
 /**
  * bloom_filter_serialize
  * serializes a bloom filter to compact binary format using:
+ * -- optional version prefix -- a v2+ filter leads with a 0x00 sentinel byte followed by the
+ *    hash_version byte (0x00 is impossible for a v1 filter, whose first byte is varint32(m)
+ *    with m >= 1, so the format stays backward compatible); legacy v1 filters omit it and
+ *    deserialize defaults to the legacy hash
  * -- varint encoding for header fields (m, h, non_zero_count)
  * -- sparse encoding     -- only stores non-zero words with their indices
  * typical space savings  -- 70-90% for low fill rates (< 50%)

--- a/src/btree.h
+++ b/src/btree.h
@@ -73,14 +73,17 @@ typedef struct btree_node_t btree_node_t;
 typedef struct btree_entry_t btree_entry_t;
 typedef struct btree_arena_t btree_arena_t;
 
-/**
- * btree_arena_t
- * simple arena allocator for btree nodes to reduce malloc/free overhead
- * allocations are bump-pointer style, freed all at once when arena is destroyed
- */
 #define BTREE_ARENA_BLOCK_SIZE     (64 * 1024) /* 64KB blocks */
 #define BTREE_ARENA_MIN_BLOCK_SIZE 256         /* minimum arena block size */
 
+/**
+ * btree_arena_block_t
+ * one bump-allocated block in a btree_arena_t's block chain
+ * @param data the block's memory buffer
+ * @param size total capacity of the block in bytes
+ * @param used bytes consumed so far (bump pointer offset into data)
+ * @param next next block in the arena's linked list
+ */
 typedef struct btree_arena_block_t
 {
     uint8_t *data;
@@ -464,6 +467,8 @@ int btree_get(btree_t *tree, const uint8_t *key, size_t key_size, uint8_t **valu
 /**
  * btree_get_entry_count
  * returns total number of entries
+ * @param tree the B+tree
+ * @return total number of entries in the tree
  */
 uint64_t btree_get_entry_count(const btree_t *tree);
 
@@ -490,6 +495,8 @@ int btree_get_max_key(btree_t *tree, uint8_t **key, size_t *key_size);
 /**
  * btree_get_max_seq
  * returns maximum sequence number in tree
+ * @param tree the B+tree
+ * @return maximum sequence number across all entries in the tree
  */
 uint64_t btree_get_max_seq(const btree_t *tree);
 

--- a/src/clock_cache.h
+++ b/src/clock_cache.h
@@ -38,6 +38,7 @@ typedef void (*clock_cache_evict_fn)(void *payload, size_t payload_len);
  * @param max_bytes maximum total bytes across all partitions
  * @param num_partitions number of partitions (power of 2 recommended)
  * @param slots_per_partition initial slots per partition
+ * @param avg_entry_size expected average entry size in bytes (0 = use default 100)
  * @param evict_callback optional callback for custom cleanup on eviction (can be NULL)
  */
 typedef struct
@@ -45,7 +46,7 @@ typedef struct
     size_t max_bytes;
     size_t num_partitions;
     size_t slots_per_partition;
-    size_t avg_entry_size; /* expected average entry size in bytes (0 = use default 100) */
+    size_t avg_entry_size;
     clock_cache_evict_fn evict_callback;
 } cache_config_t;
 

--- a/src/compress.c
+++ b/src/compress.c
@@ -19,20 +19,57 @@
 
 #include "compress.h"
 
+/* third-party backend headers, included only when the backend is compiled in. the TIDESDB_HAVE_*
+ * macros are PRIVATE compile definitions set by CMake from the -DTIDESDB_WITH_* options, so a build
+ * can drop any subset (or all) of them and still produce a working library that supports the
+ * remaining algorithms plus TDB_COMPRESS_NONE. */
+#ifdef TIDESDB_HAVE_LZ4
+#include <lz4.h>
+#endif
+#ifdef TIDESDB_HAVE_SNAPPY
+#include <snappy-c.h>
+#endif
+#ifdef TIDESDB_HAVE_ZSTD
+#include <zstd.h>
+#endif
+
 /* the compression_algorithm enum values are an on-disk + ABI contract, they are written into
  * sstable/vlog metadata, so they must never change, and the duplicate enum in db.h (the
  * standalone FFI header, which cannot include this header) MUST hold identical values. pin them
  * at compile time so any drift in compress.h fails the build; db.h carries the matching contract
- * comment. guarded on C11 so older/non-conforming C front-ends still compile. */
+ * comment. the asserts are unconditional -- the enumerators exist regardless of which backends are
+ * compiled in. guarded on C11 so older/non-conforming C front-ends still compile. */
 #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
 _Static_assert(TDB_COMPRESS_NONE == 0, "compression_algorithm wire drift: NONE must be 0");
-#ifndef __sun
 _Static_assert(TDB_COMPRESS_SNAPPY == 1, "compression_algorithm wire drift: SNAPPY must be 1");
-#endif
 _Static_assert(TDB_COMPRESS_LZ4 == 2, "compression_algorithm wire drift: LZ4 must be 2");
 _Static_assert(TDB_COMPRESS_ZSTD == 3, "compression_algorithm wire drift: ZSTD must be 3");
 _Static_assert(TDB_COMPRESS_LZ4_FAST == 4, "compression_algorithm wire drift: LZ4_FAST must be 4");
 #endif
+
+int tidesdb_compression_available(const compression_algorithm type)
+{
+    switch (type)
+    {
+        case TDB_COMPRESS_NONE:
+            return 1;
+#ifdef TIDESDB_HAVE_SNAPPY
+        case TDB_COMPRESS_SNAPPY:
+            return 1;
+#endif
+#ifdef TIDESDB_HAVE_LZ4
+        case TDB_COMPRESS_LZ4:
+        case TDB_COMPRESS_LZ4_FAST:
+            return 1;
+#endif
+#ifdef TIDESDB_HAVE_ZSTD
+        case TDB_COMPRESS_ZSTD:
+            return 1;
+#endif
+        default:
+            return 0;
+    }
+}
 
 uint8_t *compress_data(const uint8_t *data, const size_t data_size, size_t *compressed_size,
                        const compression_algorithm type)
@@ -46,7 +83,7 @@ uint8_t *compress_data(const uint8_t *data, const size_t data_size, size_t *comp
 
     switch (type)
     {
-#ifndef __sun
+#ifdef TIDESDB_HAVE_SNAPPY
         case TDB_COMPRESS_SNAPPY:
         {
             *compressed_size = snappy_max_compressed_length(data_size);
@@ -70,6 +107,7 @@ uint8_t *compress_data(const uint8_t *data, const size_t data_size, size_t *comp
         }
 #endif
 
+#ifdef TIDESDB_HAVE_LZ4
         case TDB_COMPRESS_LZ4:
         case TDB_COMPRESS_LZ4_FAST:
         {
@@ -94,7 +132,9 @@ uint8_t *compress_data(const uint8_t *data, const size_t data_size, size_t *comp
             *compressed_size = (size_t)lz4_result + sizeof(uint64_t);
             break;
         }
+#endif
 
+#ifdef TIDESDB_HAVE_ZSTD
         case TDB_COMPRESS_ZSTD:
         {
             *compressed_size = ZSTD_compressBound(data_size);
@@ -115,6 +155,7 @@ uint8_t *compress_data(const uint8_t *data, const size_t data_size, size_t *comp
             *compressed_size = actual_size + sizeof(uint64_t);
             break;
         }
+#endif
 
         default:
             return NULL;
@@ -143,7 +184,7 @@ uint8_t *decompress_data(const uint8_t *data, const size_t data_size, size_t *de
 
     switch (type)
     {
-#ifndef __sun
+#ifdef TIDESDB_HAVE_SNAPPY
         case TDB_COMPRESS_SNAPPY:
         {
             if (TDB_UNLIKELY(data_size < sizeof(uint64_t)))
@@ -183,6 +224,7 @@ uint8_t *decompress_data(const uint8_t *data, const size_t data_size, size_t *de
         }
 #endif
 
+#ifdef TIDESDB_HAVE_LZ4
         case TDB_COMPRESS_LZ4:
         case TDB_COMPRESS_LZ4_FAST:
         {
@@ -213,7 +255,9 @@ uint8_t *decompress_data(const uint8_t *data, const size_t data_size, size_t *de
             }
             break;
         }
+#endif
 
+#ifdef TIDESDB_HAVE_ZSTD
         case TDB_COMPRESS_ZSTD:
         {
             if (TDB_UNLIKELY(data_size < sizeof(uint64_t)))
@@ -243,6 +287,7 @@ uint8_t *decompress_data(const uint8_t *data, const size_t data_size, size_t *de
             }
             break;
         }
+#endif
 
         default:
             return NULL;

--- a/src/compress.h
+++ b/src/compress.h
@@ -18,25 +18,24 @@
  */
 #ifndef __COMPRESS_H__
 #define __COMPRESS_H__
-#include <lz4.h>
-#ifndef __sun
-#include <snappy-c.h>
-#endif
-#include <zstd.h>
 
 #include "compat.h"
 
-/* snappy, lz4, zstd supported to use for compression purposes */
-/* snappy is not available on SunOS/OmniOS/Illumos */
-/* ABI/on-disk contract, these numeric values are persisted in sstable/vlog metadata and are
+/* snappy, lz4 and zstd are the supported compression backends. each is optional at build time --
+ * the -DTIDESDB_WITH_{SNAPPY,LZ4,ZSTD} CMake options (default ON) select which are compiled in, and
+ * a build with all three off has no compression dependencies at all (TDB_COMPRESS_NONE only). the
+ * third-party headers are included only in compress.c, guarded by the TIDESDB_HAVE_* build macros,
+ * so a consumer of the installed library does not need the compression dev headers just to include
+ * this file.
+ * ABI/on-disk contract -- these numeric values are persisted in sstable/vlog metadata and are
  * duplicated in db.h (the standalone FFI header). the two copies MUST stay identical; compress.c
- * pins these values with _Static_assert to catch drift at build time. */
+ * pins them with _Static_assert to catch drift at build time. every enumerator is defined
+ * regardless of which backends are compiled in, so an sstable's algorithm id is always
+ * recognizable -- an unavailable backend yields a clean runtime error, not an unknown algorithm. */
 typedef enum
 {
     TDB_COMPRESS_NONE = 0,
-#ifndef __sun
     TDB_COMPRESS_SNAPPY = 1,
-#endif
     TDB_COMPRESS_LZ4 = 2,
     TDB_COMPRESS_ZSTD = 3,
     TDB_COMPRESS_LZ4_FAST = 4,
@@ -49,7 +48,8 @@ typedef enum
  * @param data_size the size of the data
  * @param compressed_size the size of the compressed data
  * @param type the compression algorithm to use
- * @return the compressed data
+ * @return newly allocated compressed data (caller frees), or NULL on failure (bad args,
+ *         allocation failure, unsupported type, or a codec error)
  */
 uint8_t *compress_data(const uint8_t *data, size_t data_size, size_t *compressed_size,
                        compression_algorithm type);
@@ -61,9 +61,21 @@ uint8_t *compress_data(const uint8_t *data, size_t data_size, size_t *compressed
  * @param data_size the size of the data
  * @param decompressed_size the size of the decompressed data
  * @param type the compression algorithm to use
- * @return the decompressed data
+ * @return newly allocated decompressed data (caller frees), or NULL on failure (bad args,
+ *         allocation failure, or a codec/corruption error)
  */
 uint8_t *decompress_data(const uint8_t *data, size_t data_size, size_t *decompressed_size,
                          compression_algorithm type);
+
+/**
+ * tidesdb_compression_available
+ * report whether a compression backend is compiled into this build. TDB_COMPRESS_NONE is always
+ * available; the rest depend on the TIDESDB_HAVE_* build flags (which mirror the -DTIDESDB_WITH_*
+ * CMake options). lets callers reject an unsupported algorithm up front instead of failing at
+ * compress/flush time.
+ * @param type the compression algorithm to query
+ * @return 1 if the algorithm can be used in this build, 0 otherwise
+ */
+int tidesdb_compression_available(compression_algorithm type);
 
 #endif /* __COMPRESS_H__ */

--- a/src/db.h
+++ b/src/db.h
@@ -129,13 +129,13 @@ typedef enum
 /** compression algorithms */
 /* ABI/on-disk contract, these numeric values are persisted in sstable/vlog metadata and are
  * duplicated in compress.h. the two copies MUST stay identical -- compress.c _Static_asserts the
- * compress.h copy; keep this copy in lockstep. */
+ * compress.h copy; keep this copy in lockstep. every enumerator is always defined; whether a
+ * backend can actually be used is a build-time choice (the -DTIDESDB_WITH_* options), queryable at
+ * runtime via tidesdb_compression_available. */
 typedef enum
 {
     TDB_COMPRESS_NONE = 0,
-#ifndef __sun
     TDB_COMPRESS_SNAPPY = 1,
-#endif
     TDB_COMPRESS_LZ4 = 2,
     TDB_COMPRESS_ZSTD = 3,
     TDB_COMPRESS_LZ4_FAST = 4
@@ -171,7 +171,11 @@ typedef enum
 #define TDB_MAX_COMPARATOR_CTX  256
 #define TDB_MAX_CF_NAME_LEN     128
 
-/** comparator function type */
+/** comparator function type.
+ * ABI contract -- this MUST stay structurally identical to skip_list_comparator_fn in
+ * skip_list.h. tidesdb_register_comparator / tidesdb_get_comparator are declared with this
+ * type in the FFI header and with skip_list_comparator_fn internally, so the two function
+ * pointer signatures have to match exactly or an FFI caller passes an incompatible callback. */
 typedef int (*tidesdb_comparator_fn)(const uint8_t *key1, size_t key1_size, const uint8_t *key2,
                                      size_t key2_size, void *ctx);
 

--- a/src/local_cache.h
+++ b/src/local_cache.h
@@ -92,7 +92,9 @@ void tdb_local_cache_destroy(tdb_local_cache_t *cache);
 /**
  * tdb_local_cache_track
  * register a file in the cache. stats the file for size, adds to LRU head,
- * and triggers eviction if the cache is over its size limit.
+ * and triggers eviction if the cache is over its size limit. if the file is
+ * already tracked it is simply moved to the LRU head (no duplicate entry and
+ * no eviction) and 0 is returned, so re-tracking is safe and acts as a touch.
  * @param cache      cache manager
  * @param local_path path to the cached file
  * @return 0 on success, -1 on error

--- a/src/manifest.h
+++ b/src/manifest.h
@@ -54,7 +54,9 @@ typedef struct
  * @param capacity capacity of entries array
  * @param sequence current global sequence number
  * @param path path to manifest file
- * @param fp file pointer (kept open for efficient commits)
+ * @param fp read-mode handle to the manifest file; opened when the manifest is parsed and
+ *           reopened after each commit. commits write a temp file and atomically rename it into
+ *           place, so they never write through this handle
  * @param lock reader-writer lock for thread safety
  * @param active_ops count of active operations (for safe shutdown)
  */
@@ -121,9 +123,11 @@ void tidesdb_manifest_update_sequence(tidesdb_manifest_t *manifest, uint64_t seq
 
 /**
  * tidesdb_manifest_commit
- * updates manifest on disk
+ * atomically writes the manifest to disk -- writes a temp file, fsyncs it, renames it into
+ * place, then syncs the parent directory so the commit survives a crash. if path differs from
+ * the manifest's currently stored path, the manifest is re-pointed to path.
  * @param manifest manifest to write
- * @param path path to manifest file
+ * @param path destination path; also becomes the manifest's stored path if it differs
  * @return 0 on success, -1 on error
  */
 int tidesdb_manifest_commit(tidesdb_manifest_t *manifest, const char *path);

--- a/src/queue.h
+++ b/src/queue.h
@@ -52,7 +52,9 @@ typedef struct queue_node_t
  * @param waiter_count number of threads currently waiting in queue_dequeue_wait
  * @param head_lock mutex for dequeue/write operations on head
  * @param tail_lock mutex for enqueue operations
- * @param read_lock rwlock for read-only operations (peek, foreach)
+ * @param read_lock rwlock coordinating read-only iterators against destructive ops --
+ *        peek, peek_at, foreach and snapshot take it shared; dequeue, dequeue_wait, clear
+ *        and remove_if take it exclusive so iteration never races a removal
  * @param not_empty condition variable signaled when queue becomes non-empty
  * @param node_pool free list of reusable nodes for performance
  * @param pool_size current size of node pool

--- a/src/skip_list.h
+++ b/src/skip_list.h
@@ -136,7 +136,9 @@ struct skip_list_version_t
 
 /**
  * skip_list_comparator_fn
- * comparator function type for custom key comparison
+ * comparator function type for custom key comparison.
+ * ABI contract -- must stay structurally identical to tidesdb_comparator_fn in db.h, which
+ * the FFI header uses for tidesdb_register_comparator / tidesdb_get_comparator.
  * @param key1 first key
  * @param key1_size size of first key
  * @param key2 second key
@@ -407,6 +409,13 @@ int skip_list_delete(skip_list_t *list, const uint8_t *key, size_t key_size, uin
 /**
  * skip_list_batch_entry_t
  * entry for batch put operations
+ * @param key key data
+ * @param key_size size of key
+ * @param value value data (NULL for tombstones)
+ * @param value_size size of value (0 for tombstones)
+ * @param seq sequence number for this entry (MVCC version)
+ * @param ttl time-to-live (0 = no expiry)
+ * @param flags bitmask of SKIP_LIST_FLAG_* (see below)
  *
  * flags is a bitmask of SKIP_LIST_FLAG_*. a live put leaves flags = 0; a regular
  * tombstone sets SKIP_LIST_FLAG_DELETED; a single-delete tombstone also sets

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -34904,10 +34904,8 @@ static int ini_config_handler(void *user, const char *section, const char *name,
             ctx->config->compression_algorithm = TDB_COMPRESS_LZ4_FAST;
         else if (strcmp(value, TDB_INI_VAL_COMPRESS_ZSTD) == 0)
             ctx->config->compression_algorithm = TDB_COMPRESS_ZSTD;
-#ifndef __sun
         else if (strcmp(value, TDB_INI_VAL_COMPRESS_SNAPPY) == 0)
             ctx->config->compression_algorithm = TDB_COMPRESS_SNAPPY;
-#endif
     }
     else if (strcmp(name, TDB_INI_KEY_ENABLE_BLOOM_FILTER) == 0)
     {
@@ -35052,11 +35050,9 @@ int tidesdb_cf_config_save_to_ini(const char *ini_file, const char *section_name
         case TDB_COMPRESS_ZSTD:
             compression_str = TDB_INI_VAL_COMPRESS_ZSTD;
             break;
-#ifndef __sun
         case TDB_COMPRESS_SNAPPY:
             compression_str = TDB_INI_VAL_COMPRESS_SNAPPY;
             break;
-#endif
     }
     fprintf(fp, TDB_INI_KEY_COMPRESSION_ALGORITHM " = %s\n", compression_str);
 

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -2571,16 +2571,14 @@ static int sstable_metadata_deserialize(const uint8_t *data, const size_t data_s
     /* we restore compression algorithm from metadata */
     if (sst->config)
     {
-        /* we validate compression algorithm value */
-        if (compression_algorithm != TDB_COMPRESS_NONE &&
-#ifndef __sun
-            compression_algorithm != TDB_COMPRESS_SNAPPY &&
-#endif
-            compression_algorithm != TDB_COMPRESS_LZ4 &&
-            compression_algorithm != TDB_COMPRESS_LZ4_FAST &&
-            compression_algorithm != TDB_COMPRESS_ZSTD)
+        /* reject an algorithm this build cannot use -- catches both an invalid id and a valid one
+         * whose backend was compiled out (e.g. reading zstd data in a build without zstd). failing
+         * here is honest, the compressed blocks could not be decoded anyway */
+        if (!tidesdb_compression_available(compression_algorithm))
         {
-            TDB_DEBUG_LOG(TDB_LOG_ERROR, "SSTable metadata has invalid compression_algorithm: %u",
+            TDB_DEBUG_LOG(TDB_LOG_ERROR,
+                          "SSTable metadata compression_algorithm %u is invalid or not available "
+                          "in this build",
                           compression_algorithm);
             return -1;
         }
@@ -2800,13 +2798,14 @@ int tidesdb_comparator_case_insensitive(const uint8_t *key1, size_t key1_size, c
 
 tidesdb_column_family_config_t tidesdb_default_column_family_config(void)
 {
-    return (tidesdb_column_family_config_t){
+    tidesdb_column_family_config_t config = (tidesdb_column_family_config_t){
         .write_buffer_size = TDB_DEFAULT_WRITE_BUFFER_SIZE,
         .level_size_ratio = TDB_DEFAULT_LEVEL_SIZE_RATIO,
         .min_levels = TDB_DEFAULT_MIN_LEVELS,
         .dividing_level_offset = TDB_DEFAULT_DIVIDING_LEVEL_OFFSET,
         .klog_value_threshold = TDB_DEFAULT_KLOG_VALUE_THRESHOLD,
-        .compression_algorithm = TDB_COMPRESS_LZ4,
+        .compression_algorithm =
+            TDB_COMPRESS_NONE, /* replaced below by the best available backend */
         .enable_bloom_filter = 1,
         .bloom_fpr = TDB_DEFAULT_BLOOM_FPR,
         .enable_block_indexes = 1,
@@ -2830,6 +2829,18 @@ tidesdb_column_family_config_t tidesdb_default_column_family_config(void)
         .object_target_file_size = 0, /* reserved, not used */
         .object_lazy_compaction = 0,
         .object_prefetch_compaction = 1};
+
+    /* pick the best compression backend this build actually has, preferring LZ4 for speed, then
+     * ZSTD, then Snappy, falling back to NONE so a dependency-free build still yields a usable
+     * default config rather than one that fails at the first flush */
+    if (tidesdb_compression_available(TDB_COMPRESS_LZ4))
+        config.compression_algorithm = TDB_COMPRESS_LZ4;
+    else if (tidesdb_compression_available(TDB_COMPRESS_ZSTD))
+        config.compression_algorithm = TDB_COMPRESS_ZSTD;
+    else if (tidesdb_compression_available(TDB_COMPRESS_SNAPPY))
+        config.compression_algorithm = TDB_COMPRESS_SNAPPY;
+
+    return config;
 }
 
 tidesdb_config_t tidesdb_default_config(void)
@@ -22202,6 +22213,17 @@ int tidesdb_create_column_family(tidesdb_t *db, const char *name,
         return TDB_ERR_INVALID_ARGS;
     }
 
+    /* reject a compression backend this build does not have, up front, so the caller learns
+     * immediately instead of hitting a flush failure later. NONE is always available */
+    if (!tidesdb_compression_available(config->compression_algorithm))
+    {
+        TDB_DEBUG_LOG(TDB_LOG_WARN,
+                      "CF '%s' requests compression_algorithm %u which is not available in this "
+                      "build (rebuild with the matching -DTIDESDB_WITH_* option)",
+                      name, (unsigned int)config->compression_algorithm);
+        return TDB_ERR_INVALID_ARGS;
+    }
+
     /** unified memtable mode requires all CFs to use memcmp comparator
      *  because the single shared skip list uses a single comparator.. */
     if (db->unified_mt.enabled)
@@ -25215,6 +25237,15 @@ int tidesdb_txn_get(tidesdb_txn_t *txn, tidesdb_column_family_t *cf, const uint8
     const int cf_index = tidesdb_txn_add_cf_internal(txn, cf);
     if (cf_index < 0) return TDB_ERR_MEMORY;
 
+    /* sstable scan layout guard -- the per-level scan below is not atomic across levels, so a
+     * compaction can relocate a key from a level we already passed into one we have not reached
+     * and a present key falls through as a false NOT_FOUND. snapshot the layout version before
+     * scanning, re-check before concluding NOT_FOUND, retry the scan while it differs, then surface
+     * a retryable BUSY. declared before the goto unified_sst_search so the jump cannot skip init.
+     */
+    int sst_scan_restarts = 0;
+    uint64_t sst_scan_layout_v = 0;
+
     /* we check write set first (read your own writes)
      * transaction must see its own uncommitted changes before checking cache/memtable
      * we use search strategy based on transaction size:
@@ -25603,6 +25634,7 @@ int tidesdb_txn_get(tidesdb_txn_t *txn, tidesdb_column_family_t *cf, const uint8
     }
 
 unified_sst_search:;
+    sst_scan_layout_v = atomic_load_explicit(&cf->sstable_layout_version, memory_order_acquire);
     int num_levels = atomic_load_explicit(&cf->num_active_levels, memory_order_acquire);
 
     for (int level_num = 0; level_num < num_levels; level_num++)
@@ -25820,6 +25852,21 @@ unified_sst_search:;
             if (best_value) free(best_value);
             return (!best_is_dead) ? TDB_ERR_MEMORY : TDB_ERR_NOT_FOUND;
         }
+    }
+
+    /* nothing matched in any level. if the layout moved while we scanned, a compaction may have
+     * carried the key past our cursor -- retry the whole scan rather than report a false miss, and
+     * once the restart budget is spent return a retryable BUSY instead of a definitive NOT_FOUND.
+     */
+    if (atomic_load_explicit(&cf->sstable_layout_version, memory_order_acquire) !=
+        sst_scan_layout_v)
+    {
+        if (sst_scan_restarts < TDB_SST_RETRY_MAX_LEVEL_RETRIES)
+        {
+            sst_scan_restarts++;
+            goto unified_sst_search;
+        }
+        return TDB_ERR_BUSY;
     }
 
     return TDB_ERR_NOT_FOUND;

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -240,7 +240,7 @@ typedef enum
  * @param key2 second key to compare
  * @param key2_size size of second key in bytes
  * @param ctx user-provided context pointer
- * @return <0 if key1 < key2, 0 if equal, >0 if key1 > key2
+ * @return < 0 if key1 < key2, 0 if equal, >0 if key1 > key2
  */
 typedef int (*tidesdb_comparator_fn)(const uint8_t *key1, size_t key1_size, const uint8_t *key2,
                                      size_t key2_size, void *ctx);
@@ -900,21 +900,21 @@ struct tidesdb_t
     /* unified memtable mode -- single skip_list + single WAL for all CFs */
     struct
     {
-        int enabled;
-        _Atomic(tidesdb_memtable_t *) active;
+        int enabled;                          /* 1 when unified memtable mode is active */
+        _Atomic(tidesdb_memtable_t *) active; /* current active unified memtable */
         /* read-side epoch for the unified active slot. see the analogous
          * cf->active_mt_readers field for the protocol */
         _Atomic(int) active_mt_readers;
-        queue_t *immutables;
-        _Atomic(int) is_flushing;
-        _Atomic(int) immutable_cleanup_counter;
-        size_t write_buffer_size;
-        _Atomic(uint32_t) next_cf_index;
-        _Atomic(uint64_t) wal_generation;
+        queue_t *immutables;                    /* rotated unified memtables awaiting flush */
+        _Atomic(int) is_flushing;               /* 1 while a rotation/flush is in progress */
+        _Atomic(int) immutable_cleanup_counter; /* batched immutable cleanup counter */
+        size_t write_buffer_size;               /* rotation threshold for the unified memtable */
+        _Atomic(uint32_t) next_cf_index;        /* next CF prefix index to assign */
+        _Atomic(uint64_t) wal_generation;       /* current unified WAL generation */
         tidesdb_unified_cf_index_entry_t *cf_index_map; /* name -> index, mirrors UNIMAP file */
-        int cf_index_map_count;
-        int cf_index_map_capacity;
-        pthread_mutex_t cf_index_map_lock;
+        int cf_index_map_count;                         /* live entries in cf_index_map */
+        int cf_index_map_capacity;                      /* allocated capacity of cf_index_map */
+        pthread_mutex_t cf_index_map_lock;              /* guards cf_index_map mutation */
         pthread_mutex_t wal_group_sync_lock; /* coordinates group-commit fsync on the unified WAL */
         pthread_cond_t wal_group_sync_cond;
         /* last-emit timestamp (seconds) for the throttled unified ceiling-stall warning */
@@ -988,7 +988,10 @@ struct tidesdb_t
  * @param cf_capacity capacity of column families array
  * @param last_cf cached last-used column family for O(1) single-CF lookup
  * @param last_cf_index cached index of last-used column family
- * @param savepoints array of savepoint transaction states
+ * @param savepoint_op_counts per-savepoint snapshot of num_ops -- the op-array length to truncate
+ * back to on rollback to that savepoint
+ * @param savepoint_cf_counts per-savepoint snapshot of num_cfs -- the cf-array length to truncate
+ * back to on rollback to that savepoint
  * @param savepoint_names array of savepoint names
  * @param num_savepoints number of savepoints
  * @param savepoints_capacity capacity of savepoints array

--- a/src/tidesdb_version.h.in
+++ b/src/tidesdb_version.h.in
@@ -8,4 +8,12 @@
  * without having to re-pass the build flag. */
 #cmakedefine TIDESDB_HAS_S3
 
+/* defined per compression backend that was compiled into libtidesdb (mirrors the
+ * -DTIDESDB_WITH_{SNAPPY,LZ4,ZSTD} build options). TDB_COMPRESS_NONE is always available;
+ * for the rest, consumers can compile-time detect support here or query it at runtime via
+ * tidesdb_compression_available(). */
+#cmakedefine TIDESDB_HAVE_SNAPPY
+#cmakedefine TIDESDB_HAVE_LZ4
+#cmakedefine TIDESDB_HAVE_ZSTD
+
 #endif

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -23287,7 +23287,10 @@ static void test_concurrent_multi_cf_deep_sst_mixed_ops(void)
             ASSERT_EQ(tidesdb_txn_put(txn, idx_cf, (uint8_t *)idx_key, strlen(idx_key) + 1,
                                       (uint8_t *)"\x00", 1, 0),
                       0);
-            ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+            /* see tdb_test_commit_with_retry -- the 512 byte write buffer rotates the active
+             * memtable on nearly every commit, so this seed commit can hit the retryable
+             * TDB_ERR_BUSY backpressure stall on a slow runner (qemu DragonFlyBSD); retry it */
+            ASSERT_EQ(tdb_test_commit_with_retry(txn, 20), 0);
             tidesdb_txn_free(txn);
         }
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tidesdb",
-  "version-string": "9.3.3",
+  "version-string": "9.3.4",
   "description": "TidesDB is a high-performance durable, transactional embeddable storage engine designed for flash and RAM optimization with optional object storage support for unlimited data scaling.",
   "dependencies": ["zstd", "snappy", "lz4", "pthreads"],
   "features": {


### PR DESCRIPTION
each compression backend (snappy, lz4, zstd) is now optional at build time via the TIDESDB_WITH_SNAPPY, TIDESDB_WITH_LZ4 and TIDESDB_WITH_ZSTD options, all defaulting on. turning one off drops its link dependency, and a build with all three off has no compression dependencies at all and supports the none algorithm only, so the library can be installed with nothing beyond libc. the third party headers moved out of compress.h into compress.c (guarded by TIDESDB_HAVE_ build macros) so a consumer of the installed library no longer needs the compression dev headers just to include tidesdb. the algorithm enum stays complete and unconditional, so an sstable written with a backend this build lacks is reported with a clear error rather than an unknown algorithm. the default column family config now picks the best available backend, lz4 then zstd then snappy then none, cf creation rejects an unavailable backend up front with a clear log, and sstable load rejects an unavailable or unknown algorithm the same way. adds tidesdb_compression_available for callers and a generated header that exposes the TIDESDB_HAVE_ flags to consumers.

compression linking now flows through one resolver used by every posix platform branch, not just linux. each backend resolves in three steps, an explicit TIDESDB_SNAPPY_TARGET, TIDESDB_LZ4_TARGET or TIDESDB_ZSTD_TARGET override, then a probe of known cmake target names, then a bare system link fallback. this lets a downstream build that vendors a compression library under any target name link it without a forced system flag, which resolves issue #618.

documentation sweep over the public headers, fixing real gaps found by reading the implementations. completed a truncated allocator override comment and documented the allocator globals in alloc.h. corrected the queue read_lock comment to say readers take it shared while dequeue, clear and remove_if take it exclusive. fixed the manifest fp comment, which is a read handle reopened around each commit, and documented that commit writes a temp file and atomically renames it. documented btree_arena_block_t, removed a misplaced duplicate arena comment, and added param and return to btree_get_entry_count and btree_get_max_seq. fixed two doc title mismatches in block_manager.h and documented the sync mode enum. documented the bloom filter serialize version prefix. documented the skip_list_batch_entry_t fields. recorded the comparator function pointer abi contract in db.h and skip_list.h. fixed a stale savepoint param in tidesdb.h and documented the unified memtable sub struct fields.

guard the point get scan against a concurrent compaction layout change

the multi level sstable scan in tidesdb_txn_get was not atomic across levels, so a compaction landing mid scan could carry a key past the scan cursor and a durably present key read back as a definitive TDB_ERR_NOT_FOUND instead of a retryable TDB_ERR_BUSY. snapshot cf->sstable_layout_version before scanning and recheck it before concluding NOT_FOUND, retry the whole scan while it differs then return BUSY.