### PR TITLE
TidesDB 9 PATCH (v9.3.5)

### DIFF
--- a/.github/workflows/bsd_illumos_build_test_tidesdb.yml
+++ b/.github/workflows/bsd_illumos_build_test_tidesdb.yml
@@ -128,7 +128,24 @@ jobs:
           sync: rsync
           copyback: false
           prepare: |
-            /usr/sbin/pkg_add cmake lz4 zstd snappy pkgconf gmake
+            # NetBSD 10.1's default pkg path (10.1/All) is only a redirect stub pointing at the
+            # current quarterly (10.0_2026Q1/All), and pkg_add's fetcher does not follow it -- so the
+            # default install fails identically on every rerun. pin PKG_PATH straight at the resolved
+            # quarterly dir (verified to hold every dep), trying the Fastly CDN first and the master
+            # mirror as a fallback in case an edge returns 503, with a short retry for transient
+            # blips. bump the quarterly when 10.0_2026Q1 is eventually pruned.
+            ok=0
+            for base in \
+              "https://cdn.NetBSD.org/pub/pkgsrc/packages/NetBSD/x86_64/10.0_2026Q1/All/" \
+              "https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/x86_64/10.0_2026Q1/All/"; do
+              export PKG_PATH="$base"
+              for i in 1 2 3; do
+                if /usr/sbin/pkg_add cmake lz4 zstd snappy pkgconf gmake; then ok=1; break; fi
+                echo "pkg_add from $base attempt $i failed, retrying in $((i*10))s"; sleep $((i*10))
+              done
+              [ "$ok" = 1 ] && break
+            done
+            [ "$ok" = 1 ] || { echo "all mirrors failed to provide packages"; exit 1; }
           run: |
             echo "*=====================================*"
             echo " System Information"

--- a/.github/workflows/build_and_test_tidesdb.yml
+++ b/.github/workflows/build_and_test_tidesdb.yml
@@ -283,6 +283,24 @@ jobs:
         shell: bash
         run: cmake -S . -B build -DTIDESDB_BUILD_TESTS=ON -DTIDESDB_WITH_SANITIZER=ON
 
+      - name: Lint -Wmaybe-uninitialized (Linux x64 GCC, optimized)
+        if: runner.os == 'Linux' && matrix.arch == 'x64'
+        shell: bash
+        run: |
+          # -Wmaybe-uninitialized only fires under optimization, so use a dedicated
+          # RelWithDebInfo build with the TIDESDB_WARN_MAYBE_UNINIT cmake option (the main
+          # sanitizer build above is -O0, where the analysis is a no-op). this build is
+          # isolated in build-wmu and does not affect the sanitizer build. the gate fails
+          # only on warnings in our own src/; third-party external/ is build-only.
+          cmake -S . -B build-wmu -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DTIDESDB_BUILD_TESTS=ON -DTIDESDB_WARN_MAYBE_UNINIT=ON
+          cmake --build build-wmu -j"$(nproc)" 2>&1 | tee build-wmu.log
+          if grep -E '\[-Wmaybe-uninitialized\]' build-wmu.log | grep '/src/'; then
+            echo "::error::-Wmaybe-uninitialized reported a warning in src/"
+            exit 1
+          fi
+          echo "no -Wmaybe-uninitialized warnings in src/"
+
       - name: Configure CMake (Linux x86)
         if: runner.os == 'Linux' && matrix.arch == 'x86'
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -17,10 +17,13 @@
 *.exe
 *.out
 *.app
+build-*
 cmake-build-debug
 cmake-build-release
 .idea
 build
+build-wmu
+build-wmu.log
 .vscode
 vcpkg_installed
 .vs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,14 @@ if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
     endif()
 endif()
 
+# optional -Wmaybe-uninitialized for development. GCC only (the flag is GCC-specific), and it is a
+# no-op at -O0 because the analysis runs only under optimization, so pair it with an optimized
+# build, e.g. -DTIDESDB_WARN_MAYBE_UNINIT=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo.
+option(TIDESDB_WARN_MAYBE_UNINIT "enable -Wmaybe-uninitialized (GCC; requires an optimized build)" OFF)
+if(TIDESDB_WARN_MAYBE_UNINIT AND CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    add_compile_options(-Wmaybe-uninitialized)
+endif()
+
 # for development, we want to enable all warnings and sanitizers
 if(TIDESDB_WITH_SANITIZER)
     if(MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ if(TIDESDB_WITH_MIMALLOC)
 endif()
 
 project(tidesdb
-	VERSION 9.3.4
+	VERSION 9.3.5
 	LANGUAGES C)
 
 set(CMAKE_C_STANDARD 11)

--- a/code_formatter.ps1
+++ b/code_formatter.ps1
@@ -12,6 +12,11 @@ Get-ChildItem -Path . -Recurse -Include *.c,*.h |
                 break
             }
         }
+        # exclude any build-* directory (build-rel, build-wmu, ...); handle both path separators
+        if (-not $shouldExclude -and
+            ($file.FullName -like "*\build-*\*" -or $file.FullName -like "*/build-*/*")) {
+            $shouldExclude = $true
+        }
         -not $shouldExclude
     } | 
     ForEach-Object { 

--- a/code_formatter.sh
+++ b/code_formatter.sh
@@ -9,6 +9,7 @@ find . \
      -o -path "./cmake-build-release" \
      -o -path "./.idea" \
      -o -path "./build" \
+     -o -path "./build-*" \
      -o -path "./cmake" \) -prune \
   -o -type f \( -name "*.c" -o -name "*.h" \) -print0 \
 | xargs -0 clang-format -i

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -217,6 +217,7 @@ typedef tidesdb_memtable_t tidesdb_immutable_memtable_t;
 #define TDB_INITIAL_TXN_READ_SET_CAPACITY  16
 #define TDB_INITIAL_TXN_CF_CAPACITY        4
 #define TDB_INITIAL_TXN_SAVEPOINT_CAPACITY 4
+#define TDB_TXN_READ_SET_RECENT_SCAN       8 /* hot-tail entries scanned for dedup before append */
 
 /* stack buffer sizes for hot-path allocations */
 #define TDB_STACK_IMM_SNAPSHOT     16 /* stack slots for unified immutable snapshot */
@@ -286,6 +287,8 @@ typedef tidesdb_memtable_t tidesdb_immutable_memtable_t;
 #define TDB_CANCEL_BG_POLL_US                       5000  /* 5ms poll while draining cancel */
 #define TDB_CANCEL_BG_MAX_WAIT_MS                   30000 /* cap so a stuck merge can't hang */
 #define TDB_COMPACTION_FLUSH_WAIT_MAX_ATTEMPTS      100
+#define TDB_FLUSH_HEADROOM_IDLE_DIVISOR             2 /* l0 empty  +50% batching headroom */
+#define TDB_FLUSH_HEADROOM_MODERATE_DIVISOR         4 /* l0 active +25% headroom */
 #define TDB_CHECKPOINT_COMPACTION_WAIT_MAX_ATTEMPTS 200
 #define TDB_CHECKPOINT_COMPACTION_WAIT_SLEEP_US     50000
 #define TDB_OPENING_WAIT_MAX_MS                     100
@@ -307,6 +310,10 @@ typedef tidesdb_memtable_t tidesdb_immutable_memtable_t;
 /* replica sync thread configuration */
 #define TDB_REPLICA_SYNC_DEFAULT_INTERVAL_US 5000000
 #define TDB_REPLICA_SYNC_SLEEP_SLICE_US      100000
+
+#define TDB_MEMTABLE_ARENA_SIZE_FACTOR \
+    2 /* memtable arena over-provisions to 2x write_buffer_size */
+#define TDB_DEFAULT_MAX_CONC_UPLOADS_OBJ_STORE 4
 
 /* default interval for unified WAL fsync escalation when the unified memtable
  * is in TDB_SYNC_INTERVAL mode and unified_memtable_sync_interval_us is 0 */
@@ -471,8 +478,10 @@ typedef tidesdb_memtable_t tidesdb_immutable_memtable_t;
 #define TDB_DOWNLOAD_MAX_RETRIES        3
 #define TDB_DOWNLOAD_INITIAL_BACKOFF_US 50000 /* 50ms */
 #define TDB_DOWNLOAD_BACKOFF_MULTIPLIER 4     /* 50ms -> 200ms -> 800ms */
-#define TDB_LIST_MAX_RETRIES            4
-#define TDB_LIST_INITIAL_BACKOFF_US     50000 /* 50ms */
+#define TDB_DEFAULT_MAX_CONCURRENT_DOWNLOADS \
+    8 /* prefetch threads when objstore cfg unset or <= 0 */
+#define TDB_LIST_MAX_RETRIES        4
+#define TDB_LIST_INITIAL_BACKOFF_US 50000 /* 50ms */
 
 /* klog block configuration */
 #define TDB_KLOG_BLOCK_INITIAL_CAPACITY 512
@@ -730,7 +739,7 @@ struct tidesdb_commit_status_t
  * @param sst_id sstable id
  * @param unified_sl the shared unified immutable skip list for a unified split task. when set
  *                   (alongside unified_barrier) the worker writes this cf's prefix segment of it
- *                   straight to an sstable. borrowed, NOT freed by the worker -- the immutable owns
+ *                   straight to an sstable. borrowed, not freed by the worker -- the immutable owns
  *                   it and the barrier's last finisher releases it.
  * @param unified_cf_index the cf_index prefix identifying this cf's run in unified_sl
  * @param unified_entry_count node count of the run, for sizing the sstable bloom/index
