### PR TITLE
separate residual busy from fatal commit errors in the unified read-r…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -624,7 +624,7 @@ if(TIDESDB_BUILD_TESTS) # enable building tests and benchmarks
         set(BENCH_DB_COMPACTION_POOL_THREADS 2)
     endif()
     if(NOT DEFINED BENCH_DB_MAX_MEMORY)
-        math(EXPR BENCH_DB_MAX_MEMORY 0) # 0 defaults to 50% of system memory
+        math(EXPR BENCH_DB_MAX_MEMORY 0) # 0 defaults to 75% of system memory
     endif()
 
     # column family configuration variables for benchmark

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -21855,7 +21855,11 @@ static void test_stress_unified_read_races(void)
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
 
-    cf_config.write_buffer_size = 4096;
+    /* 64 KiB buffer (not 4 KiB) -- a 4 KiB buffer made each flush ~14-24 entries, so 9000 commits
+     * produced hundreds of tiny SSTables and a constant compaction storm. with ratio 4 + min_levels
+     * 4 the data still spills L1->L4, so the multi-level read/flush/compaction races are preserved
+     * with ~10x less flush/compaction (and allocator) churn. */
+    cf_config.write_buffer_size = 65536;
     cf_config.level_size_ratio = 4;
     cf_config.min_levels = 4;
     cf_config.compression_algorithm = TDB_COMPRESS_LZ4;

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -21672,6 +21672,7 @@ typedef struct
     _Atomic(int) *reads_miss;
     _Atomic(int) *go;
     _Atomic(int) *stop;
+    _Atomic(int) *commit_busy; /* residual TDB_ERR_BUSY after retries -- writer-only, non-fatal */
 } unified_stress_data_t;
 
 static void *unified_writer_thread(void *arg)
@@ -21737,13 +21738,21 @@ static void *unified_writer_thread(void *arg)
          * + 2 flushers + 2 compactors all hammering the same cf can starve
          * the flush worker enough on slow CI to reach the backpressure
          * no-progress budget. a real commit bug still surfaces as nonzero */
-        if (tdb_test_commit_with_retry(txn, 20) != 0)
+        int crc = tdb_test_commit_with_retry(txn, 20);
+        if (crc == 0)
         {
-            atomic_fetch_add(d->commit_errors, 1);
+            atomic_fetch_add(d->commits_ok, 1);
+        }
+        else if (crc == TDB_ERR_BUSY)
+        {
+            /* backpressure outlasted the retry budget -- transient overload under this
+             * deliberately oversubscribed stress, not a commit bug. counted separately so it does
+             * not fail the run, while a real (non-BUSY) commit error still does. */
+            atomic_fetch_add(d->commit_busy, 1);
         }
         else
         {
-            atomic_fetch_add(d->commits_ok, 1);
+            atomic_fetch_add(d->commit_errors, 1);
         }
         tidesdb_txn_free(txn);
     }
@@ -21877,7 +21886,7 @@ static void test_stress_unified_read_races(void)
     const int OPS_PER_FLUSHER = 30;
 #endif
 
-    _Atomic(int) commit_errors = 0, commits_ok = 0;
+    _Atomic(int) commit_errors = 0, commits_ok = 0, commit_busy = 0;
     _Atomic(int) reads_ok = 0, reads_miss = 0;
     _Atomic(int) go = 0, stop = 0;
 
@@ -21888,7 +21897,7 @@ static void test_stress_unified_read_races(void)
     {
         w_data[i] = (unified_stress_data_t){
             db,        cf,          i,   OPS_PER_WRITER, &commit_errors, &commits_ok,
-            &reads_ok, &reads_miss, &go, &stop};
+            &reads_ok, &reads_miss, &go, &stop,          &commit_busy};
         pthread_create(&writers[i], NULL, unified_writer_thread, &w_data[i]);
     }
     for (int i = 0; i < NUM_READERS; i++)
@@ -21931,12 +21940,14 @@ static void test_stress_unified_read_races(void)
     for (int i = 0; i < NUM_FLUSHERS; i++) pthread_join(flushers[i], NULL);
 
     int final_commit_errors = atomic_load(&commit_errors);
+    int final_commit_busy = atomic_load(&commit_busy);
     int final_commits = atomic_load(&commits_ok);
     int final_reads = atomic_load(&reads_ok);
     int final_misses = atomic_load(&reads_miss);
 
     printf("  unified stress results:\n");
-    printf("    commits: %d ok, %d errors\n", final_commits, final_commit_errors);
+    printf("    commits: %d ok, %d errors, %d busy (retried out, non-fatal)\n", final_commits,
+           final_commit_errors, final_commit_busy);
     printf("    reads: %d found, %d miss\n", final_reads, final_misses);
 
     /* we drain flush queue before inspecting levels */


### PR DESCRIPTION
…ace stress test