### PR TITLE
TidesDB 9 PATCH (v9.3.7)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ if(TIDESDB_WITH_MIMALLOC)
 endif()
 
 project(tidesdb
-	VERSION 9.3.6
+	VERSION 9.3.7
 	LANGUAGES C)
 
 set(CMAKE_C_STANDARD 11)

--- a/src/block_manager.c
+++ b/src/block_manager.c
@@ -165,6 +165,22 @@ static inline int is_sync_full(const block_manager_t *bm)
 }
 
 /**
+ * bm_smooth_writeback
+ * single-writer construction pacing once at least BLOCK_MANAGER_SMOOTH_WRITEBACK_BYTES have
+ * been appended since the last hint, start async writeback of that range. only ever reached
+ * from the lone thread building this sstable, so smooth_synced_offset needs no atomicity.
+ * @param bm the block manager (smooth_writeback already known set)
+ */
+static inline void bm_smooth_writeback(block_manager_t *bm)
+{
+    const uint64_t size = atomic_load_explicit(&bm->current_file_size, memory_order_relaxed);
+    if (size - bm->smooth_synced_offset < BLOCK_MANAGER_SMOOTH_WRITEBACK_BYTES) return;
+    (void)smooth_writeback_region(bm->fd, (off_t)bm->smooth_synced_offset,
+                                  (off_t)(size - bm->smooth_synced_offset));
+    bm->smooth_synced_offset = size;
+}
+
+/**
  * compute_checksum
  * compute xxHash32 checksum
  * @param data the data to compute the checksum for
@@ -410,6 +426,8 @@ static int block_manager_open_internal(block_manager_t **bm, const char *file_pa
 
     new_bm->sync_mode = sync_mode;
     new_bm->sync_full_cached = (sync_mode == BLOCK_MANAGER_SYNC_FULL);
+    new_bm->smooth_writeback = 0;
+    new_bm->smooth_synced_offset = 0;
 
     const int file_exists = access(file_path, F_OK) == 0;
 
@@ -633,6 +651,11 @@ static int64_t bm_append_block(block_manager_t *bm, const void *data, const uint
         if (fdatasync(bm->fd) != 0) return -1;
     }
 
+    /* sstable construction (single writer, no per-write sync) in which we pace dirty pages out so
+     * the closing fdatasync barrier never stalls on the whole file. predictable not-taken on the
+     * concurrently-written files, which never enables smoothing */
+    if (BM_UNLIKELY(bm->smooth_writeback)) bm_smooth_writeback(bm);
+
     return offset;
 }
 
@@ -775,6 +798,8 @@ int block_manager_block_write_batch(block_manager_t *bm, block_manager_block_t *
             return -1;
         }
     }
+
+    if (BM_UNLIKELY(bm->smooth_writeback)) bm_smooth_writeback(bm);
 
     return (int)valid_count;
 }
@@ -1466,6 +1491,13 @@ int block_manager_escalate_fsync(block_manager_t *bm)
 {
     if (!bm) return -1;
     return fdatasync(bm->fd);
+}
+
+void block_manager_enable_smooth_writeback(block_manager_t *bm)
+{
+    if (!bm) return;
+    bm->smooth_writeback = 1;
+    bm->smooth_synced_offset = atomic_load_explicit(&bm->current_file_size, memory_order_relaxed);
 }
 
 time_t block_manager_last_modified(block_manager_t *bm)

--- a/src/block_manager.h
+++ b/src/block_manager.h
@@ -63,6 +63,11 @@
 #define BLOCK_MANAGER_PREALLOC_CHUNK    (64ull * 1024 * 1024) /* extend by 64 MB at a time */
 #define BLOCK_MANAGER_PREALLOC_LOWWATER (4ull * 1024 * 1024)  /* trigger extend when 4 MB left */
 