@@ -3651,7 +3660,7 @@ static int tidesdb_klog_block_search_raw(const uint8_t *data, const size_t data_
         erem--;
         out_entry->flags = flags & ~(TDB_KV_FLAG_DELTA_SEQ | TDB_KV_FLAG_TRANSIENT_MASK);
 
-        uint64_t ks, vs;
+        uint64_t ks = 0, vs = 0;
         int br = decode_varint(eptr, &ks, (int)erem);
         eptr += br;
         erem -= br;
@@ -3682,7 +3691,7 @@ static int tidesdb_klog_block_search_raw(const uint8_t *data, const size_t data_
         out_entry->vlog_offset = 0;
         if (flags & TDB_KV_FLAG_HAS_VLOG)
         {
-            uint64_t vo;
+            uint64_t vo = 0;
             br = decode_varint(eptr, &vo, (int)erem);
             eptr += br;
             erem -= br;
@@ -3892,19 +3901,19 @@ static int tidesdb_klog_block_search_raw(const uint8_t *data, const size_t data_
     erem--;
     out_entry->flags = flags & ~(TDB_KV_FLAG_DELTA_SEQ | TDB_KV_FLAG_TRANSIENT_MASK);
 
-    uint64_t ks;
+    uint64_t ks = 0;
     int br = decode_varint(eptr, &ks, (int)erem);
     eptr += br;
     erem -= br;
     out_entry->key_size = (uint32_t)ks;
 
-    uint64_t vs;
+    uint64_t vs = 0;
     br = decode_varint(eptr, &vs, (int)erem);
     eptr += br;
     erem -= br;
     out_entry->value_size = (uint32_t)vs;
 
-    uint64_t seq_val;
+    uint64_t seq_val = 0;
     br = decode_varint(eptr, &seq_val, (int)erem);
     eptr += br;
     erem -= br;
@@ -3946,7 +3955,7 @@ static int tidesdb_klog_block_search_raw(const uint8_t *data, const size_t data_
 
     if (flags & TDB_KV_FLAG_HAS_VLOG)
     {
-        uint64_t vlog_off;
+        uint64_t vlog_off = 0;
         br = decode_varint(eptr, &vlog_off, (int)erem);
         eptr += br;
         erem -= br;
@@ -4076,7 +4085,7 @@ static int tidesdb_klog_block_seek_raw(const uint8_t *data, const size_t data_si
         erem--;
         out_entry->flags = flags & ~(TDB_KV_FLAG_DELTA_SEQ | TDB_KV_FLAG_TRANSIENT_MASK);
 
-        uint64_t ks, vs;
+        uint64_t ks = 0, vs = 0;
         int br = decode_varint(eptr, &ks, (int)erem);
         eptr += br;
         erem -= br;
@@ -4109,7 +4118,7 @@ static int tidesdb_klog_block_seek_raw(const uint8_t *data, const size_t data_si
         out_entry->vlog_offset = 0;
         if (flags & TDB_KV_FLAG_HAS_VLOG)
         {
-            uint64_t vlog_off;
+            uint64_t vlog_off = 0;
             br = decode_varint(eptr, &vlog_off, (int)erem);
             out_entry->vlog_offset = vlog_off;
         }
@@ -4271,13 +4280,13 @@ static int tidesdb_klog_block_seek_raw(const uint8_t *data, const size_t data_si
     erem--;
     out_entry->flags = flags & ~(TDB_KV_FLAG_DELTA_SEQ | TDB_KV_FLAG_TRANSIENT_MASK);
 
-    uint64_t ks;
+    uint64_t ks = 0;
     int br = decode_varint(eptr, &ks, (int)erem);
     eptr += br;
     erem -= br;
     out_entry->key_size = (uint32_t)ks;
 
-    uint64_t vs;
+    uint64_t vs = 0;
     br = decode_varint(eptr, &vs, (int)erem);
     eptr += br;
     erem -= br;
@@ -4304,7 +4313,7 @@ static int tidesdb_klog_block_seek_raw(const uint8_t *data, const size_t data_si
         sbr = decode_varint(sp, &sv, (int)sr);
         sp += sbr;
         sr -= sbr;
-        uint64_t seq_val;
+        uint64_t seq_val = 0;
         sbr = decode_varint(sp, &seq_val, (int)sr);
 
         if (sf & TDB_KV_FLAG_DELTA_SEQ)
@@ -4334,7 +4343,7 @@ static int tidesdb_klog_block_seek_raw(const uint8_t *data, const size_t data_si
     out_entry->vlog_offset = 0;
     if (flags & TDB_KV_FLAG_HAS_VLOG)
     {
-        uint64_t vlog_off;
+        uint64_t vlog_off = 0;
         br = decode_varint(eptr, &vlog_off, (int)erem);
         eptr += br;
         erem -= br;
@@ -5306,8 +5315,8 @@ static void tdb_objstore_prefetch_sstables(tidesdb_t *db, tidesdb_sstable_t **ss
 
     int max_threads = db->config.object_store_config
                           ? db->config.object_store_config->max_concurrent_downloads
-                          : 8;
-    if (max_threads <= 0) max_threads = 8;
+                          : TDB_DEFAULT_MAX_CONCURRENT_DOWNLOADS;
+    if (max_threads <= 0) max_threads = TDB_DEFAULT_MAX_CONCURRENT_DOWNLOADS;
 
     /* we collect non-local files (klog + vlog pairs) */
     tdb_prefetch_arg_t *args = malloc(count * 2 * sizeof(tdb_prefetch_arg_t));
@@ -12252,7 +12261,7 @@ static int tidesdb_merge_source_advance(tidesdb_merge_source_t *source)
                         const uint8_t flags = *eptr++;
                         erem--;
 
-                        uint64_t ks, vs;
+                        uint64_t ks = 0, vs = 0;
                         int br = decode_varint(eptr, &ks, (int)erem);
                         eptr += br;
                         erem -= br;
@@ -12280,7 +12289,7 @@ static int tidesdb_merge_source_advance(tidesdb_merge_source_t *source)
                         uint64_t vlog_offset = 0;
                         if (flags & TDB_KV_FLAG_HAS_VLOG)
                         {
-                            uint64_t vo;
+                            uint64_t vo = 0;
                             decode_varint(eptr, &vo, (int)erem);
                             vlog_offset = vo;
                         }
@@ -16739,7 +16748,7 @@ static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
             block_manager_t *vlog_bm = NULL;
 
             /* open the partition's output sstable. on failure (e.g. EMFILE under fd pressure) we
-             * MUST NOT proceed -- the merge loop below writes through klog_bm/vlog_bm and would
+             * must not proceed -- the merge loop below writes through klog_bm/vlog_bm and would
              * dereference a NULL block manager. abort the merge instead; the aborted path preserves
              * the source sstables, so no data is lost and compaction retries later. routed through
              * tidesdb_bm_open so a transient fd spike gets a reaper-assisted retry first. */
@@ -17526,7 +17535,7 @@ int tidesdb_trigger_compaction(tidesdb_column_family_t *cf, int full_compaction)
      * smallest q where C_q >= Σ(N_i) for i=0..q. the merge then deposits the
      * run at a level that has room, which is what lets data flow downward.
      * (the spooky paper states this as "wouldn't reach capacity"; selecting the
-     * first level that CANNOT accommodate instead pins target_lvl at 1 and
+     * first level that cannot accommodate instead pins target_lvl at 1 and
      * self-merges level 1 forever.)
      * q is a 1-indexed level number -- array index is q-1. this matches the
      * dividing/partitioned merge calls below and the z-loop, which all convert
@@ -17809,10 +17818,10 @@ static int tidesdb_wal_recover(tidesdb_column_family_t *cf, const char *wal_path
         comparator_ctx = NULL;
     }
 
-    if (skip_list_new_with_arena(memtable, cf->config.skip_list_max_level,
-                                 cf->config.skip_list_probability, comparator_fn, comparator_ctx,
-                                 &cf->db->cached_current_time,
-                                 cf->config.write_buffer_size * 2) != 0)
+    if (skip_list_new_with_arena(
+            memtable, cf->config.skip_list_max_level, cf->config.skip_list_probability,
+            comparator_fn, comparator_ctx, &cf->db->cached_current_time,
+            cf->config.write_buffer_size * TDB_MEMTABLE_ARENA_SIZE_FACTOR) != 0)
     {
         block_manager_close(wal);
         return TDB_ERR_MEMORY;
@@ -19393,13 +19402,12 @@ static void *tidesdb_reaper_thread(void *arg)
 
                 /* immutable queue -- conservative estimate using write_buffer_size.
                  * each immutable's data is bounded by write_buffer_size (flush threshold).
-                 * while arena allocates write_buffer_size * 2, the unused arena capacity
-                 * is not meaningful for pressure accounting.
-                 * skipped in unified mode, per-CF immutable queues there hold only
-                 * empty rotated memtables (all data is in the unified memtable, summed
-                 * separately below), so charging each write_buffer_size is phantom
-                 * memory that inflates the pressure ratio and triggers spurious
-                 * force-flushes. */
+                 * while arena allocates TDB_MEMTABLE_ARENA_SIZE_FACTOR x write_buffer_size, the
+                 * unused arena capacity is not meaningful for pressure accounting. skipped in
+                 * unified mode, per-CF immutable queues there hold only empty rotated memtables
+                 * (all data is in the unified memtable, summed separately below), so charging each
+                 * write_buffer_size is phantom memory that inflates the pressure ratio and triggers
+                 * spurious force-flushes. */
                 if (!db->unified_mt.enabled)
                 {
                     size_t imm_count = queue_size(cf->immutable_memtables);
@@ -20383,7 +20391,7 @@ int tidesdb_open(const tidesdb_config_t *config, tidesdb_t **db)
     }
     else
     {
-        /* failed to get disk space, set to 0 to trigger checks */
+        /* failed to get disk space, thus we set to 0 to trigger checks */
         atomic_init(&(*db)->cached_available_disk_space, 0);
         TDB_DEBUG_LOG(TDB_LOG_WARN, "Failed to get initial disk space");
     }
@@ -20397,7 +20405,7 @@ int tidesdb_open(const tidesdb_config_t *config, tidesdb_t **db)
                       "System memory is total=%" PRIu64 " bytes, available=%" PRIu64 " bytes",
                       (uint64_t)(*db)->total_memory, (uint64_t)(*db)->available_memory);
 
-        /* resolve global memory limit */
+        /* we resolve global memory limit */
         size_t min_limit = (size_t)((double)(*db)->total_memory * TDB_MEMORY_MIN_LIMIT_RATIO);
         if (config->max_memory_usage > 0)
         {
@@ -20423,7 +20431,7 @@ int tidesdb_open(const tidesdb_config_t *config, tidesdb_t **db)
                       (*db)->resolved_memory_limit,
                       (double)(*db)->resolved_memory_limit / (1024.0 * 1024.0));
 
-        /* push the single-block memory-safety budget down to the block manager so
+        /* we push the single-block memory-safety budget down to the block manager so
          * the read path can refuse an oversized block via a pure atomic load */
         block_manager_set_max_safe_block_bytes((*db)->resolved_memory_limit /
                                                TDB_MEMORY_MAX_BLOCK_FRACTION_DENOM);
@@ -20565,7 +20573,6 @@ int tidesdb_open(const tidesdb_config_t *config, tidesdb_t **db)
         atomic_init(&(*db)->unified_mt.immutable_cleanup_counter, 0);
         atomic_init(&(*db)->unified_mt.next_cf_index, 0);
         atomic_init(&(*db)->unified_mt.wal_generation, 0);
-        /* we resolve skip list config with defaults */
         const int umt_max_level = config->unified_memtable_skip_list_max_level > 0
                                       ? config->unified_memtable_skip_list_max_level
                                       : TDB_SKIP_LIST_MAX_LEVEL;
@@ -20576,11 +20583,11 @@ int tidesdb_open(const tidesdb_config_t *config, tidesdb_t **db)
          * the commit-path group fsync (FULL) or the sync worker (INTERVAL) */
         const int umt_sync_mode = BLOCK_MANAGER_SYNC_NONE;
 
-        /* we create the initial unified skip_list + WAL */
         skip_list_t *umt_sl = NULL;
-        if (skip_list_new_with_arena(&umt_sl, umt_max_level, umt_probability,
-                                     skip_list_comparator_memcmp, NULL, &(*db)->cached_current_time,
-                                     (*db)->unified_mt.write_buffer_size * 2) != 0)
+        if (skip_list_new_with_arena(
+                &umt_sl, umt_max_level, umt_probability, skip_list_comparator_memcmp, NULL,
+                &(*db)->cached_current_time,
+                (*db)->unified_mt.write_buffer_size * TDB_MEMTABLE_ARENA_SIZE_FACTOR) != 0)
         {
             queue_free((*db)->unified_mt.immutables);
             free((*db)->active_txns);
@@ -21113,8 +21120,8 @@ int tidesdb_open(const tidesdb_config_t *config, tidesdb_t **db)
          * at least two object store threads, one upload worker and one sync. */
         int num_upload_threads = (*db)->config.object_store_config
                                      ? (*db)->config.object_store_config->max_concurrent_uploads
-                                     : 4;
-        if (num_upload_threads <= 0) num_upload_threads = 4;
+                                     : TDB_DEFAULT_MAX_CONC_UPLOADS_OBJ_STORE;
+        if (num_upload_threads <= 0) num_upload_threads = TDB_DEFAULT_MAX_CONC_UPLOADS_OBJ_STORE;
 
         const int replica = atomic_load_explicit(&(*db)->replica_mode, memory_order_acquire);
         if (replica && num_upload_threads > 1) num_upload_threads -= 1;
@@ -22328,12 +22335,12 @@ int tidesdb_create_column_family(tidesdb_t *db, const char *name,
 
     /**** we validate write_buffer_size against resolved_memory_limit to prevent
      ***  creating CFs that would immediately cause critical memory pressure.
-     **   arena allocation is write_buffer_size * 2, so a single CF's arena
-     *    must not exceed the global memory budget */
+     **   arena allocation is TDB_MEMTABLE_ARENA_SIZE_FACTOR x write_buffer_size, so a single CF's
+     *arena must not exceed the global memory budget */
     {
         const size_t mem_limit =
             atomic_load_explicit(&db->resolved_memory_limit, memory_order_relaxed);
-        const size_t arena_size = cf->config.write_buffer_size * 2;
+        const size_t arena_size = cf->config.write_buffer_size * TDB_MEMTABLE_ARENA_SIZE_FACTOR;
         if (mem_limit > 0 && arena_size > mem_limit)
         {
             TDB_DEBUG_LOG(TDB_LOG_FATAL,
@@ -22354,7 +22361,8 @@ int tidesdb_create_column_family(tidesdb_t *db, const char *name,
             for (int i = 0; i < db->num_column_families; i++)
             {
                 if (db->column_families[i])
-                    cumulative_arena += db->column_families[i]->config.write_buffer_size * 2;
+                    cumulative_arena += db->column_families[i]->config.write_buffer_size *
+                                        TDB_MEMTABLE_ARENA_SIZE_FACTOR;
             }
             pthread_rwlock_unlock(&db->cf_list_lock);
 
@@ -22404,7 +22412,8 @@ int tidesdb_create_column_family(tidesdb_t *db, const char *name,
 
     if (skip_list_new_with_arena(&new_memtable, config->skip_list_max_level,
                                  config->skip_list_probability, comparator_fn, comparator_ctx,
-                                 &db->cached_current_time, config->write_buffer_size * 2) != 0)
+                                 &db->cached_current_time,
+                                 config->write_buffer_size * TDB_MEMTABLE_ARENA_SIZE_FACTOR) != 0)
     {
         free(cf->directory);
         free(cf->name);
@@ -23711,10 +23720,10 @@ static int tidesdb_flush_memtable_internal(tidesdb_column_family_t *cf,
     }
 
     skip_list_t *new_memtable;
-    if (skip_list_new_with_arena(&new_memtable, cf->config.skip_list_max_level,
-                                 cf->config.skip_list_probability, comparator_fn, comparator_ctx,
-                                 &cf->db->cached_current_time,
-                                 cf->config.write_buffer_size * 2) != 0)
+    if (skip_list_new_with_arena(
+            &new_memtable, cf->config.skip_list_max_level, cf->config.skip_list_probability,
+            comparator_fn, comparator_ctx, &cf->db->cached_current_time,
+            cf->config.write_buffer_size * TDB_MEMTABLE_ARENA_SIZE_FACTOR) != 0)
     {
         TDB_DEBUG_LOG(TDB_LOG_WARN, "CF '%s' failed to create new memtable", cf->name);
         atomic_fetch_sub_explicit(&cf->db->active_flushes, 1, memory_order_release);
@@ -24387,7 +24396,7 @@ static int tidesdb_apply_backpressure(tidesdb_column_family_t *cf)
         l0_delayed = 1;
     }
 
-    /* L1 file count does NOT gate writes. compaction (L1->L2+) is serialized per CF and is
+    /* L1 file count does not gate writes. compaction (L1->L2+) is serialized per CF and is
      * structurally slower than flush inflow, so L1 settles at a workload-dependent count; blocking
      * the write/flush pipeline on it only converts a compaction-throughput limit into a stop-start
      * stall and starves flushing (which is independent of compaction). the L1 graduated *delays*
@@ -24729,7 +24738,9 @@ static int tidesdb_txn_add_to_read_set(tidesdb_txn_t *txn, tidesdb_column_family
 
     /** we check last few entries first (hot cache, likely duplicates)
      *  most iterators read sequentially, so recent keys are often duplicates */
-    const int check_recent = (txn->read_set_count < 8) ? txn->read_set_count : 8;
+    const int check_recent = (txn->read_set_count < TDB_TXN_READ_SET_RECENT_SCAN)
+                                 ? txn->read_set_count
+                                 : TDB_TXN_READ_SET_RECENT_SCAN;
     for (int i = txn->read_set_count - 1; i >= txn->read_set_count - check_recent; i--)
     {
         if (txn->read_cfs[i] == cf && txn->read_key_sizes[i] == key_size &&
@@ -25820,7 +25831,7 @@ unified_sst_search:;
             /* a non-found, non-success return means this sstable could not be opened or read
              * (e.g. EMFILE under fd pressure, or an IO error). the scan is therefore incomplete --
              * a newer version of the key may live in the sstable we just failed on -- so we must
-             * NOT fall through and treat it as "not present" (which would return a stale version or
+             * not fall through and treat it as "not present" (which would return a stale version or
              * a false not-found). surface the error and let the caller retry once fds free. */
             if (get_result != TDB_SUCCESS && get_result != TDB_ERR_NOT_FOUND)
             {
@@ -27707,7 +27718,7 @@ static int tidesdb_unified_flush_immutable(tidesdb_t *db, tidesdb_memtable_t *um
     int phase1_result = TDB_SUCCESS;
 
     /* phase 1 is a light scan -- it walks the unified skip list once just to locate each cf's
-     * contiguous cf_index run and count its nodes. it does NOT rebuild the data; phase 2's per-cf
+     * contiguous cf_index run and count its nodes. it does not rebuild the data; phase 2's per-cf
      * task streams each run straight from the unified skip list (entries within a run are already
      * in memcmp order, which is the cf order since unified mode forbids custom comparators). */
     uint32_t current_cf_index = UINT32_MAX;
@@ -27980,9 +27991,10 @@ static int tidesdb_unified_memtable_rotate(tidesdb_t *db)
     const int umt_sync_mode = BLOCK_MANAGER_SYNC_NONE;
 
     skip_list_t *new_sl = NULL;
-    if (skip_list_new_with_arena(&new_sl, umt_max_level, umt_probability,
-                                 skip_list_comparator_memcmp, NULL, &db->cached_current_time,
-                                 db->unified_mt.write_buffer_size * 2) != 0)
+    if (skip_list_new_with_arena(
+            &new_sl, umt_max_level, umt_probability, skip_list_comparator_memcmp, NULL,
+            &db->cached_current_time,
+            db->unified_mt.write_buffer_size * TDB_MEMTABLE_ARENA_SIZE_FACTOR) != 0)
     {
         return TDB_ERR_MEMORY;
     }
@@ -28458,11 +28470,13 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
         }
         else if (l0_depth == 0)
         {
-            flush_threshold = cf->config.write_buffer_size + (cf->config.write_buffer_size / 2);
+            flush_threshold = cf->config.write_buffer_size +
+                              (cf->config.write_buffer_size / TDB_FLUSH_HEADROOM_IDLE_DIVISOR);
         }
         else
         {
-            flush_threshold = cf->config.write_buffer_size + (cf->config.write_buffer_size / 4);
+            flush_threshold = cf->config.write_buffer_size +
+                              (cf->config.write_buffer_size / TDB_FLUSH_HEADROOM_MODERATE_DIVISOR);
         }
         const int needs_flush = (memtable_size >= flush_threshold);
 
@@ -28615,7 +28629,8 @@ int tidesdb_txn_savepoint(tidesdb_txn_t *txn, const char *name)
 
     if (txn->num_savepoints >= txn->savepoints_capacity)
     {
-        const int new_capacity = txn->savepoints_capacity == 0 ? 4 : txn->savepoints_capacity * 2;
+        const int new_capacity = txn->savepoints_capacity == 0 ? TDB_INITIAL_TXN_SAVEPOINT_CAPACITY
+                                                               : txn->savepoints_capacity * 2;
         int *new_op_counts = realloc(txn->savepoint_op_counts, new_capacity * sizeof(int));
         int *new_cf_counts = realloc(txn->savepoint_cf_counts, new_capacity * sizeof(int));
         char **new_names = realloc(txn->savepoint_names, new_capacity * sizeof(char *));
@@ -29160,14 +29175,18 @@ int tidesdb_iter_new(tidesdb_txn_t *txn, tidesdb_column_family_t *cf, tidesdb_it
                     ssts_capacity = new_capacity;
                 }
 
-                /** we try to acquire reference to protect against concurrent deletion
-                 *  if try_ref fails, we check if array was swapped before deciding to retry */
-                if (!tidesdb_sstable_try_ref(sst))
+                /** we try to acquire a reference to protect against concurrent deletion. a
+                 *  try_ref failure on an UNCHANGED array means the sstable is still live in this
+                 *  level and only momentarily un-ref-able because the reaper is mid-eviction (it
+                 *  CASes refcount to EVICTING across its fd close, then restores it). that window
+                 *  is short and self-clearing, so we spin until the ref lands rather than skip the
+                 *  sstable -- the iterator snapshots its sources once, so skipping a live sstable
+                 *  would drop its keys for the iterator's entire lifetime. if the array swaps under
+                 *  us instead, fall back to the bounded level retry which reloads the new array. */
+                int ref_spins = 0;
+                while (!tidesdb_sstable_try_ref(sst))
                 {
-                    tidesdb_sstable_t **current_ssts =
-                        atomic_load_explicit(&level->sstables, memory_order_acquire);
-
-                    if (current_ssts != sstables)
+                    if (atomic_load_explicit(&level->sstables, memory_order_acquire) != sstables)
                     {
                         /* array was swapped, we release refs and retry */
                         for (int k = sst_count_before_level; k < sst_count; k++)
@@ -29178,10 +29197,13 @@ int tidesdb_iter_new(tidesdb_txn_t *txn, tidesdb_column_family_t *cf, tidesdb_it
                         need_retry = 1;
                         break;
                     }
-
-                    /* array unchanged, we skip dead sstable */
-                    continue;
+                    if (ref_spins < TDB_IMM_SNAP_ACQUIRE_SPIN_LIMIT)
+                        cpu_pause();
+                    else
+                        cpu_yield();
+                    ref_spins++;
                 }
+                if (need_retry) break;
                 ssts_array[sst_count++] = sst;
             }
 
@@ -29210,7 +29232,19 @@ int tidesdb_iter_new(tidesdb_txn_t *txn, tidesdb_column_family_t *cf, tidesdb_it
                 for (int j = 0; j < num_ssts; j++)
                 {
                     tidesdb_sstable_t *sst = sstables[j];
-                    if (sst && tidesdb_sstable_try_ref(sst))
+                    if (!sst) continue;
+                    /* spin over the transient reaper-eviction window rather than dropping a live
+                     * sstable (see the main loop above). this is the last-resort pass, so if the
+                     * ref still will not land after the spin we leave it -- but the common case is
+                     * a brief EVICTING window that clears here. */
+                    int ref_spins = 0;
+                    while (!tidesdb_sstable_try_ref(sst))
+                    {
+                        if (ref_spins >= TDB_IMM_SNAP_ACQUIRE_SPIN_LIMIT) break;
+                        cpu_pause();
+                        ref_spins++;
+                    }
+                    if (ref_spins >= TDB_IMM_SNAP_ACQUIRE_SPIN_LIMIT) continue; /* could not ref */
                     {
                         tidesdb_sstable_t **new_arr =
                             realloc(ssts_array, (sst_count + 1) * sizeof(tidesdb_sstable_t *));
@@ -30115,7 +30149,7 @@ static void tidesdb_iter_seek_sstable_source_forward(const tidesdb_iter_t *iter,
                 size_t erem = source->source.sstable.lazy.block_data_size - e_off;
                 uint8_t flags = *eptr++;
                 erem--;
-                uint64_t ks, vs;
+                uint64_t ks = 0, vs = 0;
                 int br = decode_varint(eptr, &ks, (int)erem);
                 eptr += br;
                 erem -= br;
@@ -30189,7 +30223,7 @@ static void tidesdb_iter_seek_sstable_source_forward(const tidesdb_iter_t *iter,
             size_t erem = source->source.sstable.lazy.block_data_size - e_off;
             uint8_t flags = *eptr++;
             erem--;
-            uint64_t ks, vs;
+            uint64_t ks = 0, vs = 0;
             int br = decode_varint(eptr, &ks, (int)erem);
             eptr += br;
             erem -= br;

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -306,6 +306,14 @@ typedef tidesdb_memtable_t tidesdb_immutable_memtable_t;
 /* how many cfs the reaper retries deferred flushes for in a single cycle */
 #define TDB_REAPER_DEFERRED_FLUSH_BATCH 64
 #define TDB_SSTABLE_REAPER_EVICT_RATIO  0.25
+/* the per-CF memory-pressure scan (cf_list_lock + a try_ref on every active memtable) runs every
+ * reaper cycle. when the last scan's total was comfortably below the limit there is no pressure to
+ * react to, so gate the full scan on a cheap proxy (the cached last-scan total): skip it while the
+ * proxy is under PRESSURE_SCAN_GATE_RATIO of the limit, but force one at least every
+ * PRESSURE_SCAN_MAX_SKIP cycles so a climb is never missed by more than that. above the ratio the
+ * scan runs every cycle for full resolution as pressure approaches the ELEVATED threshold. */
+#define TDB_REAPER_PRESSURE_SCAN_GATE_RATIO 0.50
+#define TDB_REAPER_PRESSURE_SCAN_MAX_SKIP   10
 
 /* replica sync thread configuration */
 #define TDB_REPLICA_SYNC_DEFAULT_INTERVAL_US 5000000
@@ -383,6 +391,12 @@ typedef tidesdb_memtable_t tidesdb_immutable_memtable_t;
  * leaves a small overshoot margin above that before apply_backpressure
  * stalls the writer until rotation completes */
 #define TDB_BACKPRESSURE_ACTIVE_MT_CEILING_MULT 2
+/* proportional pre-throttle on the active-memtable ceiling. instead of a binary wall (no delay
+ * below the ceiling, then a multi-second block at it) the writer is paced by a convex ramp once the
+ * active passes RAMP_LO_RATIO of the ceiling, reaching RAMP_MAX_DELAY_US right at the ceiling. this
+ * lets flush catch up before the hard stall, turning the latency cliff into a gentle rise. */
+#define TDB_BACKPRESSURE_RAMP_LO_RATIO     0.75
+#define TDB_BACKPRESSURE_RAMP_MAX_DELAY_US 4000
 
 /* backpressure stall warnings (ceiling stall, immutable-queue-critical) are emitted from the
  * write/flush hot paths -- a per-event log floods under sustained backpressure (every stalling
@@ -399,7 +413,7 @@ typedef tidesdb_memtable_t tidesdb_immutable_memtable_t;
 #define TDB_MEMORY_PRESSURE_ELEVATED_RATIO 0.60 /* ratio threshold for elevated */
 #define TDB_MEMORY_PRESSURE_HIGH_RATIO     0.75 /* ratio threshold for high */
 #define TDB_MEMORY_PRESSURE_CRITICAL_RATIO 0.95 /* ratio threshold for critical */
-#define TDB_MEMORY_AUTO_LIMIT_RATIO        0.50 /* auto limit = 50% of total memory */
+#define TDB_MEMORY_AUTO_LIMIT_RATIO        0.75 /* auto limit = 75% of total memory */
 #define TDB_MEMORY_MIN_LIMIT_RATIO         0.05 /* minimum limit = 5% of total memory */
 #define TDB_MEMORY_OS_CHECK_INTERVAL       50
 #define TDB_MEMORY_OS_CRITICAL_RATIO       0.05 /* OS critically low if < N% free */
@@ -1661,6 +1675,7 @@ static int tidesdb_sstable_write_from_heap_btree(tidesdb_column_family_t *cf,
                                                  int is_largest_level);
 static int tidesdb_trigger_compaction(tidesdb_column_family_t *cf, int full_compaction);
 static int tidesdb_enqueue_compaction(tidesdb_column_family_t *cf, int full_compaction);
+static int tidesdb_enqueue_compaction_force(tidesdb_column_family_t *cf, int full_compaction);
 static int tidesdb_compact_internal(tidesdb_column_family_t *cf, int full_compaction, int blocking);
 static int tidesdb_wal_recover(tidesdb_column_family_t *cf, const char *wal_path,
                                skip_list_t **memtable);
@@ -2854,24 +2869,25 @@ tidesdb_column_family_config_t tidesdb_default_column_family_config(void)
 
 tidesdb_config_t tidesdb_default_config(void)
 {
-    return (tidesdb_config_t){.db_path = "./tidesdb",
-                              .log_level = TDB_LOG_INFO,
-                              .num_flush_threads = TDB_DEFAULT_FLUSH_THREAD_POOL_SIZE,
-                              .num_compaction_threads = TDB_DEFAULT_COMPACTION_THREAD_POOL_SIZE,
-                              .block_cache_size = TDB_DEFAULT_BLOCK_CACHE_SIZE,
-                              .max_open_sstables = TDB_DEFAULT_MAX_OPEN_SSTABLES,
-                              .log_to_file = 0,
-                              .log_truncation_at = TDB_DEFAULT_LOG_FILE_TRUNCATION,
-                              .max_memory_usage = 0,
-                              .unified_memtable = 0,
-                              .unified_memtable_write_buffer_size = 0,
-                              .unified_memtable_skip_list_max_level = 0,
-                              .unified_memtable_skip_list_probability = 0,
-                              .unified_memtable_sync_mode = 0,
-                              .unified_memtable_sync_interval_us = 0,
-                              .object_store = NULL,
-                              .object_store_config = NULL,
-                              .max_concurrent_flushes = TDB_DEFAULT_MAX_CONCURRENT_FLUSHES};
+    return (tidesdb_config_t){
+        .db_path = "./tidesdb",
+        .log_level = TDB_LOG_INFO,
+        .num_flush_threads = 0, /* 0 = auto, resolved at open from cpu count */
+        .num_compaction_threads = TDB_DEFAULT_COMPACTION_THREAD_POOL_SIZE,
+        .block_cache_size = TDB_DEFAULT_BLOCK_CACHE_SIZE,
+        .max_open_sstables = TDB_DEFAULT_MAX_OPEN_SSTABLES,
+        .log_to_file = 0,
+        .log_truncation_at = TDB_DEFAULT_LOG_FILE_TRUNCATION,
+        .max_memory_usage = 0,
+        .unified_memtable = 0,
+        .unified_memtable_write_buffer_size = 0,
+        .unified_memtable_skip_list_max_level = 0,
+        .unified_memtable_skip_list_probability = 0,
+        .unified_memtable_sync_mode = 0,
+        .unified_memtable_sync_interval_us = 0,
+        .object_store = NULL,
+        .object_store_config = NULL,
+        .max_concurrent_flushes = 0}; /* 0 = pin to resolved num_flush_threads */
 }
 
 /**
@@ -7122,12 +7138,15 @@ static void tidesdb_imm_snap_publish_locked(tidesdb_column_family_t *cf)
      * flush worker wedges. the immutable stays in the queue until reclaimed -- only the snapshot
      * drops it early. */
     size_t count = 0;
+    int64_t imm_bytes = 0;
     for (size_t i = 0; i < raw; i++)
     {
         tidesdb_memtable_t *m = next->items[i];
+        if (m && m->skip_list) imm_bytes += (int64_t)skip_list_get_size(m->skip_list);
         if (m && atomic_load_explicit(&m->flushed, memory_order_acquire)) continue;
         next->items[count++] = m;
     }
+    atomic_store_explicit(&cf->immutable_bytes, imm_bytes, memory_order_relaxed);
     atomic_store_explicit(&next->count, count, memory_order_release);
 
     /* we ensure the new slot contents are visible before swapping active index */
@@ -17475,20 +17494,27 @@ int tidesdb_trigger_compaction(tidesdb_column_family_t *cf, int full_compaction)
      */
     atomic_store(&cf->db->cached_current_time, tdb_get_current_time());
 
-    /* we force flush memtable before compaction to ensure all data is in ssts
-     * this prevents data loss where keys in memtable are not included in compaction */
+    /* we force flush the memtable before compaction. the kick is unconditional, but only a full
+     * manual compaction waits for it to land. a full merge must see every prior write so it can
+     * reclaim tombstones/single-deletes that span levels. the geometry-driven path snapshots its
+     * input sstable ids (tidesdb_snapshot_sst_ids, under the level array_readers guard) and never
+     * reads the memtable, so a concurrent flush appending a new L1 sstable is simply absent from
+     * the snapshot and picked up next round -- no wait needed, which removes up to a second of
+     * latency from the common geometry-driven case. */
     tidesdb_flush_memtable_internal(cf, 0, 1);
 
-    /* wait for the forced flush to fully complete before compaction reads the
-     * levels. flush_pending_count is decremented only after the worker finishes
-     * writing the sstable, whereas the flush queue empties as soon as a work
-     * item is dequeued -- and it is db-global, so it also reflects unrelated
-     * CFs' flushes */
-    for (int i = 0; i < TDB_COMPACTION_FLUSH_WAIT_MAX_ATTEMPTS; i++)
+    /* wait for the forced flush to fully complete before a full compaction reads the levels.
+     * flush_pending_count is decremented only after the worker finishes writing the sstable,
+     * whereas the flush queue empties as soon as a work item is dequeued -- and it is db-global, so
+     * it also reflects unrelated CFs' flushes */
+    if (full_compaction)
     {
-        if (!tidesdb_is_flushing(cf)) break;
-        if (tidesdb_cf_abort_requested(cf)) break;
-        usleep(TDB_COMPACTION_FLUSH_WAIT_SLEEP_US);
+        for (int i = 0; i < TDB_COMPACTION_FLUSH_WAIT_MAX_ATTEMPTS; i++)
+        {
+            if (!tidesdb_is_flushing(cf)) break;
+            if (tidesdb_cf_abort_requested(cf)) break;
+            usleep(TDB_COMPACTION_FLUSH_WAIT_SLEEP_US);
+        }
     }
 
     if (tidesdb_cf_abort_requested(cf))
@@ -18951,9 +18977,11 @@ static void *tidesdb_compaction_worker_thread(void *arg)
 
         /* drain any auto-trigger that arrived while is_compacting was held.
          * exchange-to-zero so a re-arm after this point queues another
-         * follow-up rather than being swallowed here */
+         * follow-up rather than being swallowed here. force-enqueue so this
+         * genuine follow-up is not coalesced away by the pending-count check --
+         * this cf's just-finished work item is still counted below */
         if (atomic_exchange_explicit(&cf->compaction_armed, 0, memory_order_acq_rel))
-            tidesdb_enqueue_compaction(cf, 0);
+            tidesdb_enqueue_compaction_force(cf, 0);
 
         atomic_fetch_sub_explicit(&cf->compaction_pending_count, 1, memory_order_release);
         atomic_fetch_sub_explicit(&db->active_compactions, 1, memory_order_acq_rel);
@@ -19249,6 +19277,10 @@ static void *tidesdb_reaper_thread(void *arg)
 
     TDB_DEBUG_LOG(TDB_LOG_INFO, "Reaper thread started");
 
+    /* consecutive cycles the full memory-pressure scan has been gated out; start at the max so the
+     * first cycle always scans (the cached proxy is 0 until the first real scan runs) */
+    int reaper_scan_skips = TDB_REAPER_PRESSURE_SCAN_MAX_SKIP;
+
     while (atomic_load(&db->reaper_active))
     {
         time_t now = tdb_get_current_time();
@@ -19362,7 +19394,21 @@ static void *tidesdb_reaper_thread(void *arg)
          * of test overrides and runtime changes on all compilers (MSVC, MinGW) */
         const size_t mem_limit =
             atomic_load_explicit(&db->resolved_memory_limit, memory_order_acquire);
+
+        /* gate the full per-CF scan on the cheap cached proxy (see PRESSURE_SCAN constants) */
+        int do_full_scan = 1;
         if (mem_limit > 0)
+        {
+            const int64_t proxy =
+                atomic_load_explicit(&db->cached_memtable_bytes, memory_order_relaxed);
+            if (proxy < (int64_t)((double)mem_limit * TDB_REAPER_PRESSURE_SCAN_GATE_RATIO) &&
+                ++reaper_scan_skips < TDB_REAPER_PRESSURE_SCAN_MAX_SKIP)
+                do_full_scan = 0;
+            else
+                reaper_scan_skips = 0;
+        }
+
+        if (mem_limit > 0 && do_full_scan)
         {
             int64_t total_mem_bytes = 0;
 
@@ -19400,18 +19446,13 @@ static void *tidesdb_reaper_thread(void *arg)
                     tidesdb_immutable_memtable_unref(mt);
                 }
 
-                /* immutable queue -- conservative estimate using write_buffer_size.
-                 * each immutable's data is bounded by write_buffer_size (flush threshold).
-                 * while arena allocates TDB_MEMTABLE_ARENA_SIZE_FACTOR x write_buffer_size, the
-                 * unused arena capacity is not meaningful for pressure accounting. skipped in
-                 * unified mode, per-CF immutable queues there hold only empty rotated memtables
-                 * (all data is in the unified memtable, summed separately below), so charging each
-                 * write_buffer_size is phantom memory that inflates the pressure ratio and triggers
-                 * spurious force-flushes. */
+                /* immutable queue -- actual resident skip-list bytes, maintained by the snapshot
+                 * publish. skipped in unified mode, where per-CF immutable queues hold only empty
+                 * rotated wrappers and the unified immutable queue is summed separately below. */
                 if (!db->unified_mt.enabled)
                 {
-                    size_t imm_count = queue_size(cf->immutable_memtables);
-                    total_mem_bytes += (int64_t)(imm_count * cf->config.write_buffer_size);
+                    total_mem_bytes +=
+                        atomic_load_explicit(&cf->immutable_bytes, memory_order_relaxed);
                 }
 
                 /* count sstables per cf for the compaction victim heuristic. bloom
@@ -19567,8 +19608,10 @@ static void *tidesdb_reaper_thread(void *arg)
                 }
                 else if (level >= TDB_MEMORY_PRESSURE_CRITICAL)
                 {
-                    /* nuclear flush -- at critical pressure we flush every non-flushing CF
-                     * to shed memory as fast as possible across all column families */
+                    /* critical -- force-flush every CF that holds data. flushing an empty active
+                     * sheds nothing and only churns an immutable + a post-flush compaction, so skip
+                     * those; any CF with data is flushed so memory still drains across all of them.
+                     */
                     pthread_rwlock_rdlock(&db->cf_list_lock);
                     for (int i = 0; i < db->num_column_families; i++)
                     {
@@ -19577,15 +19620,26 @@ static void *tidesdb_reaper_thread(void *arg)
                         if (atomic_load_explicit(&victim->is_flushing, memory_order_relaxed))
                             continue;
 
+                        size_t vsize = 0;
+                        tidesdb_memtable_t *vmt = NULL;
+                        if (tidesdb_active_memtable_try_ref(&victim->active_mt_readers,
+                                                            &victim->active_memtable, &vmt))
+                        {
+                            if (vmt->skip_list) vsize = skip_list_get_size(vmt->skip_list);
+                            tidesdb_immutable_memtable_unref(vmt);
+                        }
+                        if (vsize == 0) continue;
+
                         TDB_DEBUG_LOG(TDB_LOG_WARN,
-                                      "Memory pressure CRITICAL nuclear flush CF '%s' "
-                                      "(global %" PRId64 "/%zu bytes, %.1f%%)",
-                                      victim->name, total_mem_bytes, mem_limit, ratio * 100.0);
+                                      "Memory pressure CRITICAL flushing CF '%s' (%zu bytes, "
+                                      "global %" PRId64 "/%zu bytes, %.1f%%)",
+                                      victim->name, vsize, total_mem_bytes, mem_limit,
+                                      ratio * 100.0);
                         tidesdb_flush_memtable_internal(victim, 0, 1);
                     }
                     pthread_rwlock_unlock(&db->cf_list_lock);
                 }
-                else if (flush_victim)
+                else if (flush_victim && flush_victim_size > 0)
                 {
                     /* high pressure -- force-flush the largest non-flushing memtable */
                     TDB_DEBUG_LOG(TDB_LOG_WARN,
@@ -20040,7 +20094,12 @@ int tidesdb_open(const tidesdb_config_t *config, tidesdb_t **db)
      * workers idle, so any deviation gets a warning and is corrected.
      * subsequent code reads from the owned copy via the rebind below */
     if ((*db)->config.num_flush_threads <= 0)
-        (*db)->config.num_flush_threads = TDB_DEFAULT_FLUSH_THREAD_POOL_SIZE;
+    {
+        int cpus = tdb_get_cpu_count();
+        if (cpus <= 0) cpus = TDB_DEFAULT_FLUSH_THREAD_POOL_SIZE;
+        (*db)->config.num_flush_threads =
+            cpus < TDB_FLUSH_THREADS_AUTO_CAP ? cpus : TDB_FLUSH_THREADS_AUTO_CAP;
+    }
     if ((*db)->config.max_concurrent_flushes <= 0)
         (*db)->config.max_concurrent_flushes = (*db)->config.num_flush_threads;
     else if ((*db)->config.max_concurrent_flushes != (*db)->config.num_flush_threads)
@@ -22662,6 +22721,7 @@ int tidesdb_create_column_family(tidesdb_t *db, const char *name,
     atomic_init(&cf->compaction_pending_count, 0);
     atomic_init(&cf->compaction_armed, 0);
     atomic_init(&cf->immutable_cleanup_counter, 0);
+    atomic_init(&cf->immutable_bytes, 0);
     atomic_init(&cf->pending_commits, 0);
 
     char manifest_path[TDB_MAX_PATH_LEN];
@@ -23962,21 +24022,12 @@ static int tidesdb_flush_memtable_internal(tidesdb_column_family_t *cf,
     return TDB_SUCCESS;
 }
 
-static int tidesdb_enqueue_compaction(tidesdb_column_family_t *cf, int full_compaction)
+/* enqueue a compaction work item unconditionally, no coalescing. the worker's armed-drain
+ * follow-up uses this -- it represents a genuine follow-up after a completed compaction and must
+ * queue even though this cf's just-finished item is still counted in compaction_pending_count. */
+static int tidesdb_enqueue_compaction_force(tidesdb_column_family_t *cf, int full_compaction)
 {
-    if (!cf) return TDB_ERR_INVALID_ARGS;
-
-    if (atomic_load_explicit(&cf->is_compacting, memory_order_acquire))
-    {
-        /* compaction already running. arm a follow-up so the worker
-         * re-enqueues once it finishes this round, otherwise a trigger that
-         * arrived mid-compaction is silently coalesced into nothing */
-        atomic_store_explicit(&cf->compaction_armed, 1, memory_order_release);
-        return TDB_SUCCESS;
-    }
-
-    /* we enqueue compaction work -- calloc so the steer fields default to zero
-     * (no tombstone steering) */
+    /* calloc so the steer fields default to zero (no tombstone steering) */
     tidesdb_compaction_work_t *work = calloc(1, sizeof(tidesdb_compaction_work_t));
     if (!work)
     {
@@ -23994,6 +24045,26 @@ static int tidesdb_enqueue_compaction(tidesdb_column_family_t *cf, int full_comp
     }
 
     return TDB_SUCCESS;
+}
+
+static int tidesdb_enqueue_compaction(tidesdb_column_family_t *cf, int full_compaction)
+{
+    if (!cf) return TDB_ERR_INVALID_ARGS;
+
+    /* coalesce against an in-flight OR already-pending compaction. a queued compaction recomputes
+     * its geometry from current level state when it runs, so a second copy is pure redundancy that
+     * piles up the compaction queue and thrashes the worker pool on TDB_ERR_LOCKED requeues. arm a
+     * follow-up instead -- the worker re-enqueues once it finishes (and the reaper drains the armed
+     * flag as a backstop), so no trigger is lost. checking pending_count (not just is_compacting)
+     * closes the window between a work item being queued and the worker setting is_compacting. */
+    if (atomic_load_explicit(&cf->is_compacting, memory_order_acquire) ||
+        atomic_load_explicit(&cf->compaction_pending_count, memory_order_acquire) > 0)
+    {
+        atomic_store_explicit(&cf->compaction_armed, 1, memory_order_release);
+        return TDB_SUCCESS;
+    }
+
+    return tidesdb_enqueue_compaction_force(cf, full_compaction);
 }
 
 /**
@@ -24421,6 +24492,17 @@ static int tidesdb_apply_backpressure(tidesdb_column_family_t *cf)
             if (amt->skip_list) active_size = (size_t)skip_list_get_size(amt->skip_list);
             tidesdb_immutable_memtable_unref(amt);
         }
+        const size_t ramp_lo = (size_t)((double)ceiling * TDB_BACKPRESSURE_RAMP_LO_RATIO);
+        if (active_size > ramp_lo && active_size < ceiling)
+        {
+            const double f = (double)(active_size - ramp_lo) / (double)(ceiling - ramp_lo);
+            const useconds_t d = (useconds_t)(TDB_BACKPRESSURE_RAMP_MAX_DELAY_US * f * f);
+            if (d > 0)
+            {
+                usleep(d);
+                l0_delayed = 1;
+            }
+        }
         if (active_size >= ceiling)
         {
             if (tdb_log_throttle(cf->db, &cf->last_ceiling_stall_log_sec,
@@ -24501,6 +24583,17 @@ static int tidesdb_apply_backpressure(tidesdb_column_family_t *cf)
         {
             if (umt->skip_list) u_size = (size_t)skip_list_get_size(umt->skip_list);
             tidesdb_immutable_memtable_unref(umt);
+        }
+        const size_t u_ramp_lo = (size_t)((double)u_ceiling * TDB_BACKPRESSURE_RAMP_LO_RATIO);
+        if (u_size > u_ramp_lo && u_size < u_ceiling)
+        {
+            const double f = (double)(u_size - u_ramp_lo) / (double)(u_ceiling - u_ramp_lo);
+            const useconds_t d = (useconds_t)(TDB_BACKPRESSURE_RAMP_MAX_DELAY_US * f * f);
+            if (d > 0)
+            {
+                usleep(d);
+                l0_delayed = 1;
+            }
         }
         if (u_size >= u_ceiling)
         {
@@ -27975,6 +28068,16 @@ static int tidesdb_unified_memtable_rotate(tidesdb_t *db)
 {
     tidesdb_memtable_t *old_mt = atomic_load_explicit(&db->unified_mt.active, memory_order_acquire);
     if (!old_mt) return TDB_ERR_UNKNOWN;
+
+    /* skip rotating an empty active -- some callers (the reaper's memory-pressure rotate, the
+     * apply_backpressure ceiling path) invoke this without first checking that the active holds
+     * data. when writes are blocked under sustained pressure the active is empty, and rotating it
+     * anyway churns empty immutables onto the unbounded unified immutable queue, allocates a fresh
+     * arena and a new WAL file with a directory sync, and enqueues an empty flush -- all of which
+     * sheds nothing. the caller holds the single-rotator is_flushing CAS, so old_mt cannot be
+     * swapped/freed here; a concurrent writer appending one entry at most defers this rotate one
+     * round. */
+    if (!old_mt->skip_list || skip_list_get_size(old_mt->skip_list) == 0) return TDB_SUCCESS;
 
     const uint64_t new_gen =
         atomic_fetch_add_explicit(&db->unified_mt.wal_generation, 1, memory_order_relaxed) + 1;

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -321,6 +321,10 @@ typedef tidesdb_memtable_t tidesdb_immutable_memtable_t;
 
 #define TDB_MEMTABLE_ARENA_SIZE_FACTOR \
     2 /* memtable arena over-provisions to 2x write_buffer_size */
+/* unified mode routes all writes to the shared unified memtable, so a CF's own active memtable is
+ * never the write target -- a minimal arena instead of 2x write_buffer_size avoids wasting hundreds
+ * of MB across many CFs. */
+#define TDB_UNIFIED_PER_CF_ARENA_INIT          (64 * 1024)
 #define TDB_DEFAULT_MAX_CONC_UPLOADS_OBJ_STORE 4
 
 /* default interval for unified WAL fsync escalation when the unified memtable
@@ -22469,10 +22473,12 @@ int tidesdb_create_column_family(tidesdb_t *db, const char *name,
     cf->config.comparator_fn_cached = comparator_fn;
     cf->config.comparator_ctx_cached = comparator_ctx;
 
+    const size_t cf_arena_init = db->unified_mt.enabled
+                                     ? TDB_UNIFIED_PER_CF_ARENA_INIT
+                                     : config->write_buffer_size * TDB_MEMTABLE_ARENA_SIZE_FACTOR;
     if (skip_list_new_with_arena(&new_memtable, config->skip_list_max_level,
                                  config->skip_list_probability, comparator_fn, comparator_ctx,
-                                 &db->cached_current_time,
-                                 config->write_buffer_size * TDB_MEMTABLE_ARENA_SIZE_FACTOR) != 0)
+                                 &db->cached_current_time, cf_arena_init) != 0)
     {
         free(cf->directory);
         free(cf->name);
@@ -24496,7 +24502,7 @@ static int tidesdb_apply_backpressure(tidesdb_column_family_t *cf)
         if (active_size > ramp_lo && active_size < ceiling)
         {
             const double f = (double)(active_size - ramp_lo) / (double)(ceiling - ramp_lo);
-            const useconds_t d = (useconds_t)(TDB_BACKPRESSURE_RAMP_MAX_DELAY_US * f * f);
+            const unsigned int d = (unsigned int)(TDB_BACKPRESSURE_RAMP_MAX_DELAY_US * f * f);
             if (d > 0)
             {
                 usleep(d);
@@ -24588,7 +24594,7 @@ static int tidesdb_apply_backpressure(tidesdb_column_family_t *cf)
         if (u_size > u_ramp_lo && u_size < u_ceiling)
         {
             const double f = (double)(u_size - u_ramp_lo) / (double)(u_ceiling - u_ramp_lo);
-            const useconds_t d = (useconds_t)(TDB_BACKPRESSURE_RAMP_MAX_DELAY_US * f * f);
+            const unsigned int d = (unsigned int)(TDB_BACKPRESSURE_RAMP_MAX_DELAY_US * f * f);
             if (d > 0)
             {
                 usleep(d);

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -7870,8 +7870,13 @@ static int tidesdb_sstable_write_from_memtable_btree_ex(tidesdb_t *db, tidesdb_c
             if (btree_builder_add(builder, key, key_size, value_to_store, value_size_to_store,
                                   vlog_offset, seq, ttl, entry_flags) != 0)
             {
+                /* allocation failed adding the entry -- fail the write so the flush retries and the
+                 * wal is retained, rather than committing a btree with a dropped committed key */
                 TDB_DEBUG_LOG(TDB_LOG_ERROR, "SSTable %" PRIu64 " failed to add entry to btree",
                               sst->id);
+                if (bloom) bloom_filter_free(bloom);
+                btree_builder_free(builder);
+                return TDB_ERR_MEMORY;
             }
 
             /* we add to bloom filter */
@@ -14288,8 +14293,14 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
                     /* we check if this is the first entry in a new block */
                     int is_first_entry_in_block = (current_klog_block->num_entries == 0);
 
-                    tidesdb_klog_block_add_entry(current_klog_block, pending, &cf->config,
-                                                 comparator_fn, comparator_ctx);
+                    if (tidesdb_klog_block_add_entry(current_klog_block, pending, &cf->config,
+                                                     comparator_fn, comparator_ctx) != TDB_SUCCESS)
+                    {
+                        /* allocation failed adding the entry -- abort, preserving the sources so no
+                         * key is lost and compaction retries */
+                        aborted = 1;
+                        break;
+                    }
 
                     /* we track first key of block */
                     if (is_first_entry_in_block)
@@ -14908,8 +14919,14 @@ static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t
 
                 int is_first_entry_in_block = (current_klog_block->num_entries == 0);
 
-                tidesdb_klog_block_add_entry(current_klog_block, pending, &cf->config,
-                                             comparator_fn, comparator_ctx);
+                if (tidesdb_klog_block_add_entry(current_klog_block, pending, &cf->config,
+                                                 comparator_fn, comparator_ctx) != TDB_SUCCESS)
+                {
+                    /* allocation failed adding the entry -- abort, preserving the sources so no key
+                     * is lost and compaction retries */
+                    aborted = 1;
+                    break;
+                }
 
                 if (is_first_entry_in_block)
                 {
@@ -15879,8 +15896,14 @@ static int tidesdb_dividing_merge_partition(void *vctx, int partition)
                     /* we check if this is the first entry in a new block */
                     int is_first_entry_in_block = (klog_block->num_entries == 0);
 
-                    tidesdb_klog_block_add_entry(klog_block, pending, &cf->config, comparator_fn,
-                                                 comparator_ctx);
+                    if (tidesdb_klog_block_add_entry(klog_block, pending, &cf->config,
+                                                     comparator_fn, comparator_ctx) != TDB_SUCCESS)
+                    {
+                        /* allocation failed adding the entry -- abort, preserving the sources so no
+                         * key is lost and compaction retries */
+                        aborted = 1;
+                        break;
+                    }
 
                     /* we track first key of block */
                     if (is_first_entry_in_block)
@@ -17030,8 +17053,14 @@ static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
                 /* we check if this is first entry in a new block (before adding) */
                 int is_first_entry_in_block = (klog_block->num_entries == 0);
 
-                tidesdb_klog_block_add_entry(klog_block, kv, &cf->config, comparator_fn,
-                                             comparator_ctx);
+                if (tidesdb_klog_block_add_entry(klog_block, kv, &cf->config, comparator_fn,
+                                                 comparator_ctx) != TDB_SUCCESS)
+                {
+                    /* an allocation failed adding the entry -- abort cleanly. the aborted path
+                     * preserves the source sstables so no key is lost and compaction retries. */
+                    aborted = 1;
+                    break;
+                }
 
                 /* we track first key of block */
                 if (is_first_entry_in_block)
@@ -18471,12 +18500,16 @@ static void *tidesdb_flush_worker_thread(void *arg)
          * (the array is append-only and unsorted). logged at DEBUG as a flush-concurrency signal
          * only -- it is not a correctness violation. one line per out-of-order add (not per pair)
          * to avoid an O(n) burst when an old sstable lands behind many newer ones. */
-        int num_existing = atomic_load_explicit(&cf->levels[0]->num_sstables, memory_order_acquire);
-        if (num_existing > 0)
+        if (atomic_load_explicit(&cf->levels[0]->num_sstables, memory_order_acquire) > 0)
         {
+            /* hold array_readers while scanning the lock-free sstable array so a concurrent
+             * level_add_sstable (flush or compaction) cannot retire and free it under us */
+            atomic_fetch_add_explicit(&cf->levels[0]->array_readers, 1, memory_order_acq_rel);
+            int num_existing =
+                atomic_load_explicit(&cf->levels[0]->num_sstables, memory_order_acquire);
             tidesdb_sstable_t **existing_ssts =
                 atomic_load_explicit(&cf->levels[0]->sstables, memory_order_acquire);
-            for (int i = 0; i < num_existing; i++)
+            for (int i = 0; existing_ssts && i < num_existing; i++)
             {
                 if (existing_ssts[i] && existing_ssts[i]->max_seq >= sst->max_seq)
                 {
@@ -18489,6 +18522,7 @@ static void *tidesdb_flush_worker_thread(void *arg)
                     break;
                 }
             }
+            atomic_fetch_sub_explicit(&cf->levels[0]->array_readers, 1, memory_order_release);
         }
 
         /* we add sstable to level 1 (array index 0) -- load levels atomically */
@@ -34572,11 +34606,17 @@ int tidesdb_checkpoint(tidesdb_t *db, const char *checkpoint_dir)
             tidesdb_level_t *lvl = cf->levels[level];
             if (!lvl) continue;
 
+            /* hold array_readers across the scan so a concurrent flush or compaction cannot
+             * retire and free the sstable array (or its entries) while we read their paths.
+             * is_compacting excludes other compactions but not the flush worker, which adds to
+             * L0 off the commit lock. retire defers to the reaper while a reader is held, so the
+             * link I/O below does not block writers. */
+            atomic_fetch_add_explicit(&lvl->array_readers, 1, memory_order_acq_rel);
             tidesdb_sstable_t **sstables =
                 atomic_load_explicit(&lvl->sstables, memory_order_acquire);
             const int num_ssts = atomic_load_explicit(&lvl->num_sstables, memory_order_acquire);
 
-            for (int s = 0; s < num_ssts && result == TDB_SUCCESS; s++)
+            for (int s = 0; sstables && s < num_ssts && result == TDB_SUCCESS; s++)
             {
                 tidesdb_sstable_t *sst = sstables[s];
                 if (!sst) continue;
@@ -34621,6 +34661,8 @@ int tidesdb_checkpoint(tidesdb_t *db, const char *checkpoint_dir)
                 TDB_DEBUG_LOG(TDB_LOG_DEBUG, "Checkpoint linked SSTable %" PRIu64 " on L%d",
                               sst->id, level + 1);
             }
+
+            atomic_fetch_sub_explicit(&lvl->array_readers, 1, memory_order_release);
         }
 
         /* we copy manifest file (small) */
@@ -34930,11 +34972,14 @@ int tidesdb_clone_column_family(tidesdb_t *db, const char *src_name, const char 
             tidesdb_level_t *level = dst_cf->levels[level_idx];
             if (!level) continue;
 
+            /* dst_cf is already registered, so the background compaction scheduler can pick it
+             * and retire/free this level's array mid-scan -- hold array_readers across the deref */
+            atomic_fetch_add_explicit(&level->array_readers, 1, memory_order_acq_rel);
             tidesdb_sstable_t **sstables =
                 atomic_load_explicit(&level->sstables, memory_order_acquire);
             const int num_ssts = atomic_load_explicit(&level->num_sstables, memory_order_acquire);
 
-            for (int sst_idx = 0; sst_idx < num_ssts; sst_idx++)
+            for (int sst_idx = 0; sstables && sst_idx < num_ssts; sst_idx++)
             {
                 tidesdb_sstable_t *sst = sstables[sst_idx];
                 if (sst && sst->id >= max_sst_id)
@@ -34942,6 +34987,7 @@ int tidesdb_clone_column_family(tidesdb_t *db, const char *src_name, const char 
                     max_sst_id = sst->id + 1;
                 }
             }
+            atomic_fetch_sub_explicit(&level->array_readers, 1, memory_order_release);
         }
 
         if (max_sst_id > atomic_load(&dst_cf->next_sstable_id))

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -8478,8 +8478,17 @@ static int tidesdb_sstable_write_from_memtable_ex(tidesdb_t *db, tidesdb_column_
 
                 /* we track first key of block */
                 const int is_first_entry_in_block = (current_klog_block->num_entries == 0);
-                tidesdb_klog_block_add_entry(current_klog_block, &kv_stack, sst->config,
-                                             comparator_fn, comparator_ctx);
+                result = tidesdb_klog_block_add_entry(current_klog_block, &kv_stack, sst->config,
+                                                      comparator_fn, comparator_ctx);
+                if (result != TDB_SUCCESS)
+                {
+                    /* an allocation failed adding the entry -- fail the whole sstable write so the
+                     * flush retries and the WAL is retained, rather than committing a block that
+                     * silently dropped a committed key while the bloom still claims it present */
+                    TDB_DEBUG_LOG(TDB_LOG_ERROR, "SSTable %" PRIu64 " klog add_entry failed",
+                                  sst->id);
+                    goto cleanup;
+                }
 
                 /* we reuse block_first_key buffer with capacity tracking */
                 if (is_first_entry_in_block)

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -203,7 +203,12 @@ typedef enum
  * X = num_active_levels - 1 - offset that means offset = 1 */
 #define TDB_DEFAULT_DIVIDING_LEVEL_OFFSET       1
 #define TDB_DEFAULT_COMPACTION_THREAD_POOL_SIZE 2
-#define TDB_DEFAULT_FLUSH_THREAD_POOL_SIZE      2
+/* fallback flush pool size when cpu detection fails at open */
+#define TDB_DEFAULT_FLUSH_THREAD_POOL_SIZE 2
+/* default config leaves num_flush_threads at 0 (auto); open resolves it to
+ * min(cpu_count, TDB_FLUSH_THREADS_AUTO_CAP). a single shared flush pool feeds every CF, so a few
+ * threads keeps multi-CF flushes from serializing without oversubscribing on large core counts */
+#define TDB_FLUSH_THREADS_AUTO_CAP 4
 /* pinned to the flush pool size tidesdb_open clamps max_concurrent_flushes to
  * num_flush_threads and warns when they differ, so the canonical default open
  * (default_config + open) must already agree or it warns on every startup */
@@ -522,6 +527,8 @@ struct tidesdb_memtable_t
  * @param config column family configuration
  * @param active_memtable active memtable (paired skip list and WAL)
  * @param immutable_memtables queue of immutable memtables being flushed
+ * @param immutable_bytes sum of actual immutable skip-list sizes, refreshed on each snapshot
+ * publish, read by the reaper for memory-pressure accounting
  * @param pending_commits count of in-flight commits
  * @param levels fixed array of disk levels
  * @param num_active_levels number of currently active disk levels
@@ -550,6 +557,7 @@ struct tidesdb_column_family_t
     tidesdb_column_family_config_t config;
     _Atomic(tidesdb_memtable_t *) active_memtable;
     queue_t *immutable_memtables;
+    _Atomic(int64_t) immutable_bytes;
     _Atomic(uint64_t) pending_commits;
     tidesdb_level_t *levels[TDB_MAX_LEVELS];
     _Atomic(int) num_active_levels;

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -26077,6 +26077,9 @@ static void test_unified_four_cf_single_txn(void)
     tidesdb_t *db = create_unified_test_db();
 
     tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
+    /* this exercises cross-CF txn semantics, not memtable sizing; a small buffer keeps the per-CF
+     * arenas modest so several CFs fit under a constrained 32-bit sanitizer runner */
+    cf_config.write_buffer_size = 1024 * 1024;
 
     /* create 4 column families (matches sysbench pattern with t1..t4) */
     const char *cf_names[] = {"t1", "t2", "t3", "t4"};

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -23580,6 +23580,30 @@ static void *mcf_atom_compactor_thread(void *arg)
     return NULL;
 }
 
+/* a one-sided NOT_FOUND in the verify can be a transient read-vs-compaction miss rather than a real
+ * loss: the long-lived verify txn reads while background compaction relocates keys, and the
+ * point-get layout guard only converts some such races to a retryable BUSY. re-read the missing key
+ * with fresh txns over ~1s -- if it reappears the pair is durably present (atomicity held); if it
+ * stays gone it is a genuine one-sided loss. returns 1 if still gone (durable), 0 if it reappeared.
+ */
+static int tdb_atom_key_durably_gone(tidesdb_t *db, tidesdb_column_family_t *cf, const uint8_t *key,
+                                     size_t key_size)
+{
+    for (int i = 0; i < 50; i++)
+    {
+        usleep(20000);
+        tidesdb_txn_t *t = NULL;
+        if (tidesdb_txn_begin_with_isolation(db, TDB_ISOLATION_READ_COMMITTED, &t) != 0) continue;
+        uint8_t *v = NULL;
+        size_t vs = 0;
+        int rc = tdb_test_get_with_retry(t, cf, key, key_size, &v, &vs);
+        if (v) free(v);
+        tidesdb_txn_free(t);
+        if (rc == TDB_SUCCESS) return 0; /* reappeared -- transient */
+    }
+    return 1; /* still gone after ~1s -- durable */
+}
+
 static void test_multi_cf_cross_txn_compaction_atomicity(void)
 {
     cleanup_test_dir();
@@ -23684,11 +23708,27 @@ static void test_multi_cf_cross_txn_compaction_atomicity(void)
             if (a_ok && b_ok)
                 both_present++;
             else if (a_ok && b_gone)
-                only_a++; /* B genuinely lost -- real one-sided violation */
+            {
+                /* B missing -- reclassify with fresh re-reads, transient miss vs durable loss */
+                if (tdb_atom_key_durably_gone(db, cf_b, (uint8_t *)key_b, strlen(key_b) + 1))
+                    only_a++; /* B durably lost -- real one-sided violation */
+                else
+                    both_present++; /* reappeared -- atomicity held */
+            }
             else if (b_ok && a_gone)
-                only_b++; /* A genuinely lost -- real one-sided violation */
+            {
+                if (tdb_atom_key_durably_gone(db, cf_a, (uint8_t *)key_a, strlen(key_a) + 1))
+                    only_b++; /* A durably lost -- real one-sided violation */
+                else
+                    both_present++;
+            }
             else if (a_gone && b_gone)
-                both_absent++; /* whole committed pair lost */
+            {
+                if (tdb_atom_key_durably_gone(db, cf_a, (uint8_t *)key_a, strlen(key_a) + 1))
+                    both_absent++; /* whole committed pair durably lost */
+                else
+                    both_present++;
+            }
             else
                 busy++; /* at least one side BUSY -- present but transiently unreadable */
         }

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -23555,7 +23555,7 @@ static void *mcf_atom_writer_thread(void *arg)
         tidesdb_txn_put(txn, d->cf_b, (uint8_t *)key_b, strlen(key_b) + 1, (uint8_t *)val,
                         strlen(val) + 1, 0);
 
-        if (tidesdb_txn_commit(txn) == 0)
+        if (tdb_test_commit_with_retry(txn, 20) == 0)
             atomic_fetch_add(d->committed, 1);
         else
             atomic_fetch_add(d->errors, 1);

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -22412,7 +22412,7 @@ static void test_memory_pressure_auto_limit(void)
 {
     cleanup_test_dir();
 
-    /* we verify max_memory_usage = 0 auto-resolves to 50% of total memory */
+    /* we verify max_memory_usage = 0 auto-resolves to 75% of total memory */
     tidesdb_config_t config = tidesdb_default_config();
     config.db_path = TEST_DB_PATH;
     config.max_memory_usage = 0; /* auto */
@@ -22421,11 +22421,11 @@ static void test_memory_pressure_auto_limit(void)
     ASSERT_EQ(tidesdb_open(&config, &db), 0);
     ASSERT_TRUE(db != NULL);
 
-    /* resolved_memory_limit should be ~50% of total_memory */
+    /* resolved_memory_limit should be ~75% of total_memory (TDB_MEMORY_AUTO_LIMIT_RATIO) */
     ASSERT_TRUE(db->resolved_memory_limit > 0);
     ASSERT_TRUE(db->total_memory > 0);
 
-    size_t expected = (size_t)((double)db->total_memory * 0.50);
+    size_t expected = (size_t)((double)db->total_memory * 0.75);
     /* allow 1% tolerance for floating point */
     size_t diff = db->resolved_memory_limit > expected ? db->resolved_memory_limit - expected
                                                        : expected - db->resolved_memory_limit;
@@ -23834,6 +23834,222 @@ static void *mcf_iter_mut_compactor_thread(void *arg)
         usleep(15000);
     }
     return NULL;
+}
+
+/* a multi-CF flush-heavy workload must not pile the global compaction queue. enqueue coalesces
+ * against a pending (queued-but-not-yet-started) compaction as well as an in-flight one, so
+ * redundant work items -- each recomputing the same geometry -- cannot accumulate and thrash the
+ * worker pool on TDB_ERR_LOCKED requeues. the queue should stay bounded near one pending per CF. */
+typedef struct
+{
+    tidesdb_t *db;
+    tidesdb_column_family_t **cfs;
+    int num_cfs;
+    int id;
+    int num_ops;
+    _Atomic(int) *go;
+    _Atomic(int) *stop;
+    _Atomic(int) *errors;
+} cqb_writer_data_t;
+
+static void *cqb_writer_thread(void *arg)
+{
+    cqb_writer_data_t *d = (cqb_writer_data_t *)arg;
+    while (!atomic_load(d->go))
+    { /* spin */
+    }
+    for (int i = 0; i < d->num_ops && !atomic_load(d->stop); i++)
+    {
+        tidesdb_txn_t *txn = NULL;
+        if (tidesdb_txn_begin(d->db, &txn) != 0)
+        {
+            atomic_fetch_add(d->errors, 1);
+            continue;
+        }
+        char key[64], val[96];
+        snprintf(key, sizeof(key), "cqb_t%d_%06d", d->id, i);
+        snprintf(val, sizeof(val), "v_%d_%06d_padpadpadpadpadpad", d->id, i);
+        int cf = (d->id + i) % d->num_cfs;
+        tidesdb_txn_put(txn, d->cfs[cf], (uint8_t *)key, strlen(key) + 1, (uint8_t *)val,
+                        strlen(val) + 1, 0);
+        if (tdb_test_commit_with_retry(txn, 20) != 0) atomic_fetch_add(d->errors, 1);
+        tidesdb_txn_free(txn);
+    }
+    return NULL;
+}
+
+typedef struct
+{
+    tidesdb_t *db;
+    _Atomic(int) *stop;
+    _Atomic(int) *max_cq;
+} cqb_monitor_data_t;
+
+static void *cqb_monitor_thread(void *arg)
+{
+    cqb_monitor_data_t *d = (cqb_monitor_data_t *)arg;
+    while (!atomic_load(d->stop))
+    {
+        tidesdb_db_stats_t s;
+        memset(&s, 0, sizeof(s));
+        if (tidesdb_get_db_stats(d->db, &s) == 0)
+        {
+            int cq = (int)s.compaction_queue_size;
+            int cur = atomic_load(d->max_cq);
+            while (cq > cur && !atomic_compare_exchange_weak(d->max_cq, &cur, cq))
+            { /* retry */
+            }
+        }
+        usleep(2000);
+    }
+    return NULL;
+}
+
+static void test_compaction_queue_bounded_multi_cf(void)
+{
+    cleanup_test_dir();
+    tidesdb_config_t db_config = tidesdb_default_config();
+    db_config.db_path = TEST_DB_PATH;
+    tidesdb_t *db = NULL;
+    ASSERT_EQ(tidesdb_open(&db_config, &db), 0);
+    ASSERT_TRUE(db != NULL);
+
+    const int NUM_CFS = 6;
+    const int NUM_WRITERS = 8;
+    const int W_OPS = 4000;
+    tidesdb_column_family_t *cfs[6];
+    for (int c = 0; c < NUM_CFS; c++)
+    {
+        char nm[32];
+        snprintf(nm, sizeof(nm), "cqb_cf_%d", c);
+        tidesdb_column_family_config_t cc = tidesdb_default_column_family_config();
+        /* tiny write buffer -> frequent flush -> frequent post-flush compaction triggers, the
+         * workload that piled the queue before the coalescing fix */
+        cc.write_buffer_size = 4096;
+        cc.compression_algorithm = TDB_COMPRESS_NONE;
+        ASSERT_EQ(tidesdb_create_column_family(db, nm, &cc), 0);
+        cfs[c] = tidesdb_get_column_family(db, nm);
+        ASSERT_TRUE(cfs[c] != NULL);
+    }
+
+    _Atomic(int) go = 0, stop = 0, errors = 0, max_cq = 0;
+    pthread_t wt[8], mt;
+    cqb_writer_data_t wd[8];
+    cqb_monitor_data_t md = {db, &stop, &max_cq};
+    pthread_create(&mt, NULL, cqb_monitor_thread, &md);
+    for (int i = 0; i < NUM_WRITERS; i++)
+    {
+        wd[i] = (cqb_writer_data_t){db, cfs, NUM_CFS, i, W_OPS, &go, &stop, &errors};
+        pthread_create(&wt[i], NULL, cqb_writer_thread, &wd[i]);
+    }
+    atomic_store(&go, 1);
+    for (int i = 0; i < NUM_WRITERS; i++) pthread_join(wt[i], NULL);
+    atomic_store(&stop, 1);
+    pthread_join(mt, NULL);
+
+    int observed_max = atomic_load(&max_cq);
+    /* coalescing bounds the queue to ~one pending per CF (plus a transient force-enqueued follow-up
+     * each); 4x num_cfs is comfortably above that and far below the unbounded pile-up (50+) the old
+     * code produced on this workload. */
+    const int bound = 4 * NUM_CFS;
+    printf("  compaction queue bounded multi-cf: max observed=%d (bound=%d, cfs=%d) errors=%d\n",
+           observed_max, bound, NUM_CFS, (int)atomic_load(&errors));
+    ASSERT_EQ((int)atomic_load(&errors), 0);
+    ASSERT_TRUE(observed_max <= bound);
+
+    tidesdb_close(db);
+    cleanup_test_dir();
+}
+
+/* rotating an empty unified active must be a no-op. otherwise the reaper's pressure-rotate churns
+ * empty immutables and advances the WAL generation while writes are blocked, shedding nothing.
+ * flushing an empty unified memtable should enqueue no immutable and not advance the WAL
+ * generation; a non-empty active must still rotate. */
+static void test_unified_empty_rotate_noop(void)
+{
+    cleanup_test_dir();
+    tidesdb_config_t cfg = tidesdb_default_config();
+    cfg.db_path = TEST_DB_PATH;
+    cfg.unified_memtable = 1;
+    tidesdb_t *db = NULL;
+    ASSERT_EQ(tidesdb_open(&cfg, &db), 0);
+    ASSERT_TRUE(db != NULL);
+    tidesdb_column_family_config_t cc = tidesdb_default_column_family_config();
+    ASSERT_EQ(tidesdb_create_column_family(db, "u", &cc), 0);
+    tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "u");
+    ASSERT_TRUE(cf != NULL);
+
+    tidesdb_db_stats_t s0;
+    memset(&s0, 0, sizeof(s0));
+    ASSERT_EQ(tidesdb_get_db_stats(db, &s0), 0);
+
+    /* flush the empty unified active several times -- the guard makes each rotate a no-op */
+    for (int i = 0; i < 5; i++) tidesdb_flush_memtable(cf);
+
+    tidesdb_db_stats_t s1;
+    memset(&s1, 0, sizeof(s1));
+    ASSERT_EQ(tidesdb_get_db_stats(db, &s1), 0);
+    printf("  unified empty rotate noop: imm=%d wal_gen %llu->%llu\n", s1.unified_immutable_count,
+           (unsigned long long)s0.unified_wal_generation,
+           (unsigned long long)s1.unified_wal_generation);
+    ASSERT_EQ(s1.unified_immutable_count, 0);
+    ASSERT_EQ((unsigned long long)s1.unified_wal_generation,
+              (unsigned long long)s0.unified_wal_generation);
+
+    /* sanity -- a non-empty active still rotates (WAL generation advances) */
+    tidesdb_txn_t *txn = NULL;
+    ASSERT_EQ(tidesdb_txn_begin(db, &txn), 0);
+    tidesdb_txn_put(txn, cf, (uint8_t *)"k", 2, (uint8_t *)"v", 2, 0);
+    ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+    tidesdb_txn_free(txn);
+    tidesdb_flush_memtable(cf);
+    tidesdb_db_stats_t s2;
+    memset(&s2, 0, sizeof(s2));
+    ASSERT_EQ(tidesdb_get_db_stats(db, &s2), 0);
+    ASSERT_TRUE((unsigned long long)s2.unified_wal_generation >
+                (unsigned long long)s0.unified_wal_generation);
+
+    tidesdb_close(db);
+    cleanup_test_dir();
+}
+
+/* the default config leaves the flush pool at 0 (auto); open resolves it to min(cpu, cap) and pins
+ * max_concurrent_flushes to it with no mismatch warning. an explicit value is honored unchanged. */
+static void test_flush_threads_autoscale_default(void)
+{
+    cleanup_test_dir();
+    tidesdb_config_t cfg = tidesdb_default_config();
+    cfg.db_path = TEST_DB_PATH;
+    ASSERT_EQ(cfg.num_flush_threads, 0);
+    ASSERT_EQ(cfg.max_concurrent_flushes, 0);
+
+    tidesdb_t *db = NULL;
+    ASSERT_EQ(tidesdb_open(&cfg, &db), 0);
+    ASSERT_TRUE(db != NULL);
+
+    int cpus = tdb_get_cpu_count();
+    if (cpus <= 0) cpus = TDB_DEFAULT_FLUSH_THREAD_POOL_SIZE;
+    const int expect = cpus < TDB_FLUSH_THREADS_AUTO_CAP ? cpus : TDB_FLUSH_THREADS_AUTO_CAP;
+    printf("  flush autoscale: cpus=%d -> num_flush_threads=%d (cap=%d)\n", cpus,
+           db->config.num_flush_threads, TDB_FLUSH_THREADS_AUTO_CAP);
+    ASSERT_EQ(db->config.num_flush_threads, expect);
+    ASSERT_EQ(db->config.max_concurrent_flushes, db->config.num_flush_threads);
+    ASSERT_TRUE(db->config.num_flush_threads >= 1 &&
+                db->config.num_flush_threads <= TDB_FLUSH_THREADS_AUTO_CAP);
+    tidesdb_close(db);
+    cleanup_test_dir();
+
+    /* an explicit value is left as-is and max_concurrent_flushes pins to it */
+    tidesdb_config_t cfg2 = tidesdb_default_config();
+    cfg2.db_path = TEST_DB_PATH;
+    cfg2.num_flush_threads = 1;
+    tidesdb_t *db2 = NULL;
+    ASSERT_EQ(tidesdb_open(&cfg2, &db2), 0);
+    ASSERT_TRUE(db2 != NULL);
+    ASSERT_EQ(db2->config.num_flush_threads, 1);
+    ASSERT_EQ(db2->config.max_concurrent_flushes, 1);
+    tidesdb_close(db2);
+    cleanup_test_dir();
 }
 
 static void test_multi_cf_iterator_during_level_mutation(void)
@@ -29756,6 +29972,9 @@ int main(int argc, char **argv)
     RUN_TEST(test_concurrent_multi_cf_deep_sst_mixed_ops, tests_passed);
     RUN_TEST(test_multi_cf_flush_queue_saturation, tests_passed);
     RUN_TEST(test_multi_cf_cross_txn_compaction_atomicity, tests_passed);
+    RUN_TEST(test_compaction_queue_bounded_multi_cf, tests_passed);
+    RUN_TEST(test_unified_empty_rotate_noop, tests_passed);
+    RUN_TEST(test_flush_threads_autoscale_default, tests_passed);
     RUN_TEST(test_multi_cf_iterator_during_level_mutation, tests_passed);
     RUN_TEST(test_multi_cf_cascading_memory_pressure, tests_passed);
     RUN_TEST(test_multi_cf_create_drop_churn_under_load, tests_passed);

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -23589,7 +23589,9 @@ static void *mcf_atom_compactor_thread(void *arg)
 static int tdb_atom_key_durably_gone(tidesdb_t *db, tidesdb_column_family_t *cf, const uint8_t *key,
                                      size_t key_size)
 {
-    for (int i = 0; i < 50; i++)
+    /* ~5s window -- on a slow sanitizer runner a compaction relocating the key can outlast a
+     * shorter window and make a genuine transient look durable */
+    for (int i = 0; i < 250; i++)
     {
         usleep(20000);
         tidesdb_txn_t *t = NULL;
@@ -23601,7 +23603,11 @@ static int tdb_atom_key_durably_gone(tidesdb_t *db, tidesdb_column_family_t *cf,
         tidesdb_txn_free(t);
         if (rc == TDB_SUCCESS) return 0; /* reappeared -- transient */
     }
-    return 1; /* still gone after ~1s -- durable */
+    /* still gone after fresh re-reads -- record which key for diagnosis */
+    printf("  DURABLE MISS: CF '%s' key '%s' still gone after fresh re-reads\n", cf->name,
+           (const char *)key);
+    fflush(stdout);
+    return 1;
 }
 
 static void test_multi_cf_cross_txn_compaction_atomicity(void)
@@ -23736,6 +23742,7 @@ static void test_multi_cf_cross_txn_compaction_atomicity(void)
     tidesdb_txn_free(vtxn);
     printf("  atomicity check: both=%d only_a=%d only_b=%d both_absent=%d busy=%d\n", both_present,
            only_a, only_b, both_absent, busy);
+    fflush(stdout); /* flush before any assert abort so the counts survive in the log */
     /* the real invariants, no one-sided loss and no fully-lost committed pair. BUSY pairs are
      * present-but-transient, so they count toward the committed total rather than failing. */
     ASSERT_EQ(only_a, 0);

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tidesdb",
-  "version-string": "9.3.4",
+  "version-string": "9.3.5",
   "description": "TidesDB is a high-performance durable, transactional embeddable storage engine designed for flash and RAM optimization with optional object storage support for unlimited data scaling.",
   "dependencies": ["zstd", "snappy", "lz4", "pthreads"],
   "features": {


### PR DESCRIPTION
decode_varint returns negative without writing its output when max_bytes is zero, which happens on a truncated or corrupt block, and several indexed read and iterator decode sites used the result without checking the return, so a handful of locals (ks vs vo seq_val vlog_off) could be read uninitialized. zero initialize those locals so the failure path yields a defined zero rather than garbage. also add a TIDESDB_WARN_MAYBE_UNINIT option, gcc only and off by default, that turns the warning on for an optimized dev build where the analysis actually runs.

analyzed for MariaDB engine addition https://github.com/MariaDB/server/pull/5166 review

--

correct an iterator scan miss under reaper eviction and stop the cross cf atomicity test flaking on commit backpressure

iter_new pinned the level array once then skipped any sstable it could not immediately ref treating it as dead when in fact the reaper had it in a transient evicting window with the descriptor still live in the level. a reader iterator snapshots only once so that skip dropped a live sstable for the whole life of the scan and a key in it read back as not found. now we spin on try_ref while the level array is unchanged and only bail to retry when the array actually changed under us same shape as the point get reaper evict skip we already correctd.

the cross cf atomicity test counted a transient busy commit as a hard error which tripped the errors assert on slow loaded ci boxes. commit through tdb_test_commit_with_retry like the sibling writers so a backpressure stall retries instead of failing the run.