### PR TITLE
Apply log level before open-time logging

### DIFF
--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -20119,6 +20119,11 @@ int tidesdb_open(const tidesdb_config_t *config, tidesdb_t **db)
 
     if (!config || !db) return TDB_ERR_INVALID_ARGS;
 
+    /* apply the configured log level before any open-time logging, otherwise every TDB_DEBUG_LOG
+     * during open (the fd-budget line, thread-pool notes, recovery) is gated on the default DEBUG
+     * level and prints even when the caller asked for a quieter level or TDB_LOG_NONE */
+    _tidesdb_log_level = config->log_level;
+
     *db = calloc(1, sizeof(tidesdb_t));
     if (!*db)
     {
@@ -20230,8 +20235,6 @@ int tidesdb_open(const tidesdb_config_t *config, tidesdb_t **db)
         ((*db)->config.object_store_config && (*db)->config.object_store_config->replica_mode) ? 1
                                                                                                : 0);
     atomic_init(&(*db)->replica_sync_thread_active, 0);
-
-    _tidesdb_log_level = config->log_level;
 
     /* we initialize log file to NULL (stderr) by default. the log file globals
      * are read by tidesdb_log_write under tidesdb_log_mutex, so writes here take


### PR DESCRIPTION
## Summary

This moves the assignment of `_tidesdb_log_level` earlier in `tidesdb_open`, immediately after the config arguments are validated.

That lets the caller-provided `config->log_level` apply to all startup logging that happens while opening the database.

## What happens today

When opening a database with a quieter log level, for example `TDB_LOG_ERROR` or `TDB_LOG_NONE`, some INFO startup messages can still be printed.

One visible example is the fd-budget message from `tidesdb_open`:

```text
sstable fd budget set to max_open_sstables=...
```

That log happens before `_tidesdb_log_level` is copied from `config->log_level`, so it is still gated by the default global log level instead of the level requested by the caller.

This is noticeable for embedders that intentionally silence TidesDB logs during setup or benchmarks. They can configure a quiet log level and still receive startup output.

## Change

The fix is small: copy `config->log_level` into `_tidesdb_log_level` before any open-time `TDB_DEBUG_LOG` calls can run.

The existing later assignment is removed because the configured value has already been applied.

## Validation

Built locally with:

```sh
cmake -S . -B /private/tmp/tidesdb-build -DTIDESDB_BUILD_TESTS=OFF -DBUILD_SHARED_LIBS=OFF -DTIDESDB_WITH_SNAPPY=OFF -DTIDESDB_WITH_LZ4=OFF -DTIDESDB_WITH_ZSTD=OFF
cmake --build /private/tmp/tidesdb-build
```