+/* sstable-construction writeback pacing: when smoothing is enabled, start async writeback
+ * of the file each time this many bytes accumulate since the last hint, so the final
+ * fdatasync barrier flushes only a small residual rather than the whole sstable */
+#define BLOCK_MANAGER_SMOOTH_WRITEBACK_BYTES (1ull * 1024 * 1024)
+
 typedef enum
 {
     BLOCK_MANAGER_SYNC_NONE, /* no per-write fsync; durability left to the caller/group-commit */
@@ -93,6 +98,12 @@ typedef enum
  * @param group_durable_size bytes of the file confirmed fdatasync'd, used by group-commit
  *                           callers to tell whether their write is already durable
  * @param group_sync_active set while a group-commit leader is mid-fdatasync on this file
+ * @param smooth_writeback 1 when this file is a single-writer sstable under construction and
+ *                         block writes should dribble async writeback every
+ *                         BLOCK_MANAGER_SMOOTH_WRITEBACK_BYTES. read-only after open.
+ * @param smooth_synced_offset construction-writer cursor, file offset already handed to async
+ *                             writeback. only touched by the single construction thread (never
+ *                             set on concurrently-written files), so it needs no atomicity.
  */
 typedef struct
 {
@@ -100,6 +111,8 @@ typedef struct
     char file_path[MAX_FILE_PATH_LENGTH];
     block_manager_sync_mode_t sync_mode;
     int sync_full_cached; /* cached result of (sync_mode == BLOCK_MANAGER_SYNC_FULL) */
+    int smooth_writeback; /* read-only after open; see block_manager_enable_smooth_writeback */
+    uint64_t smooth_synced_offset; /* single-writer construction cursor, no atomicity needed */
     /* explicit alignment for atomic uint64_t to avoid ABI issues on 32-bit platforms */
     ATOMIC_ALIGN(8) _Atomic uint64_t current_file_size;
     ATOMIC_ALIGN(8) _Atomic uint64_t preallocated_size;
@@ -444,6 +457,16 @@ uint64_t block_manager_framed_size(uint32_t payload_size);
  * @return 0 if successful, -1 if not
  */
 int block_manager_escalate_fsync(block_manager_t *bm);
+
+/**
+ * block_manager_enable_smooth_writeback
+ * marks this block manager as a single-writer sstable under construction, so each block
+ * write dribbles asynchronous writeback every BLOCK_MANAGER_SMOOTH_WRITEBACK_BYTES. this
+ * keeps the closing fdatasync barrier from flushing the whole file in one stalling syscall.
+ * must only be called on a freshly opened, exclusively written file (never the WAL).
+ * @param bm the block manager
+ */
+void block_manager_enable_smooth_writeback(block_manager_t *bm);
 
 /**
  * block_manager_cursor_at_last

--- a/src/compat.h
+++ b/src/compat.h
@@ -3255,6 +3255,33 @@ static inline int evict_file_region(int fd, off_t offset, off_t len)
 }
 
 /*
+ * smooth_writeback_region
+ * starts asynchronous writeback of a dirty file region without waiting and without
+ * issuing a durability barrier. used to dribble an sstable's dirty pages out to the
+ * device during construction so the final fdatasync barrier flushes only a small
+ * residual instead of the whole file. this is a pacing hint only -- it makes no
+ * durability promise (the caller still fdatasync's at the end) and never orders
+ * against concurrent writers, so it is safe to call on a shared descriptor.
+ * @param fd the file descriptor
+ * @param offset starting offset of the range to write back
+ * @param len number of bytes (must be > 0)
+ * @return 0 on success, -1 on failure (non-critical, can be ignored)
+ */
+static inline int smooth_writeback_region(int fd, off_t offset, off_t len)
+{
+#ifdef __linux__
+    return sync_file_range(fd, offset, len, SYNC_FILE_RANGE_WRITE);
+#else
+    /* no async range-writeback primitive elsewhere -- the final fdatasync barrier
+     * still bounds durability; we just forgo the incremental pacing */
+    (void)fd;
+    (void)offset;
+    (void)len;
+    return 0;
+#endif
+}
+
+/*
  * set_file_noreuse_hint
  * hints that specified region will be accessed only once (streaming)
  * kernel page replacement can deprioritize these pages

--- a/src/compat.h
+++ b/src/compat.h
@@ -3269,7 +3269,9 @@ static inline int evict_file_region(int fd, off_t offset, off_t len)
  */
 static inline int smooth_writeback_region(int fd, off_t offset, off_t len)
 {
-#ifdef __linux__
+    /* sync_file_range + its flags are GNU extensions, declared only when _GNU_SOURCE is set;
+     * guard on the flag macro so a translation unit without _GNU_SOURCE falls back cleanly */
+#if defined(__linux__) && defined(SYNC_FILE_RANGE_WRITE)
     return sync_file_range(fd, offset, len, SYNC_FILE_RANGE_WRITE);
 #else
     /* no async range-writeback primitive elsewhere -- the final fdatasync barrier

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -368,7 +368,7 @@ void tidesdb_manifest_update_sequence(tidesdb_manifest_t *manifest, uint64_t seq
     }
 }
 
-int tidesdb_manifest_commit(tidesdb_manifest_t *manifest, const char *path)
+int tidesdb_manifest_commit(tidesdb_manifest_t *manifest, const char *path, const int durable_sync)
 {
     if (!manifest || !path) return -1;
 
@@ -419,16 +419,19 @@ int tidesdb_manifest_commit(tidesdb_manifest_t *manifest, const char *path)
         return -1;
     }
 
-    const int fd = tdb_fileno(fp);
-    if (fd >= 0)
+    if (durable_sync)
     {
-        if (tdb_fsync(fd) != 0)
+        const int fd = tdb_fileno(fp);
+        if (fd >= 0)
         {
-            fclose(fp);
-            remove(temp_path);
-            pthread_rwlock_unlock(&manifest->lock);
-            atomic_fetch_sub(&manifest->active_ops, 1);
-            return -1;
+            if (tdb_fsync(fd) != 0)
+            {
+                fclose(fp);
+                remove(temp_path);
+                pthread_rwlock_unlock(&manifest->lock);
+                atomic_fetch_sub(&manifest->active_ops, 1);
+                return -1;
+            }
         }
     }
 
@@ -445,7 +448,9 @@ int tidesdb_manifest_commit(tidesdb_manifest_t *manifest, const char *path)
 
     /* we sync the parent directory to ensure the rename is durable.
      * without this, a crash after rename could lose the directory entry
-     * on POSIX systems that don't flush directory metadata automatically. */
+     * on POSIX systems that don't flush directory metadata automatically.
+     * skipped under TDB_SYNC_NONE (durable_sync clear) along with the file fsync above. */
+    if (durable_sync)
     {
         /* sized to the full manifest path length -- a 1024-byte buffer silently truncated
          * paths > 1023 chars and synced the wrong directory */

--- a/src/manifest.h
+++ b/src/manifest.h
@@ -123,14 +123,18 @@ void tidesdb_manifest_update_sequence(tidesdb_manifest_t *manifest, uint64_t seq
 
 /**
  * tidesdb_manifest_commit
- * atomically writes the manifest to disk -- writes a temp file, fsyncs it, renames it into
- * place, then syncs the parent directory so the commit survives a crash. if path differs from
- * the manifest's currently stored path, the manifest is re-pointed to path.
+ * atomically writes the manifest to disk -- writes a temp file, renames it into place. when
+ * durable_sync is set it also fsyncs the temp file before the rename and syncs the parent
+ * directory after, so the commit survives a crash. with durable_sync clear (TDB_SYNC_NONE) both
+ * are skipped -- the rename is still atomic, but a crash may leave a manifest whose contents or
+ * directory entry never reached disk, and which can reference a not-yet-durable sstable. if path
+ * differs from the manifest's currently stored path, the manifest is re-pointed to path.
  * @param manifest manifest to write
  * @param path destination path; also becomes the manifest's stored path if it differs
+ * @param durable_sync non-zero to fsync the manifest + parent directory; zero to skip both
  * @return 0 on success, -1 on error
  */
-int tidesdb_manifest_commit(tidesdb_manifest_t *manifest, const char *path);
+int tidesdb_manifest_commit(tidesdb_manifest_t *manifest, const char *path, int durable_sync);
 
 /**
  * tidesdb_manifest_close

--- a/src/skip_list.c
+++ b/src/skip_list.c
@@ -19,10 +19,14 @@
 
 #include "skip_list.h"
 
+/* global counter for generating unique arena IDs */
+static _Atomic(uint64_t) global_arena_id_counter = 0;
+
 /* thread-local cache for arena slot assignment
  * each thread caches its slot for one arena at a time
  * if the arena changes, we must get a new slot from that arena */
 static _Thread_local skip_list_arena_t *tl_cached_arena = NULL;
+static _Thread_local uint64_t tl_cached_arena_id = 0; /* cache the generation ID */
 static _Thread_local int tl_arena_slot = -1;
 
 /**
@@ -95,6 +99,10 @@ static skip_list_arena_t *skip_list_arena_create(const size_t initial_capacity)
         atomic_init(&arena->tl_blocks[i], NULL);
     }
 
+    /* we must assign a globally unique generation ID */
+    arena->arena_id =
+        atomic_fetch_add_explicit(&global_arena_id_counter, 1, memory_order_relaxed) + 1;
+
     return arena;
 }
 
@@ -107,8 +115,11 @@ static skip_list_arena_t *skip_list_arena_create(const size_t initial_capacity)
  */
 static inline int skip_list_arena_get_slot(skip_list_arena_t *arena)
 {
-    /* fast path -- cached slot for this arena */
-    if (SKIP_LIST_LIKELY(tl_cached_arena == arena && tl_arena_slot >= 0))
+    /* fast path -- cached slot for this arena.
+     * we check both the memory address AND the unique generation ID to prevent ABA
+     * collisions if the OS recycles the arena's memory address. */
+    if (SKIP_LIST_LIKELY(tl_cached_arena == arena && tl_cached_arena_id == arena->arena_id &&
+                         tl_arena_slot >= 0))
     {
         return tl_arena_slot;
     }
@@ -120,7 +131,9 @@ static inline int skip_list_arena_get_slot(skip_list_arena_t *arena)
         return -1;
     }
 
+    /* cache the pointer, the ID, and the slot */
     tl_cached_arena = arena;
+    tl_cached_arena_id = arena->arena_id;
     tl_arena_slot = slot;
     return slot;
 }

--- a/src/skip_list.h
+++ b/src/skip_list.h
@@ -72,6 +72,7 @@ struct skip_list_arena_block_t
  * @param tl_blocks thread-local block pointers indexed by thread slot
  * @param tl_slot_counter atomic counter for assigning thread slots
  * @param all_blocks_head atomic linked list of all blocks for destruction
+ * @param arena_id unique generation ID to prevent ABA slot collisions
  */
 struct skip_list_arena_t
 {
@@ -80,6 +81,7 @@ struct skip_list_arena_t
     _Atomic(skip_list_arena_block_t *) tl_blocks[SKIP_LIST_ARENA_MAX_THREADS];
     _Atomic(int) tl_slot_counter;
     _Atomic(skip_list_arena_block_t *) all_blocks_head;
+    uint64_t arena_id;
 };
 
 /* skip_list_version_t flag bits */

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -1124,6 +1124,47 @@ static int tidesdb_bm_open(tidesdb_t *db, block_manager_t **bm, const char *path
 }
 
 /**
+ * tidesdb_sstable_sync_barrier
+ * durability barrier for a freshly built sstable -- flushes the klog and vlog so they are on disk
+ * before the manifest commit publishes them. honored only when sync is on FULL and INTERVAL both
+ * fsync here (INTERVAL sstables carry full durability; only their WAL is deferred to the interval
+ * worker). TDB_SYNC_NONE intentionally skips, mirroring InnoDB's O_DIRECT_NO_FSYNC -- a crash may
+ * then leave a manifest referencing a not-yet-durable sstable. smooth-writeback pacing during
+ * construction keeps this barrier from stalling on the whole file in one syscall.
+ * @param sync_mode the column family's sync mode
+ * @param klog_bm klog block manager (may be NULL)
+ * @param vlog_bm vlog block manager (may be NULL)
+ */
+static inline void tidesdb_sstable_sync_barrier(int sync_mode, block_manager_t *klog_bm,
+                                                block_manager_t *vlog_bm)
+{
+    if (sync_mode == TDB_SYNC_NONE) return;
+    if (klog_bm) block_manager_escalate_fsync(klog_bm);
+    if (vlog_bm) block_manager_escalate_fsync(vlog_bm);
+}
+
+/**
+ * tidesdb_bm_open_sstable
+ * opens a block manager over an sstable file (klog or vlog), for construction or reopen. sstables
+ * are immutable once built and reads never sync, so per-write syncing is never needed -- we open
+ * without it (TDB_SYNC_NONE) and enable smooth writeback. on the single-writer construction path
+ * that paces dirty pages out so the closing tidesdb_sstable_sync_barrier flushes only a small
+ * residual instead of the whole file in one stalling syscall; on reopened read-only sstables it
+ * never fires. durability for FULL/INTERVAL is provided by that closing barrier (and the manifest
+ * commit); NONE skips both.
+ * @param db database instance
+ * @param bm receives the opened block manager
+ * @param path the sstable file path
+ * @return 0 on success, non-zero on failure (same as tidesdb_bm_open)
+ */
+static int tidesdb_bm_open_sstable(tidesdb_t *db, block_manager_t **bm, const char *path)
+{
+    const int rc = tidesdb_bm_open(db, bm, path, TDB_SYNC_NONE);
+    if (rc == 0 && *bm) block_manager_enable_smooth_writeback(*bm);
+    return rc;
+}
+
+/**
  * tidesdb_sstable_open_budget
  * the descriptor budget for resident open sstables, max_open_sstables minus the reserve held for
  * flush/compaction. both the reader admission check and the reaper's eviction trigger use this, so
@@ -6234,10 +6275,7 @@ static int tidesdb_sstable_ensure_klog_open(tidesdb_t *db, tidesdb_sstable_t *ss
     }
 
     block_manager_t *new_klog_bm = NULL;
-    if (tidesdb_bm_open(db, &new_klog_bm, sst->klog_path,
-                        convert_sync_mode(sst->config->sync_mode == TDB_SYNC_INTERVAL
-                                              ? TDB_SYNC_FULL
-                                              : sst->config->sync_mode)) != 0)
+    if (tidesdb_bm_open_sstable(db, &new_klog_bm, sst->klog_path) != 0)
     {
         if (tdb_log_throttle(db, &db->last_open_fail_log_sec,
                              TDB_BACKPRESSURE_STALL_LOG_INTERVAL_SEC))
@@ -6285,8 +6323,7 @@ static int tidesdb_sstable_ensure_vlog_open(tidesdb_t *db, tidesdb_sstable_t *ss
     }
 
     block_manager_t *new_vlog_bm = NULL;
-    if (tidesdb_bm_open(db, &new_vlog_bm, sst->vlog_path,
-                        convert_sync_mode(sst->config->sync_mode)) != 0)
+    if (tidesdb_bm_open_sstable(db, &new_vlog_bm, sst->vlog_path) != 0)
     {
         if (tdb_log_throttle(db, &db->last_open_fail_log_sec,
                              TDB_BACKPRESSURE_STALL_LOG_INTERVAL_SEC))
@@ -7687,8 +7724,7 @@ static int tidesdb_sstable_write_footer(tidesdb_sstable_t *sst, block_manager_t 
     block_manager_get_size(klog_bm, &sst->klog_size);
     block_manager_get_size(vlog_bm, &sst->vlog_size);
 
-    if (klog_bm) block_manager_escalate_fsync(klog_bm);
-    if (vlog_bm) block_manager_escalate_fsync(vlog_bm);
+    tidesdb_sstable_sync_barrier(sst->config->sync_mode, klog_bm, vlog_bm);
 
     return TDB_SUCCESS;
 }
@@ -7996,8 +8032,7 @@ static int tidesdb_sstable_write_from_memtable_btree_ex(tidesdb_t *db, tidesdb_c
     block_manager_get_size(klog_bm, &sst->klog_size);
     block_manager_get_size(vlog_bm, &sst->vlog_size);
 
-    if (klog_bm) block_manager_escalate_fsync(klog_bm);
-    if (vlog_bm) block_manager_escalate_fsync(vlog_bm);
+    tidesdb_sstable_sync_barrier(sst->config->sync_mode, klog_bm, vlog_bm);
 
     TDB_DEBUG_LOG(TDB_LOG_INFO,
                   "SSTable %" PRIu64 " btree flush complete: %" PRIu64 " entries, root=%ld",
@@ -8320,8 +8355,7 @@ static int tidesdb_sstable_write_from_heap_btree(
     btree_free(tree);
     btree_builder_free(builder);
 
-    if (klog_bm) block_manager_escalate_fsync(klog_bm);
-    if (vlog_bm) block_manager_escalate_fsync(vlog_bm);
+    tidesdb_sstable_sync_barrier(sst->config->sync_mode, klog_bm, vlog_bm);
 
     /* write-amplification -- on-disk bytes this merge output produced. read the managers
      * directly, the metadata block above lands after sst->klog_size was snapshotted, so a
@@ -13727,7 +13761,8 @@ static void tidesdb_cleanup_merged_sstables(tidesdb_column_family_t *cf, queue_t
             if (any_removed)
             {
                 tidesdb_bump_sstable_layout_version(cf);
-                if (tidesdb_manifest_commit(cf->manifest, cf->manifest->path) != 0)
+                if (tidesdb_manifest_commit(cf->manifest, cf->manifest->path,
+                                            cf->config.sync_mode != TDB_SYNC_NONE) != 0)
                 {
                     TDB_DEBUG_LOG(TDB_LOG_ERROR, "Failed to commit manifest after merge cleanup");
                 }
@@ -14202,14 +14237,8 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
 
         block_manager_t *klog_bm = NULL;
         block_manager_t *vlog_bm = NULL;
-        if (tidesdb_bm_open(cf->db, &klog_bm, new_sst->klog_path,
-                            convert_sync_mode(cf->config.sync_mode == TDB_SYNC_INTERVAL
-                                                  ? TDB_SYNC_FULL
-                                                  : cf->config.sync_mode)) != 0 ||
-            tidesdb_bm_open(cf->db, &vlog_bm, new_sst->vlog_path,
-                            convert_sync_mode(cf->config.sync_mode == TDB_SYNC_INTERVAL
-                                                  ? TDB_SYNC_FULL
-                                                  : cf->config.sync_mode)) != 0)
+        if (tidesdb_bm_open_sstable(cf->db, &klog_bm, new_sst->klog_path) != 0 ||
+            tidesdb_bm_open_sstable(cf->db, &vlog_bm, new_sst->vlog_path) != 0)
         {
             if (klog_bm) block_manager_close(klog_bm);
             if (vlog_bm) block_manager_close(vlog_bm);
@@ -14675,8 +14704,7 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
 
         tidesdb_merge_heap_free(heap);
 
-        block_manager_escalate_fsync(klog_bm);
-        block_manager_escalate_fsync(vlog_bm);
+        tidesdb_sstable_sync_barrier(cf->config.sync_mode, klog_bm, vlog_bm);
 
         new_sst->klog_bm = klog_bm;
         new_sst->vlog_bm = vlog_bm;
@@ -14764,7 +14792,8 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
                                              new_sst->id, new_sst->num_entries,
                                              new_sst->klog_size + new_sst->vlog_size);
                 atomic_store(&cf->manifest->sequence, atomic_load(&cf->next_sstable_id));
-                int manifest_result = tidesdb_manifest_commit(cf->manifest, cf->manifest->path);
+                int manifest_result = tidesdb_manifest_commit(
+                    cf->manifest, cf->manifest->path, cf->config.sync_mode != TDB_SYNC_NONE);
                 if (manifest_result != 0)
                 {
                     TDB_DEBUG_LOG(TDB_LOG_ERROR,
@@ -14879,10 +14908,7 @@ static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t
     block_manager_t *klog_bm = NULL;
     block_manager_t *vlog_bm = NULL;
 
-    if (block_manager_open(&klog_bm, new_sst->klog_path,
-                           convert_sync_mode(cf->config.sync_mode == TDB_SYNC_INTERVAL
-                                                 ? TDB_SYNC_FULL
-                                                 : cf->config.sync_mode)) != 0)
+    if (tidesdb_bm_open_sstable(cf->db, &klog_bm, new_sst->klog_path) != 0)
     {
         /* mark so sstable_free unlinks any klog file the failed open created */
         atomic_store_explicit(&new_sst->marked_for_deletion, 1, memory_order_release);
@@ -14893,10 +14919,7 @@ static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t
         return TDB_ERR_IO;
     }
 
-    if (block_manager_open(&vlog_bm, new_sst->vlog_path,
-                           convert_sync_mode(cf->config.sync_mode == TDB_SYNC_INTERVAL
-                                                 ? TDB_SYNC_FULL
-                                                 : cf->config.sync_mode)) != 0)
+    if (tidesdb_bm_open_sstable(cf->db, &vlog_bm, new_sst->vlog_path) != 0)
     {
         block_manager_close(klog_bm);
         /* mark so sstable_free unlinks the klog file the successful open created */
@@ -15314,8 +15337,7 @@ static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t
 
     tidesdb_merge_heap_free(heap);
 
-    block_manager_escalate_fsync(klog_bm);
-    block_manager_escalate_fsync(vlog_bm);
+    tidesdb_sstable_sync_barrier(cf->config.sync_mode, klog_bm, vlog_bm);
 
     new_sst->klog_bm = klog_bm;
     new_sst->vlog_bm = vlog_bm;
@@ -15388,7 +15410,8 @@ merge_complete:;
                                          new_sst->id, new_sst->num_entries,
                                          new_sst->klog_size + new_sst->vlog_size);
             atomic_store(&cf->manifest->sequence, atomic_load(&cf->next_sstable_id));
-            tidesdb_manifest_commit(cf->manifest, cf->manifest->path);
+            tidesdb_manifest_commit(cf->manifest, cf->manifest->path,
+                                    cf->config.sync_mode != TDB_SYNC_NONE);
             tdb_objstore_upload_manifest(cf->db, cf);
 
             tidesdb_sstable_unref(cf->db, new_sst);
@@ -15825,20 +15848,14 @@ static int tidesdb_dividing_merge_partition(void *vctx, int partition)
         block_manager_t *klog_bm = NULL;
         block_manager_t *vlog_bm = NULL;
 
-        if (block_manager_open(&klog_bm, new_sst->klog_path,
-                               convert_sync_mode(cf->config.sync_mode == TDB_SYNC_INTERVAL
-                                                     ? TDB_SYNC_FULL
-                                                     : cf->config.sync_mode)) != 0)
+        if (tidesdb_bm_open_sstable(cf->db, &klog_bm, new_sst->klog_path) != 0)
         {
             tidesdb_merge_heap_free(partition_heap);
             tidesdb_sstable_unref(cf->db, new_sst);
             continue;
         }
 
-        if (block_manager_open(&vlog_bm, new_sst->vlog_path,
-                               convert_sync_mode(cf->config.sync_mode == TDB_SYNC_INTERVAL
-                                                     ? TDB_SYNC_FULL
-                                                     : cf->config.sync_mode)) != 0)
+        if (tidesdb_bm_open_sstable(cf->db, &vlog_bm, new_sst->vlog_path) != 0)
         {
             block_manager_close(klog_bm);
             tidesdb_merge_heap_free(partition_heap);
@@ -16370,7 +16387,8 @@ static int tidesdb_dividing_merge_partition(void *vctx, int partition)
                                              new_sst->id, new_sst->num_entries,
                                              new_sst->klog_size + new_sst->vlog_size);
                 atomic_store(&cf->manifest->sequence, atomic_load(&cf->next_sstable_id));
-                int manifest_result = tidesdb_manifest_commit(cf->manifest, cf->manifest->path);
+                int manifest_result = tidesdb_manifest_commit(
+                    cf->manifest, cf->manifest->path, cf->config.sync_mode != TDB_SYNC_NONE);
                 if (manifest_result != 0)
                 {
                     TDB_DEBUG_LOG(TDB_LOG_ERROR,
@@ -16524,7 +16542,8 @@ static int tdb_partitioned_merge_finalize_sst(
         tidesdb_manifest_add_sstable(cf->manifest, cf->levels[target_idx]->level_num, sst->id,
                                      sst->num_entries, sst->klog_size + sst->vlog_size);
         atomic_store(&cf->manifest->sequence, atomic_load(&cf->next_sstable_id));
-        const int manifest_result = tidesdb_manifest_commit(cf->manifest, cf->manifest->path);
+        const int manifest_result = tidesdb_manifest_commit(cf->manifest, cf->manifest->path,
+                                                            cf->config.sync_mode != TDB_SYNC_NONE);
         if (manifest_result != 0)
         {
             TDB_DEBUG_LOG(TDB_LOG_ERROR,
@@ -17022,14 +17041,8 @@ static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
              * dereference a NULL block manager. abort the merge instead; the aborted path preserves
              * the source sstables, so no data is lost and compaction retries later. routed through
              * tidesdb_bm_open so a transient fd spike gets a reaper-assisted retry first. */
-            if (tidesdb_bm_open(cf->db, &klog_bm, new_sst->klog_path,
-                                convert_sync_mode(cf->config.sync_mode == TDB_SYNC_INTERVAL
-                                                      ? TDB_SYNC_FULL
-                                                      : cf->config.sync_mode)) != 0 ||
-                tidesdb_bm_open(cf->db, &vlog_bm, new_sst->vlog_path,
-                                convert_sync_mode(cf->config.sync_mode == TDB_SYNC_INTERVAL
-                                                      ? TDB_SYNC_FULL
-                                                      : cf->config.sync_mode)) != 0)
+            if (tidesdb_bm_open_sstable(cf->db, &klog_bm, new_sst->klog_path) != 0 ||
+                tidesdb_bm_open_sstable(cf->db, &vlog_bm, new_sst->vlog_path) != 0)
             {
                 TDB_DEBUG_LOG(TDB_LOG_ERROR,
                               "CF '%s' partitioned merge failed to open output sstable for "
@@ -17448,16 +17461,9 @@ static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
                              * key (dedup by seq) and compaction retries. the post-loop finalize is
                              * guarded on new_sst/klog_bm so the NULL'd state below is never used.
                              */
-                            if (tidesdb_bm_open(
-                                    cf->db, &klog_bm, new_sst->klog_path,
-                                    convert_sync_mode(cf->config.sync_mode == TDB_SYNC_INTERVAL
-                                                          ? TDB_SYNC_FULL
-                                                          : cf->config.sync_mode)) != 0 ||
-                                tidesdb_bm_open(
-                                    cf->db, &vlog_bm, new_sst->vlog_path,
-                                    convert_sync_mode(cf->config.sync_mode == TDB_SYNC_INTERVAL
-                                                          ? TDB_SYNC_FULL
-                                                          : cf->config.sync_mode)) != 0)
+                            if (tidesdb_bm_open_sstable(cf->db, &klog_bm, new_sst->klog_path) !=
+                                    0 ||
+                                tidesdb_bm_open_sstable(cf->db, &vlog_bm, new_sst->vlog_path) != 0)
                             {
                                 TDB_DEBUG_LOG(TDB_LOG_ERROR,
                                               "CF '%s' partitioned merge failed to open split "
@@ -18657,13 +18663,13 @@ static void *tidesdb_flush_worker_thread(void *arg)
                                   memory_order_relaxed);
         atomic_fetch_add_explicit(&cf->flush_count, 1, memory_order_relaxed);
 
-        /* we must always sync sstable files regardless of sync_mode
-         * sstable durability is required before we can delete WAL */
+        /* durability barrier before the WAL is deleted FULL/INTERVAL fsync the sstable here, so
+         * a crash can never lose flushed data that the WAL no longer holds. NONE skips (the WAL is
+         * likewise unsynced under NONE, so the contract is uniform) */
         tidesdb_block_managers_t bms;
         if (tidesdb_sstable_get_block_managers(db, sst, &bms) == TDB_SUCCESS)
         {
-            if (bms.klog_bm) block_manager_escalate_fsync(bms.klog_bm);
-            if (bms.vlog_bm) block_manager_escalate_fsync(bms.vlog_bm);
+            tidesdb_sstable_sync_barrier(cf->config.sync_mode, bms.klog_bm, bms.vlog_bm);
         }
 
         /* we ensure all writes are visible before making sstable discoverable */
@@ -18769,7 +18775,8 @@ static void *tidesdb_flush_worker_thread(void *arg)
         tidesdb_manifest_add_sstable(cf->manifest, 1, work->sst_id, sst->num_entries,
                                      sst->klog_size + sst->vlog_size);
         atomic_store(&cf->manifest->sequence, atomic_load(&cf->next_sstable_id));
-        int manifest_result = tidesdb_manifest_commit(cf->manifest, cf->manifest->path);
+        int manifest_result = tidesdb_manifest_commit(cf->manifest, cf->manifest->path,
+                                                      cf->config.sync_mode != TDB_SYNC_NONE);
         if (manifest_result != 0)
         {
             TDB_DEBUG_LOG(TDB_LOG_ERROR,
@@ -23101,7 +23108,8 @@ int tidesdb_create_column_family(tidesdb_t *db, const char *name,
 
         /* commit + upload the empty MANIFEST so replicas can discover this CF
          * before its first flush -- discovery keys off <cf>/MANIFEST */
-        if (tidesdb_manifest_commit(cf->manifest, cf->manifest->path) == 0)
+        if (tidesdb_manifest_commit(cf->manifest, cf->manifest->path,
+                                    cf->config.sync_mode != TDB_SYNC_NONE) == 0)
         {
             tdb_objstore_upload_file_sync(db, cf->manifest->path);
         }
@@ -23707,7 +23715,8 @@ int tidesdb_rename_column_family(tidesdb_t *db, const char *old_name, const char
             pthread_rwlock_unlock(&cf->manifest->lock);
 
             /* we commit manifest to new location to ensure it's written */
-            tidesdb_manifest_commit(cf->manifest, manifest_path);
+            tidesdb_manifest_commit(cf->manifest, manifest_path,
+                                    cf->config.sync_mode != TDB_SYNC_NONE);
         }
     }
 
@@ -27913,8 +27922,7 @@ static int tidesdb_unified_write_cf_sstable(tidesdb_t *db, tidesdb_column_family
     tidesdb_block_managers_t bms;
     if (tidesdb_sstable_get_block_managers(db, sst, &bms) == TDB_SUCCESS)
     {
-        if (bms.klog_bm) block_manager_escalate_fsync(bms.klog_bm);
-        if (bms.vlog_bm) block_manager_escalate_fsync(bms.vlog_bm);
+        tidesdb_sstable_sync_barrier(cf->config.sync_mode, bms.klog_bm, bms.vlog_bm);
     }
     /* the write opened the klog via tidesdb_sstable_ensure_open, which counted it in
      * num_open_sstables (the count is keyed on the klog). closing it here must drop that count or
@@ -27958,7 +27966,8 @@ static int tidesdb_unified_write_cf_sstable(tidesdb_t *db, tidesdb_column_family
     tidesdb_manifest_add_sstable(cf->manifest, 1, sst_id, sst->num_entries,
                                  sst->klog_size + sst->vlog_size);
     atomic_store(&cf->manifest->sequence, atomic_load(&cf->next_sstable_id));
-    const int manifest_result = tidesdb_manifest_commit(cf->manifest, cf->manifest->path);
+    const int manifest_result = tidesdb_manifest_commit(cf->manifest, cf->manifest->path,
+                                                        cf->config.sync_mode != TDB_SYNC_NONE);
     if (manifest_result != 0)
         TDB_DEBUG_LOG(TDB_LOG_ERROR,
                       "Unified flush CF '%s' failed to commit manifest for SSTable %" PRIu64
@@ -34851,7 +34860,8 @@ int tidesdb_checkpoint(tidesdb_t *db, const char *checkpoint_dir)
         /* we commit manifest to ensure it reflects current state */
         if (cf->manifest)
         {
-            tidesdb_manifest_commit(cf->manifest, cf->manifest->path);
+            tidesdb_manifest_commit(cf->manifest, cf->manifest->path,
+                                    cf->config.sync_mode != TDB_SYNC_NONE);
         }
 
         /* we create CF directory in checkpoint */

--- a/test/manifest__tests.c
+++ b/test/manifest__tests.c
@@ -198,7 +198,7 @@ void test_manifest_commit_and_load()
     tidesdb_manifest_add_sstable(manifest, 1, 101, 1500, 98304);
     tidesdb_manifest_update_sequence(manifest, 54321);
 
-    int result = tidesdb_manifest_commit(manifest, TEST_MANIFEST_PATH);
+    int result = tidesdb_manifest_commit(manifest, TEST_MANIFEST_PATH, 1);
     ASSERT_EQ(result, 0);
 
     tidesdb_manifest_close(manifest);
@@ -253,7 +253,7 @@ void test_manifest_atomic_commit()
 
     tidesdb_manifest_add_sstable(manifest, 1, 100, 1000, 65536);
 
-    int result = tidesdb_manifest_commit(manifest, TEST_MANIFEST_PATH);
+    int result = tidesdb_manifest_commit(manifest, TEST_MANIFEST_PATH, 1);
     ASSERT_EQ(result, 0);
 
     tidesdb_manifest_t *loaded = tidesdb_manifest_open(TEST_MANIFEST_PATH);
@@ -328,7 +328,7 @@ void test_manifest_persistence_cycle()
     tidesdb_manifest_add_sstable(m1, 1, 0, 100, 1024);
     tidesdb_manifest_add_sstable(m1, 1, 1, 200, 2048);
     tidesdb_manifest_update_sequence(m1, 1000);
-    ASSERT_EQ(tidesdb_manifest_commit(m1, TEST_MANIFEST_PATH), 0);
+    ASSERT_EQ(tidesdb_manifest_commit(m1, TEST_MANIFEST_PATH, 1), 0);
     tidesdb_manifest_close(m1);
 
     /* cycle load, modify, commit */
@@ -338,7 +338,7 @@ void test_manifest_persistence_cycle()
     tidesdb_manifest_add_sstable(m2, 2, 0, 300, 4096);
     tidesdb_manifest_remove_sstable(m2, 1, 0);
     tidesdb_manifest_update_sequence(m2, 2000);
-    ASSERT_EQ(tidesdb_manifest_commit(m2, TEST_MANIFEST_PATH), 0);
+    ASSERT_EQ(tidesdb_manifest_commit(m2, TEST_MANIFEST_PATH, 1), 0);
     tidesdb_manifest_close(m2);
 
     /* cycle load and verify */
@@ -374,7 +374,7 @@ void test_manifest_auto_compaction()
 
     /* commit manifest */
     ASSERT_EQ(tidesdb_manifest_commit(
-                  m1, "." PATH_SEPARATOR "test_manifest_dir" PATH_SEPARATOR "manifest"),
+                  m1, "." PATH_SEPARATOR "test_manifest_dir" PATH_SEPARATOR "manifest", 1),
               0);
     tidesdb_manifest_close(m1);
 
@@ -406,7 +406,7 @@ void test_manifest_crash_recovery()
     tidesdb_manifest_add_sstable(m1, 2, 200, 2000, 131072);
     tidesdb_manifest_update_sequence(m1, 5000);
 
-    ASSERT_EQ(tidesdb_manifest_commit(m1, crash_test_path), 0);
+    ASSERT_EQ(tidesdb_manifest_commit(m1, crash_test_path, 1), 0);
     tidesdb_manifest_close(m1);
 
     tidesdb_manifest_t *m2 = tidesdb_manifest_open(crash_test_path);
@@ -437,7 +437,7 @@ void test_manifest_crash_recovery()
 
     tidesdb_manifest_add_sstable(m3, 3, 301, 3500, 200000);
     tidesdb_manifest_update_sequence(m3, 7000);
-    ASSERT_EQ(tidesdb_manifest_commit(m3, crash_test_path), 0);
+    ASSERT_EQ(tidesdb_manifest_commit(m3, crash_test_path, 1), 0);
     tidesdb_manifest_close(m3);
 
     tidesdb_manifest_t *m4 = tidesdb_manifest_open(crash_test_path);
@@ -461,7 +461,7 @@ void test_manifest_orphaned_temp_cleanup()
     ASSERT_TRUE(m1 != NULL);
     tidesdb_manifest_add_sstable(m1, 1, 100, 1000, 65536);
     tidesdb_manifest_update_sequence(m1, 1000);
-    ASSERT_EQ(tidesdb_manifest_commit(m1, test_path), 0);
+    ASSERT_EQ(tidesdb_manifest_commit(m1, test_path, 1), 0);
     tidesdb_manifest_close(m1);
 
     char temp1[256], temp2[256], temp3[256];
@@ -582,7 +582,7 @@ void test_manifest_concurrent_operations()
     ASSERT_EQ(manifest->num_entries, num_threads * ops_per_thread);
 
     /* commit and verify persistence */
-    ASSERT_EQ(tidesdb_manifest_commit(manifest, test_path), 0);
+    ASSERT_EQ(tidesdb_manifest_commit(manifest, test_path, 1), 0);
     tidesdb_manifest_close(manifest);
 
     /* reload and verify */
@@ -689,7 +689,7 @@ void test_manifest_large_stress()
 
     /* we commit large manifest */
     tidesdb_manifest_update_sequence(manifest, 999999);
-    ASSERT_EQ(tidesdb_manifest_commit(manifest, test_path), 0);
+    ASSERT_EQ(tidesdb_manifest_commit(manifest, test_path, 1), 0);
     tidesdb_manifest_close(manifest);
 
     /* we reload and verify all entries */
@@ -761,7 +761,7 @@ void test_manifest_duplicate_id_handling()
     ASSERT_FALSE(tidesdb_manifest_has_sstable(manifest, 1, 100));
 
     /* we commit and reload to verify persistence */
-    ASSERT_EQ(tidesdb_manifest_commit(manifest, test_path), 0);
+    ASSERT_EQ(tidesdb_manifest_commit(manifest, test_path, 1), 0);
     tidesdb_manifest_close(manifest);
 
     tidesdb_manifest_t *m2 = tidesdb_manifest_open(test_path);
@@ -793,12 +793,12 @@ void test_manifest_null_safety(void)
     tidesdb_manifest_update_sequence(NULL, 12345);
 
     /* tidesdb_manifest_commit with NULL manifest */
-    ASSERT_EQ(tidesdb_manifest_commit(NULL, "some_path"), -1);
+    ASSERT_EQ(tidesdb_manifest_commit(NULL, "some_path", 1), -1);
 
     /* tidesdb_manifest_commit with NULL path */
     tidesdb_manifest_t *manifest = tidesdb_manifest_open(TEST_MANIFEST_PATH);
     ASSERT_TRUE(manifest != NULL);
-    ASSERT_EQ(tidesdb_manifest_commit(manifest, NULL), -1);
+    ASSERT_EQ(tidesdb_manifest_commit(manifest, NULL, 1), -1);
     tidesdb_manifest_close(manifest);
     remove(TEST_MANIFEST_PATH);
 
@@ -818,12 +818,12 @@ void test_manifest_commit_different_path(void)
     tidesdb_manifest_update_sequence(manifest, 5000);
 
     /* we commit to path1 first */
-    ASSERT_EQ(tidesdb_manifest_commit(manifest, path1), 0);
+    ASSERT_EQ(tidesdb_manifest_commit(manifest, path1, 1), 0);
 
     /* we add more data and commit to a different path */
     tidesdb_manifest_add_sstable(manifest, 2, 200, 2000, 131072);
     tidesdb_manifest_update_sequence(manifest, 6000);
-    ASSERT_EQ(tidesdb_manifest_commit(manifest, path2), 0);
+    ASSERT_EQ(tidesdb_manifest_commit(manifest, path2, 1), 0);
 
     tidesdb_manifest_close(manifest);
 
@@ -895,7 +895,7 @@ void test_manifest_commit_empty(void)
 
     /* we commit with zero entries */
     tidesdb_manifest_update_sequence(manifest, 42);
-    ASSERT_EQ(tidesdb_manifest_commit(manifest, test_path), 0);
+    ASSERT_EQ(tidesdb_manifest_commit(manifest, test_path, 1), 0);
     tidesdb_manifest_close(manifest);
 
     /* we reload and verify */
@@ -922,7 +922,7 @@ void test_manifest_large_uint64_roundtrip(void)
     tidesdb_manifest_add_sstable(manifest, 1, large_id, large_entries, large_size);
     tidesdb_manifest_update_sequence(manifest, UINT64_MAX);
 
-    ASSERT_EQ(tidesdb_manifest_commit(manifest, test_path), 0);
+    ASSERT_EQ(tidesdb_manifest_commit(manifest, test_path, 1), 0);
     tidesdb_manifest_close(manifest);
 
     /* we reload and verify large values survived round-trip */

--- a/test/skip_list__tests.c
+++ b/test/skip_list__tests.c
@@ -2680,6 +2680,121 @@ void test_skip_list_cursor_advance_in_node()
     skip_list_free(list);
 }
 
+typedef struct
+{
+    skip_list_t *list1;
+    skip_list_t *list2;
+    _Atomic(int) *sync_state;
+} aba_ctx_t;
+
+void *aba_thread_a(void *arg)
+{
+    aba_ctx_t *ctx = (aba_ctx_t *)arg;
+
+    /* Phase 1: Thread A does an insert to initialize its _Thread_local cache.
+     * tl_cached_arena is now set to list1->arena. */
+    uint8_t key[] = "A_init";
+    uint8_t val[] = "val";
+    skip_list_put_with_seq(ctx->list1, key, sizeof(key), val, sizeof(val), -1, 1, 0);
+
+    /* Signal the Main thread to destroy list1 and create list2 */
+    atomic_store_explicit(ctx->sync_state, 1, memory_order_release);
+
+    /* Wait for the green light (state == 2) from Main */
+    while (atomic_load_explicit(ctx->sync_state, memory_order_acquire) < 2)
+    {
+    }
+
+    /* Phase 2: Insert into list2.
+     * BUG TRIGGER: list2->arena has the exact same memory address that list1->arena had.
+     * Thread A bypasses the slot counter and incorrectly assumes it owns slot 0! */
+    for (int i = 0; i < 50000; i++)
+    {
+        char k[32];
+        snprintf(k, sizeof(k), "A_concurrent_%d", i);
+        skip_list_put_with_seq(ctx->list2, (uint8_t *)k, strlen(k) + 1, val, sizeof(val), -1,
+                               10 + i, 0);
+    }
+    return NULL;
+}
+
+void *aba_thread_b(void *arg)
+{
+    aba_ctx_t *ctx = (aba_ctx_t *)arg;
+
+    while (atomic_load_explicit(ctx->sync_state, memory_order_acquire) < 2)
+    {
+    }
+
+    uint8_t val[] = "val";
+    for (int i = 0; i < 50000; i++)
+    {
+        char k[32];
+        snprintf(k, sizeof(k), "B_concurrent_%d", i);
+        skip_list_put_with_seq(ctx->list2, (uint8_t *)k, strlen(k) + 1, val, sizeof(val), -1,
+                               100000 + i, 0);
+    }
+    return NULL;
+}
+
+void test_skip_list_arena_aba()
+{
+    _Atomic(int) sync_state = 0;
+    aba_ctx_t ctx = {0};
+    ctx.sync_state = &sync_state;
+
+    size_t arena_cap = 16 * 1024 * 1024; /* 16MB */
+
+    ASSERT_EQ(skip_list_new_with_arena(&ctx.list1, 12, 0.25f, skip_list_comparator_memcmp, NULL,
+                                       NULL, arena_cap),
+              0);
+    void *arena_1_ptr = ctx.list1->arena;
+
+    pthread_t thread_a;
+    pthread_create(&thread_a, NULL, aba_thread_a, &ctx);
+
+    while (atomic_load_explicit(&sync_state, memory_order_acquire) < 1)
+    {
+    }
+
+    skip_list_free(ctx.list1);
+
+    ASSERT_EQ(skip_list_new_with_arena(&ctx.list2, 12, 0.25f, skip_list_comparator_memcmp, NULL,
+                                       NULL, arena_cap),
+              0);
+    void *arena_2_ptr = ctx.list2->arena;
+
+    if (arena_1_ptr != arena_2_ptr)
+    {
+        printf(YELLOW
+               "  [Warn] malloc did not recycle the arena pointer (%p vs %p). The bug may not "
+               "trigger on this run.\n" RESET,
+               arena_1_ptr, arena_2_ptr);
+    }
+    else
+    {
+        printf(RED
+               "  [Danger] malloc recycled the arena pointer (%p). ABA collision imminent!\n" RESET,
+               arena_2_ptr);
+    }
+
+    pthread_t thread_b;
+    pthread_create(&thread_b, NULL, aba_thread_b, &ctx);
+
+    atomic_store_explicit(&sync_state, 2, memory_order_release);
+
+    pthread_join(thread_a, NULL);
+    pthread_join(thread_b, NULL);
+
+    int expected_count = 100000;
+    int actual_count = skip_list_count_entries(ctx.list2);
+
+    printf(CYAN "  Final list count: %d (Expected: %d)\n" RESET, actual_count, expected_count);
+    ASSERT_EQ(actual_count, expected_count);
+
+    skip_list_free(ctx.list2);
+}
+
 void benchmark_skip_list_read_path()
 {
     printf(BOLDWHITE "\n----------------- Read Path Benchmark -----------------\n" RESET);
@@ -3007,6 +3122,7 @@ int main(int argc, char **argv)
     RUN_TEST(test_skip_list_get_ref, tests_passed);
     RUN_TEST(test_skip_list_cursor_next_get, tests_passed);
     RUN_TEST(test_skip_list_cursor_advance_in_node, tests_passed);
+    RUN_TEST(test_skip_list_arena_aba, tests_passed);
 
     RUN_TEST(benchmark_skip_list, tests_passed);
     RUN_TEST(benchmark_skip_list_sequential, tests_passed);

--- a/test/skip_list__tests.c
+++ b/test/skip_list__tests.c
@@ -2691,8 +2691,6 @@ void *aba_thread_a(void *arg)
 {
     aba_ctx_t *ctx = (aba_ctx_t *)arg;
 
-    /* Phase 1: Thread A does an insert to initialize its _Thread_local cache.
-     * tl_cached_arena is now set to list1->arena. */
     uint8_t key[] = "A_init";
     uint8_t val[] = "val";
     skip_list_put_with_seq(ctx->list1, key, sizeof(key), val, sizeof(val), -1, 1, 0);
@@ -2705,9 +2703,6 @@ void *aba_thread_a(void *arg)
     {
     }
 
-    /* Phase 2: Insert into list2.
-     * BUG TRIGGER: list2->arena has the exact same memory address that list1->arena had.
-     * Thread A bypasses the slot counter and incorrectly assumes it owns slot 0! */
     for (int i = 0; i < 50000; i++)
     {
         char k[32];

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tidesdb",
-  "version-string": "9.3.6",
+  "version-string": "9.3.7",
   "description": "TidesDB is a high-performance durable, transactional embeddable storage engine designed for flash and RAM optimization with optional object storage support for unlimited data scaling.",
   "dependencies": ["zstd", "snappy", "lz4", "pthreads", "curl"],
   "features": {


### PR DESCRIPTION
correct memtable corruption from arena aba problem @JonathanBMiller QA find
with TAF.

the arena allocator used raw pointers for thread local cache validation
when an arena was freed and a new one was created at the same memory address
threads would reuse stale cache slots

addition of a global generation id to the arena to validate cache freshness
this forces threads to get new memory slots when addresses are recycled