### PR TITLE
TidesDB 9 PATCH (v9.3.8)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+build
+build-*
+*.o
+*.so
+*.so.*
+mariadb-plugin
+artwork

--- a/.github/workflows/build_and_test_tidesdb.yml
+++ b/.github/workflows/build_and_test_tidesdb.yml
@@ -57,6 +57,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.name }}
+    timeout-minutes: 60
 
     steps:
       - name: Checkout repository
@@ -122,14 +123,18 @@ jobs:
       - name: Install dependencies (Linux RISC-V 64-bit)
         if: runner.os == 'Linux' && matrix.arch == 'riscv64'
         run: |
-          sudo apt update
-          sudo apt install -y \
+          # cmake, build-essential, pkg-config, git and wget ship on the runner image;
+          # only the cross toolchain and qemu need installing. retries plus a per-connection
+          # timeout keep a slow or stalling apt mirror from hanging the job indefinitely.
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            -o Acquire::Retries=5 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
             crossbuild-essential-riscv64 \
             gcc-riscv64-linux-gnu \
             g++-riscv64-linux-gnu \
-            qemu-user-static \
-            build-essential cmake pkg-config \
-            git wget
+            qemu-user-static
 
           mkdir -p /tmp/riscv64-deps
           cd /tmp/riscv64-deps

--- a/.github/workflows/failover_k8s.yml
+++ b/.github/workflows/failover_k8s.yml
@@ -1,0 +1,52 @@
+name: Failover (cloud sim, kind + MinIO)
+
+# higher-fidelity failover: real pods on a kind cluster fencing against a real MinIO bucket over
+# the S3 connector's conditional writes. heavier than the local fs run, so it is nightly + manual,
+# plus on PRs that touch the fencing / object-store code.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * *"
+  pull_request:
+    branches: [ "master" ]
+    paths:
+      - "src/objstore*"
+      - "src/tidesdb.c"
+      - "src/tidesdb.h"
+      - "test/failover/**"
+      - ".github/workflows/failover_k8s.yml"
+
+jobs:
+  failover-k8s:
+    runs-on: ubuntu-latest
+    name: Kubernetes Failover Simulation
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.10.0
+        with:
+          cluster_name: tidesdb-failover
+
+      - name: Build node image
+        run: docker build -f test/failover/Dockerfile -t tidesdb-node:ci .
+
+      - name: Load image into kind
+        run: kind load docker-image tidesdb-node:ci --name tidesdb-failover
+
+      - name: Run failover scenarios
+        run: |
+          chmod +x test/failover/run_k8s.sh
+          ./test/failover/run_k8s.sh
+
+      - name: Diagnostics on failure
+        if: failure()
+        run: |
+          kubectl get pods -o wide || true
+          kubectl describe pods -l app=tdb-node || true
+          for p in tdb-primary tdb-replica-0 tdb-replica-1 tdb-replica-2; do
+            echo "=== logs $p ==="; kubectl logs "$p" --tail=80 || true
+          done
+          kubectl logs deploy/minio --tail=40 || true

--- a/.github/workflows/failover_local.yml
+++ b/.github/workflows/failover_local.yml
@@ -1,0 +1,37 @@
+name: Failover (local, fs backend)
+
+# fast, dependency-free failover coverage: real tidesdb_node processes share a filesystem
+# bucket on the runner (the fs connector uses flock, so the single-writer fence holds across
+# processes) and the suite drives clean failover, zombie-primary fencing, and RPO=0 recovery.
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  workflow_dispatch:
+
+jobs:
+  failover-local:
+    runs-on: ubuntu-latest
+    name: Local Failover Scenarios
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake build-essential liblz4-dev libzstd-dev libsnappy-dev \
+            libcurl4-openssl-dev
+
+      - name: Build library and node
+        run: |
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DTIDESDB_WITH_SANITIZER=OFF
+          cmake --build build --target tidesdb tidesdb_node -j"$(nproc)"
+
+      - name: Run failover scenarios
+        env:
+          TDB_NODE_BIN: ${{ github.workspace }}/build/tidesdb_node
+          TDB_NODE_LIBDIR: ${{ github.workspace }}/build
+        run: ./test/failover/run_local.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -778,6 +778,10 @@ if(TIDESDB_BUILD_TESTS) # enable building tests and benchmarks
         if(TIDESDB_WITH_S3)
             target_compile_definitions(tidesdb_node PRIVATE TIDESDB_WITH_S3)
         endif()
+        # on illumos/Solaris the socket calls live in libsocket/libnsl, not libc
+        if(CMAKE_SYSTEM_NAME STREQUAL "SunOS")
+            target_link_libraries(tidesdb_node PRIVATE socket nsl)
+        endif()
     endif()
 
     # add include and link directories for test executables

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -768,6 +768,18 @@ if(TIDESDB_BUILD_TESTS) # enable building tests and benchmarks
             BENCH_USE_BTREE=${BENCH_USE_BTREE}
     )
 
+    # failover harness node -- a minimal networked tidesdb instance (one process = one cluster
+    # node) driven by the object-store failover tests in test/failover. POSIX sockets, so it is
+    # not built on Windows.
+    if(NOT WIN32)
+        add_executable(tidesdb_node test/failover/tidesdb_node.c)
+        target_link_libraries(tidesdb_node PRIVATE tidesdb)
+        target_include_directories(tidesdb_node PRIVATE src external)
+        if(TIDESDB_WITH_S3)
+            target_compile_definitions(tidesdb_node PRIVATE TIDESDB_WITH_S3)
+        endif()
+    endif()
+
     # add include and link directories for test executables
     foreach(test_target block_manager_tests skip_list_tests compress_tests bloom_filter_tests manifest_tests clock_cache_tests queue_tests btree_tests local_cache_tests objstore_tests sha256_tests hmac_sha256_tests tidesdb_tests tidesdb_bench)
         target_link_libraries(${test_target} PRIVATE tidesdb)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ if(TIDESDB_WITH_MIMALLOC)
 endif()
 
 project(tidesdb
-	VERSION 9.3.7
+	VERSION 9.3.8
 	LANGUAGES C)
 
 set(CMAKE_C_STANDARD 11)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ It is not a full-featured database, but rather a library that can be used to bui
 - Ability to clone column families
 - Easy pluggable custom allocator support
 - Object store mode with S3-compatible storage, local file caching, and node-failure recovery
+- Primary/replica replication over the object store · one primary and many read-only replicas share a bucket; replicas poll and lazily fetch, a replica promotes to primary on failure with a catch-up sync, and single-writer fencing (a lease epoch claimed via conditional writes) stops a superseded-but-alive primary from causing split-brain. Optional synchronous WAL upload for RPO=0 failover.
 
 ## Getting Started
 To learn more about TidesDB, check out [What is TidesDB?](https://tidesdb.com/getting-started/what-is-tidesdb/)

--- a/src/block_manager.c
+++ b/src/block_manager.c
@@ -168,6 +168,39 @@ static uint8_t *bm_get_read_buf(const size_t needed)
 }
 
 /**
+ * pwrite_all
+ * write exactly nbyte bytes at offset, retrying short writes and EINTR. a bare pwrite treats a
+ * short write as a hard error, but a large write_raw can legitimately come up short under a
+ * signal. the append path already gets this via tdb_pwritev_safe.
+ * @param fd the file descriptor
+ * @param buf the buffer to write
+ * @param nbyte the number of bytes that must be written
+ * @param offset the file offset to write at
+ * @return 0 if all bytes were written, -1 on error (errno set)
+ */
+static inline int pwrite_all(int fd, const void *buf, size_t nbyte, off_t offset)
+{
+    size_t total = 0;
+    while (total < nbyte)
+    {
+        const ssize_t written =
+            pwrite(fd, (const uint8_t *)buf + total, nbyte - total, offset + total);
+        if (BM_UNLIKELY(written < 0))
+        {
+            if (errno == EINTR) continue;
+            return -1;
+        }
+        if (BM_UNLIKELY(written == 0))
+        {
+            errno = EIO;
+            return -1;
+        }
+        total += (size_t)written;
+    }
+    return 0;
+}
+
+/**
  * odsync_available
  * check if O_DSYNC is available on the specific platform
  * @return 1 if O_DSYNC is available, 0 otherwise
@@ -331,8 +364,7 @@ static int write_header(const int fd)
     encode_uint32_le_compat(header + BLOCK_MANAGER_MAGIC_SIZE + BLOCK_MANAGER_VERSION_SIZE,
                             padding);
 
-    const ssize_t written = pwrite(fd, header, BLOCK_MANAGER_HEADER_SIZE, 0);
-    return (written == BLOCK_MANAGER_HEADER_SIZE) ? 0 : -1;
+    return pwrite_all(fd, header, BLOCK_MANAGER_HEADER_SIZE, 0);
 }
 
 /**
@@ -847,8 +879,7 @@ int block_manager_write_at(block_manager_t *bm, const int64_t offset, const uint
      * grow the file without advancing current_file_size, desyncing the two */
     if ((uint64_t)offset + size > atomic_load(&bm->current_file_size)) return -1;
 
-    const ssize_t written = pwrite(bm->fd, data, size, offset);
-    if (written != (ssize_t)size)
+    if (pwrite_all(bm->fd, data, size, offset) != 0)
     {
         return -1;
     }
@@ -895,8 +926,7 @@ int block_manager_update_checksum(block_manager_t *bm, const int64_t block_offse
     encode_uint32_le_compat(checksum_buf, new_checksum);
 
     const off_t checksum_offset = block_offset + BLOCK_MANAGER_SIZE_FIELD_SIZE;
-    if (pwrite(bm->fd, checksum_buf, BLOCK_MANAGER_CHECKSUM_LENGTH, checksum_offset) !=
-        BLOCK_MANAGER_CHECKSUM_LENGTH)
+    if (pwrite_all(bm->fd, checksum_buf, BLOCK_MANAGER_CHECKSUM_LENGTH, checksum_offset) != 0)
     {
         return -1;
     }

--- a/src/block_manager.c
+++ b/src/block_manager.c
@@ -47,14 +47,6 @@
  * memory-based refusal happens (e.g. block_manager unit tests with no db). */
 static _Atomic(uint64_t) bm_max_safe_block_bytes = 0;
 
-void block_manager_set_max_safe_block_bytes(uint64_t bytes)
-{
-    atomic_store_explicit(&bm_max_safe_block_bytes, bytes, memory_order_relaxed);
-}
-
-static pthread_key_t bm_tls_key;
-static pthread_once_t bm_tls_once = PTHREAD_ONCE_INIT;
-
 /**
  *
  *  * * * * * * * * * *
@@ -97,12 +89,31 @@ static pthread_once_t bm_tls_once = PTHREAD_ONCE_INIT;
  * global block cache in tidesdb.c uses these functions for safe sharing
  */
 
+static pthread_key_t bm_tls_key;
+static pthread_once_t bm_tls_once = PTHREAD_ONCE_INIT;
+
+/**
+ * bm_tls_read_buf_t
+ * per-thread reusable read buffer (see bm_get_read_buf)
+ * @param buf the buffer, grown on demand and freed on thread exit
+ * @param capacity allocated size of buf in bytes
+ */
 typedef struct
 {
     uint8_t *buf;
     size_t capacity;
 } bm_tls_read_buf_t;
 
+void block_manager_set_max_safe_block_bytes(uint64_t bytes)
+{
+    atomic_store_explicit(&bm_max_safe_block_bytes, bytes, memory_order_relaxed);
+}
+
+/**
+ * bm_tls_destructor
+ * frees a thread's read buffer when the thread exits
+ * @param ptr the thread-local bm_tls_read_buf_t
+ */
 static void bm_tls_destructor(void *ptr)
 {
     if (ptr)
@@ -113,11 +124,24 @@ static void bm_tls_destructor(void *ptr)
     }
 }
 
+/**
+ * bm_tls_init_key
+ * one-time creation of the thread-local read-buffer key
+ */
 static void bm_tls_init_key(void)
 {
     pthread_key_create(&bm_tls_key, bm_tls_destructor);
 }
 
+/**
+ * bm_get_read_buf
+ * returns the calling thread's reusable read buffer, growing it (capacity doubling)
+ * to hold at least needed bytes. avoids a fresh malloc and its page faults on every
+ * read. the grow uses realloc, so bytes already in the buffer are preserved -- callers
+ * rely on this to keep an already-read header across a grow for the payload remainder.
+ * @param needed minimum buffer size in bytes
+ * @return the buffer, or NULL on allocation failure
+ */
 static uint8_t *bm_get_read_buf(const size_t needed)
 {
     pthread_once(&bm_tls_once, bm_tls_init_key);
@@ -156,7 +180,7 @@ static inline int odsync_available(void)
 /**
  * is_sync_full
  * is a block manager in sync full mode?
- * @param bm
+ * @param bm the block manager
  * @return 1 if sync mode is full, 0 otherwise
  */
 static inline int is_sync_full(const block_manager_t *bm)
@@ -379,7 +403,9 @@ static int reopen_fd(block_manager_t *bm)
 
 /**
  * truncate_to_header
- * truncates a block manager file to just the header and syncs
+ * truncates a block manager file back to just the header, resetting the tracked file
+ * size and preallocation extent. syncs in full-sync mode (ftruncate is not covered by
+ * O_DSYNC).
  * @param bm the block manager
  * @return 0 if successful, -1 if not
  */
@@ -402,10 +428,12 @@ static int truncate_to_header(block_manager_t *bm)
 
 /**
  * block_manager_open_internal
- * opens a block manager (no cache)
- * @param bm the block manager to open
+ * allocates the block manager, opens or creates the file, then writes a fresh header
+ * (new file) or validates the existing one. on failure the errno of the failing syscall
+ * is preserved for the caller.
+ * @param bm output, set to the opened block manager (NULL on failure)
  * @param file_path the path of the file
- * @param sync_mode the sync mode (TDB_SYNC_NONE, TDB_SYNC_FULL)
+ * @param sync_mode the sync mode (BLOCK_MANAGER_SYNC_NONE, BLOCK_MANAGER_SYNC_FULL)
  * @return 0 if successful, -1 if not
  */
 static int block_manager_open_internal(block_manager_t **bm, const char *file_path,
@@ -612,6 +640,9 @@ block_manager_block_t *block_manager_block_create_from_buffer(const uint64_t siz
  * reserved tail offset via a single pwritev. shared by block_write and write_raw
  * so the on-disk encoding lives in one place. data must be non-NULL and size
  * non-zero -- the caller validates (a zero size_field reads back as EOF).
+ * @param bm the block manager
+ * @param data the payload to frame and append
+ * @param size the payload size in bytes
  * @return the offset written at, or -1 on failure
  */
 static int64_t bm_append_block(block_manager_t *bm, const void *data, const uint32_t size)

--- a/src/block_manager.c
+++ b/src/block_manager.c
@@ -161,7 +161,7 @@ static inline int odsync_available(void)
  */
 static inline int is_sync_full(const block_manager_t *bm)
 {
-    return bm->sync_full_cached;
+    return atomic_load_explicit(&bm->sync_full_cached, memory_order_relaxed);
 }
 
 /**
@@ -425,7 +425,7 @@ static int block_manager_open_internal(block_manager_t **bm, const char *file_pa
     atomic_init(&new_bm->group_sync_active, 0);
 
     new_bm->sync_mode = sync_mode;
-    new_bm->sync_full_cached = (sync_mode == BLOCK_MANAGER_SYNC_FULL);
+    atomic_init(&new_bm->sync_full_cached, sync_mode == BLOCK_MANAGER_SYNC_FULL);
     new_bm->smooth_writeback = 0;
     new_bm->smooth_synced_offset = 0;
 
@@ -705,8 +705,11 @@ int block_manager_block_write_batch(block_manager_t *bm, block_manager_block_t *
         }
         if (blocks[i]->size > UINT32_MAX) return -1;
 
-        total_batch_size +=
+        const size_t framed =
             BLOCK_MANAGER_BLOCK_HEADER_SIZE + blocks[i]->size + BLOCK_MANAGER_FOOTER_SIZE;
+        /* guard size_t overflow of the running total on 32-bit platforms */
+        if (framed > SIZE_MAX - total_batch_size) return -1;
+        total_batch_size += framed;
         valid_count++;
     }
 
@@ -921,7 +924,6 @@ int block_manager_cursor_init_stack(block_manager_cursor_t *cursor, block_manage
     /* we initialize to position before first block */
     cursor->current_pos = BLOCK_MANAGER_HEADER_SIZE;
     cursor->current_block_size = 0;
-    cursor->block_index = -1; /* -1 means before first block */
     cursor->block_size_valid = 0;
 
     /* we position at first block so cursor_read works immediately */
@@ -977,7 +979,6 @@ int block_manager_cursor_next(block_manager_cursor_t *cursor)
         BLOCK_MANAGER_BLOCK_HEADER_SIZE + (uint64_t)block_size + BLOCK_MANAGER_FOOTER_SIZE;
     cursor->current_block_size = 0;
     cursor->block_size_valid = 0; /* we invalidate cache after moving */
-    cursor->block_index++;
 
     return 0;
 }
@@ -1053,7 +1054,6 @@ int block_manager_cursor_skip_corrupt(block_manager_cursor_t *cursor)
             BLOCK_MANAGER_BLOCK_HEADER_SIZE + (uint64_t)block_size + BLOCK_MANAGER_FOOTER_SIZE;
         cursor->current_block_size = 0;
         cursor->block_size_valid = 0;
-        cursor->block_index++;
         return 0;
     }
 
@@ -1067,7 +1067,6 @@ int block_manager_cursor_skip_corrupt(block_manager_cursor_t *cursor)
         BLOCK_MANAGER_BLOCK_HEADER_SIZE + (uint64_t)block_size + BLOCK_MANAGER_FOOTER_SIZE;
     cursor->current_block_size = 0;
     cursor->block_size_valid = 0;
-    cursor->block_index++;
     return 0;
 }
 
@@ -1259,7 +1258,6 @@ block_manager_block_t *block_manager_cursor_read_and_advance(block_manager_curso
         BLOCK_MANAGER_BLOCK_HEADER_SIZE + block->size + BLOCK_MANAGER_FOOTER_SIZE;
     cursor->current_block_size = 0;
     cursor->block_size_valid = 0; /* invalidate cache -- we moved to a new position */
-    cursor->block_index++;
 
     return block;
 }
@@ -1321,7 +1319,6 @@ int block_manager_cursor_prev(block_manager_cursor_t *cursor)
     cursor->current_pos = prev_block_start;
     cursor->current_block_size = prev_block_size;
     cursor->block_size_valid = 1; /* we know the size from footer */
-    cursor->block_index--;
 
     return 0;
 }
@@ -1332,7 +1329,6 @@ int block_manager_cursor_goto_first(block_manager_cursor_t *cursor)
 
     cursor->current_pos = BLOCK_MANAGER_HEADER_SIZE;
     cursor->current_block_size = 0;
-    cursor->block_index = -1;
     cursor->block_size_valid = 0;
 
     return 0;
@@ -1378,7 +1374,6 @@ int block_manager_cursor_goto_last_before(block_manager_cursor_t *cursor, const 
     cursor->current_pos = end_offset - total_block_size;
     cursor->current_block_size = block_size;
     cursor->block_size_valid = 1; /* we know the size from footer */
-    cursor->block_index = -1;     /* unknown index */
 
     return 0;
 }
@@ -1483,7 +1478,6 @@ int block_manager_cursor_goto(block_manager_cursor_t *cursor, const uint64_t pos
 
     cursor->current_pos = pos;
     cursor->block_size_valid = 0; /* we invalidate cache when jumping to arbitrary position */
-    cursor->block_index = -1;     /* index is unknown after an arbitrary jump */
     return 0;
 }
 
@@ -1699,20 +1693,20 @@ int block_manager_validate_last_block(block_manager_t *bm,
             scan_pos += total_block_size;
         }
 
-        /* if we stopped without explicit corruption, verify the trailing region is
-         * all zeros -- that confirms it's preallocation tail, not a partial write. */
-        const int trailing_zero =
-            hit_corruption ? 0 : is_trailing_zero(bm->fd, valid_size, file_size);
-
         if (validation == BLOCK_MANAGER_STRICT_BLOCK_VALIDATION)
         {
+            /* the trailing region must be all zeros to confirm it's preallocation tail
+             * rather than a partial write; permissive mode truncates either way and so
+             * never needs this scan */
+            const int trailing_zero =
+                hit_corruption ? 0 : is_trailing_zero(bm->fd, valid_size, file_size);
             if (hit_corruption || trailing_zero != 1) return -1;
             /* preallocation tail is legitimate; don't truncate, just record true extent */
             atomic_store(&bm->current_file_size, valid_size);
             return 0;
         }
 
-        /* permissive mode -- truncate trailing garbage OR preallocation tail so
+        /* permissive mode -- truncate trailing garbage or preallocation tail so
          * the file is always self-describing on next open */
         if (valid_size != file_size)
         {
@@ -1783,7 +1777,8 @@ void block_manager_set_sync_mode(block_manager_t *bm, const int sync_mode)
 {
     if (!bm) return;
     bm->sync_mode = convert_sync_mode(sync_mode);
-    bm->sync_full_cached = (bm->sync_mode == BLOCK_MANAGER_SYNC_FULL);
+    atomic_store_explicit(&bm->sync_full_cached, bm->sync_mode == BLOCK_MANAGER_SYNC_FULL,
+                          memory_order_relaxed);
 }
 
 int block_manager_get_block_size_at_offset(block_manager_t *bm, const uint64_t offset,

--- a/src/block_manager.h
+++ b/src/block_manager.h
@@ -63,7 +63,7 @@
 #define BLOCK_MANAGER_PREALLOC_CHUNK    (64ull * 1024 * 1024) /* extend by 64 MB at a time */
 #define BLOCK_MANAGER_PREALLOC_LOWWATER (4ull * 1024 * 1024)  /* trigger extend when 4 MB left */
 
-/* sstable-construction writeback pacing: when smoothing is enabled, start async writeback
+/* sstable-construction writeback pacing-- when smoothing is enabled, start async writeback
  * of the file each time this many bytes accumulate since the last hint, so the final
  * fdatasync barrier flushes only a small residual rather than the whole sstable */
 #define BLOCK_MANAGER_SMOOTH_WRITEBACK_BYTES (1ull * 1024 * 1024)

--- a/src/block_manager.h
+++ b/src/block_manager.h
@@ -98,19 +98,14 @@ typedef enum
  * @param group_durable_size bytes of the file confirmed fdatasync'd, used by group-commit
  *                           callers to tell whether their write is already durable
  * @param group_sync_active set while a group-commit leader is mid-fdatasync on this file
- * @param smooth_writeback 1 when this file is a single-writer sstable under construction and
- *                         block writes should dribble async writeback every
- *                         BLOCK_MANAGER_SMOOTH_WRITEBACK_BYTES. read-only after open.
- * @param smooth_synced_offset construction-writer cursor, file offset already handed to async
- *                             writeback. only touched by the single construction thread (never
- *                             set on concurrently-written files), so it needs no atomicity.
  */
 typedef struct
 {
     int fd;
     char file_path[MAX_FILE_PATH_LENGTH];
     block_manager_sync_mode_t sync_mode;
-    int sync_full_cached; /* cached result of (sync_mode == BLOCK_MANAGER_SYNC_FULL) */
+    /* atomic so a runtime sync-mode change can't race the read on the write path */
+    _Atomic int sync_full_cached;
     int smooth_writeback; /* read-only after open; see block_manager_enable_smooth_writeback */
     uint64_t smooth_synced_offset; /* single-writer construction cursor, no atomicity needed */
     /* explicit alignment for atomic uint64_t to avoid ABI issues on 32-bit platforms */
@@ -145,7 +140,6 @@ typedef struct
  * @param bm the block manager
  * @param current_pos the current position of the cursor
  * @param current_block_size the size of the current block
- * @param block_index current index in shared position cache (-1 if before first block)
  * @param block_size_valid 1 if current_block_size is cached and valid, 0 otherwise
  */
 typedef struct
@@ -153,7 +147,6 @@ typedef struct
     block_manager_t *bm;
     uint64_t current_pos;
     uint64_t current_block_size;
-    int block_index;
     int block_size_valid;
 } block_manager_cursor_t;
 
@@ -499,8 +492,8 @@ int block_manager_cursor_at_second(block_manager_cursor_t *cursor);
  * @param validation the type of validation to apply, either strict or permissive
  * @return 0 if valid or successfully recovered, -1 if validation fails
  *
- * In strict mode -- any corruption returns -1, file is not modified
- * In permissive mode -- truncates to last valid block on corruption
+ * In strict mode           -- any corruption returns -1, file is not modified
+ * In permissive mode       -- truncates to last valid block on corruption
  */
 int block_manager_validate_last_block(block_manager_t *bm,
                                       tidesdb_block_validation_mode_t validation);

--- a/src/bloom_filter.c
+++ b/src/bloom_filter.c
@@ -572,7 +572,7 @@ bloom_filter_t *bloom_filter_deserialize(const uint8_t *data, const size_t len)
 
     if (encoding == BF_ENCODING_DENSE)
     {
-        /* raw bitset: exactly size_in_words little-endian words must remain */
+        /* raw bitset-- exactly size_in_words little-endian words must remain */
         if ((size_t)(end - ptr) < (size_t)size_in_words * BF_DENSE_WORD_BYTES)
         {
             free(bitset);

--- a/src/bloom_filter.c
+++ b/src/bloom_filter.c
@@ -43,10 +43,27 @@
  * same hash that built it, so existing on-disk (v1) filters stay correct. */
 #define BF_HASH_VERSION_LEGACY  1u
 #define BF_HASH_VERSION_CURRENT 2u
-/* serialized v2 filters carry a 0x00 sentinel + version byte. a v1 filter can
+/* serialized v2+ filters carry a 0x00 sentinel + a format byte. a v1 filter can
  * never start with 0x00 because its first field is varint32(m) and m >= 1. */
 #define BF_SERIALIZE_VERSION_SENTINEL 0x00u
 #define BF_SERIALIZE_VERSION_BYTES    2
+
+/* the post-sentinel format byte packs the bitset encoding in the high nibble and
+ * the hash version in the low nibble. sparse (encoding 0) with hash version 2 is
+ * exactly 0x02 -- byte-identical to the original v2 framing -- so under-filled
+ * filters still serialize as before and even an older binary reads them. only a
+ * dense filter sets the high nibble, which an older binary rejects (it sees an
+ * unknown version and falls back to a full read). hash_version stays <= 0x0F. */
+#define BF_FORMAT_HASH_VERSION(b)     ((unsigned int)((b)&0x0Fu))
+#define BF_FORMAT_ENCODING(b)         ((unsigned int)((b) >> 4))
+#define BF_MAKE_FORMAT_BYTE(enc, ver) ((uint8_t)(((enc) << 4) | ((ver)&0x0Fu)))
+
+/* bitset encodings. sparse stores only non-zero words (varint idx + varint64 val);
+ * dense stores every word as 8 little-endian bytes. a correctly sized filter is
+ * ~50% full so almost every 64-bit word is non-zero, which makes sparse larger
+ * than the raw bitset -- serialize picks whichever encoding is smaller. */
+#define BF_ENCODING_SPARSE 0u
+#define BF_ENCODING_DENSE  1u
 
 /* upper bound on the number of hash functions accepted by bloom_filter_new.
  * derived h grows logarithmically with target false-positive rate; even at
@@ -55,13 +72,11 @@
  * floating-point edge cases). typical real-world h is 7-15. */
 #define BF_MAX_HASH_FUNCTIONS 100
 
-/* varint worst-case sizes for serialization buffer math */
+/* varint worst-case sizes -- bound the parse loops in the bounded decoders */
 #define BF_VARINT32_MAX_BYTES 5
 #define BF_VARINT64_MAX_BYTES 10
-/* serialized header is 3 varint32s -- m, h, non_zero_count */
-#define BF_SERIALIZE_HEADER_MAX_BYTES (3 * BF_VARINT32_MAX_BYTES)
-/* each non-zero word is encoded as varint32 index + varint64 value */
-#define BF_SERIALIZE_WORD_MAX_BYTES (BF_VARINT32_MAX_BYTES + BF_VARINT64_MAX_BYTES)
+/* raw bytes per dense bitset word (uint64 little-endian) */
+#define BF_DENSE_WORD_BYTES 8
 
 /* lemire's fast range reduction maps a uniform uint32_t hash into [0, range)
  * without integer division. it uses a single 64-bit multiply + shift.
@@ -211,8 +226,10 @@ int bloom_filter_new(bloom_filter_t **bf, double p, const int n)
     const double h_double = ceil(((double)(*bf)->m) / n * M_LN2);
 
     /* we validate h is reasonable -- typical real-world values are 7-15;
-     * BF_MAX_HASH_FUNCTIONS rejects pathological configs from FP edge cases */
-    if (h_double <= 0.0 || h_double > (double)BF_MAX_HASH_FUNCTIONS)
+     * BF_MAX_HASH_FUNCTIONS rejects pathological configs from FP edge cases.
+     * h_double is ceil() of a strictly positive quantity (m >= 1, n >= 1) so it
+     * is always >= 1; only the upper bound can actually trip */
+    if (h_double > (double)BF_MAX_HASH_FUNCTIONS)
     {
         free(*bf);
         *bf = NULL;
@@ -334,6 +351,36 @@ unsigned int bloom_filter_hash(const uint8_t *entry, const size_t size, const in
     return bf_hash_inline(entry, size, (uint32_t)seed);
 }
 
+/* encoded byte length of a varint, so serialize can size its buffer exactly */
+static inline size_t bf_varint32_len(uint32_t v)
+{
+    size_t n = 1;
+    while (v >= 0x80u)
+    {
+        v >>= 7;
+        n++;
+    }
+    return n;
+}
+
+static inline size_t bf_varint64_len(uint64_t v)
+{
+    size_t n = 1;
+    while (v >= 0x80u)
+    {
+        v >>= 7;
+        n++;
+    }
+    return n;
+}
+
+/* write a uint64 as 8 little-endian bytes (endian-canonical, like the varints) */
+static inline uint8_t *bf_put_u64le(uint8_t *p, uint64_t v)
+{
+    for (int i = 0; i < BF_DENSE_WORD_BYTES; i++) p[i] = (uint8_t)(v >> (8 * i));
+    return p + BF_DENSE_WORD_BYTES;
+}
+
 uint8_t *bloom_filter_serialize(const bloom_filter_t *bf, size_t *out_size)
 {
     if (bf == NULL)
@@ -341,55 +388,74 @@ uint8_t *bloom_filter_serialize(const bloom_filter_t *bf, size_t *out_size)
         return NULL;
     }
 
-    /* we count non-zero words for sparse encoding */
+    /* count non-zero words and measure the exact sparse body in one pass */
     unsigned int non_zero_count = 0;
+    size_t sparse_body = 0;
     for (unsigned int i = 0; i < bf->size_in_words; i++)
     {
-        if (bf->bitset[i] != 0) non_zero_count++;
+        if (bf->bitset[i] != 0)
+        {
+            non_zero_count++;
+            sparse_body += bf_varint32_len(i) + bf_varint64_len(bf->bitset[i]);
+        }
     }
+    sparse_body += bf_varint32_len((uint32_t)non_zero_count); /* sparse carries the count */
 
-    /* we allocate worst-case size
-     * -- header            3 varint32s (m, h, non_zero_count)
-     * -- sparse data       each non-zero word = varint32 index + varint64 value
-     */
-    const size_t max_size = BF_SERIALIZE_VERSION_BYTES + BF_SERIALIZE_HEADER_MAX_BYTES +
-                            (size_t)non_zero_count * BF_SERIALIZE_WORD_MAX_BYTES;
-    uint8_t *buffer = malloc(max_size);
+    /* dense stores every word raw; at ~50% fill nearly all words are non-zero so
+     * sparse bloats past raw -- take whichever encoding is smaller. ties favor
+     * sparse (only it is byte-identical to the legacy v2 framing). */
+    const size_t dense_body = (size_t)bf->size_in_words * BF_DENSE_WORD_BYTES;
+    const unsigned int encoding =
+        (dense_body < sparse_body) ? BF_ENCODING_DENSE : BF_ENCODING_SPARSE;
+
+    /* a 0x00 sentinel + format byte leads any filter that is not a legacy-hash
+     * sparse filter (which stays in the original sentinel-free v1 layout). the
+     * sentinel is impossible for a v1 filter, whose first byte is varint32(m),
+     * m >= 1, so deserialize can tell the formats apart with no ambiguity. */
+    const int versioned =
+        (bf->hash_version > BF_HASH_VERSION_LEGACY) || (encoding != BF_ENCODING_SPARSE);
+
+    size_t total = bf_varint32_len((uint32_t)bf->m) + bf_varint32_len((uint32_t)bf->h);
+    total += versioned ? BF_SERIALIZE_VERSION_BYTES : 0;
+    total += (encoding == BF_ENCODING_DENSE) ? dense_body : sparse_body;
+
+    uint8_t *buffer = malloc(total);
     if (buffer == NULL)
     {
         return NULL;
     }
 
     uint8_t *ptr = buffer;
-
-    /* any non-legacy filter leads with a 0x00 sentinel (impossible for a v1 filter,
-     * whose first byte is varint32(m) with m >= 1) followed by the hash version
-     * byte, so deserialize routes the filter back to the hash that built it. keyed
-     * off "> LEGACY" rather than a specific version so a future bump stays recorded. */
-    if (bf->hash_version > BF_HASH_VERSION_LEGACY)
+    if (versioned)
     {
         *ptr++ = BF_SERIALIZE_VERSION_SENTINEL;
-        *ptr++ = (uint8_t)bf->hash_version;
+        *ptr++ = BF_MAKE_FORMAT_BYTE(encoding, bf->hash_version);
     }
 
-    /* we write header with varint encoding */
     ptr = encode_varint32(ptr, (uint32_t)bf->m);
     ptr = encode_varint32(ptr, (uint32_t)bf->h);
-    ptr = encode_varint32(ptr, (uint32_t)non_zero_count);
 
-    /* we write sparse bitset -- only non-zero words with their indices */
-    for (unsigned int i = 0; i < bf->size_in_words; i++)
+    if (encoding == BF_ENCODING_DENSE)
     {
-        if (bf->bitset[i] != 0)
+        /* raw bitset, one little-endian word at a time -- size_in_words is
+         * re-derived from m on read so no length prefix is needed */
+        for (unsigned int i = 0; i < bf->size_in_words; i++) ptr = bf_put_u64le(ptr, bf->bitset[i]);
+    }
+    else
+    {
+        ptr = encode_varint32(ptr, (uint32_t)non_zero_count);
+        for (unsigned int i = 0; i < bf->size_in_words; i++)
         {
-            ptr = encode_varint32(ptr, (uint32_t)i);   /* word index */
-            ptr = encode_varint64(ptr, bf->bitset[i]); /* word value */
+            if (bf->bitset[i] != 0)
+            {
+                ptr = encode_varint32(ptr, (uint32_t)i);   /* word index */
+                ptr = encode_varint64(ptr, bf->bitset[i]); /* word value */
+            }
         }
     }
 
-    /* we return actual size used, no realloc shrink since the overallocation
-     * is at most 15 bytes per non-zero word and glibc typically won't release it anyway */
-    *out_size = ptr - buffer;
+    /* the buffer was sized exactly, so no shrink is needed */
+    *out_size = (size_t)(ptr - buffer);
     return buffer;
 }
 
@@ -451,26 +517,34 @@ bloom_filter_t *bloom_filter_deserialize(const uint8_t *data, const size_t len)
 
     /* a leading 0x00 marks the versioned format (v1 can never start with 0x00,
      * its first field is varint32(m) with m >= 1). absent it, this is a legacy
-     * v1 filter that must keep being queried with the v1 hash. */
+     * v1 sparse filter that must keep being queried with the v1 hash. the format
+     * byte packs the bitset encoding (high nibble) and hash version (low nibble);
+     * a legacy v2 filter's byte is 0x02 -> sparse + hash version 2. */
     unsigned int hash_version = BF_HASH_VERSION_LEGACY;
+    unsigned int encoding = BF_ENCODING_SPARSE;
     if (ptr[0] == BF_SERIALIZE_VERSION_SENTINEL)
     {
-        if (end - ptr < BF_SERIALIZE_VERSION_BYTES) return NULL; /* sentinel + version */
+        if (end - ptr < BF_SERIALIZE_VERSION_BYTES) return NULL; /* sentinel + format byte */
         ptr++;                                                   /* skip sentinel */
-        hash_version = (unsigned int)*ptr++;                     /* read hash version */
-        /* reject an unknown version -- querying with an undefined scheme would
-         * silently produce false negatives on an otherwise valid filter */
+        const uint8_t format = *ptr++;
+        hash_version = BF_FORMAT_HASH_VERSION(format);
+        encoding = BF_FORMAT_ENCODING(format);
+        /* reject an unknown hash version (querying with an undefined scheme would
+         * silently false-negative) or an unknown bitset encoding */
         if (hash_version < BF_HASH_VERSION_LEGACY || hash_version > BF_HASH_VERSION_CURRENT)
+        {
+            return NULL;
+        }
+        if (encoding != BF_ENCODING_SPARSE && encoding != BF_ENCODING_DENSE)
         {
             return NULL;
         }
     }
 
     /* we read header with bounded varint decoding */
-    uint32_t m_u32, h_u32, non_zero_count;
+    uint32_t m_u32, h_u32;
     if (bf_get_varint32(&ptr, end, &m_u32) != 0) return NULL;
     if (bf_get_varint32(&ptr, end, &h_u32) != 0) return NULL;
-    if (bf_get_varint32(&ptr, end, &non_zero_count) != 0) return NULL;
 
     const unsigned int m = m_u32;
     const unsigned int h = h_u32;
@@ -489,13 +563,6 @@ bloom_filter_t *bloom_filter_deserialize(const uint8_t *data, const size_t len)
 
     const unsigned int size_in_words = (m + BF_BITS_PER_WORD - 1) / BF_BITS_PER_WORD;
 
-    /* a valid filter never has more non-zero words than total words; reject a
-     * corrupt count up front so the loop below can't be driven past the buffer */
-    if (non_zero_count > size_in_words)
-    {
-        return NULL;
-    }
-
     /* we allocate and zero-initialize bitset */
     uint64_t *bitset = calloc((size_t)size_in_words, sizeof(uint64_t));
     if (bitset == NULL)
@@ -503,25 +570,58 @@ bloom_filter_t *bloom_filter_deserialize(const uint8_t *data, const size_t len)
         return NULL;
     }
 
-    /* we read sparse bitset -- only non-zero words */
-    for (uint32_t i = 0; i < non_zero_count; i++)
+    if (encoding == BF_ENCODING_DENSE)
     {
-        uint32_t index;
-        uint64_t value;
-        if (bf_get_varint32(&ptr, end, &index) != 0 || bf_get_varint64(&ptr, end, &value) != 0)
+        /* raw bitset: exactly size_in_words little-endian words must remain */
+        if ((size_t)(end - ptr) < (size_t)size_in_words * BF_DENSE_WORD_BYTES)
+        {
+            free(bitset);
+            return NULL;
+        }
+        for (unsigned int i = 0; i < size_in_words; i++)
+        {
+            uint64_t value = 0;
+            for (int j = 0; j < BF_DENSE_WORD_BYTES; j++) value |= (uint64_t)(*ptr++) << (8 * j);
+            bitset[i] = value;
+        }
+    }
+    else
+    {
+        uint32_t non_zero_count;
+        if (bf_get_varint32(&ptr, end, &non_zero_count) != 0)
         {
             free(bitset);
             return NULL;
         }
 
-        /* we validate index is within bounds */
-        if (index >= (uint32_t)size_in_words)
+        /* a valid filter never has more non-zero words than total words; reject a
+         * corrupt count up front so the loop below can't be driven past the buffer */
+        if (non_zero_count > size_in_words)
         {
             free(bitset);
             return NULL;
         }
 
-        bitset[index] = value;
+        /* we read sparse bitset -- only non-zero words */
+        for (uint32_t i = 0; i < non_zero_count; i++)
+        {
+            uint32_t index;
+            uint64_t value;
+            if (bf_get_varint32(&ptr, end, &index) != 0 || bf_get_varint64(&ptr, end, &value) != 0)
+            {
+                free(bitset);
+                return NULL;
+            }
+
+            /* we validate index is within bounds */
+            if (index >= (uint32_t)size_in_words)
+            {
+                free(bitset);
+                return NULL;
+            }
+
+            bitset[index] = value;
+        }
     }
 
     bloom_filter_t *bf = malloc(sizeof(bloom_filter_t));

--- a/src/bloom_filter.h
+++ b/src/bloom_filter.h
@@ -48,17 +48,21 @@ typedef struct
 
 /**
  * bloom_filter_new
- * creates a new bloom filter
- * @param bf the bloom filter to create
- * @param p the false positive rate
- * @param n the number of elements
- * @return 0 if successful, -1 if not
+ * creates a new bloom filter sized for n elements at false-positive rate p.
+ * @param bf out -- on success receives the new filter. set to NULL on an
+ *           allocation or range failure; the initial invalid-argument check
+ *           returns before writing *bf, so initialize it to NULL if you intend
+ *           to ignore the return code
+ * @param p the target false positive rate, in the open interval (0, 1)
+ * @param n the expected number of elements, must be > 0
+ * @return 0 on success, -1 on invalid arguments or allocation failure
  */
 int bloom_filter_new(bloom_filter_t **bf, double p, int n);
 
 /**
  * bloom_filter_add
- * adds an entry to the bloom filter
+ * adds an entry to the bloom filter. a no-op if bf is NULL, entry is NULL, or
+ * size is 0.
  * @param bf the bloom filter to add to
  * @param entry the entry to add
  * @param size the size of the entry
@@ -71,48 +75,60 @@ void bloom_filter_add(const bloom_filter_t *bf, const uint8_t *entry, size_t siz
  * @param bf the bloom filter to check
  * @param entry the entry to check
  * @param size the size of the entry
- * @return 1 if the entry is in the bloom filter, 0 if not
+ * @return 1 if probably present, 0 if definitely absent, -1 if bf is NULL or the
+ *         entry is empty (NULL entry or size 0)
  */
 int bloom_filter_contains(const bloom_filter_t *bf, const uint8_t *entry, size_t size);
 
 /**
  * bloom_filter_is_full
- * checks if the bloom filter is full
+ * checks if every bit in the filter is set
  * @param bf the bloom filter to check
- * @return 1 if the bloom filter is full, 0 if not
+ * @return 1 if full, 0 if not, -1 if bf or its bitset is NULL
  */
 int bloom_filter_is_full(const bloom_filter_t *bf);
 
 /**
  * bloom_filter_hash
- * hashes an entry
+ * hashes an entry with the base (version-1) hash. the internal version-2 index
+ * hash applies an additional finalizer on top of this.
  * @param entry the entry to hash
  * @param size the size of the entry
  * @param seed the seed for the hash
- * @return the hash
+ * @return the 32-bit hash, or 0 if entry is NULL or size is 0
  */
 unsigned int bloom_filter_hash(const uint8_t *entry, size_t size, int seed);
 
 /**
  * bloom_filter_serialize
- * serializes a bloom filter to compact binary format using:
- * -- optional version prefix -- a v2+ filter leads with a 0x00 sentinel byte followed by the
- *    hash_version byte (0x00 is impossible for a v1 filter, whose first byte is varint32(m)
- *    with m >= 1, so the format stays backward compatible); legacy v1 filters omit it and
- *    deserialize defaults to the legacy hash
- * -- varint encoding for header fields (m, h, non_zero_count)
- * -- sparse encoding     -- only stores non-zero words with their indices
- * typical space savings  -- 70-90% for low fill rates (< 50%)
+ * serializes a bloom filter to a compact binary buffer, sized exactly:
+ * -- optional version prefix -- a filter that is not a legacy-hash sparse filter
+ *    leads with a 0x00 sentinel byte (impossible for a v1 filter, whose first
+ *    byte is varint32(m) with m >= 1) followed by a format byte whose high nibble
+ *    is the bitset encoding and low nibble the hash version. a sparse hash-v2
+ *    filter's format byte is 0x02 -- byte-identical to the original v2 framing --
+ *    so older readers still accept it; legacy v1 sparse filters omit the prefix
+ * -- header              -- varint32 m and h
+ * -- bitset, whichever encoding is smaller for this filter:
+ *      sparse  -- varint32 non_zero_count, then per non-zero word a varint32
+ *                 index and a varint64 value. wins for under-filled filters
+ *                 (70-90% savings below ~50% fill)
+ *      dense   -- every word as 8 little-endian bytes, no index or count. wins
+ *                 for a correctly sized (~50% full) filter, where almost every
+ *                 word is non-zero and sparse would exceed the raw bitset
  * @param bf the bloom filter to serialize
- * @param out_size the size of the serialized bloom filter
- * @return the serialized bloom filter
+ * @param out_size set to the number of bytes returned (untouched on NULL return)
+ * @return the serialized buffer (caller frees), or NULL if bf is NULL or on
+ *         allocation failure
  */
 uint8_t *bloom_filter_serialize(const bloom_filter_t *bf, size_t *out_size);
 
 /**
  * bloom_filter_deserialize
- * deserializes a bloom filter. every field read is bounded by len, so a
- * truncated or corrupt buffer is rejected (NULL) rather than over-read.
+ * deserializes a bloom filter, accepting every format bloom_filter_serialize
+ * produces -- legacy v1 sparse, v2 sparse, and dense. every field read is bounded
+ * by len, so a truncated or corrupt buffer is rejected (NULL) rather than
+ * over-read; an unknown hash version or bitset encoding is rejected too.
  * @param data the serialized bloom filter
  * @param len the length in bytes of the serialized buffer
  * @return the deserialized bloom filter, or NULL on malformed/truncated input

--- a/src/compat.h
+++ b/src/compat.h
@@ -663,7 +663,7 @@ static inline int tdb_spawn_wait(const char *cmd, char *const argv[])
 
 /* struct timeval (used by gettimeofday) lives in winsock. windows.h pulls winsock in normally but
  * not under WIN32_LEAN_AND_MEAN (e.g. the mariadb build). only define it ourselves when winsock is
- * not in the translation unit: newer SDK winsock.h guards the file with _WINSOCKAPI_ and does not
+ * not in the translation unit-- newer SDK winsock.h guards the file with _WINSOCKAPI_ and does not
  * set the inner _TIMEVAL_DEFINED, so a bare _TIMEVAL_DEFINED check would redefine it when winsock
  * is present. */
 #if !defined(_TIMEVAL_DEFINED) && !defined(_WINSOCKAPI_) && !defined(_WINSOCK2API_)
@@ -3885,11 +3885,11 @@ static inline long tdb_max_open_files(void)
 
 /**
  * tdb_raise_max_open_files
- * raise THIS process's open-file ceiling toward `desired` descriptors and return the ceiling in
+ * raise this process's open-file ceiling toward `desired` descriptors and return the ceiling in
  * effect afterwards. POSIX raises the RLIMIT_NOFILE soft limit toward the hard limit (never
  * lowering it, clamped to the hard limit); Windows raises the CRT stdio cap via _setmaxstdio
  * (clamped to its 8192 maximum). an explicit, opt-in action -- tidesdb never raises the limit on
- * its own. a partial or failed raise is non-fatal: the prior ceiling simply stands.
+ * its own. a partial or failed raise is non-fatal-- the prior ceiling simply stands.
  * @param desired target descriptor count; <= 0 just reports the current ceiling without raising
  * @return the open-file ceiling after the attempt
  */

--- a/src/db.h
+++ b/src/db.h
@@ -165,6 +165,7 @@ typedef enum
 #define TDB_ERR_LOCKED       -12
 #define TDB_ERR_READONLY     -13
 #define TDB_ERR_BUSY         -14
+#define TDB_ERR_PRECONDITION -15
 
 /** configuration limits */
 #define TDB_MAX_COMPARATOR_NAME 64
@@ -515,6 +516,12 @@ typedef struct tidesdb_db_stats_t
     uint64_t total_uploads;
     uint64_t total_upload_failures;
     int replica_mode;
+    /* single-writer fencing (object-store mode). primary_epoch is the lease epoch this primary
+     * currently holds (0 when not a primary / no lease); seen_epoch is the highest lease epoch a
+     * replica has observed. a promotion that took bumps primary_epoch; a fenced primary sees
+     * replica_mode flip back to 1. */
+    uint64_t primary_epoch;
+    uint64_t seen_epoch;
     /* write-amplification counters (lifetime since open, on-disk framed bytes). uwal is the
      * shared unified WAL volume (zero when unified mode is off); the remaining fields are
      * summed across all column families. db-wide WA = (uwal + wal + flush + compaction) /

--- a/src/objstore.h
+++ b/src/objstore.h
@@ -33,6 +33,27 @@ typedef enum
     TDB_BACKEND_UNKNOWN = 99
 } tidesdb_objstore_backend_t;
 
+/* maximum stored object ETag length (quotes included, as returned by S3) */
+#define TDB_OBJSTORE_ETAG_MAX 128
+
+/* connector return code for a failed conditional precondition (HTTP 412)-- the shared
+ * object was changed by another writer. defined here so the backends need not pull the
+ * public header; tidesdb.h carries an identical definition for the engine side. */
+#ifndef TDB_ERR_PRECONDITION
+#define TDB_ERR_PRECONDITION -15
+#endif
+
+/**
+ * tidesdb_put_cond_t
+ * precondition mode for the conditional put_if op (single-writer fencing).
+ */
+typedef enum
+{
+    TDB_PUT_OVERWRITE = 0,     /* unconditional overwrite (no precondition) */
+    TDB_PUT_IF_NONE_MATCH = 1, /* create only -- fail if the object already exists */
+    TDB_PUT_IF_MATCH = 2       /* fail unless the object's current ETag equals expected_etag */
+} tidesdb_put_cond_t;
+
 /**
  * tidesdb_objstore_backend_name
  * return a human-readable string for a backend enum value
@@ -133,6 +154,39 @@ typedef struct
      */
     int (*list)(void *ctx, const char *prefix,
                 void (*cb)(const char *key, size_t size, void *cb_ctx), void *cb_ctx);
+
+    /**
+     * put_if -- conditional upload carrying an optional epoch tag.
+     * used by single-writer fencing to make the manifest publish and the primary
+     * lease CAS-style writes against shared state. NULL when the backend predates
+     * fencing (callers must NULL-check).
+     * @param ctx           opaque connector context
+     * @param key           object key
+     * @param local_path    local file to upload
+     * @param cond          precondition mode (see tidesdb_put_cond_t)
+     * @param expected_etag  ETag to match for TDB_PUT_IF_MATCH (ignored otherwise)
+     * @param meta_epoch    when nonzero, stored as object metadata (x-amz-meta-epoch)
+     * @param etag_out      when non-NULL, receives the new object ETag on success
+     * @param etag_out_sz   size of etag_out
+     * @return 0 on success, TDB_ERR_PRECONDITION when the precondition fails (HTTP 412),
+     *         -1 on any other error
+     */
+    int (*put_if)(void *ctx, const char *key, const char *local_path, tidesdb_put_cond_t cond,
+                  const char *expected_etag, uint64_t meta_epoch, char *etag_out,
+                  size_t etag_out_sz);
+
+    /**
+     * head -- fetch an object's ETag and epoch metadata without downloading the body.
+     * NULL when the backend predates fencing (callers must NULL-check).
+     * @param ctx            opaque connector context
+     * @param key            object key
+     * @param etag_out       when non-NULL, receives the object ETag (empty if none)
+     * @param etag_out_sz    size of etag_out
+     * @param meta_epoch_out when non-NULL, receives x-amz-meta-epoch (0 if absent)
+     * @return 1 if the object exists, 0 if not, -1 on error
+     */
+    int (*head)(void *ctx, const char *key, char *etag_out, size_t etag_out_sz,
+                uint64_t *meta_epoch_out);
 
     /**
      * destroy -- free connector resources.

--- a/src/objstore.h
+++ b/src/objstore.h
@@ -168,12 +168,15 @@ typedef struct
      * @param meta_epoch    when nonzero, stored as object metadata (x-amz-meta-epoch)
      * @param etag_out      when non-NULL, receives the new object ETag on success
      * @param etag_out_sz   size of etag_out
+     * @param max_bytes     when nonzero, upload only the first max_bytes of the file instead of
+     *                      the whole file -- used to ship a WAL's logical length and skip its
+     *                      preallocated zero tail
      * @return 0 on success, TDB_ERR_PRECONDITION when the precondition fails (HTTP 412),
      *         -1 on any other error
      */
     int (*put_if)(void *ctx, const char *key, const char *local_path, tidesdb_put_cond_t cond,
                   const char *expected_etag, uint64_t meta_epoch, char *etag_out,
-                  size_t etag_out_sz);
+                  size_t etag_out_sz, size_t max_bytes);
 
     /**
      * head -- fetch an object's ETag and epoch metadata without downloading the body.

--- a/src/objstore_fs.c
+++ b/src/objstore_fs.c
@@ -70,6 +70,9 @@ typedef struct
     char root_dir[TDB_FS_MAX_PATH];
 } fs_ctx_t;
 
+static void fs_meta_path(const fs_ctx_t *ctx, const char *key, const char *suffix, char *out,
+                         size_t out_size);
+
 /**
  * fs_mkdir_p
  * create all intermediate directories for a file path
@@ -263,6 +266,15 @@ static int fs_delete_object(void *ctx, const char *key)
 #else
     unlink(full);
 #endif
+
+    /* drop the put_if sidecars too, or a later create-only would see the key as still present */
+    const char *suffixes[] = {".etag", ".epoch", ".lock"};
+    for (size_t i = 0; i < sizeof(suffixes) / sizeof(suffixes[0]); i++)
+    {
+        char meta[TDB_FS_META_PATH];
+        fs_meta_path(fs, key, suffixes[i], meta, sizeof(meta));
+        tdb_unlink(meta);
+    }
     return 0;
 }
 

--- a/src/objstore_fs.c
+++ b/src/objstore_fs.c
@@ -17,7 +17,9 @@
  * limitations under the License.
  */
 #include <errno.h>
+#include <fcntl.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
 
@@ -25,6 +27,7 @@
 
 #ifndef _WIN32
 #include <dirent.h>
+#include <sys/file.h> /* flock -- serializes the put_if read-modify-write */
 #include <unistd.h>
 #else
 #include <direct.h>
@@ -36,6 +39,10 @@
 #define TDB_FS_DIR_MODE 0755
 /* extra bytes reserved for the ".tmp.<pid>.<tid>" suffix on the atomic-put temp path */
 #define TDB_FS_TMP_SUFFIX_MAX 64
+/* sidecar directory holding put_if ETag/epoch/lock state, isolated from the object
+ * keyspace so list() under data prefixes (uwal_, cf/MANIFEST) never sees it */
+#define TDB_FS_META_DIR  ".tdb_objmeta"
+#define TDB_FS_META_PATH (TDB_FS_MAX_PATH * 2 + 64)
 
 /* default object store config values */
 #define TDB_OBJSTORE_DEFAULT_CACHE_ON_READ         1
@@ -70,7 +77,9 @@ typedef struct
  */
 static void fs_mkdir_p(const char *file_path)
 {
-    char tmp[TDB_FS_MAX_PATH];
+    /* sized to the largest path any caller passes (full object paths and meta sidecars are
+     * root + key, up to TDB_FS_META_PATH) so a long key's parent dirs are not truncated */
+    char tmp[TDB_FS_META_PATH];
     snprintf(tmp, sizeof(tmp), "%s", file_path);
 
     /* we find last separator to get directory portion */
@@ -283,6 +292,187 @@ static int fs_exists(void *ctx, const char *key, size_t *size_out)
 }
 
 /**
+ * fs_meta_path
+ * build the sidecar metadata path for a key under the isolated meta directory:
+ * <root>/.tdb_objmeta/<key><suffix>
+ * @param ctx connector context
+ * @param key object key
+ * @param suffix sidecar suffix (".etag", ".epoch", ".lock")
+ * @param out output buffer
+ * @param out_size size of the output buffer
+ */
+static void fs_meta_path(const fs_ctx_t *ctx, const char *key, const char *suffix, char *out,
+                         size_t out_size)
+{
+    snprintf(out, out_size, "%s/%s/%s%s", ctx->root_dir, TDB_FS_META_DIR, key, suffix);
+}
+
+/**
+ * fs_read_text
+ * read a short text sidecar, NUL-terminate, and trim a trailing newline.
+ * @return 0 on success, -1 if the file is absent or unreadable
+ */
+static int fs_read_text(const char *path, char *out, size_t out_size)
+{
+    FILE *f = fopen(path, "rb");
+    if (!f) return -1;
+    size_t n = fread(out, 1, out_size - 1, f);
+    fclose(f);
+    out[n] = '\0';
+    while (n > 0 && (out[n - 1] == '\n' || out[n - 1] == '\r')) out[--n] = '\0';
+    return 0;
+}
+
+/**
+ * fs_write_text
+ * write text to a sidecar atomically (tmp + rename), creating parent dirs.
+ * @return 0 on success, -1 on error
+ */
+static int fs_write_text(const char *path, const char *text)
+{
+    fs_mkdir_p(path);
+    char tmp[TDB_FS_META_PATH + TDB_FS_TMP_SUFFIX_MAX];
+    snprintf(tmp, sizeof(tmp), "%s.tmp.%ld.%lu", path, (long)TDB_GETPID(), TDB_THREAD_ID());
+
+    FILE *f = fopen(tmp, "wb");
+    if (!f) return -1;
+    int ok = (fputs(text, f) >= 0);
+    if (fclose(f) != 0) ok = 0;
+    if (!ok)
+    {
+        tdb_unlink(tmp);
+        return -1;
+    }
+    if (atomic_rename_file(tmp, path) != 0)
+    {
+        tdb_unlink(tmp);
+        return -1;
+    }
+    return 0;
+}
+
+/**
+ * fs_put_if
+ * conditional upload emulated with ETag/epoch sidecars under a per-key lock, so the
+ * single-writer fence is exercised by the test backend without a live S3.
+ *
+ * the critical section uses flock() rather than the compat.h lock helpers on purpose --
+ * those carry whole-DB PID / F_SETLK semantics (same-process re-lock is allowed), whereas
+ * a primary and a replica handle in one test process must serialize against each other.
+ * flock locks the open file description, so two independent opens contend even in-process.
+ * @return 0 on success, TDB_ERR_PRECONDITION on precondition failure, -1 on error
+ */
+static int fs_put_if(void *ctx, const char *key, const char *local_path, tidesdb_put_cond_t cond,
+                     const char *expected_etag, uint64_t meta_epoch, char *etag_out,
+                     size_t etag_out_sz)
+{
+    fs_ctx_t *fs = (fs_ctx_t *)ctx;
+
+    char etag_path[TDB_FS_META_PATH];
+    char epoch_path[TDB_FS_META_PATH];
+    char lock_path[TDB_FS_META_PATH];
+    fs_meta_path(fs, key, ".etag", etag_path, sizeof(etag_path));
+    fs_meta_path(fs, key, ".epoch", epoch_path, sizeof(epoch_path));
+    fs_meta_path(fs, key, ".lock", lock_path, sizeof(lock_path));
+
+    fs_mkdir_p(lock_path);
+    int lockfd = open(lock_path, O_CREAT | O_RDWR, 0644);
+    if (lockfd < 0) return -1;
+#ifndef _WIN32
+    if (flock(lockfd, LOCK_EX) != 0)
+    {
+        close(lockfd);
+        return -1;
+    }
+#endif
+
+    char cur_etag[TDB_OBJSTORE_ETAG_MAX] = {0};
+    int have = (fs_read_text(etag_path, cur_etag, sizeof(cur_etag)) == 0);
+
+    int precond_fail = 0;
+    if (cond == TDB_PUT_IF_NONE_MATCH && have)
+        precond_fail = 1;
+    else if (cond == TDB_PUT_IF_MATCH &&
+             (!have || !expected_etag || strcmp(cur_etag, expected_etag) != 0))
+        precond_fail = 1;
+
+    int rc;
+    if (precond_fail)
+    {
+        rc = TDB_ERR_PRECONDITION;
+    }
+    else if (fs_put(ctx, key, local_path) != 0)
+    {
+        rc = -1;
+    }
+    else
+    {
+        /* a strictly increasing per-object counter -- a fresh ETag on every write so a
+         * superseded writer that renews with identical content still sees its old ETag go
+         * stale (a content-hash ETag would not change and would defeat the CAS). */
+        unsigned long long counter = 0;
+        if (have) sscanf(cur_etag, "%llu", &counter);
+        counter++;
+        char new_etag[TDB_OBJSTORE_ETAG_MAX];
+        snprintf(new_etag, sizeof(new_etag), "%llu", counter);
+
+        if (fs_write_text(etag_path, new_etag) != 0)
+        {
+            rc = -1;
+        }
+        else
+        {
+            char epoch_buf[32];
+            snprintf(epoch_buf, sizeof(epoch_buf), "%llu", (unsigned long long)meta_epoch);
+            fs_write_text(epoch_path, epoch_buf); /* best-effort; 0 reads back as 'absent' */
+            if (etag_out) snprintf(etag_out, etag_out_sz, "%s", new_etag);
+            rc = 0;
+        }
+    }
+
+#ifndef _WIN32
+    flock(lockfd, LOCK_UN);
+#endif
+    close(lockfd);
+    return rc;
+}
+
+/**
+ * fs_head
+ * return a key's ETag and epoch sidecars without reading the object body.
+ * @return 1 if the object exists, 0 if not, -1 on error
+ */
+static int fs_head(void *ctx, const char *key, char *etag_out, size_t etag_out_sz,
+                   uint64_t *meta_epoch_out)
+{
+    fs_ctx_t *fs = (fs_ctx_t *)ctx;
+    char full[TDB_FS_MAX_PATH * 2];
+    fs_full_path(fs, key, full, sizeof(full));
+
+    struct stat st;
+    int exists = (stat(full, &st) == 0);
+    int stat_errno = errno;
+
+    if (etag_out)
+    {
+        char etag_path[TDB_FS_META_PATH];
+        fs_meta_path(fs, key, ".etag", etag_path, sizeof(etag_path));
+        if (fs_read_text(etag_path, etag_out, etag_out_sz) != 0) etag_out[0] = '\0';
+    }
+    if (meta_epoch_out)
+    {
+        char epoch_path[TDB_FS_META_PATH];
+        char buf[32];
+        fs_meta_path(fs, key, ".epoch", epoch_path, sizeof(epoch_path));
+        *meta_epoch_out =
+            (fs_read_text(epoch_path, buf, sizeof(buf)) == 0) ? strtoull(buf, NULL, 10) : 0;
+    }
+
+    if (exists) return 1;
+    return (stat_errno == ENOENT) ? 0 : -1;
+}
+
+/**
  * fs_list_walk
  * recursively walk abs_dir and invoke cb for each regular file whose
  * relative key starts with prefix. subdirectories whose relative path
@@ -314,6 +504,9 @@ static int fs_list_walk(const char *abs_dir, const char *rel_dir, size_t rel_dir
     {
         if (fd.name[0] == '.' && (fd.name[1] == '\0' || (fd.name[1] == '.' && fd.name[2] == '\0')))
             continue;
+
+        /* the put_if meta sidecar dir is internal bookkeeping, never an object */
+        if (rel_dir_len == 0 && strcmp(fd.name, TDB_FS_META_DIR) == 0) continue;
 
         char child_rel[TDB_FS_MAX_PATH];
         int n = (rel_dir_len == 0)
@@ -353,6 +546,9 @@ static int fs_list_walk(const char *abs_dir, const char *rel_dir, size_t rel_dir
         if (ent->d_name[0] == '.' &&
             (ent->d_name[1] == '\0' || (ent->d_name[1] == '.' && ent->d_name[2] == '\0')))
             continue;
+
+        /* the put_if meta sidecar dir is internal bookkeeping, never an object */
+        if (rel_dir_len == 0 && strcmp(ent->d_name, TDB_FS_META_DIR) == 0) continue;
 
         char child_rel[TDB_FS_MAX_PATH];
         int n = (rel_dir_len == 0)
@@ -535,6 +731,8 @@ tidesdb_objstore_t *tidesdb_objstore_fs_create(const char *root_dir)
     store->delete_object = fs_delete_object;
     store->exists = fs_exists;
     store->list = fs_list;
+    store->put_if = fs_put_if;
+    store->head = fs_head;
     store->destroy = fs_destroy;
     store->ctx = fs;
 

--- a/src/objstore_fs.c
+++ b/src/objstore_fs.c
@@ -137,9 +137,10 @@ static void fs_full_path(const fs_ctx_t *ctx, const char *key, char *out, size_t
  * copy file contents from src_path to dst_path
  * @param src_path source file path
  * @param dst_path destination file path (parent dirs created if needed)
+ * @param limit when nonzero, copy only the first limit bytes (skips a WAL's preallocated tail)
  * @return 0 on success, -1 on error
  */
-static int fs_copy_file(const char *src_path, const char *dst_path)
+static int fs_copy_file(const char *src_path, const char *dst_path, size_t limit)
 {
     FILE *src = fopen(src_path, "rb");
     if (!src) return -1;
@@ -155,14 +156,18 @@ static int fs_copy_file(const char *src_path, const char *dst_path)
 
     char buf[TDB_FS_COPY_BUF];
     size_t n;
+    size_t copied = 0;
     int rc = 0;
     while ((n = fread(buf, 1, sizeof(buf), src)) > 0)
     {
+        if (limit && copied + n > limit) n = limit - copied;
         if (fwrite(buf, 1, n, dst) != n)
         {
             rc = -1;
             break;
         }
+        copied += n;
+        if (limit && copied >= limit) break;
     }
     if (ferror(src)) rc = -1;
 
@@ -177,14 +182,15 @@ static int fs_copy_file(const char *src_path, const char *dst_path)
 }
 
 /**
- * fs_put
- * upload a local file as an object by copying it to the root directory
+ * fs_put_limited
+ * write a local file as an object, optionally only its first limit bytes (0 = whole file)
  * @param ctx opaque connector context
  * @param key object key (relative path)
  * @param local_path local file to upload
+ * @param limit byte limit (0 = whole file)
  * @return 0 on success, -1 on error
  */
-static int fs_put(void *ctx, const char *key, const char *local_path)
+static int fs_put_limited(void *ctx, const char *key, const char *local_path, size_t limit)
 {
     fs_ctx_t *fs = (fs_ctx_t *)ctx;
     char full[TDB_FS_MAX_PATH * 2];
@@ -197,7 +203,7 @@ static int fs_put(void *ctx, const char *key, const char *local_path)
     char tmp[TDB_FS_MAX_PATH * 2 + TDB_FS_TMP_SUFFIX_MAX];
     snprintf(tmp, sizeof(tmp), "%s.tmp.%ld.%lu", full, (long)TDB_GETPID(), TDB_THREAD_ID());
 
-    if (fs_copy_file(local_path, tmp) != 0) return -1;
+    if (fs_copy_file(local_path, tmp, limit) != 0) return -1;
 
     if (atomic_rename_file(tmp, full) != 0)
     {
@@ -205,6 +211,19 @@ static int fs_put(void *ctx, const char *key, const char *local_path)
         return -1;
     }
     return 0;
+}
+
+/**
+ * fs_put
+ * upload a local file as an object (whole file)
+ * @param ctx opaque connector context
+ * @param key object key (relative path)
+ * @param local_path local file to upload
+ * @return 0 on success, -1 on error
+ */
+static int fs_put(void *ctx, const char *key, const char *local_path)
+{
+    return fs_put_limited(ctx, key, local_path, 0);
 }
 
 /**
@@ -220,7 +239,7 @@ static int fs_get(void *ctx, const char *key, const char *local_path)
     fs_ctx_t *fs = (fs_ctx_t *)ctx;
     char full[TDB_FS_MAX_PATH * 2];
     fs_full_path(fs, key, full, sizeof(full));
-    return fs_copy_file(full, local_path);
+    return fs_copy_file(full, local_path, 0);
 }
 
 /**
@@ -376,7 +395,7 @@ static int fs_write_text(const char *path, const char *text)
  */
 static int fs_put_if(void *ctx, const char *key, const char *local_path, tidesdb_put_cond_t cond,
                      const char *expected_etag, uint64_t meta_epoch, char *etag_out,
-                     size_t etag_out_sz)
+                     size_t etag_out_sz, size_t max_bytes)
 {
     fs_ctx_t *fs = (fs_ctx_t *)ctx;
 
@@ -413,7 +432,7 @@ static int fs_put_if(void *ctx, const char *key, const char *local_path, tidesdb
     {
         rc = TDB_ERR_PRECONDITION;
     }
-    else if (fs_put(ctx, key, local_path) != 0)
+    else if (fs_put_limited(ctx, key, local_path, max_bytes) != 0)
     {
         rc = -1;
     }

--- a/src/objstore_s3.c
+++ b/src/objstore_s3.c
@@ -55,10 +55,11 @@
 #define TDB_S3_REGION_MAX   64
 
 /* HTTP status codes */
-#define TDB_S3_HTTP_OK        200
-#define TDB_S3_HTTP_PARTIAL   206
-#define TDB_S3_HTTP_REDIRECT  300
-#define TDB_S3_HTTP_NOT_FOUND 404
+#define TDB_S3_HTTP_OK           200
+#define TDB_S3_HTTP_PARTIAL      206
+#define TDB_S3_HTTP_REDIRECT     300
+#define TDB_S3_HTTP_NOT_FOUND    404
+#define TDB_S3_HTTP_PRECONDITION 412 /* If-Match / If-None-Match precondition failed */
 
 /* signing and response buffers. host and key_date buffers must be large
  * enough for concatenated bucket+endpoint or "AWS4"+secret_key strings. */
@@ -256,7 +257,7 @@ static void s3_signing_key(const char *secret_key, const char *date8, const char
     snprintf(key_date, sizeof(key_date), "AWS4%s", secret_key);
 
     /* each HMAC-SHA-256 step emits exactly TDB_S3_SHA256_DIGEST bytes, which is the key for the
-     * next step: date -> region -> service -> aws4_request */
+     * next step-- date -> region -> service -> aws4_request */
     unsigned char k1[TDB_S3_SHA256_DIGEST], k2[TDB_S3_SHA256_DIGEST], k3[TDB_S3_SHA256_DIGEST];
     hmac_sha256(key_date, strlen(key_date), date8, strlen(date8), k1);
     hmac_sha256(k1, TDB_S3_SHA256_DIGEST, region, strlen(region), k2);
@@ -1237,6 +1238,215 @@ static int s3_put_single(s3_ctx_t *s3, const char *key, FILE *fp, long file_size
 }
 
 /**
+ * s3_head_ctx_t
+ * captures the ETag and x-amz-meta-epoch response headers of a HEAD/PUT.
+ * @param etag receives the object ETag (quotes included, as returned)
+ * @param epoch receives the x-amz-meta-epoch value (0 if absent)
+ * @param found_etag set once an ETag header has been captured
+ */
+typedef struct
+{
+    char etag[TDB_S3_ETAG_MAX];
+    uint64_t epoch;
+    int found_etag;
+} s3_head_ctx_t;
+
+/**
+ * s3_capture_head_header
+ * curl header callback capturing both ETag and x-amz-meta-epoch. header field
+ * names are case-insensitive per RFC 7230.
+ * @param userdata pointer to s3_head_ctx_t
+ * @return number of bytes consumed (must equal size * nitems)
+ */
+/* case-insensitive match of a header field name (buffer[0..name_len)) against a
+ * lowercase literal -- avoids strncasecmp, which is not portable to MSVC */
+static int s3_header_name_is(const char *buffer, size_t name_len, const char *lower)
+{
+    if (name_len != strlen(lower)) return 0;
+    for (size_t i = 0; i < name_len; i++)
+        if ((char)tolower((unsigned char)buffer[i]) != lower[i]) return 0;
+    return 1;
+}
+
+static size_t s3_capture_head_header(char *buffer, size_t size, size_t nitems, void *userdata)
+{
+    s3_head_ctx_t *h = (s3_head_ctx_t *)userdata;
+    size_t len = size * nitems;
+
+    const char *colon = memchr(buffer, ':', len);
+    if (!colon) return len;
+
+    size_t name_len = (size_t)(colon - buffer);
+    const char *v = colon + 1;
+    size_t vlen = len - name_len - 1;
+    while (vlen > 0 && (*v == ' ' || *v == '\t'))
+    {
+        v++;
+        vlen--;
+    }
+    while (vlen > 0 && (v[vlen - 1] == '\r' || v[vlen - 1] == '\n' || v[vlen - 1] == ' ')) vlen--;
+
+    if (s3_header_name_is(buffer, name_len, "etag"))
+    {
+        if (vlen >= sizeof(h->etag)) vlen = sizeof(h->etag) - 1;
+        memcpy(h->etag, v, vlen);
+        h->etag[vlen] = '\0';
+        h->found_etag = 1;
+    }
+    else if (s3_header_name_is(buffer, name_len, "x-amz-meta-epoch"))
+    {
+        char num[32] = {0};
+        size_t n = vlen < sizeof(num) - 1 ? vlen : sizeof(num) - 1;
+        memcpy(num, v, n);
+        h->epoch = strtoull(num, NULL, 10);
+    }
+    return len;
+}
+
+/**
+ * s3_put_if
+ * conditional single PUT carrying an optional x-amz-meta-epoch, capturing the
+ * new ETag. used by single-writer fencing for the lease and manifest publish,
+ * which are small control objects (always a single PUT, never multipart).
+ * @return 0 on success, TDB_ERR_PRECONDITION on 412, -1 on any other error
+ */
+static int s3_put_if(void *ctx, const char *key, const char *local_path, tidesdb_put_cond_t cond,
+                     const char *expected_etag, uint64_t meta_epoch, char *etag_out,
+                     size_t etag_out_sz)
+{
+    s3_ctx_t *s3 = (s3_ctx_t *)ctx;
+
+    FILE *fp = fopen(local_path, "rb");
+    if (!fp) return -1;
+    if (fseek(fp, 0, SEEK_END) != 0)
+    {
+        fclose(fp);
+        return -1;
+    }
+    long file_size = ftell(fp);
+    if (file_size < 0)
+    {
+        fclose(fp);
+        return -1;
+    }
+    rewind(fp);
+
+    /* x-amz-* metadata must be signed; build the canonical (trailing newline preserves the
+     * SigV4 separator line) and signed-header fragments. the epoch sorts after x-amz-date. */
+    char extra_canonical[64] = {0};
+    const char *extra_signed = NULL;
+    if (meta_epoch)
+    {
+        snprintf(extra_canonical, sizeof(extra_canonical), "x-amz-meta-epoch:%llu\n",
+                 (unsigned long long)meta_epoch);
+        extra_signed = ";x-amz-meta-epoch";
+    }
+
+    struct curl_slist *headers =
+        s3_sign_request(s3, "PUT", key, "UNSIGNED-PAYLOAD",
+                        extra_canonical[0] ? extra_canonical : NULL, extra_signed);
+
+    /* the signed metadata header (value must match the canonical, trimmed form) */
+    char hdr[TDB_S3_MAX_HEADER];
+    if (meta_epoch)
+    {
+        snprintf(hdr, sizeof(hdr), "x-amz-meta-epoch: %llu", (unsigned long long)meta_epoch);
+        headers = curl_slist_append(headers, hdr);
+    }
+
+    /* conditional headers are standard HTTP and sent unsigned (S3 does not require them signed) */
+    if (cond == TDB_PUT_IF_NONE_MATCH)
+        headers = curl_slist_append(headers, "If-None-Match: *");
+    else if (cond == TDB_PUT_IF_MATCH && expected_etag)
+    {
+        snprintf(hdr, sizeof(hdr), "If-Match: %s", expected_etag);
+        headers = curl_slist_append(headers, hdr);
+    }
+
+    char url[TDB_S3_MAX_PATH];
+    s3_build_url(s3, key, url, sizeof(url));
+
+    CURL *curl = s3_curl_new(s3);
+    if (!curl)
+    {
+        curl_slist_free_all(headers);
+        fclose(fp);
+        return -1;
+    }
+
+    s3_head_ctx_t hctx = {.epoch = 0, .found_etag = 0};
+    curl_easy_setopt(curl, CURLOPT_URL, url);
+    curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
+    curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t)file_size);
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, s3_write_discard);
+    curl_easy_setopt(curl, CURLOPT_READDATA, fp);
+    curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, s3_capture_head_header);
+    curl_easy_setopt(curl, CURLOPT_HEADERDATA, &hctx);
+
+    CURLcode res = curl_easy_perform(curl);
+    long http_code = 0;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+    curl_slist_free_all(headers);
+    curl_easy_cleanup(curl);
+    fclose(fp);
+
+    if (res != CURLE_OK) return -1;
+    if (http_code == TDB_S3_HTTP_PRECONDITION) return TDB_ERR_PRECONDITION;
+    if (http_code < TDB_S3_HTTP_OK || http_code >= TDB_S3_HTTP_REDIRECT) return -1;
+
+    if (etag_out && etag_out_sz > 0)
+        snprintf(etag_out, etag_out_sz, "%s", hctx.found_etag ? hctx.etag : "");
+    return 0;
+}
+
+/**
+ * s3_head
+ * issue a HEAD and return the object's ETag and x-amz-meta-epoch.
+ * @return 1 if the object exists, 0 if not, -1 on error
+ */
+static int s3_head(void *ctx, const char *key, char *etag_out, size_t etag_out_sz,
+                   uint64_t *meta_epoch_out)
+{
+    s3_ctx_t *s3 = (s3_ctx_t *)ctx;
+    char empty_sha[TDB_S3_HASH_HEX_LEN];
+    sha256_hex("", 0, empty_sha);
+    struct curl_slist *headers = s3_sign_request(s3, "HEAD", key, empty_sha, NULL, NULL);
+
+    char url[TDB_S3_MAX_PATH];
+    s3_build_url(s3, key, url, sizeof(url));
+
+    CURL *curl = s3_curl_new(s3);
+    if (!curl)
+    {
+        curl_slist_free_all(headers);
+        return -1;
+    }
+
+    s3_head_ctx_t hctx = {.epoch = 0, .found_etag = 0};
+    curl_easy_setopt(curl, CURLOPT_URL, url);
+    curl_easy_setopt(curl, CURLOPT_NOBODY, 1L);
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+    curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, s3_capture_head_header);
+    curl_easy_setopt(curl, CURLOPT_HEADERDATA, &hctx);
+
+    CURLcode res = curl_easy_perform(curl);
+    long http_code = 0;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+    curl_slist_free_all(headers);
+    curl_easy_cleanup(curl);
+
+    if (etag_out && etag_out_sz > 0)
+        snprintf(etag_out, etag_out_sz, "%s", hctx.found_etag ? hctx.etag : "");
+    if (meta_epoch_out) *meta_epoch_out = hctx.epoch;
+
+    if (res != CURLE_OK) return -1;
+    if (http_code == TDB_S3_HTTP_OK) return 1;
+    if (http_code == TDB_S3_HTTP_NOT_FOUND) return 0;
+    return -1;
+}
+
+/**
  * s3_put_multipart
  * upload a large object as a multipart upload -- create, stream fixed-size
  * parts from the file, then complete. on any failure the upload is aborted
@@ -1586,6 +1796,8 @@ tidesdb_objstore_t *tidesdb_objstore_s3_create_config(const tidesdb_objstore_s3_
     store->delete_object = s3_delete_object;
     store->exists = s3_exists;
     store->list = s3_list;
+    store->put_if = s3_put_if;
+    store->head = s3_head;
     store->destroy = s3_destroy;
     store->ctx = s3;
 

--- a/src/objstore_s3.c
+++ b/src/objstore_s3.c
@@ -1312,7 +1312,7 @@ static size_t s3_capture_head_header(char *buffer, size_t size, size_t nitems, v
  */
 static int s3_put_if(void *ctx, const char *key, const char *local_path, tidesdb_put_cond_t cond,
                      const char *expected_etag, uint64_t meta_epoch, char *etag_out,
-                     size_t etag_out_sz)
+                     size_t etag_out_sz, size_t max_bytes)
 {
     s3_ctx_t *s3 = (s3_ctx_t *)ctx;
 
@@ -1330,6 +1330,10 @@ static int s3_put_if(void *ctx, const char *key, const char *local_path, tidesdb
         return -1;
     }
     rewind(fp);
+
+    /* upload only the logical length when asked, so a WAL's preallocated zero tail is not shipped.
+     * curl uploads exactly INFILESIZE bytes from the read stream. */
+    if (max_bytes > 0 && (long)max_bytes < file_size) file_size = (long)max_bytes;
 
     /* x-amz-* metadata must be signed; build the canonical (trailing newline preserves the
      * SigV4 separator line) and signed-header fragments. the epoch sorts after x-amz-date. */

--- a/src/sha256.c
+++ b/src/sha256.c
@@ -178,7 +178,7 @@ void sha256_final(sha256_ctx *ctx, uint8_t out[SHA256_DIGEST_SIZE])
      * byte first). This converts the internal 8x32-bit state into the
      * 32-byte digest expected by callers.
      *
-     * state[i] == 0x11223344 -> bytes: 0x11, 0x22, 0x33, 0x44
+     * state[i] == 0x11223344 -> bytes -- 0x11, 0x22, 0x33, 0x44
      */
     for (i = 0; i < 8; ++i)
     {

--- a/src/skip_list.c
+++ b/src/skip_list.c
@@ -22,12 +22,20 @@
 /* global counter for generating unique arena IDs */
 static _Atomic(uint64_t) global_arena_id_counter = 0;
 
-/* thread-local cache for arena slot assignment
- * each thread caches its slot for one arena at a time
- * if the arena changes, we must get a new slot from that arena */
-static _Thread_local skip_list_arena_t *tl_cached_arena = NULL;
-static _Thread_local uint64_t tl_cached_arena_id = 0; /* cache the generation ID */
-static _Thread_local int tl_arena_slot = -1;
+/* per-thread cache of arena slot assignments. caching a small set rather than a single
+ * arena keeps the fast path when a thread interleaves writes across several arenas (e.g. a
+ * base column family and its index families) instead of re-fetching a slot on every switch. */
+#define SKIP_LIST_ARENA_TL_CACHE_SIZE 8
+
+typedef struct
+{
+    skip_list_arena_t *arena;
+    uint64_t arena_id;
+    int slot;
+} skip_list_arena_tl_slot_t;
+
+static _Thread_local skip_list_arena_tl_slot_t tl_slot_cache[SKIP_LIST_ARENA_TL_CACHE_SIZE];
+static _Thread_local unsigned tl_slot_cache_next = 0;
 
 /**
  * skip_list_arena_create_block
@@ -109,32 +117,29 @@ static skip_list_arena_t *skip_list_arena_create(const size_t initial_capacity)
 /**
  * skip_list_arena_get_slot
  * gets or assigns a thread-local slot for this thread and arena
- * the slot is cached per-thread but invalidated when switching arenas
+ * slots are cached in a small per-thread set so interleaving a few arenas stays on the fast
+ * path; the arena_id generation guards against the OS recycling a freed arena's address
  * @param arena the arena
  * @return slot index (0 to SKIP_LIST_ARENA_MAX_THREADS-1), or -1 if slots exhausted
  */
 static inline int skip_list_arena_get_slot(skip_list_arena_t *arena)
 {
-    /* fast path -- cached slot for this arena.
-     * we check both the memory address AND the unique generation ID to prevent ABA
-     * collisions if the OS recycles the arena's memory address. */
-    if (SKIP_LIST_LIKELY(tl_cached_arena == arena && tl_cached_arena_id == arena->arena_id &&
-                         tl_arena_slot >= 0))
+    const uint64_t arena_id = arena->arena_id;
+
+    for (int i = 0; i < SKIP_LIST_ARENA_TL_CACHE_SIZE; i++)
     {
-        return tl_arena_slot;
+        const skip_list_arena_tl_slot_t *e = &tl_slot_cache[i];
+        if (SKIP_LIST_LIKELY(e->arena == arena && e->arena_id == arena_id)) return e->slot;
     }
 
-    /* different arena or first allocation -- get a new slot */
+    /* miss -- claim a fresh slot from the arena and remember it, evicting round-robin */
     int slot = atomic_fetch_add_explicit(&arena->tl_slot_counter, 1, memory_order_relaxed);
-    if (slot >= SKIP_LIST_ARENA_MAX_THREADS)
-    {
-        return -1;
-    }
+    if (slot >= SKIP_LIST_ARENA_MAX_THREADS) return -1;
 
-    /* cache the pointer, the ID, and the slot */
-    tl_cached_arena = arena;
-    tl_cached_arena_id = arena->arena_id;
-    tl_arena_slot = slot;
+    const unsigned idx = tl_slot_cache_next++ % SKIP_LIST_ARENA_TL_CACHE_SIZE;
+    tl_slot_cache[idx].arena = arena;
+    tl_slot_cache[idx].arena_id = arena_id;
+    tl_slot_cache[idx].slot = slot;
     return slot;
 }
 
@@ -1307,6 +1312,14 @@ int skip_list_delete(skip_list_t *list, const uint8_t *key, const size_t key_siz
     {
         return -1;
     }
+
+    /* a tombstone is an inserted version too -- floor min_seq so compaction never reaps it as
+     * older than data still held unflushed, matching skip_list_put_with_seq */
+    uint64_t cur = atomic_load_explicit(&list->min_seq, memory_order_relaxed);
+    while (seq < cur && !atomic_compare_exchange_weak_explicit(
+                            &list->min_seq, &cur, seq, memory_order_relaxed, memory_order_relaxed))
+    {
+    }
     return 0;
 }
 
@@ -1341,6 +1354,7 @@ int skip_list_clear(skip_list_t *list)
     atomic_store_explicit(&list->level, 0, memory_order_release);
     atomic_store_explicit(&list->total_size, 0, memory_order_release);
     atomic_store_explicit(&list->entry_count, 0, memory_order_release);
+    atomic_store_explicit(&list->min_seq, UINT64_MAX, memory_order_release);
 
     return 0;
 }

--- a/src/skip_list.h
+++ b/src/skip_list.h
@@ -364,7 +364,7 @@ int skip_list_new_with_arena(skip_list_t **list, int max_level, float probabilit
  * skip_list_random_level
  * generates a random level for a new node
  * @param list skip list
- * @return random level
+ * @return random level, or -1 if list is NULL
  */
 int skip_list_random_level(const skip_list_t *list);
 
@@ -376,7 +376,7 @@ int skip_list_random_level(const skip_list_t *list);
  * @param key1_size size of first key
  * @param key2 second key
  * @param key2_size size of second key
- * @return negative if key1 < key2, 0 if equal, positive if key1 > key2
+ * @return negative if key1 < key2, 0 if equal (or if list/key is NULL), positive if key1 > key2
  */
 int skip_list_compare_keys(const skip_list_t *list, const uint8_t *key1, size_t key1_size,
                            const uint8_t *key2, size_t key2_size);
@@ -407,8 +407,10 @@ int skip_list_put_with_seq(skip_list_t *list, const uint8_t *key, size_t key_siz
  * @param list skip list
  * @param key key data
  * @param key_size size of key
- * @param seq sequence number for the deletion (must be greater than existing versions)
- * @return 0 on success, -1 on failure (including if seq <= existing version seq)
+ * @param seq sequence number for the tombstone; must differ from every existing version of the
+ *            key, but need not exceed them (out-of-order seqs splice into the chain)
+ * @return 0 on success or when the key is absent (no-op), -1 only on a duplicate seq or
+ *         allocation failure
  */
 int skip_list_delete(skip_list_t *list, const uint8_t *key, size_t key_size, uint64_t seq);
 
@@ -629,7 +631,8 @@ int skip_list_cursor_next_get(skip_list_cursor_t *cursor, uint8_t **key, size_t 
  * @param value pointer to value
  * @param value_size pointer to value size
  * @param ttl pointer to TTL
- * @param deleted pointer to deleted flag
+ * @param deleted out flag carrying the version's SKIP_LIST_FLAG_* bits -- SKIP_LIST_FLAG_DELETED
+ *                for a tombstone or expired ttl, OR'd with SKIP_LIST_FLAG_SINGLE_DELETE when set
  * @param seq pointer to sequence number
  * @return 0 on success, -1 on failure
  */
@@ -675,7 +678,7 @@ int skip_list_cursor_at_end(const skip_list_cursor_t *cursor);
  * skip_list_cursor_has_next
  * checks if cursor has next entry
  * @param cursor cursor
- * @return 1 if has next, 0 if not
+ * @return 1 if has next, 0 if not, -1 on error or when positioned at the tail
  */
 int skip_list_cursor_has_next(skip_list_cursor_t *cursor);
 
@@ -683,7 +686,7 @@ int skip_list_cursor_has_next(skip_list_cursor_t *cursor);
  * skip_list_cursor_has_prev
  * checks if cursor has previous entry
  * @param cursor cursor
- * @return 1 if has prev, 0 if not
+ * @return 1 if has prev, 0 if not, -1 on error or when positioned at the tail
  */
 int skip_list_cursor_has_prev(skip_list_cursor_t *cursor);
 
@@ -733,11 +736,12 @@ int skip_list_cursor_seek_ge(skip_list_cursor_t *cursor, const uint8_t *key, siz
 
 /**
  * skip_list_cursor_seek_for_prev
- * seeks cursor to last key <= target
+ * seeks cursor to the last key <= target
  * @param cursor cursor
  * @param key target key
  * @param key_size size of target key
- * @return 0 on success, -1 on failure
+ * @return 0 on success, -1 only on invalid arguments. when no key <= target exists the cursor
+ *         parks on the header sentinel and skip_list_cursor_valid then returns 0
  */
 int skip_list_cursor_seek_for_prev(skip_list_cursor_t *cursor, const uint8_t *key, size_t key_size);
 
@@ -766,10 +770,10 @@ void skip_list_free(skip_list_t *list);
 
 /**
  * skip_list_check_and_update_ttl
- * checks and updates TTL for a node
+ * checks whether a node's latest version has expired by TTL
  * @param list skip list
  * @param node node to check
- * @return 0 on success, -1 on failure
+ * @return 1 if the latest version has expired, 0 if not, -1 if node is NULL
  */
 int skip_list_check_and_update_ttl(const skip_list_t *list, skip_list_node_t *node);
 
@@ -785,7 +789,7 @@ size_t skip_list_get_size(skip_list_t *list);
  * skip_list_count_entries
  * counts number of entries in skip list
  * @param list skip list
- * @return number of entries
+ * @return number of entries, or -1 if list is NULL
  */
 int skip_list_count_entries(skip_list_t *list);
 

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -117,9 +117,13 @@ typedef tidesdb_memtable_t tidesdb_immutable_memtable_t;
 #define TDB_UNIFIED_CF_INDEX_MAP_LINE_MAX    (TDB_MAX_CF_NAME_LEN + 32)
 #define TDB_REPLICA_WAL_TMP                  "replica_wal_tmp.log"
 #define TDB_REPLICA_MANIFEST_TMP             "MANIFEST.replica_tmp"
-#define TDB_PREFIXED_KEY_STACK_MAX           256
-#define TDB_BUP_CPY_FILE_SRC_MODE            "rb"
-#define TDB_BUP_CPY_FILE_DST_MODE            "wb"
+/* single-writer fencing -- object-store key of the primary lease, and the local temp
+ * file used to stage its small body before a conditional upload */
+#define TDB_PRIMARY_LEASE_KEY      "_tdb_primary_lease"
+#define TDB_PRIMARY_LEASE_TMP      "primary_lease_tmp"
+#define TDB_PREFIXED_KEY_STACK_MAX 256
+#define TDB_BUP_CPY_FILE_SRC_MODE  "rb"
+#define TDB_BUP_CPY_FILE_DST_MODE  "wb"
 
 #define TDB_CNF_FILE_MODE "w"
 
@@ -4852,6 +4856,7 @@ typedef struct
     char local_path[TDB_MAX_PATH_LEN];
     char object_key[TDB_MAX_PATH_LEN];
     uint64_t wal_generation; /* WAL gen to fence after upload (0 = no fence) */
+    uint64_t meta_epoch;     /* single-writer lease epoch to tag the object with (0 = untagged) */
 } tdb_upload_job_t;
 
 /**
@@ -4875,7 +4880,15 @@ static void *tdb_upload_worker_thread(void *arg)
             unsigned int backoff_us = TDB_UPLOAD_INITIAL_BACKOFF_US;
             for (int attempt = 0; attempt < TDB_UPLOAD_MAX_RETRIES; attempt++)
             {
-                rc = db->object_store->put(db->object_store->ctx, job->object_key, job->local_path);
+                /* tag with the lease epoch when set (WAL fencing) so a replica can skip a
+                 * superseded primary's segments; otherwise a plain put. */
+                if (job->meta_epoch && db->object_store->put_if)
+                    rc = db->object_store->put_if(db->object_store->ctx, job->object_key,
+                                                  job->local_path, TDB_PUT_OVERWRITE, NULL,
+                                                  job->meta_epoch, NULL, 0);
+                else
+                    rc = db->object_store->put(db->object_store->ctx, job->object_key,
+                                               job->local_path);
                 if (rc != 0)
                 {
                     TDB_DEBUG_LOG(TDB_LOG_WARN, "Upload attempt %d/%d failed: %s", attempt + 1,
@@ -4960,9 +4973,10 @@ static void *tdb_upload_worker_thread(void *arg)
  * @param db database instance
  * @param local_path local file path to upload
  * @param wal_generation WAL generation to fence after upload (0 = no fence)
+ * @param meta_epoch single-writer lease epoch to tag the object with (0 = untagged)
  */
 static void tdb_objstore_enqueue_upload(const tidesdb_t *db, const char *local_path,
-                                        const uint64_t wal_generation)
+                                        const uint64_t wal_generation, const uint64_t meta_epoch)
 {
     if (!db->object_store || !db->upload_queue || !local_path) return;
 
@@ -4972,6 +4986,7 @@ static void tdb_objstore_enqueue_upload(const tidesdb_t *db, const char *local_p
     snprintf(job->local_path, sizeof(job->local_path), "%s", local_path);
     tdb_path_to_object_key(db, local_path, job->object_key, sizeof(job->object_key));
     job->wal_generation = wal_generation;
+    job->meta_epoch = meta_epoch;
 
     if (queue_enqueue(db->upload_queue, job) != 0)
     {
@@ -5017,6 +5032,46 @@ static void tdb_objstore_upload_file_sync(tidesdb_t *db, const char *local_path)
 }
 
 /**
+ * tdb_objstore_upload_wal_sync
+ * synchronous WAL upload that tags the object with the current lease epoch so a replica can
+ * skip a superseded primary's segments. falls back to the plain sync upload when fencing is off.
+ * @param db database instance
+ * @param local_path WAL file path to upload
+ */
+static void tdb_objstore_upload_wal_sync(tidesdb_t *db, const char *local_path)
+{
+    if (!db->object_store || !local_path) return;
+
+    uint64_t epoch = atomic_load_explicit(&db->primary_epoch, memory_order_acquire);
+    if (epoch == 0 || !db->object_store->put_if)
+    {
+        tdb_objstore_upload_file_sync(db, local_path);
+        return;
+    }
+
+    char key[TDB_MAX_PATH_LEN];
+    tdb_path_to_object_key(db, local_path, key, sizeof(key));
+
+    unsigned int delay_us = TDB_UPLOAD_INITIAL_BACKOFF_US;
+    for (int attempt = 0; attempt < TDB_UPLOAD_MAX_RETRIES; attempt++)
+    {
+        if (db->object_store->put_if(db->object_store->ctx, key, local_path, TDB_PUT_OVERWRITE,
+                                     NULL, epoch, NULL, 0) == 0)
+        {
+            atomic_fetch_add_explicit(&db->total_uploads, 1, memory_order_relaxed);
+            return;
+        }
+        TDB_DEBUG_LOG(TDB_LOG_WARN, "Object store sync WAL upload attempt %d/%d failed: %s",
+                      attempt + 1, TDB_UPLOAD_MAX_RETRIES, key);
+        if (attempt + 1 < TDB_UPLOAD_MAX_RETRIES) usleep(delay_us);
+        delay_us *= TDB_UPLOAD_BACKOFF_MULTIPLIER;
+    }
+    atomic_fetch_add_explicit(&db->total_upload_failures, 1, memory_order_relaxed);
+    TDB_DEBUG_LOG(TDB_LOG_ERROR, "Object store sync WAL upload failed after %d attempts: %s",
+                  TDB_UPLOAD_MAX_RETRIES, key);
+}
+
+/**
  * tdb_objstore_upload_file
  * upload a local file to the object store.
  * uses async pipeline for sstable data files, falls back to synchronous.
@@ -5030,7 +5085,7 @@ static void tdb_objstore_upload_file(tidesdb_t *db, const char *local_path)
     /* we use async pipeline if upload queue exists */
     if (db->upload_queue)
     {
-        tdb_objstore_enqueue_upload(db, local_path, 0);
+        tdb_objstore_enqueue_upload(db, local_path, 0, 0);
         return;
     }
 
@@ -5325,9 +5380,151 @@ static int tidesdb_vlog_range_get_value(const tidesdb_t *db, const tidesdb_sstab
     return TDB_SUCCESS;
 }
 
+/* tdb_objstore_fencing_enabled
+ * fencing is active only when the connector implements the conditional-write and head
+ * primitives. legacy connectors fall back to the unfenced upload paths. */
+static int tdb_objstore_fencing_enabled(const tidesdb_t *db)
+{
+    return db->object_store && db->object_store->put_if && db->object_store->head;
+}
+
+/* tdb_objstore_obj_epoch_is_stale
+ * an object tagged with a nonzero epoch below the current lease epoch was written by a
+ * superseded primary and must be ignored. epoch 0 (legacy / written before any lease was
+ * acquired) is never treated as stale, which keeps pre-fencing buckets readable. */
+static int tdb_objstore_obj_epoch_is_stale(uint64_t obj_epoch, uint64_t lease_epoch)
+{
+    return obj_epoch != 0 && obj_epoch < lease_epoch;
+}
+
+/* tdb_objstore_lease_epoch
+ * read the current primary lease epoch from the object store (0 if absent or unsupported). */
+static uint64_t tdb_objstore_lease_epoch(tidesdb_t *db)
+{
+    tidesdb_objstore_t *os = db->object_store;
+    if (!os || !os->head) return 0;
+    uint64_t epoch = 0;
+    if (os->head(os->ctx, TDB_PRIMARY_LEASE_KEY, NULL, 0, &epoch) < 0) return 0;
+    return epoch;
+}
+
+/* tdb_objstore_lease_stage_body
+ * write the small human-readable lease body (epoch + node id) to the staging temp file.
+ * @return 0 on success, -1 on error */
+static int tdb_objstore_lease_stage_body(tidesdb_t *db, uint64_t epoch, char *path_out,
+                                         size_t path_out_sz)
+{
+    snprintf(path_out, path_out_sz, "%s" PATH_SEPARATOR TDB_PRIMARY_LEASE_TMP, db->db_path);
+    FILE *lf = fopen(path_out, "wb");
+    if (!lf) return -1;
+    fprintf(lf, "epoch=%llu\nnode=%s\n", (unsigned long long)epoch, db->node_id);
+    if (fclose(lf) != 0)
+    {
+        tdb_unlink(path_out);
+        return -1;
+    }
+    return 0;
+}
+
+/* tdb_objstore_lease_acquire_locked
+ * claim or advance the primary lease by CAS-incrementing its epoch -- read the current lease
+ * (head -> etag + epoch), then conditionally write epoch+1 (create-only if absent, else
+ * If-Match on the etag we just read). on success records the new epoch + etag on db.
+ * caller holds lease_lock.
+ * @return TDB_SUCCESS, TDB_ERR_PRECONDITION if another node won the race, or an error code */
+static int tdb_objstore_lease_acquire_locked(tidesdb_t *db)
+{
+    tidesdb_objstore_t *os = db->object_store;
+    if (!os || !os->head || !os->put_if) return TDB_ERR_INVALID_ARGS;
+
+    char cur_etag[TDB_OBJSTORE_ETAG_MAX] = {0};
+    uint64_t cur_epoch = 0;
+    int hr = os->head(os->ctx, TDB_PRIMARY_LEASE_KEY, cur_etag, sizeof(cur_etag), &cur_epoch);
+    if (hr < 0) return TDB_ERR_IO;
+    int exists = (hr == 1);
+
+    uint64_t new_epoch = cur_epoch + 1;
+    char lease_path[TDB_MAX_PATH_LEN];
+    if (tdb_objstore_lease_stage_body(db, new_epoch, lease_path, sizeof(lease_path)) != 0)
+        return TDB_ERR_IO;
+
+    char new_etag[TDB_OBJSTORE_ETAG_MAX] = {0};
+    int rc = os->put_if(os->ctx, TDB_PRIMARY_LEASE_KEY, lease_path,
+                        exists ? TDB_PUT_IF_MATCH : TDB_PUT_IF_NONE_MATCH, exists ? cur_etag : NULL,
+                        new_epoch, new_etag, sizeof(new_etag));
+    tdb_unlink(lease_path);
+
+    if (rc == TDB_ERR_PRECONDITION) return TDB_ERR_PRECONDITION;
+    if (rc != 0) return TDB_ERR_IO;
+
+    atomic_store_explicit(&db->primary_epoch, new_epoch, memory_order_release);
+    snprintf(db->lease_etag, sizeof(db->lease_etag), "%s", new_etag);
+    TDB_DEBUG_LOG(TDB_LOG_INFO, "Acquired primary lease epoch %llu (node %s)",
+                  (unsigned long long)new_epoch, db->node_id);
+    return TDB_SUCCESS;
+}
+
+/* tdb_objstore_lease_acquire
+ * lease_lock-guarded wrapper around tdb_objstore_lease_acquire_locked. */
+static int tdb_objstore_lease_acquire(tidesdb_t *db)
+{
+    pthread_mutex_lock(&db->lease_lock);
+    int rc = tdb_objstore_lease_acquire_locked(db);
+    pthread_mutex_unlock(&db->lease_lock);
+    return rc;
+}
+
+/* tdb_objstore_lease_renew_locked
+ * re-assert that we still hold the lease by CAS-writing it conditional on our stored etag,
+ * keeping the same epoch and refreshing the etag. a primary that never acquired a lease (the
+ * first primary of a fresh cluster, which does not go through promotion) acquires one here on
+ * its first publish. caller holds lease_lock.
+ * @return TDB_SUCCESS, TDB_ERR_PRECONDITION if superseded, or an error */
+static int tdb_objstore_lease_renew_locked(tidesdb_t *db)
+{
+    tidesdb_objstore_t *os = db->object_store;
+    if (!os || !os->put_if) return TDB_ERR_INVALID_ARGS;
+
+    uint64_t epoch = atomic_load_explicit(&db->primary_epoch, memory_order_acquire);
+    if (epoch == 0 || db->lease_etag[0] == '\0') return tdb_objstore_lease_acquire_locked(db);
+
+    char lease_path[TDB_MAX_PATH_LEN];
+    if (tdb_objstore_lease_stage_body(db, epoch, lease_path, sizeof(lease_path)) != 0)
+        return TDB_ERR_IO;
+
+    char new_etag[TDB_OBJSTORE_ETAG_MAX] = {0};
+    int rc = os->put_if(os->ctx, TDB_PRIMARY_LEASE_KEY, lease_path, TDB_PUT_IF_MATCH,
+                        db->lease_etag, epoch, new_etag, sizeof(new_etag));
+    tdb_unlink(lease_path);
+
+    if (rc == TDB_ERR_PRECONDITION) return TDB_ERR_PRECONDITION;
+    if (rc != 0) return TDB_ERR_IO;
+    snprintf(db->lease_etag, sizeof(db->lease_etag), "%s", new_etag);
+    return TDB_SUCCESS;
+}
+
+/* tdb_objstore_self_demote
+ * a primary write found the lease taken by another node. stop writing immediately and fall
+ * back to replica so this node re-syncs from the bucket instead of uploading orphans. this is
+ * hygiene, not correctness -- a superseded writer's manifest is already ignored by readers. */
+static void tdb_objstore_self_demote(tidesdb_t *db, const char *reason)
+{
+    if (atomic_exchange_explicit(&db->replica_mode, 1, memory_order_acq_rel) == 0)
+    {
+        TDB_DEBUG_LOG(
+            TDB_LOG_WARN,
+            "Primary lease lost (%s) -- self-demoting to replica (node %s, epoch %llu)", reason,
+            db->node_id,
+            (unsigned long long)atomic_load_explicit(&db->primary_epoch, memory_order_acquire));
+    }
+}
+
 /**
  * tdb_objstore_upload_manifest
- * upload the MANIFEST file to object store after a commit.
+ * publish the MANIFEST to the object store after a commit. under fencing this is the one
+ * authoritative write that makes data real, so it re-asserts the primary lease and tags the
+ * manifest with the lease epoch before publishing; a superseded primary self-demotes and skips
+ * the upload. without the fencing primitives it falls back to the unfenced async upload.
  * @param db database instance
  * @param cf column family whose MANIFEST should be uploaded
  */
@@ -5339,10 +5536,39 @@ static void tdb_objstore_upload_manifest(tidesdb_t *db, tidesdb_column_family_t 
      * it would obsolete the primary's real-data sstables. mirrors the sstable-upload gate in
      * tidesdb_level_add_sstable; promotion clears replica_mode before any primary write. */
     if (atomic_load_explicit(&db->replica_mode, memory_order_acquire)) return;
-    /* MANIFEST is uploaded via the async pipeline to avoid blocking flush workers.
-     * the local MANIFEST is always up to date for same-node readers. remote readers
-     * doing cold start will see it after the upload completes. the async queue
-     * preserves ordering so the MANIFEST always reflects the latest sstable inventory. */
+
+    if (tdb_objstore_fencing_enabled(db))
+    {
+        tidesdb_objstore_t *os = db->object_store;
+        char manifest_key[TDB_MAX_PATH_LEN];
+        snprintf(manifest_key, sizeof(manifest_key), "%s/" TDB_COLUMN_FAMILY_MANIFEST_NAME,
+                 cf->name);
+
+        /* re-assert the lease, then publish tagged with our epoch -- both under lease_lock so a
+         * concurrent publish cannot interleave a stale etag. the manifest overwrite needs no
+         * precondition -- the lease renew already proved we are the unique holder, and readers
+         * ignore any manifest whose epoch is below the lease. small + synchronous on purpose;
+         * correctness here outranks the async pipeline's latency saving. */
+        pthread_mutex_lock(&db->lease_lock);
+        int rc = tdb_objstore_lease_renew_locked(db);
+        if (rc == TDB_SUCCESS)
+        {
+            uint64_t epoch = atomic_load_explicit(&db->primary_epoch, memory_order_acquire);
+            rc = os->put_if(os->ctx, manifest_key, cf->manifest->path, TDB_PUT_OVERWRITE, NULL,
+                            epoch, NULL, 0);
+            if (rc == 0) atomic_fetch_add_explicit(&db->total_uploads, 1, memory_order_relaxed);
+        }
+        pthread_mutex_unlock(&db->lease_lock);
+
+        if (rc == TDB_ERR_PRECONDITION)
+            tdb_objstore_self_demote(db, "manifest publish");
+        else if (rc != TDB_SUCCESS)
+            TDB_DEBUG_LOG(TDB_LOG_WARN, "Fenced manifest publish failed for CF '%s' (rc=%d)",
+                          cf->name, rc);
+        return;
+    }
+
+    /* legacy connector without fencing primitives -- async, ordering preserved by the queue */
     tdb_objstore_upload_file(db, cf->manifest->path);
 }
 
@@ -5470,6 +5696,13 @@ static void tdb_replica_sync_manifests(tidesdb_t *db)
     /* we discover and create any new CFs the primary added since last sync */
     tdb_replica_discover_new_cfs(db);
 
+    /* resolve the current lease epoch once per sweep. any manifest tagged
+     * with an older epoch was written by a superseded primary and is skipped so a zombie's
+     * manifest never becomes a replica's truth. 0 when fencing is off (legacy bucket). */
+    uint64_t lease_epoch = tdb_objstore_lease_epoch(db);
+    if (lease_epoch > atomic_load_explicit(&db->seen_epoch, memory_order_acquire))
+        atomic_store_explicit(&db->seen_epoch, lease_epoch, memory_order_release);
+
     pthread_rwlock_rdlock(&db->cf_list_lock);
     for (int i = 0; i < db->num_column_families; i++)
     {
@@ -5482,6 +5715,23 @@ static void tdb_replica_sync_manifests(tidesdb_t *db)
         char tmp_path[TDB_MAX_PATH_LEN];
         snprintf(tmp_path, sizeof(tmp_path), "%s" PATH_SEPARATOR TDB_REPLICA_MANIFEST_TMP,
                  cf->directory);
+
+        /* skip a manifest a superseded primary may have published at an old epoch -- the head
+         * is cheap and avoids both the download and applying a stale sstable inventory. */
+        if (db->object_store->head)
+        {
+            uint64_t mepoch = 0;
+            if (db->object_store->head(db->object_store->ctx, remote_key, NULL, 0, &mepoch) == 1 &&
+                tdb_objstore_obj_epoch_is_stale(mepoch, lease_epoch))
+            {
+                TDB_DEBUG_LOG(
+                    TDB_LOG_WARN,
+                    "Replica sync skipping stale MANIFEST for CF '%s' (epoch %llu < lease "
+                    "%llu)",
+                    cf->name, (unsigned long long)mepoch, (unsigned long long)lease_epoch);
+                continue;
+            }
+        }
 
         if (db->object_store->get(db->object_store->ctx, remote_key, tmp_path) != 0) continue;
 
@@ -5902,11 +6152,30 @@ static void tdb_objstore_replay_remote_wals(tidesdb_t *db, int cold_start)
     const uint64_t start_max_seq = max_seq;
     int total_replayed = 0;
 
+    /* a WAL tagged with an epoch below the current lease was uploaded by a
+     * superseded primary; replaying it would diverge the replica from the live primary's
+     * timeline. resolve the lease epoch once and skip those segments. */
+    uint64_t lease_epoch = tdb_objstore_lease_epoch(db);
+
     for (int wi = 0; wi < discovery.count; wi++)
     {
         char wal_key[TDB_MAX_PATH_LEN];
         snprintf(wal_key, sizeof(wal_key), TDB_UNIFIED_WAL_PREFIX TDB_U64_FMT TDB_WAL_EXT,
                  TDB_U64_CAST(discovery.generations[wi]));
+
+        if (lease_epoch > 0 && db->object_store->head)
+        {
+            uint64_t wepoch = 0;
+            if (db->object_store->head(db->object_store->ctx, wal_key, NULL, 0, &wepoch) == 1 &&
+                tdb_objstore_obj_epoch_is_stale(wepoch, lease_epoch))
+            {
+                TDB_DEBUG_LOG(TDB_LOG_WARN,
+                              "Replica WAL replay skipping stale segment %s (epoch %llu < lease "
+                              "%llu)",
+                              wal_key, (unsigned long long)wepoch, (unsigned long long)lease_epoch);
+                continue;
+            }
+        }
 
         if (db->object_store->get(db->object_store->ctx, wal_key, wal_local) != 0) continue;
 
@@ -5989,6 +6258,7 @@ typedef struct
 {
     tidesdb_t *db;
     const char *cf_name;
+    uint64_t lease_epoch; /* current primary lease epoch, for stale-manifest fencing (0 = off) */
 } tdb_cold_start_download_arg_t;
 
 /**
@@ -6002,6 +6272,25 @@ static void *tdb_cold_start_download_worker(void *arg)
     tdb_cold_start_download_arg_t *ctx = (tdb_cold_start_download_arg_t *)arg;
     const tidesdb_t *db = ctx->db;
     const char *cf_name = ctx->cf_name;
+
+    /* if a superseded primary published this CF's MANIFEST at an old epoch,
+     * skip it entirely rather than cold-start onto stale data -- the periodic replica sync picks
+     * the CF up once the current primary republishes at the live epoch. */
+    if (db->object_store->head)
+    {
+        char mkey[TDB_MAX_PATH_LEN];
+        snprintf(mkey, sizeof(mkey), "%s/" TDB_COLUMN_FAMILY_MANIFEST_NAME, cf_name);
+        uint64_t mepoch = 0;
+        if (db->object_store->head(db->object_store->ctx, mkey, NULL, 0, &mepoch) == 1 &&
+            tdb_objstore_obj_epoch_is_stale(mepoch, ctx->lease_epoch))
+        {
+            TDB_DEBUG_LOG(
+                TDB_LOG_WARN,
+                "Cold start skipping stale MANIFEST for CF '%s' (epoch %llu < lease %llu)", cf_name,
+                (unsigned long long)mepoch, (unsigned long long)ctx->lease_epoch);
+            return NULL;
+        }
+    }
 
     /* we create local CF directory (leave room for /config.ini and /MANIFEST suffixes) */
     char cf_dir[TDB_MAX_PATH_LEN - TDB_PATH_SUFFIX_RESERVE];
@@ -6072,6 +6361,12 @@ static void tdb_objstore_cold_start_discover(tidesdb_t *db)
     TDB_DEBUG_LOG(TDB_LOG_INFO, "Object store cold start discovered %d CFs in remote store",
                   discovery.count);
 
+    /* resolve the lease epoch once so every CF's worker fences its MANIFEST against the same
+     * value (0 when fencing is off) */
+    uint64_t lease_epoch = tdb_objstore_lease_epoch(db);
+    if (lease_epoch > atomic_load_explicit(&db->seen_epoch, memory_order_acquire))
+        atomic_store_explicit(&db->seen_epoch, lease_epoch, memory_order_release);
+
     /* we download config + MANIFEST for all CFs in parallel */
     tdb_cold_start_download_arg_t args[TDB_MAX_CF_DISCOVERY];
     pthread_t threads[TDB_MAX_CF_DISCOVERY];
@@ -6081,6 +6376,7 @@ static void tdb_objstore_cold_start_discover(tidesdb_t *db)
     {
         args[i].db = db;
         args[i].cf_name = discovery.cf_names[i];
+        args[i].lease_epoch = lease_epoch;
         if (pthread_create(&threads[launched], NULL, tdb_cold_start_download_worker, &args[i]) == 0)
         {
             launched++;
@@ -20020,7 +20316,9 @@ static void *tidesdb_reaper_thread(void *arg)
                              * pressure tracking and sstable eviction. generation 0
                              * means a plain snapshot upload -- the worker must not
                              * fence or delete the still-active WAL. */
-                            tdb_objstore_enqueue_upload(db, umt->wal->file_path, 0);
+                            tdb_objstore_enqueue_upload(
+                                db, umt->wal->file_path, 0,
+                                atomic_load_explicit(&db->primary_epoch, memory_order_acquire));
                             TDB_DEBUG_LOG(TDB_LOG_INFO,
                                           "Unified WAL sync enqueued for async upload");
                             db->last_wal_sync_size = wal_size;
@@ -20559,6 +20857,16 @@ int tidesdb_open(const tidesdb_config_t *config, tidesdb_t **db)
         ((*db)->config.object_store_config && (*db)->config.object_store_config->replica_mode) ? 1
                                                                                                : 0);
     atomic_init(&(*db)->replica_sync_thread_active, 0);
+
+    /* single-writer fencing lease state. epoch 0 means no lease held yet; a primary
+     * acquires one on promotion (or first publish, see tdb_objstore_lease_renew). the
+     * node id is for observability only -- correctness rests on the lease CAS, not it. */
+    atomic_init(&(*db)->primary_epoch, 0);
+    atomic_init(&(*db)->seen_epoch, 0);
+    pthread_mutex_init(&(*db)->lease_lock, NULL);
+    (*db)->lease_etag[0] = '\0';
+    snprintf((*db)->node_id, sizeof((*db)->node_id), "%ld-%lu", (long)TDB_GETPID(),
+             (unsigned long)TDB_THREAD_ID());
 
     /* we initialize log file to NULL (stderr) by default. the log file globals
      * are read by tidesdb_log_write under tidesdb_log_mutex, so writes here take
@@ -21774,6 +22082,7 @@ int tidesdb_close(tidesdb_t *db)
     pthread_cond_destroy(&db->sync_thread_cond);
     pthread_mutex_destroy(&db->btree_cache_lock);
     pthread_mutex_destroy(&db->compaction_gate_lock);
+    pthread_mutex_destroy(&db->lease_lock);
 
     if (atomic_load(&db->reaper_active))
     {
@@ -22077,6 +22386,22 @@ int tidesdb_promote_to_primary(tidesdb_t *db)
         return TDB_ERR_INVALID_ARGS; /* already primary */
 
     TDB_DEBUG_LOG(TDB_LOG_INFO, "Promoting replica to primary mode");
+
+    /* claim the lease before tearing down any replica machinery, so a
+     * failed acquire leaves the node a working replica (sync thread still running). winning the
+     * CAS makes us the unique epoch holder and immediately fences the old primary -- its next
+     * manifest publish will fail the lease renew and self-demote. if another node already
+     * advanced the epoch we refuse promotion; the orchestrator can retry. */
+    if (tdb_objstore_fencing_enabled(db))
+    {
+        int lrc = tdb_objstore_lease_acquire(db);
+        if (lrc != TDB_SUCCESS)
+        {
+            TDB_DEBUG_LOG(TDB_LOG_WARN, "Promotion aborted -- could not acquire primary lease (%d)",
+                          lrc);
+            return (lrc == TDB_ERR_PRECONDITION) ? TDB_ERR_PRECONDITION : TDB_ERR_IO;
+        }
+    }
 
     /* stop the dedicated replica sync thread before flipping replica_mode.
      * joining it drains any in-flight MANIFEST sync / WAL replay -- flipping
@@ -27740,15 +28065,18 @@ static void tidesdb_unified_close_wal(tidesdb_t *db, tidesdb_memtable_t *umt_imm
     {
         if (db->config.object_store_config->wal_upload_sync)
         {
-            tdb_objstore_upload_file_sync(db, wal_path);
+            tdb_objstore_upload_wal_sync(db, wal_path);
             tdb_unlink(wal_path);
             tdb_sync_directory(db->db_path);
         }
         else
         {
-            /** async upload with the wal generation for fence tracking. the reaper
+            /** async upload with the wal generation for fence tracking, tagged with the
+             *  lease epoch so a replica skips a superseded primary's WAL. the reaper
              *  cleans up the local file after the upload confirms. */
-            tdb_objstore_enqueue_upload(db, wal_path, imm_gen);
+            tdb_objstore_enqueue_upload(
+                db, wal_path, imm_gen,
+                atomic_load_explicit(&db->primary_epoch, memory_order_acquire));
         }
     }
     else
@@ -28486,7 +28814,7 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
         if (txn->db->object_store && txn->db->config.object_store_config &&
             txn->db->config.object_store_config->wal_sync_on_commit && umt->wal)
         {
-            tdb_objstore_upload_file_sync(txn->db, umt->wal->file_path);
+            tdb_objstore_upload_wal_sync(txn->db, umt->wal->file_path);
         }
 
         /* we apply ops to unified skip list with prefixed keys */

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -119,8 +119,12 @@ typedef tidesdb_memtable_t tidesdb_immutable_memtable_t;
 #define TDB_REPLICA_MANIFEST_TMP             "MANIFEST.replica_tmp"
 /* single-writer fencing -- object-store key of the primary lease, and the local temp
  * file used to stage its small body before a conditional upload */
-#define TDB_PRIMARY_LEASE_KEY      "_tdb_primary_lease"
-#define TDB_PRIMARY_LEASE_TMP      "primary_lease_tmp"
+#define TDB_PRIMARY_LEASE_KEY "_tdb_primary_lease"
+#define TDB_PRIMARY_LEASE_TMP "primary_lease_tmp"
+/* startup probe verifying the backend enforces conditional writes (key suffixed with the node
+ * id); local temp file staging the probe body */
+#define TDB_FENCE_PROBE_KEY        "_tdb_fence_probe"
+#define TDB_FENCE_PROBE_TMP        "fence_probe_tmp"
 #define TDB_PREFIXED_KEY_STACK_MAX 256
 #define TDB_BUP_CPY_FILE_SRC_MODE  "rb"
 #define TDB_BUP_CPY_FILE_DST_MODE  "wb"
@@ -5382,10 +5386,55 @@ static int tidesdb_vlog_range_get_value(const tidesdb_t *db, const tidesdb_sstab
 
 /* tdb_objstore_fencing_enabled
  * fencing is active only when the connector implements the conditional-write and head
- * primitives. legacy connectors fall back to the unfenced upload paths. */
+ * primitives and the backend was proven to enforce the precondition (tdb_objstore_verify_
+ * conditional_writes). otherwise the write paths fall back to unfenced uploads rather than
+ * give false safety. */
 static int tdb_objstore_fencing_enabled(const tidesdb_t *db)
 {
-    return db->object_store && db->object_store->put_if && db->object_store->head;
+    return db->object_store && db->object_store->put_if && db->object_store->head &&
+           atomic_load_explicit(&db->fencing_supported, memory_order_acquire);
+}
+
+/* tdb_objstore_verify_conditional_writes
+ * probe whether the backend actually enforces conditional puts: a create-only put on a fresh
+ * key must succeed and an immediate second create-only on the same key must fail the
+ * precondition. a store that ignores If-None-Match returns success twice, so fencing would be
+ * false safety -- callers disable it in that case. uses a node-unique key to avoid cross-node
+ * races and cleans up after itself.
+ * @return 1 if conditional writes are enforced, 0 otherwise */
+static int tdb_objstore_verify_conditional_writes(tidesdb_t *db)
+{
+    tidesdb_objstore_t *os = db->object_store;
+    if (!os || !os->put_if || !os->head) return 0;
+
+    char probe_body[TDB_MAX_PATH_LEN];
+    snprintf(probe_body, sizeof(probe_body), "%s" PATH_SEPARATOR TDB_FENCE_PROBE_TMP, db->db_path);
+    FILE *pf = fopen(probe_body, "wb");
+    if (!pf) return 0;
+    fputc('1', pf);
+    if (fclose(pf) != 0)
+    {
+        tdb_unlink(probe_body);
+        return 0;
+    }
+
+    char probe_key[TDB_MAX_PATH_LEN];
+    snprintf(probe_key, sizeof(probe_key), "%s_%s", TDB_FENCE_PROBE_KEY, db->node_id);
+
+    os->delete_object(os->ctx, probe_key); /* clear any leftover from a prior crash */
+    int first = os->put_if(os->ctx, probe_key, probe_body, TDB_PUT_IF_NONE_MATCH, NULL, 0, NULL, 0);
+    int second =
+        os->put_if(os->ctx, probe_key, probe_body, TDB_PUT_IF_NONE_MATCH, NULL, 0, NULL, 0);
+    os->delete_object(os->ctx, probe_key);
+    tdb_unlink(probe_body);
+
+    int enforced = (first == 0 && second == TDB_ERR_PRECONDITION);
+    if (!enforced)
+        TDB_DEBUG_LOG(TDB_LOG_WARN,
+                      "object store does not enforce conditional writes (create-only rc %d/%d) -- "
+                      "single-writer fencing disabled, no split-brain protection",
+                      first, second);
+    return enforced;
 }
 
 /* tdb_objstore_obj_epoch_is_stale
@@ -5691,15 +5740,14 @@ static void tdb_objstore_prefetch_sstables(tidesdb_t *db, tidesdb_sstable_t **ss
  * removed sstables (in local but not remote) are removed from levels.
  * @param db database instance in replica mode
  */
-static void tdb_replica_sync_manifests(tidesdb_t *db)
+static void tdb_replica_sync_manifests(tidesdb_t *db, uint64_t lease_epoch)
 {
     /* we discover and create any new CFs the primary added since last sync */
     tdb_replica_discover_new_cfs(db);
 
-    /* resolve the current lease epoch once per sweep. any manifest tagged
-     * with an older epoch was written by a superseded primary and is skipped so a zombie's
-     * manifest never becomes a replica's truth. 0 when fencing is off (legacy bucket). */
-    uint64_t lease_epoch = tdb_objstore_lease_epoch(db);
+    /* a manifest tagged below lease_epoch was written by a superseded primary and is skipped.
+     * the promotion handoff passes the outgoing epoch so it still absorbs that primary's final
+     * manifest; the periodic sweep passes the live epoch. 0 when fencing is off. */
     if (lease_epoch > atomic_load_explicit(&db->seen_epoch, memory_order_acquire))
         atomic_store_explicit(&db->seen_epoch, lease_epoch, memory_order_release);
 
@@ -6071,8 +6119,10 @@ static int tdb_replica_replay_single_wal(tidesdb_t *db, const char *wal_local,
  * idempotent replay -- entries already covered by recovered sstables are skipped.
  * @param db database instance with an object store and a unified memtable
  * @param cold_start 1 when called from cold-start recovery, 0 from the sync thread (log prefix)
+ * @param lease_epoch segments tagged below this are skipped as a superseded primary's; the
+ *                    promotion handoff passes the outgoing epoch, the sweep the live one
  */
-static void tdb_objstore_replay_remote_wals(tidesdb_t *db, int cold_start)
+static void tdb_objstore_replay_remote_wals(tidesdb_t *db, int cold_start, uint64_t lease_epoch)
 {
     if (!db->unified_mt.enabled || !db->object_store)
     {
@@ -6151,11 +6201,6 @@ static void tdb_objstore_replay_remote_wals(tidesdb_t *db, int cold_start)
     uint64_t max_seq = cur_global > 0 ? cur_global - 1 : 0;
     const uint64_t start_max_seq = max_seq;
     int total_replayed = 0;
-
-    /* a WAL tagged with an epoch below the current lease was uploaded by a
-     * superseded primary; replaying it would diverge the replica from the live primary's
-     * timeline. resolve the lease epoch once and skip those segments. */
-    uint64_t lease_epoch = tdb_objstore_lease_epoch(db);
 
     for (int wi = 0; wi < discovery.count; wi++)
     {
@@ -19765,10 +19810,11 @@ static void *tidesdb_replica_sync_thread(void *arg)
         if (!atomic_load_explicit(&db->replica_sync_thread_active, memory_order_acquire)) break;
         if (!db->object_store) continue;
 
-        tdb_replica_sync_manifests(db);
+        uint64_t lease_epoch = tdb_objstore_lease_epoch(db);
+        tdb_replica_sync_manifests(db, lease_epoch);
         if (db->config.object_store_config && db->config.object_store_config->replica_replay_wal)
         {
-            tdb_objstore_replay_remote_wals(db, 0);
+            tdb_objstore_replay_remote_wals(db, 0, lease_epoch);
         }
     }
 
@@ -20863,10 +20909,17 @@ int tidesdb_open(const tidesdb_config_t *config, tidesdb_t **db)
      * node id is for observability only -- correctness rests on the lease CAS, not it. */
     atomic_init(&(*db)->primary_epoch, 0);
     atomic_init(&(*db)->seen_epoch, 0);
+    atomic_init(&(*db)->fencing_supported, 0);
     pthread_mutex_init(&(*db)->lease_lock, NULL);
     (*db)->lease_etag[0] = '\0';
     snprintf((*db)->node_id, sizeof((*db)->node_id), "%ld-%lu", (long)TDB_GETPID(),
              (unsigned long)TDB_THREAD_ID());
+
+    /* prove the backend enforces conditional writes before relying on the fence. the probe writes
+     * a throwaway key, so only a primary runs it; a replica verifies when it promotes. */
+    if ((*db)->object_store && !atomic_load_explicit(&(*db)->replica_mode, memory_order_acquire))
+        atomic_store_explicit(&(*db)->fencing_supported,
+                              tdb_objstore_verify_conditional_writes(*db), memory_order_release);
 
     /* we initialize log file to NULL (stderr) by default. the log file globals
      * are read by tidesdb_log_write under tidesdb_log_mutex, so writes here take
@@ -22387,6 +22440,17 @@ int tidesdb_promote_to_primary(tidesdb_t *db)
 
     TDB_DEBUG_LOG(TDB_LOG_INFO, "Promoting replica to primary mode");
 
+    /* this node is now going to write, so verify the backend enforces conditional writes before
+     * trusting the fence (the open-time probe only runs on a node that started as a primary). */
+    if (db->object_store && db->object_store->put_if && db->object_store->head)
+        atomic_store_explicit(&db->fencing_supported, tdb_objstore_verify_conditional_writes(db),
+                              memory_order_release);
+
+    /* the outgoing primary's epoch, captured before we bump it. the final catch-up gates on this
+     * value so it still absorbs that primary's just-published manifest and WAL instead of
+     * skipping them as stale against our new epoch. */
+    uint64_t prev_epoch = tdb_objstore_lease_epoch(db);
+
     /* claim the lease before tearing down any replica machinery, so a
      * failed acquire leaves the node a working replica (sync thread still running). winning the
      * CAS makes us the unique epoch holder and immediately fences the old primary -- its next
@@ -22414,15 +22478,16 @@ int tidesdb_promote_to_primary(tidesdb_t *db)
         pthread_join(db->replica_sync_thread, NULL);
     }
 
-    /* final MANIFEST sync and WAL replay to catch last writes from old primary */
+    /* final MANIFEST sync and WAL replay to catch last writes from the old primary, gated on its
+     * epoch so nothing it committed is skipped as stale */
     if (db->object_store)
     {
-        tdb_replica_sync_manifests(db);
+        tdb_replica_sync_manifests(db, prev_epoch);
 
         if (db->unified_mt.enabled && db->config.object_store_config &&
             db->config.object_store_config->replica_replay_wal)
         {
-            tdb_objstore_replay_remote_wals(db, 0);
+            tdb_objstore_replay_remote_wals(db, 0, prev_epoch);
         }
     }
 
@@ -33694,7 +33759,7 @@ static int tidesdb_recover_database(tidesdb_t *db)
     {
         TDB_DEBUG_LOG(TDB_LOG_INFO,
                       "Cold start replaying remote WALs from object store for CF recovery");
-        tdb_objstore_replay_remote_wals(db, 1);
+        tdb_objstore_replay_remote_wals(db, 1, tdb_objstore_lease_epoch(db));
     }
 
     TDB_DEBUG_LOG(TDB_LOG_INFO, "Database recovery completed successfully");
@@ -34089,6 +34154,8 @@ int tidesdb_get_db_stats(tidesdb_t *db, tidesdb_db_stats_t *stats)
     }
 
     stats->replica_mode = atomic_load_explicit(&db->replica_mode, memory_order_relaxed);
+    stats->primary_epoch = atomic_load_explicit(&db->primary_epoch, memory_order_relaxed);
+    stats->seen_epoch = atomic_load_explicit(&db->seen_epoch, memory_order_relaxed);
 
     return TDB_SUCCESS;
 }

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -4859,8 +4859,9 @@ typedef struct
 {
     char local_path[TDB_MAX_PATH_LEN];
     char object_key[TDB_MAX_PATH_LEN];
-    uint64_t wal_generation; /* WAL gen to fence after upload (0 = no fence) */
-    uint64_t meta_epoch;     /* single-writer lease epoch to tag the object with (0 = untagged) */
+    uint64_t wal_generation;   /* WAL gen to fence after upload (0 = no fence) */
+    uint64_t meta_epoch;       /* single-writer lease epoch to tag the object with (0 = untagged) */
+    uint64_t upload_max_bytes; /* logical length to upload (0 = whole file) */
 } tdb_upload_job_t;
 
 /**
@@ -4884,12 +4885,13 @@ static void *tdb_upload_worker_thread(void *arg)
             unsigned int backoff_us = TDB_UPLOAD_INITIAL_BACKOFF_US;
             for (int attempt = 0; attempt < TDB_UPLOAD_MAX_RETRIES; attempt++)
             {
-                /* tag with the lease epoch when set (WAL fencing) so a replica can skip a
-                 * superseded primary's segments; otherwise a plain put. */
-                if (job->meta_epoch && db->object_store->put_if)
-                    rc = db->object_store->put_if(db->object_store->ctx, job->object_key,
-                                                  job->local_path, TDB_PUT_OVERWRITE, NULL,
-                                                  job->meta_epoch, NULL, 0);
+                /* use put_if when the object is epoch-tagged (WAL fencing) or a partial upload is
+                 * requested (active WAL's logical length, skipping its preallocated tail) -- both
+                 * need put_if, which also works untagged (epoch 0). otherwise a plain put. */
+                if ((job->meta_epoch || job->upload_max_bytes) && db->object_store->put_if)
+                    rc = db->object_store->put_if(
+                        db->object_store->ctx, job->object_key, job->local_path, TDB_PUT_OVERWRITE,
+                        NULL, job->meta_epoch, NULL, 0, (size_t)job->upload_max_bytes);
                 else
                     rc = db->object_store->put(db->object_store->ctx, job->object_key,
                                                job->local_path);
@@ -4907,16 +4909,20 @@ static void *tdb_upload_worker_thread(void *arg)
                     struct stat local_st;
                     if (stat(job->local_path, &local_st) == 0)
                     {
+                        /* a partial WAL upload's remote size is the logical length, not the
+                         * preallocated local file size */
+                        size_t expected = job->upload_max_bytes ? (size_t)job->upload_max_bytes
+                                                                : (size_t)local_st.st_size;
                         size_t remote_size = 0;
                         const int verify = db->object_store->exists(db->object_store->ctx,
                                                                     job->object_key, &remote_size);
-                        if (verify != 1 || remote_size != (size_t)local_st.st_size)
+                        if (verify != 1 || remote_size != expected)
                         {
                             TDB_DEBUG_LOG(
                                 TDB_LOG_ERROR,
-                                "Upload verification failed for %s (local=%zu, remote=%zu, "
+                                "Upload verification failed for %s (expected=%zu, remote=%zu, "
                                 "exists=%d)",
-                                job->object_key, (size_t)local_st.st_size, remote_size, verify);
+                                job->object_key, expected, remote_size, verify);
                             rc = -1;
                         }
                     }
@@ -4978,9 +4984,11 @@ static void *tdb_upload_worker_thread(void *arg)
  * @param local_path local file path to upload
  * @param wal_generation WAL generation to fence after upload (0 = no fence)
  * @param meta_epoch single-writer lease epoch to tag the object with (0 = untagged)
+ * @param max_bytes logical length to upload (0 = whole file)
  */
 static void tdb_objstore_enqueue_upload(const tidesdb_t *db, const char *local_path,
-                                        const uint64_t wal_generation, const uint64_t meta_epoch)
+                                        const uint64_t wal_generation, const uint64_t meta_epoch,
+                                        const uint64_t max_bytes)
 {
     if (!db->object_store || !db->upload_queue || !local_path) return;
 
@@ -4991,6 +4999,7 @@ static void tdb_objstore_enqueue_upload(const tidesdb_t *db, const char *local_p
     tdb_path_to_object_key(db, local_path, job->object_key, sizeof(job->object_key));
     job->wal_generation = wal_generation;
     job->meta_epoch = meta_epoch;
+    job->upload_max_bytes = max_bytes;
 
     if (queue_enqueue(db->upload_queue, job) != 0)
     {
@@ -5041,17 +5050,24 @@ static void tdb_objstore_upload_file_sync(tidesdb_t *db, const char *local_path)
  * skip a superseded primary's segments. falls back to the plain sync upload when fencing is off.
  * @param db database instance
  * @param local_path WAL file path to upload
+ * @param max_bytes logical WAL length to upload (0 = whole file); the active WAL is preallocated
+ *                  far past its data, so shipping the whole file would copy a huge zero tail
  */
-static void tdb_objstore_upload_wal_sync(tidesdb_t *db, const char *local_path)
+static void tdb_objstore_upload_wal_sync(tidesdb_t *db, const char *local_path, uint64_t max_bytes)
 {
     if (!db->object_store || !local_path) return;
 
-    uint64_t epoch = atomic_load_explicit(&db->primary_epoch, memory_order_acquire);
-    if (epoch == 0 || !db->object_store->put_if)
+    /* route through put_if whenever the connector has it, even before a lease is held (epoch 0):
+     * it is the only upload that honors max_bytes, so it ships the active WAL's logical length
+     * rather than its 64MB preallocated extent. an untagged (epoch 0) WAL is fine -- a reader
+     * treats epoch 0 as never-stale. only a legacy connector lacking put_if falls back. */
+    if (!db->object_store->put_if)
     {
         tdb_objstore_upload_file_sync(db, local_path);
         return;
     }
+
+    uint64_t epoch = atomic_load_explicit(&db->primary_epoch, memory_order_acquire);
 
     char key[TDB_MAX_PATH_LEN];
     tdb_path_to_object_key(db, local_path, key, sizeof(key));
@@ -5060,7 +5076,7 @@ static void tdb_objstore_upload_wal_sync(tidesdb_t *db, const char *local_path)
     for (int attempt = 0; attempt < TDB_UPLOAD_MAX_RETRIES; attempt++)
     {
         if (db->object_store->put_if(db->object_store->ctx, key, local_path, TDB_PUT_OVERWRITE,
-                                     NULL, epoch, NULL, 0) == 0)
+                                     NULL, epoch, NULL, 0, (size_t)max_bytes) == 0)
         {
             atomic_fetch_add_explicit(&db->total_uploads, 1, memory_order_relaxed);
             return;
@@ -5089,7 +5105,7 @@ static void tdb_objstore_upload_file(tidesdb_t *db, const char *local_path)
     /* we use async pipeline if upload queue exists */
     if (db->upload_queue)
     {
-        tdb_objstore_enqueue_upload(db, local_path, 0, 0);
+        tdb_objstore_enqueue_upload(db, local_path, 0, 0, 0);
         return;
     }
 
@@ -5422,9 +5438,10 @@ static int tdb_objstore_verify_conditional_writes(tidesdb_t *db)
     snprintf(probe_key, sizeof(probe_key), "%s_%s", TDB_FENCE_PROBE_KEY, db->node_id);
 
     os->delete_object(os->ctx, probe_key); /* clear any leftover from a prior crash */
-    int first = os->put_if(os->ctx, probe_key, probe_body, TDB_PUT_IF_NONE_MATCH, NULL, 0, NULL, 0);
+    int first =
+        os->put_if(os->ctx, probe_key, probe_body, TDB_PUT_IF_NONE_MATCH, NULL, 0, NULL, 0, 0);
     int second =
-        os->put_if(os->ctx, probe_key, probe_body, TDB_PUT_IF_NONE_MATCH, NULL, 0, NULL, 0);
+        os->put_if(os->ctx, probe_key, probe_body, TDB_PUT_IF_NONE_MATCH, NULL, 0, NULL, 0, 0);
     os->delete_object(os->ctx, probe_key);
     tdb_unlink(probe_body);
 
@@ -5500,7 +5517,7 @@ static int tdb_objstore_lease_acquire_locked(tidesdb_t *db)
     char new_etag[TDB_OBJSTORE_ETAG_MAX] = {0};
     int rc = os->put_if(os->ctx, TDB_PRIMARY_LEASE_KEY, lease_path,
                         exists ? TDB_PUT_IF_MATCH : TDB_PUT_IF_NONE_MATCH, exists ? cur_etag : NULL,
-                        new_epoch, new_etag, sizeof(new_etag));
+                        new_epoch, new_etag, sizeof(new_etag), 0);
     tdb_unlink(lease_path);
 
     if (rc == TDB_ERR_PRECONDITION) return TDB_ERR_PRECONDITION;
@@ -5543,7 +5560,7 @@ static int tdb_objstore_lease_renew_locked(tidesdb_t *db)
 
     char new_etag[TDB_OBJSTORE_ETAG_MAX] = {0};
     int rc = os->put_if(os->ctx, TDB_PRIMARY_LEASE_KEY, lease_path, TDB_PUT_IF_MATCH,
-                        db->lease_etag, epoch, new_etag, sizeof(new_etag));
+                        db->lease_etag, epoch, new_etag, sizeof(new_etag), 0);
     tdb_unlink(lease_path);
 
     if (rc == TDB_ERR_PRECONDITION) return TDB_ERR_PRECONDITION;
@@ -5604,7 +5621,7 @@ static void tdb_objstore_upload_manifest(tidesdb_t *db, tidesdb_column_family_t 
         {
             uint64_t epoch = atomic_load_explicit(&db->primary_epoch, memory_order_acquire);
             rc = os->put_if(os->ctx, manifest_key, cf->manifest->path, TDB_PUT_OVERWRITE, NULL,
-                            epoch, NULL, 0);
+                            epoch, NULL, 0, 0);
             if (rc == 0) atomic_fetch_add_explicit(&db->total_uploads, 1, memory_order_relaxed);
         }
         pthread_mutex_unlock(&db->lease_lock);
@@ -20361,10 +20378,12 @@ static void *tidesdb_reaper_thread(void *arg)
                              * reaper thread, stalling deferred-flush retry, memory
                              * pressure tracking and sstable eviction. generation 0
                              * means a plain snapshot upload -- the worker must not
-                             * fence or delete the still-active WAL. */
+                             * fence or delete the still-active WAL. ship only the logical
+                             * length, not the preallocated extent. */
                             tdb_objstore_enqueue_upload(
                                 db, umt->wal->file_path, 0,
-                                atomic_load_explicit(&db->primary_epoch, memory_order_acquire));
+                                atomic_load_explicit(&db->primary_epoch, memory_order_acquire),
+                                wal_size);
                             TDB_DEBUG_LOG(TDB_LOG_INFO,
                                           "Unified WAL sync enqueued for async upload");
                             db->last_wal_sync_size = wal_size;
@@ -28130,7 +28149,9 @@ static void tidesdb_unified_close_wal(tidesdb_t *db, tidesdb_memtable_t *umt_imm
     {
         if (db->config.object_store_config->wal_upload_sync)
         {
-            tdb_objstore_upload_wal_sync(db, wal_path);
+            /* the WAL was closed above, so it is already trimmed to its data -- ship the whole
+             * file */
+            tdb_objstore_upload_wal_sync(db, wal_path, 0);
             tdb_unlink(wal_path);
             tdb_sync_directory(db->db_path);
         }
@@ -28138,10 +28159,11 @@ static void tidesdb_unified_close_wal(tidesdb_t *db, tidesdb_memtable_t *umt_imm
         {
             /** async upload with the wal generation for fence tracking, tagged with the
              *  lease epoch so a replica skips a superseded primary's WAL. the reaper
-             *  cleans up the local file after the upload confirms. */
+             *  cleans up the local file after the upload confirms. the closed WAL is already
+             *  trimmed, so the whole file is shipped. */
             tdb_objstore_enqueue_upload(
                 db, wal_path, imm_gen,
-                atomic_load_explicit(&db->primary_epoch, memory_order_acquire));
+                atomic_load_explicit(&db->primary_epoch, memory_order_acquire), 0);
         }
     }
     else
@@ -28875,11 +28897,14 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
             }
         }
 
-        /* sync-on-commit WAL upload for RPO=0 replication */
+        /* sync-on-commit WAL upload for RPO=0 replication. ship only the active WAL's logical
+         * length, not its 64MB-preallocated extent. */
         if (txn->db->object_store && txn->db->config.object_store_config &&
             txn->db->config.object_store_config->wal_sync_on_commit && umt->wal)
         {
-            tdb_objstore_upload_wal_sync(txn->db, umt->wal->file_path);
+            uint64_t wal_len = 0;
+            block_manager_get_size(umt->wal, &wal_len);
+            tdb_objstore_upload_wal_sync(txn->db, umt->wal->file_path, wal_len);
         }
 
         /* we apply ops to unified skip list with prefixed keys */

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -969,9 +969,10 @@ struct tidesdb_t
     /* single-writer fencing (object-store mode) -- the primary lease. the lease object is a
      * conditional-write CAS target whose epoch fences a superseded primary -- it can no longer
      * publish a manifest readers honor. unused when object_store == NULL. */
-    _Atomic(uint64_t) primary_epoch;        /* lease epoch this primary holds (0 = none) */
-    _Atomic(uint64_t) seen_epoch;           /* highest lease epoch a replica has observed */
-    pthread_mutex_t lease_lock;             /* serializes lease CAS-renew + lease_etag update */
+    _Atomic(uint64_t) primary_epoch; /* lease epoch this primary holds (0 = none) */
+    _Atomic(uint64_t) seen_epoch;    /* highest lease epoch a replica has observed */
+    _Atomic(int) fencing_supported; /* 1 once the backend is proven to enforce conditional writes */
+    pthread_mutex_t lease_lock;     /* serializes lease CAS-renew + lease_etag update */
     char lease_etag[TDB_OBJSTORE_ETAG_MAX]; /* ETag of the lease we last wrote (guarded by
                                                lease_lock) */
     char node_id[TDB_NODE_ID_MAX]; /* this node's id, recorded in the lease for observability */
@@ -1291,6 +1292,12 @@ typedef struct tidesdb_db_stats_t
     uint64_t total_uploads;
     uint64_t total_upload_failures;
     int replica_mode;
+    /* single-writer fencing (object-store mode). primary_epoch is the lease epoch this primary
+     * currently holds (0 when not a primary / no lease); seen_epoch is the highest lease epoch a
+     * replica has observed. a promotion that took bumps primary_epoch; a fenced primary sees
+     * replica_mode flip back to 1. */
+    uint64_t primary_epoch;
+    uint64_t seen_epoch;
     /* write-amplification counters (lifetime since open, on-disk framed bytes). uwal is the
      * shared unified WAL volume (zero when unified mode is off); the remaining fields are
      * summed across all column families. db-wide WA = (uwal + wal + flush + compaction) /

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -140,6 +140,15 @@ typedef enum
 /* system is at capacity and the operation gave up after the backpressure
  * stall hit its no-progress budget. transient; callers should retry */
 #define TDB_ERR_BUSY -14
+/* a conditional object-store write failed its precondition (HTTP 412) -- the
+ * shared object was changed by another writer. used by single-writer fencing.
+ * objstore.h carries an identical definition for the connector backends */
+#ifndef TDB_ERR_PRECONDITION
+#define TDB_ERR_PRECONDITION -15
+#endif
+
+/* max length of the node id recorded in the primary lease (observability only) */
+#define TDB_NODE_ID_MAX 64
 
 #ifdef TDB_ENABLE_READ_PROFILING
 /**
@@ -956,6 +965,16 @@ struct tidesdb_t
     _Atomic(int) replica_mode;               /* 1 = read-only replica, 0 = primary */
     pthread_t replica_sync_thread;           /* dedicated replica MANIFEST/WAL sync thread */
     _Atomic(int) replica_sync_thread_active; /* 1 while the replica sync thread runs */
+
+    /* single-writer fencing (object-store mode) -- the primary lease. the lease object is a
+     * conditional-write CAS target whose epoch fences a superseded primary -- it can no longer
+     * publish a manifest readers honor. unused when object_store == NULL. */
+    _Atomic(uint64_t) primary_epoch;        /* lease epoch this primary holds (0 = none) */
+    _Atomic(uint64_t) seen_epoch;           /* highest lease epoch a replica has observed */
+    pthread_mutex_t lease_lock;             /* serializes lease CAS-renew + lease_etag update */
+    char lease_etag[TDB_OBJSTORE_ETAG_MAX]; /* ETag of the lease we last wrote (guarded by
+                                               lease_lock) */
+    char node_id[TDB_NODE_ID_MAX]; /* this node's id, recorded in the lease for observability */
 
     /* compaction pause gate -- tidesdb_backup holds this across its file copy
      * so the copy cannot race a compaction rewriting the manifest + sstable set */

--- a/test/block_manager__tests.c
+++ b/test/block_manager__tests.c
@@ -3506,6 +3506,93 @@ void test_block_manager_permissive_validation_truncates_prealloc_tail()
     (void)remove(path);
 }
 
+void test_block_manager_large_block_read_roundtrip(void)
+{
+    /* a payload past the read-ahead hint forces bm_read_block_tls to issue its
+     * second pread for the remainder; verify the stitched buffer is intact */
+    const char *path = "test_large_read.db";
+    (void)remove(path);
+
+    block_manager_t *bm = NULL;
+    ASSERT_TRUE(block_manager_open(&bm, path, BLOCK_MANAGER_SYNC_NONE) == 0);
+
+    const uint32_t big = 64u * 1024u;
+    uint8_t *payload = malloc(big);
+    ASSERT_TRUE(payload != NULL);
+    for (uint32_t i = 0; i < big; i++) payload[i] = (uint8_t)((i * 131u + 7u) & 0xFF);
+
+    block_manager_block_t *block = block_manager_block_create(big, payload);
+    ASSERT_TRUE(block != NULL);
+    int64_t offset = block_manager_block_write(bm, block);
+    ASSERT_TRUE(offset >= 0);
+    block_manager_block_free(block);
+
+    ASSERT_TRUE(block_manager_close(bm) == 0);
+    ASSERT_TRUE(block_manager_open(&bm, path, BLOCK_MANAGER_SYNC_NONE) == 0);
+
+    block_manager_cursor_t *cursor = NULL;
+    ASSERT_TRUE(block_manager_cursor_init(&cursor, bm) == 0);
+    block = block_manager_cursor_read(cursor);
+    ASSERT_TRUE(block != NULL);
+    ASSERT_EQ(block->size, big);
+    ASSERT_EQ(memcmp(block->data, payload, big), 0);
+    block_manager_block_free(block);
+
+    /* the offset-based reader (vlog path) must stitch the same bytes */
+    uint8_t *out = NULL;
+    uint32_t out_size = 0;
+    ASSERT_EQ(block_manager_read_block_data_at_offset(bm, (uint64_t)offset, &out, &out_size), 0);
+    ASSERT_EQ(out_size, big);
+    ASSERT_EQ(memcmp(out, payload, big), 0);
+    free(out);
+
+    block_manager_cursor_free(cursor);
+    ASSERT_TRUE(block_manager_close(bm) == 0);
+    free(payload);
+    (void)remove(path);
+}
+
+void test_block_manager_max_safe_block_bytes_refusal(void)
+{
+    /* the budget is only consulted past the large-block threshold (256 MB); a block
+     * over both threshold and budget is refused with NULL instead of being allocated */
+    const uint64_t large_block_threshold = 256ull * 1024 * 1024;
+    const uint32_t big = (uint32_t)(large_block_threshold + 4096);
+
+    const char *path = "test_budget_refusal.db";
+    (void)remove(path);
+
+    block_manager_t *bm = NULL;
+    ASSERT_TRUE(block_manager_open(&bm, path, BLOCK_MANAGER_SYNC_NONE) == 0);
+
+    uint8_t *payload = calloc(1, big);
+    ASSERT_TRUE(payload != NULL);
+    int64_t offset = block_manager_write_raw(bm, payload, big);
+    ASSERT_TRUE(offset >= 0);
+    free(payload);
+
+    block_manager_cursor_t *cursor = NULL;
+    ASSERT_TRUE(block_manager_cursor_init(&cursor, bm) == 0);
+
+    /* no budget configured -- the oversized block reads back fine */
+    block_manager_set_max_safe_block_bytes(0);
+    block_manager_block_t *block = block_manager_cursor_read(cursor);
+    ASSERT_TRUE(block != NULL);
+    ASSERT_EQ(block->size, big);
+    block_manager_block_free(block);
+
+    /* budget below the block size -- the read is refused (graceful, no OOM) */
+    block_manager_set_max_safe_block_bytes(large_block_threshold);
+    ASSERT_TRUE(block_manager_cursor_read(cursor) == NULL);
+
+    /* restore the process-wide budget so later tests are unaffected */
+    block_manager_set_max_safe_block_bytes(0);
+
+    block_manager_cursor_free(cursor);
+    ASSERT_TRUE(block_manager_close(bm) == 0);
+    (void)remove(path);
+}
+
 int main(int argc, char **argv)
 {
     INIT_TEST_FILTER(argc, argv);
@@ -3574,6 +3661,8 @@ int main(int argc, char **argv)
     RUN_TEST(test_block_manager_strict_validation_accepts_prealloc_tail, tests_passed);
     RUN_TEST(test_block_manager_strict_validation_rejects_garbage_tail, tests_passed);
     RUN_TEST(test_block_manager_permissive_validation_truncates_prealloc_tail, tests_passed);
+    RUN_TEST(test_block_manager_large_block_read_roundtrip, tests_passed);
+    RUN_TEST(test_block_manager_max_safe_block_bytes_refusal, tests_passed);
 
     srand((unsigned int)time(NULL)); /* NOLINT(cert-msc51-cpp) */
     RUN_TEST(benchmark_block_manager, tests_passed);

--- a/test/bloom_filter__tests.c
+++ b/test/bloom_filter__tests.c
@@ -870,6 +870,144 @@ static void test_bloom_filter_new_failure_nulls_out(void)
     bloom_filter_add(bf2, (const uint8_t *)"x", 1); /* must not crash */
 }
 
+/* a densely filled filter (almost every 64-bit word non-zero) must serialize with
+ * the dense encoding: smaller than the raw bitset plus a small header, never the
+ * sparse bloat it used to produce. format byte high nibble == 1 marks dense. */
+void test_bloom_filter_dense_encoding(void)
+{
+    bloom_filter_t *bf;
+    ASSERT_EQ(bloom_filter_new(&bf, 0.01, 1000), 0);
+
+    /* over-fill so essentially every word has a bit set */
+    for (int i = 0; i < 2000; i++)
+    {
+        char key[24];
+        int n = snprintf(key, sizeof(key), "dense_key_%d", i);
+        bloom_filter_add(bf, (const uint8_t *)key, (size_t)n);
+    }
+
+    size_t size;
+    uint8_t *data = bloom_filter_serialize(bf, &size);
+    ASSERT_TRUE(data != NULL);
+
+    /* versioned + dense framing */
+    ASSERT_EQ(data[0], 0x00);
+    ASSERT_EQ(data[1] >> 4, 1);   /* encoding nibble == dense */
+    ASSERT_EQ(data[1] & 0x0F, 2); /* hash version 2 */
+
+    /* dense output must not exceed the raw bitset plus a tiny header -- the whole
+     * point of the encoding is that it never bloats past raw */
+    ASSERT_TRUE(size <= (size_t)bf->size_in_words * 8 + 16);
+
+    bloom_filter_t *rt = bloom_filter_deserialize(data, size);
+    ASSERT_TRUE(rt != NULL);
+    ASSERT_EQ(rt->m, bf->m);
+    ASSERT_EQ(rt->h, bf->h);
+    ASSERT_EQ(rt->size_in_words, bf->size_in_words);
+    ASSERT_EQ(rt->hash_version, bf->hash_version);
+    for (unsigned int i = 0; i < bf->size_in_words; i++) ASSERT_EQ(rt->bitset[i], bf->bitset[i]);
+
+    free(data);
+    bloom_filter_free(bf);
+    bloom_filter_free(rt);
+}
+
+/* a sparsely filled filter keeps the sparse encoding, and its framing is the
+ * byte-identical legacy v2 form (0x00, 0x02) so older binaries still read it */
+void test_bloom_filter_sparse_encoding_unchanged(void)
+{
+    bloom_filter_t *bf;
+    ASSERT_EQ(bloom_filter_new(&bf, 0.01, 100000), 0);
+
+    const char *keys[] = {"a", "b", "c"};
+    for (int i = 0; i < 3; i++) bloom_filter_add(bf, (const uint8_t *)keys[i], strlen(keys[i]));
+
+    size_t size;
+    uint8_t *data = bloom_filter_serialize(bf, &size);
+    ASSERT_TRUE(data != NULL);
+    ASSERT_EQ(data[0], 0x00);
+    ASSERT_EQ(data[1], 0x02); /* sparse + hash version 2, unchanged from legacy v2 */
+
+    bloom_filter_t *rt = bloom_filter_deserialize(data, size);
+    ASSERT_TRUE(rt != NULL);
+    for (int i = 0; i < 3; i++)
+        ASSERT_EQ(bloom_filter_contains(rt, (const uint8_t *)keys[i], strlen(keys[i])), 1);
+
+    free(data);
+    bloom_filter_free(bf);
+    bloom_filter_free(rt);
+}
+
+/* deserialize must reject malformed buffers without over-reading: a buffer ending
+ * mid-varint, a lone sentinel, an unknown hash version, an unknown encoding, and
+ * a header that promises more bitset words than the buffer holds */
+void test_bloom_filter_deserialize_malformed(void)
+{
+    /* buffer ends inside a varint (legacy framing, first byte is varint(m)) */
+    uint8_t trunc_varint[1] = {0x80};
+    ASSERT_TRUE(bloom_filter_deserialize(trunc_varint, 1) == NULL);
+
+    /* lone sentinel with no format byte */
+    uint8_t lone_sentinel[1] = {0x00};
+    ASSERT_TRUE(bloom_filter_deserialize(lone_sentinel, 1) == NULL);
+
+    /* unknown hash version (low nibble 3 > current) */
+    uint8_t bad_version[2] = {0x00, 0x03};
+    ASSERT_TRUE(bloom_filter_deserialize(bad_version, 2) == NULL);
+
+    /* unknown encoding (high nibble 2), valid hash version */
+    uint8_t bad_encoding[2] = {0x00, 0x22};
+    ASSERT_TRUE(bloom_filter_deserialize(bad_encoding, 2) == NULL);
+
+    /* sparse: count claims 3 words but only one is present */
+    uint8_t trunc_sparse[16];
+    uint8_t *p = trunc_sparse;
+    p = encode_varint32(p, 128);  /* m = 128 -> 2 words */
+    p = encode_varint32(p, 1);    /* h = 1 */
+    p = encode_varint32(p, 3);    /* non_zero_count = 3 */
+    p = encode_varint32(p, 0);    /* index 0 */
+    p = encode_varint64(p, 0xFF); /* value -- and then nothing more */
+    ASSERT_TRUE(bloom_filter_deserialize(trunc_sparse, (size_t)(p - trunc_sparse)) == NULL);
+
+    /* dense: header says 2 words but the raw body is missing */
+    uint8_t trunc_dense[8];
+    p = trunc_dense;
+    *p++ = 0x00;                    /* sentinel */
+    *p++ = (uint8_t)((1 << 4) | 2); /* dense + hash version 2 */
+    p = encode_varint32(p, 128);    /* m = 128 -> 2 words = 16 raw bytes expected */
+    p = encode_varint32(p, 1);      /* h = 1, then 0 body bytes */
+    ASSERT_TRUE(bloom_filter_deserialize(trunc_dense, (size_t)(p - trunc_dense)) == NULL);
+}
+
+/* is_full over a multi-word filter: the all-words-set return-1 path and both the
+ * partial-last-word (remaining_bits != 0) and exact-multiple (== 0) branches */
+void test_bloom_filter_is_full_multiword(void)
+{
+    /* m = 96 -> 2 words, last word holds 32 valid bits (remaining_bits != 0) */
+    bloom_filter_t *bf;
+    ASSERT_EQ(bloom_filter_new(&bf, 0.01, 10), 0);
+    ASSERT_TRUE(bf->size_in_words >= 2);
+    for (unsigned int i = 0; i < bf->size_in_words; i++) bf->bitset[i] = UINT64_MAX;
+    ASSERT_EQ(bloom_filter_is_full(bf), 1);
+
+    /* not full once a valid bit in the last word is cleared */
+    bf->bitset[bf->size_in_words - 1] &= ~1ULL;
+    ASSERT_EQ(bloom_filter_is_full(bf), 0);
+    bloom_filter_free(bf);
+
+    /* exact multiple of 64 bits -> remaining_bits == 0 branch */
+    bloom_filter_t *bf2;
+    ASSERT_EQ(bloom_filter_new(&bf2, 0.01, 10), 0);
+    bf2->m = 128; /* 2 full words, no partial tail */
+    ASSERT_EQ(bf2->size_in_words, 2u);
+    bf2->bitset[0] = UINT64_MAX;
+    bf2->bitset[1] = UINT64_MAX;
+    ASSERT_EQ(bloom_filter_is_full(bf2), 1);
+    bf2->bitset[1] = UINT64_MAX - 1;
+    ASSERT_EQ(bloom_filter_is_full(bf2), 0);
+    bloom_filter_free(bf2);
+}
+
 int main(int argc, char **argv)
 {
     INIT_TEST_FILTER(argc, argv);
@@ -900,6 +1038,10 @@ int main(int argc, char **argv)
     RUN_TEST(test_bloom_filter_is_full_null_bitset, tests_passed);
     RUN_TEST(test_bloom_filter_hash_key_sizes, tests_passed);
     RUN_TEST(test_bloom_filter_deserialize_overflow_m, tests_passed);
+    RUN_TEST(test_bloom_filter_dense_encoding, tests_passed);
+    RUN_TEST(test_bloom_filter_sparse_encoding_unchanged, tests_passed);
+    RUN_TEST(test_bloom_filter_deserialize_malformed, tests_passed);
+    RUN_TEST(test_bloom_filter_is_full_multiword, tests_passed);
     RUN_TEST(benchmark_bloom_filter, tests_passed);
 
     PRINT_TEST_RESULTS(tests_passed, tests_failed);

--- a/test/failover/Dockerfile
+++ b/test/failover/Dockerfile
@@ -1,0 +1,27 @@
+# Image for the failover harness node (test infrastructure only -- not shipped with the library).
+# One container = one cluster node (primary or replica) pointed at a shared S3/MinIO bucket.
+# Build context is the repo root:  docker build -f test/failover/Dockerfile -t tidesdb-node:ci .
+
+FROM ubuntu:24.04 AS build
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        cmake build-essential ca-certificates \
+        liblz4-dev libzstd-dev libsnappy-dev libcurl4-openssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+COPY . /src
+WORKDIR /src
+RUN cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DTIDESDB_WITH_SANITIZER=OFF \
+        -DTIDESDB_WITH_S3=ON \
+    && cmake --build build --target tidesdb tidesdb_node -j"$(nproc)"
+
+FROM ubuntu:24.04
+# bash is needed so the scenario driver can speak the node's TCP protocol via kubectl exec
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        bash libcurl4 liblz4-1 libzstd1 libsnappy1v5 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=build /src/build/tidesdb_node /usr/local/bin/tidesdb_node
+COPY --from=build /src/build/libtidesdb.so* /usr/local/lib/
+RUN ldconfig
+# data dir for the local working set; the bucket is remote (MinIO)
+RUN mkdir -p /data
+ENV TDB_NODE_DATA_DIR=/data
+ENTRYPOINT ["/usr/local/bin/tidesdb_node"]

--- a/test/failover/Dockerfile
+++ b/test/failover/Dockerfile
@@ -14,9 +14,11 @@ RUN cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DTIDESDB_WITH_SANITIZER=OFF 
     && cmake --build build --target tidesdb tidesdb_node -j"$(nproc)"
 
 FROM ubuntu:24.04
-# bash is needed so the scenario driver can speak the node's TCP protocol via kubectl exec
+# bash: the scenario driver speaks the node's TCP protocol via kubectl exec.
+# iptables: the partition scenario severs this pod's egress to MinIO from inside its own netns
+# (needs the NET_ADMIN capability, set on the pod), so no CNI NetworkPolicy support is required.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        bash libcurl4 liblz4-1 libzstd1 libsnappy1v5 \
+        bash iptables libcurl4 liblz4-1 libzstd1 libsnappy1v5 \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=build /src/build/tidesdb_node /usr/local/bin/tidesdb_node
 COPY --from=build /src/build/libtidesdb.so* /usr/local/lib/

--- a/test/failover/k8s/minio.yaml
+++ b/test/failover/k8s/minio.yaml
@@ -1,0 +1,38 @@
+# MinIO standalone, the shared object store / bucket the cluster nodes fence against.
+# test infrastructure only.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  labels: { app: minio }
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: minio }
+  template:
+    metadata:
+      labels: { app: minio }
+    spec:
+      containers:
+        - name: minio
+          image: minio/minio:latest
+          args: ["server", "/data", "--console-address", ":9001"]
+          env:
+            - { name: MINIO_ROOT_USER, value: minioadmin }
+            - { name: MINIO_ROOT_PASSWORD, value: minioadmin }
+          ports:
+            - containerPort: 9000
+          readinessProbe:
+            httpGet: { path: /minio/health/ready, port: 9000 }
+            initialDelaySeconds: 3
+            periodSeconds: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+spec:
+  selector: { app: minio }
+  ports:
+    - port: 9000
+      targetPort: 9000

--- a/test/failover/k8s/nodes.yaml
+++ b/test/failover/k8s/nodes.yaml
@@ -34,6 +34,9 @@ spec:
       env:
         - { name: TDB_NODE_REPLICA, value: "0" }
         - { name: TDB_NODE_ID, value: "primary" }
+      securityContext:
+        capabilities:
+          add: ["NET_ADMIN"] # the partition scenario runs iptables inside the pod's netns
       readinessProbe:
         tcpSocket: { port: 7400 }
         initialDelaySeconds: 2
@@ -55,6 +58,9 @@ spec:
       env:
         - { name: TDB_NODE_REPLICA, value: "1" }
         - { name: TDB_NODE_ID, value: "replica-0" }
+      securityContext:
+        capabilities:
+          add: ["NET_ADMIN"] # the partition scenario runs iptables inside the pod's netns
       readinessProbe:
         tcpSocket: { port: 7400 }
         initialDelaySeconds: 2
@@ -76,6 +82,9 @@ spec:
       env:
         - { name: TDB_NODE_REPLICA, value: "1" }
         - { name: TDB_NODE_ID, value: "replica-1" }
+      securityContext:
+        capabilities:
+          add: ["NET_ADMIN"] # the partition scenario runs iptables inside the pod's netns
       readinessProbe:
         tcpSocket: { port: 7400 }
         initialDelaySeconds: 2
@@ -97,6 +106,9 @@ spec:
       env:
         - { name: TDB_NODE_REPLICA, value: "1" }
         - { name: TDB_NODE_ID, value: "replica-2" }
+      securityContext:
+        capabilities:
+          add: ["NET_ADMIN"] # the partition scenario runs iptables inside the pod's netns
       readinessProbe:
         tcpSocket: { port: 7400 }
         initialDelaySeconds: 2

--- a/test/failover/k8s/nodes.yaml
+++ b/test/failover/k8s/nodes.yaml
@@ -1,0 +1,103 @@
+# Cluster nodes for the failover simulation: one primary and three replicas, all pointed at the
+# shared MinIO bucket. the image is built from test/failover/Dockerfile and loaded into kind.
+# restartPolicy Never so deleting a pod is a real node loss. three replicas let the matrix cover
+# fan-out convergence, surviving replicas re-following a newly promoted primary, and cascading
+# (sequential) failovers.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tdb-node-env
+data:
+  TDB_NODE_PORT: "7400"
+  TDB_NODE_BACKEND: "s3"
+  TDB_NODE_WAL_SYNC_ON_COMMIT: "1"
+  TDB_NODE_WRITE_BUFFER: "262144"
+  TDB_NODE_REPLICA_SYNC_US: "500000"
+  TIDESDB_S3_ENDPOINT: "minio:9000"
+  TIDESDB_S3_BUCKET: "tidesdb-failover"
+  TIDESDB_S3_ACCESS_KEY: "minioadmin"
+  TIDESDB_S3_SECRET_KEY: "minioadmin"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tdb-primary
+  labels: { app: tdb-node, role: primary }
+spec:
+  restartPolicy: Never
+  containers:
+    - name: node
+      image: tidesdb-node:ci
+      imagePullPolicy: Never
+      envFrom:
+        - configMapRef: { name: tdb-node-env }
+      env:
+        - { name: TDB_NODE_REPLICA, value: "0" }
+        - { name: TDB_NODE_ID, value: "primary" }
+      readinessProbe:
+        tcpSocket: { port: 7400 }
+        initialDelaySeconds: 2
+        periodSeconds: 2
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tdb-replica-0
+  labels: { app: tdb-node, role: replica }
+spec:
+  restartPolicy: Never
+  containers:
+    - name: node
+      image: tidesdb-node:ci
+      imagePullPolicy: Never
+      envFrom:
+        - configMapRef: { name: tdb-node-env }
+      env:
+        - { name: TDB_NODE_REPLICA, value: "1" }
+        - { name: TDB_NODE_ID, value: "replica-0" }
+      readinessProbe:
+        tcpSocket: { port: 7400 }
+        initialDelaySeconds: 2
+        periodSeconds: 2
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tdb-replica-1
+  labels: { app: tdb-node, role: replica }
+spec:
+  restartPolicy: Never
+  containers:
+    - name: node
+      image: tidesdb-node:ci
+      imagePullPolicy: Never
+      envFrom:
+        - configMapRef: { name: tdb-node-env }
+      env:
+        - { name: TDB_NODE_REPLICA, value: "1" }
+        - { name: TDB_NODE_ID, value: "replica-1" }
+      readinessProbe:
+        tcpSocket: { port: 7400 }
+        initialDelaySeconds: 2
+        periodSeconds: 2
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tdb-replica-2
+  labels: { app: tdb-node, role: replica }
+spec:
+  restartPolicy: Never
+  containers:
+    - name: node
+      image: tidesdb-node:ci
+      imagePullPolicy: Never
+      envFrom:
+        - configMapRef: { name: tdb-node-env }
+      env:
+        - { name: TDB_NODE_REPLICA, value: "1" }
+        - { name: TDB_NODE_ID, value: "replica-2" }
+      readinessProbe:
+        tcpSocket: { port: 7400 }
+        initialDelaySeconds: 2
+        periodSeconds: 2

--- a/test/failover/run_k8s.sh
+++ b/test/failover/run_k8s.sh
@@ -91,7 +91,6 @@ reset_cluster() {
     for p in "${ALL_PODS[@]}"; do kubectl wait --for=condition=Ready "pod/$p" --timeout=180s >/dev/null; done
 }
 
-# ----------------------------------------------------------------------------
 # every replica receives what the primary writes
 scenario_fanout_converge() {
     echo "== k8s scenario fanout_converge =="
@@ -170,7 +169,6 @@ scenario_cascading_failover() {
     check "data from the first new primary" "$(kverify tdb-replica-1 1 20 d)" 20
 }
 
-# ----------------------------------------------------------------------------
 echo "Applying MinIO..."
 kubectl apply -f "$K8S_DIR/minio.yaml" >/dev/null
 kubectl rollout status deploy/minio --timeout=180s >/dev/null

--- a/test/failover/run_k8s.sh
+++ b/test/failover/run_k8s.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+#
+# cloud-simulation failover test: real pods on a kind cluster, fencing against a real MinIO
+# bucket over the S3 connector's conditional writes (not the fs/flock shortcut). a "node loss" is
+# a real pod deletion and the writers are separate containers. one primary + three replicas let
+# the matrix cover fan-out replication, a failover the surviving replicas re-follow, split-brain
+# fencing of a live zombie, and cascading (sequential) failovers with a monotonic epoch.
+#
+# assumes a working kubectl context (the kind cluster) with the node image loaded as
+# tidesdb-node:ci. test infrastructure only.
+set -u
+
+K8S_DIR="$(cd "$(dirname "$0")/k8s" && pwd)"
+BUCKET=tidesdb-failover
+REPLICAS=(tdb-replica-0 tdb-replica-1 tdb-replica-2)
+ALL_PODS=(tdb-primary "${REPLICAS[@]}")
+fail=0
+
+check() { if [ "$2" = "$3" ]; then echo "  ok   $1"; else echo "  FAIL $1: got [$2] want [$3]"; fail=1; fi; }
+
+# run a one-line node command inside a pod via bash /dev/tcp to the node's localhost port
+kexec() {
+    kubectl exec "$1" -- bash -c '
+        exec 3<>/dev/tcp/127.0.0.1/7400 || exit 1
+        printf "%s\n" "$1" >&3
+        IFS= read -r resp <&3
+        printf "%s" "$resp"
+    ' _ "$2" 2>/dev/null | tr -d '\r'
+}
+
+# pipeline a range of PUTs over one connection inside the pod (one exec, not one per key)
+kbulk_put() { # pod start end prefix
+    kubectl exec "$1" -- bash -c '
+        exec 3<>/dev/tcp/127.0.0.1/7400 || exit 1
+        for ((i='"$2"'; i<='"$3"'; i++)); do printf "PUT '"$4"'%d v%d\n" "$i" "$i" >&3; done
+        for ((i='"$2"'; i<='"$3"'; i++)); do IFS= read -r _ <&3; done
+    ' >/dev/null 2>&1
+}
+
+# count how many keys in a range read back correctly (one exec)
+kverify() { # pod start end prefix -> count
+    kubectl exec "$1" -- bash -c '
+        exec 3<>/dev/tcp/127.0.0.1/7400 || exit 1
+        n=0
+        for ((i='"$2"'; i<='"$3"'; i++)); do printf "GET '"$4"'%d\n" "$i" >&3; done
+        for ((i='"$2"'; i<='"$3"'; i++)); do
+            IFS= read -r r <&3; r="${r%$'\''\r'\''}"
+            [ "$r" = "VAL v$i" ] && n=$((n+1))
+        done
+        echo "$n"
+    ' 2>/dev/null | tr -d '\r'
+}
+
+kstat_field() { kexec "$1" STAT | grep -o "$2=[0-9]*" | cut -d= -f2; }
+
+# run mc inside the cluster (the runner cannot reach the MinIO ClusterIP directly)
+mc_do() {
+    local name="mc-$RANDOM"
+    kubectl run "$name" --image=minio/mc:latest --restart=Never --rm -i --quiet --command -- \
+        sh -c "mc alias set m http://minio:9000 minioadmin minioadmin >/dev/null 2>&1 && $1"
+}
+
+# wait until reading <key> on <pod> returns <want> (bounded)
+kwait_val() { # pod key want
+    local i
+    for i in $(seq 1 60); do
+        [ "$(kexec "$1" "GET $2")" = "VAL $3" ] && return 0
+        sleep 1
+    done
+    return 1
+}
+
+# wait until every listed pod has the full [1..count] range of <prefix>
+wait_all_converge() { # count prefix pod...
+    local count=$1 prefix=$2; shift 2
+    local p i
+    for p in "$@"; do
+        for i in $(seq 1 60); do
+            [ "$(kverify "$p" 1 "$count" "$prefix")" = "$count" ] && break
+            sleep 1
+        done
+    done
+}
+
+# fresh nodes + empty bucket for a scenario
+reset_cluster() {
+    kubectl delete pod "${ALL_PODS[@]}" --ignore-not-found --wait=true >/dev/null 2>&1
+    mc_do "mc rb --force m/$BUCKET >/dev/null 2>&1; mc mb -p m/$BUCKET >/dev/null"
+    kubectl apply -f "$K8S_DIR/nodes.yaml" >/dev/null
+    local p
+    for p in "${ALL_PODS[@]}"; do kubectl wait --for=condition=Ready "pod/$p" --timeout=180s >/dev/null; done
+}
+
+# ----------------------------------------------------------------------------
+# every replica receives what the primary writes
+scenario_fanout_converge() {
+    echo "== k8s scenario fanout_converge =="
+    reset_cluster
+
+    kbulk_put tdb-primary 1 50 k
+    check "primary flush" "$(kexec tdb-primary FLUSH)" "OK"
+    wait_all_converge 50 k "${REPLICAS[@]}"
+
+    local r
+    for r in "${REPLICAS[@]}"; do check "$r converged" "$(kverify "$r" 1 50 k)" 50; done
+}
+
+# kill the primary, promote one replica, and the surviving replicas must re-follow the new primary
+scenario_failover_refollow() {
+    echo "== k8s scenario failover_refollow =="
+    reset_cluster
+
+    kbulk_put tdb-primary 1 50 k
+    kexec tdb-primary FLUSH >/dev/null
+    wait_all_converge 50 k "${REPLICAS[@]}"
+
+    kubectl delete pod tdb-primary --wait=true >/dev/null 2>&1
+    check "promote replica-0" "$(kexec tdb-replica-0 PROMOTE)" "OK 2"
+    check "promoted holds all data" "$(kverify tdb-replica-0 1 50 k)" 50
+    check "promoted is primary" "$(kstat_field tdb-replica-0 replica_mode)" 0
+
+    # the new primary takes fresh writes; the still-replicas must pick them up
+    kbulk_put tdb-replica-0 1 30 m
+    kexec tdb-replica-0 FLUSH >/dev/null
+    wait_all_converge 30 m tdb-replica-1 tdb-replica-2
+    check "replica-1 follows new primary" "$(kverify tdb-replica-1 1 30 m)" 30
+    check "replica-2 follows new primary" "$(kverify tdb-replica-2 1 30 m)" 30
+}
+
+# a promoted replica fences the still-alive old primary
+scenario_zombie_fence() {
+    echo "== k8s scenario zombie_fence =="
+    reset_cluster
+
+    kbulk_put tdb-primary 1 50 a
+    kexec tdb-primary FLUSH >/dev/null
+    wait_all_converge 50 a "${REPLICAS[@]}"
+
+    check "promote replica-0" "$(kexec tdb-replica-0 PROMOTE)" "OK 2"
+
+    # the zombie keeps writing then publishes -- the fence must demote it
+    kbulk_put tdb-primary 1 20 z
+    kexec tdb-primary FLUSH >/dev/null
+    sleep 2
+    check "zombie self-demoted" "$(kstat_field tdb-primary replica_mode)" 1
+    check "zombie writes fenced out" "$(kverify tdb-replica-0 1 20 z)" 0
+    check "pre-failover data preserved" "$(kverify tdb-replica-0 1 50 a)" 50
+}
+
+# two sequential failovers; the epoch advances monotonically and data survives both
+scenario_cascading_failover() {
+    echo "== k8s scenario cascading_failover =="
+    reset_cluster
+
+    kbulk_put tdb-primary 1 40 c
+    kexec tdb-primary FLUSH >/dev/null
+    wait_all_converge 40 c "${REPLICAS[@]}"
+
+    # first failover: primary -> replica-0 (epoch 2)
+    kubectl delete pod tdb-primary --wait=true >/dev/null 2>&1
+    check "first promote (epoch 2)" "$(kexec tdb-replica-0 PROMOTE)" "OK 2"
+    kbulk_put tdb-replica-0 1 20 d
+    kexec tdb-replica-0 FLUSH >/dev/null
+    wait_all_converge 20 d tdb-replica-1
+
+    # second failover: replica-0 -> replica-1 (epoch 3)
+    kubectl delete pod tdb-replica-0 --wait=true >/dev/null 2>&1
+    check "second promote (epoch 3)" "$(kexec tdb-replica-1 PROMOTE)" "OK 3"
+    check "data from before both failovers" "$(kverify tdb-replica-1 1 40 c)" 40
+    check "data from the first new primary" "$(kverify tdb-replica-1 1 20 d)" 20
+}
+
+# ----------------------------------------------------------------------------
+echo "Applying MinIO..."
+kubectl apply -f "$K8S_DIR/minio.yaml" >/dev/null
+kubectl rollout status deploy/minio --timeout=180s >/dev/null
+
+scenario_fanout_converge
+scenario_failover_refollow
+scenario_zombie_fence
+scenario_cascading_failover
+
+echo
+if [ "$fail" -eq 0 ]; then echo "ALL K8S FAILOVER SCENARIOS PASSED"; else echo "K8S FAILOVER SCENARIOS FAILED"; fi
+exit "$fail"

--- a/test/failover/run_k8s.sh
+++ b/test/failover/run_k8s.sh
@@ -53,6 +53,13 @@ kverify() { # pod start end prefix -> count
 
 kstat_field() { kexec "$1" STAT | grep -o "$2=[0-9]*" | cut -d= -f2; }
 
+minio_clusterip() { kubectl get svc minio -o jsonpath='{.spec.clusterIP}'; }
+
+# sever / restore a pod's egress to MinIO from inside its own netns (needs NET_ADMIN). works
+# regardless of the CNI because it is the pod's own iptables, not a NetworkPolicy.
+partition_from_minio() { kubectl exec "$1" -- iptables -A OUTPUT -d "$2" -p tcp --dport 9000 -j REJECT; }
+heal_partition() { kubectl exec "$1" -- iptables -D OUTPUT -d "$2" -p tcp --dport 9000 -j REJECT; }
+
 # run mc inside the cluster (the runner cannot reach the MinIO ClusterIP directly)
 mc_do() {
     local name="mc-$RANDOM"
@@ -169,6 +176,36 @@ scenario_cascading_failover() {
     check "data from the first new primary" "$(kverify tdb-replica-1 1 20 d)" 20
 }
 
+# a primary fully cut off from the bucket misses the failover entirely; on reconnect its publish
+# must still fail the lease renew and self-demote, and its isolated writes must not win
+scenario_partition_zombie() {
+    echo "== k8s scenario partition_zombie =="
+    reset_cluster
+    local minio_ip; minio_ip=$(minio_clusterip)
+
+    kbulk_put tdb-primary 1 50 p
+    kexec tdb-primary FLUSH >/dev/null
+    wait_all_converge 50 p "${REPLICAS[@]}"
+
+    # cut the primary off from the bucket -- it cannot observe the failover
+    partition_from_minio tdb-primary "$minio_ip"
+
+    # promote a replica while the primary is isolated and oblivious
+    check "promote replica-0" "$(kexec tdb-replica-0 PROMOTE)" "OK 2"
+
+    # the isolated primary keeps taking writes: they commit locally but cannot reach the bucket
+    # (each blocks on the WAL-upload retry, so keep the count small)
+    kbulk_put tdb-primary 1 3 q
+
+    # heal the partition; the primary's next publish must fail the lease renew and self-demote
+    heal_partition tdb-primary "$minio_ip"
+    kexec tdb-primary FLUSH >/dev/null
+    sleep 2
+    check "reconnected primary self-demoted" "$(kstat_field tdb-primary replica_mode)" 1
+    check "isolated writes never won" "$(kverify tdb-replica-0 1 3 q)" 0
+    check "baseline preserved" "$(kverify tdb-replica-0 1 50 p)" 50
+}
+
 echo "Applying MinIO..."
 kubectl apply -f "$K8S_DIR/minio.yaml" >/dev/null
 kubectl rollout status deploy/minio --timeout=180s >/dev/null
@@ -177,6 +214,7 @@ scenario_fanout_converge
 scenario_failover_refollow
 scenario_zombie_fence
 scenario_cascading_failover
+scenario_partition_zombie
 
 echo
 if [ "$fail" -eq 0 ]; then echo "ALL K8S FAILOVER SCENARIOS PASSED"; else echo "K8S FAILOVER SCENARIOS FAILED"; fi

--- a/test/failover/run_local.sh
+++ b/test/failover/run_local.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+#
+# local cross-process failover smoke test for the object-store single-writer fence.
+# starts real tidesdb_node processes against a shared filesystem bucket (the fs backend uses
+# flock, so the fence works across processes on one host) and drives two scenarios:
+#
+#   failover_catchup -- the replica is given a huge sync interval so it never polls; all of the
+#                       outgoing primary's data must arrive via the promotion catch-up. proves the
+#                       catch-up gates on the outgoing epoch (the ordering fix) rather than
+#                       skipping it as stale. writes enough through a small write buffer to build
+#                       many sstables and WAL generations.
+#   zombie_fence     -- after a replica is promoted, the old primary keeps writing. its next
+#                       publish must fail the lease renew and self-demote, and its post-promotion
+#                       writes must never appear on the new primary.
+#
+# this is the same node binary the kind + minio harness runs in pods; here it is a fast,
+# dependency-free smoke. requires bash with /dev/tcp.
+set -u
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+NODE="${TDB_NODE_BIN:-$ROOT/build-rel/tidesdb_node}"
+LIBDIR="${TDB_NODE_LIBDIR:-$ROOT/build-rel}"
+SCRATCH="${TDB_FAILOVER_SCRATCH:-$ROOT/test/failover/.scratch}"
+WRITE_BUFFER="${TDB_NODE_WRITE_BUFFER:-65536}"
+VOLUME="${TDB_FAILOVER_VOLUME:-600}"
+FLUSH_EVERY=150
+PORT_P=7401
+PORT_R=7402
+
+fail=0
+pids=()
+
+cleanup() {
+    for p in "${pids[@]:-}"; do kill -9 "$p" 2>/dev/null; done
+    wait 2>/dev/null
+}
+
+# always remove everything the run created. set TDB_FAILOVER_KEEP=1 to keep the scratch
+# dir (data, buckets, logs) for debugging.
+on_exit() {
+    cleanup
+    [ -n "${TDB_FAILOVER_KEEP:-}" ] || rm -rf "$SCRATCH"
+}
+trap on_exit EXIT
+
+cmd() { # cmd port "LINE" -> single reply line
+    local port=$1 line=$2 resp=""
+    exec 3<>"/dev/tcp/127.0.0.1/$port" 2>/dev/null || { echo "DOWN"; return 1; }
+    printf '%s\n' "$line" >&3
+    IFS= read -r resp <&3
+    exec 3>&- 3<&-
+    printf '%s' "${resp%$'\r'}"
+}
+
+bulk_put() { # bulk_put port start end prefix -- pipelined over one connection
+    local port=$1 start=$2 end=$3 pre=$4 i
+    exec 3<>"/dev/tcp/127.0.0.1/$port" 2>/dev/null || return 1
+    for ((i = start; i <= end; i++)); do printf 'PUT %s%d v%d\n' "$pre" "$i" "$i" >&3; done
+    for ((i = start; i <= end; i++)); do IFS= read -r _ <&3; done
+    exec 3>&- 3<&-
+}
+
+verify_range() { # verify_range port start end prefix -> count of correct values
+    local port=$1 start=$2 end=$3 pre=$4 i n=0 resp
+    exec 3<>"/dev/tcp/127.0.0.1/$port" 2>/dev/null || { echo 0; return; }
+    for ((i = start; i <= end; i++)); do printf 'GET %s%d\n' "$pre" "$i" >&3; done
+    for ((i = start; i <= end; i++)); do
+        IFS= read -r resp <&3
+        [ "${resp%$'\r'}" = "VAL v$i" ] && n=$((n + 1))
+    done
+    exec 3>&- 3<&-
+    echo "$n"
+}
+
+# write [start,end] in batches, flushing every FLUSH_EVERY keys to roll memtables into sstables
+load_volume() {
+    local port=$1 start=$2 end=$3 pre=$4 b
+    for ((b = start; b <= end; b += FLUSH_EVERY)); do
+        local e=$((b + FLUSH_EVERY - 1)); [ "$e" -gt "$end" ] && e=$end
+        bulk_put "$port" "$b" "$e" "$pre"
+        cmd "$port" FLUSH >/dev/null
+    done
+}
+
+stat_field() { cmd "$1" STAT | grep -o "$2=[0-9]*" | cut -d= -f2; }
+
+wait_ready() {
+    local port=$1 i
+    for i in $(seq 1 50); do
+        [ "$(cmd "$port" PING 2>/dev/null)" = "PONG" ] && return 0
+        sleep 0.2
+    done
+    return 1
+}
+
+wait_val() {
+    local port=$1 key=$2 want=$3 i
+    for i in $(seq 1 100); do
+        [ "$(cmd "$port" "GET $key")" = "VAL $want" ] && return 0
+        sleep 0.2
+    done
+    return 1
+}
+
+start_node() { # start_node port replica data_dir bucket sync_us id [wal_sync_on_commit]
+    # wal_sync defaults off: the failover/zombie scenarios get durability from flushed sstables +
+    # the fenced manifest, so they avoid a synchronous WAL upload per put. the rpo_zero scenario
+    # passes 1 to require that acked-but-unflushed writes reach the bucket and survive a crash.
+    local wal_sync="${7:-0}"
+    LD_LIBRARY_PATH="$LIBDIR" TDB_NODE_PORT="$1" TDB_NODE_REPLICA="$2" TDB_NODE_DATA_DIR="$3" \
+        TDB_NODE_BUCKET="$4" TDB_NODE_REPLICA_SYNC_US="$5" TDB_NODE_ID="$6" \
+        TDB_NODE_WAL_SYNC_ON_COMMIT="$wal_sync" TDB_NODE_WRITE_BUFFER="$WRITE_BUFFER" \
+        "$NODE" >"$SCRATCH/$6.log" 2>&1 &
+    pids+=("$!")
+}
+
+check() { # check label actual expected
+    if [ "$2" = "$3" ]; then echo "  ok   $1"; else echo "  FAIL $1: got [$2] want [$3]"; fail=1; fi
+}
+check_ge() { # check_ge label actual min
+    if [ "$2" -ge "$3" ] 2>/dev/null; then echo "  ok   $1 ($2)"; else echo "  FAIL $1: got [$2] want >= [$3]"; fail=1; fi
+}
+
+scenario_failover_catchup() {
+    echo "== scenario failover_catchup (volume=$VOLUME) =="
+    local bucket="$SCRATCH/fc_bucket" dp="$SCRATCH/fc_p" dr="$SCRATCH/fc_r"
+    rm -rf "$bucket" "$dp" "$dr"; mkdir -p "$bucket" "$dp" "$dr"
+    pids=()
+
+    start_node "$PORT_P" 0 "$dp" "$bucket" 500000 fc_primary
+    # replica with a 1h sync interval: it must rely on the promotion catch-up, not polling
+    start_node "$PORT_R" 1 "$dr" "$bucket" 3600000000 fc_replica
+    wait_ready "$PORT_P" || { echo "  FAIL primary not ready"; fail=1; return; }
+    wait_ready "$PORT_R" || { echo "  FAIL replica not ready"; fail=1; return; }
+
+    load_volume "$PORT_P" 1 "$VOLUME" k
+
+    check_ge "primary built many sstables" "$(stat_field "$PORT_P" sstables)" 2
+    check_ge "primary rolled many wal generations" "$(stat_field "$PORT_P" walgen)" 3
+    check_ge "primary holds a lease" "$(stat_field "$PORT_P" primary_epoch)" 1
+
+    # the replica never polled (huge interval), so it should have none of the data
+    check "replica behind before failover" "$(verify_range "$PORT_R" 1 "$VOLUME" k)" 0
+
+    kill -9 "${pids[0]}" 2>/dev/null
+    check "promote replica" "$(cmd "$PORT_R" PROMOTE)" "OK 2"
+
+    # every write must have arrived via the promotion catch-up (the ordering fix)
+    check "all keys present after catch-up" "$(verify_range "$PORT_R" 1 "$VOLUME" k)" "$VOLUME"
+    check "new primary mode" "$(stat_field "$PORT_R" replica_mode)" 0
+    cleanup; pids=()
+}
+
+scenario_zombie_fence() {
+    echo "== scenario zombie_fence (volume=$VOLUME) =="
+    local bucket="$SCRATCH/zf_bucket" dp="$SCRATCH/zf_p" dr="$SCRATCH/zf_r"
+    rm -rf "$bucket" "$dp" "$dr"; mkdir -p "$bucket" "$dp" "$dr"
+    pids=()
+
+    start_node "$PORT_P" 0 "$dp" "$bucket" 300000 zf_primary
+    start_node "$PORT_R" 1 "$dr" "$bucket" 300000 zf_replica
+    wait_ready "$PORT_P" || { echo "  FAIL primary not ready"; fail=1; return; }
+    wait_ready "$PORT_R" || { echo "  FAIL replica not ready"; fail=1; return; }
+
+    load_volume "$PORT_P" 1 "$VOLUME" a
+    check_ge "primary built many sstables" "$(stat_field "$PORT_P" sstables)" 2
+    wait_val "$PORT_R" "a$VOLUME" "v$VOLUME" || { echo "  FAIL replica did not converge"; fail=1; cleanup; return; }
+
+    # promote the replica while the old primary stays alive (the zombie)
+    check "promote replica" "$(cmd "$PORT_R" PROMOTE)" "OK 2"
+
+    # the zombie keeps writing, then publishes -- the publish must fence it and self-demote
+    bulk_put "$PORT_P" 1 200 z
+    cmd "$PORT_P" FLUSH >/dev/null
+    sleep 0.5
+    check "zombie self-demoted" "$(stat_field "$PORT_P" replica_mode)" 1
+
+    # the new primary takes writes; zombie writes must never appear on it
+    load_volume "$PORT_R" 1 200 b
+
+    check "pre-failover data preserved" "$(verify_range "$PORT_R" 1 "$VOLUME" a)" "$VOLUME"
+    check "new primary writes visible" "$(verify_range "$PORT_R" 1 200 b)" 200
+    check "zombie writes fenced out" "$(verify_range "$PORT_R" 1 200 z)" 0
+    cleanup; pids=()
+}
+
+scenario_rpo_zero() {
+    echo "== scenario rpo_zero =="
+    local bucket="$SCRATCH/rz_bucket" dp="$SCRATCH/rz_p" dr="$SCRATCH/rz_r"
+    rm -rf "$bucket" "$dp" "$dr"; mkdir -p "$bucket" "$dp" "$dr"
+    pids=()
+
+    # a write buffer just large enough to hold the unflushed batch without auto-rotating it (the
+    # small volume-scenario buffer would flush it and defeat the premise), but not so large that
+    # wal_sync_on_commit's per-commit re-upload of the active WAL copies megabytes each time
+    local WRITE_BUFFER=262144
+
+    # both nodes run wal_sync_on_commit=1, so every committed write is uploaded to the bucket.
+    # the replica gets a 1h sync interval, so the unflushed writes can only reach it via the
+    # promotion catch-up's WAL replay -- proving they were durable, not merely still local.
+    start_node "$PORT_P" 0 "$dp" "$bucket" 500000 rz_primary 1
+    start_node "$PORT_R" 1 "$dr" "$bucket" 3600000000 rz_replica 1
+    wait_ready "$PORT_P" || { echo "  FAIL primary not ready"; fail=1; return; }
+    wait_ready "$PORT_R" || { echo "  FAIL replica not ready"; fail=1; return; }
+
+    # flushed baseline so the CF, config and a manifest exist in the bucket
+    bulk_put "$PORT_P" 1 20 base
+    check "baseline flush" "$(cmd "$PORT_P" FLUSH)" "OK"
+
+    # acked writes that are committed but never flushed -- they live only in the WAL, which
+    # wal_sync_on_commit uploads to the bucket per commit. a modest count keeps the run quick:
+    # each RPO=0 commit synchronously ships the WAL, which is inherently a few-per-second operation
+    bulk_put "$PORT_P" 1 40 rpo
+
+    # hard-kill the primary with no chance to flush, simulating a crash
+    kill -9 "${pids[0]}" 2>/dev/null
+    check "promote replica" "$(cmd "$PORT_R" PROMOTE)" "OK 2"
+
+    # RPO=0: the unflushed-but-acked writes must survive via WAL replay in the catch-up
+    check "unflushed acked writes survived (rpo=0)" "$(verify_range "$PORT_R" 1 40 rpo)" 40
+    check "baseline preserved" "$(verify_range "$PORT_R" 1 20 base)" 20
+    cleanup; pids=()
+}
+
+mkdir -p "$SCRATCH"
+[ -x "$NODE" ] || { echo "node binary not found at $NODE (build it first)"; exit 2; }
+
+scenario_failover_catchup
+scenario_zombie_fence
+scenario_rpo_zero
+
+echo
+if [ "$fail" -eq 0 ]; then echo "ALL FAILOVER SCENARIOS PASSED"; else echo "FAILOVER SCENARIOS FAILED"; fi
+exit "$fail"

--- a/test/failover/tidesdb_node.c
+++ b/test/failover/tidesdb_node.c
@@ -96,10 +96,12 @@ static tidesdb_objstore_t *node_make_store(void)
 #ifdef TIDESDB_WITH_S3
     if (strcmp(backend, "s3") == 0)
     {
-        return tidesdb_objstore_s3_create(env_or("TIDESDB_S3_ENDPOINT", "localhost:9000"),
-                                          env_or("TIDESDB_S3_BUCKET", "tidesdb-test"), "",
-                                          env_or("TIDESDB_S3_ACCESS_KEY", "minioadmin"),
-                                          env_or("TIDESDB_S3_SECRET_KEY", "minioadmin"), 0, 1);
+        return tidesdb_objstore_s3_create(
+            env_or("TIDESDB_S3_ENDPOINT", "localhost:9000"),
+            env_or("TIDESDB_S3_BUCKET", "tidesdb-test"), "" /* prefix */,
+            env_or("TIDESDB_S3_ACCESS_KEY", "minioadmin"),
+            env_or("TIDESDB_S3_SECRET_KEY", "minioadmin"), env_or("TIDESDB_S3_REGION", "us-east-1"),
+            0 /* use_ssl */, 1 /* use_path_style */);
     }
 #endif
     node_log("unsupported TDB_NODE_BACKEND");
@@ -151,8 +153,8 @@ static int node_open(void)
 static void reply(int fd, const char *s)
 {
     size_t len = strlen(s);
-    (void)write(fd, s, len);
-    (void)write(fd, "\n", 1);
+    /* use the result so warn_unused_result is satisfied; a dead client is fine to ignore */
+    if (write(fd, s, len) < 0 || write(fd, "\n", 1) < 0) return;
 }
 
 static void handle_put(int fd, char *args)

--- a/test/failover/tidesdb_node.c
+++ b/test/failover/tidesdb_node.c
@@ -1,0 +1,460 @@
+/**
+ *
+ * Copyright (C) TidesDB
+ *
+ * Original Author: Alex Gaetano Padula
+ *
+ * Licensed under the Mozilla Public License, v. 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.mozilla.org/en-US/MPL/2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * tidesdb_node -- a minimal network node wrapping libtidesdb, the unit under test for the
+ * object-store failover harness. one process is one cluster node (primary or replica) pointed
+ * at a shared bucket. it speaks a tiny line protocol over TCP so the scenario driver can write,
+ * read, promote, flush, and inspect lease state without pulling in a full server.
+ *
+ * line protocol (one request per line, one reply line):
+ *   PING                -> PONG
+ *   PUT <key> <value>   -> OK | ERR <code>          (value is the rest of the line)
+ *   GET <key>           -> VAL <value> | NF | ERR <code>
+ *   DEL <key>           -> OK | ERR <code>
+ *   FLUSH               -> OK | ERR <code>          (flush + compact, forces a manifest publish)
+ *   PROMOTE             -> OK <epoch> | ERR <code>
+ *   STAT                -> replica_mode=<0|1> primary_epoch=<n> fencing=<0|1> seq=<n>
+ *   QUIT                -> closes the connection
+ *
+ * configuration is via environment:
+ *   TDB_NODE_PORT                 TCP listen port (required)
+ *   TDB_NODE_DATA_DIR             local data directory (required)
+ *   TDB_NODE_BUCKET               FS bucket directory (required for the fs backend)
+ *   TDB_NODE_BACKEND              fs (default) | s3
+ *   TDB_NODE_REPLICA              0 primary (default) | 1 replica
+ *   TDB_NODE_CF                   column family name (default "data")
+ *   TDB_NODE_WAL_SYNC_ON_COMMIT   0 | 1 (default 1, RPO=0)
+ *   TDB_NODE_REPLICA_SYNC_US      replica poll interval (default 500000)
+ *   TDB_NODE_ID                   label used in log lines (default the port)
+ * for the s3 backend: TIDESDB_S3_ENDPOINT, TIDESDB_S3_BUCKET, TIDESDB_S3_ACCESS_KEY,
+ * TIDESDB_S3_SECRET_KEY (matching the existing object-store CI workflow).
+ */
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "objstore.h"
+#include "tidesdb.h"
+
+#define NODE_LINE_MAX (64 * 1024)
+
+static tidesdb_t *g_db = NULL;
+static const char *g_cf_name = "data";
+static const char *g_node_id = "node";
+static volatile sig_atomic_t g_running = 1;
+
+static void node_log(const char *msg)
+{
+    fprintf(stderr, "[node %s] %s\n", g_node_id, msg);
+    fflush(stderr);
+}
+
+static const char *env_or(const char *name, const char *fallback)
+{
+    const char *v = getenv(name);
+    return (v && v[0]) ? v : fallback;
+}
+
+/* build the object store connector from the environment, or NULL on misconfiguration */
+static tidesdb_objstore_t *node_make_store(void)
+{
+    const char *backend = env_or("TDB_NODE_BACKEND", "fs");
+    if (strcmp(backend, "fs") == 0)
+    {
+        const char *bucket = getenv("TDB_NODE_BUCKET");
+        if (!bucket || !bucket[0])
+        {
+            node_log("TDB_NODE_BUCKET is required for the fs backend");
+            return NULL;
+        }
+        return tidesdb_objstore_fs_create(bucket);
+    }
+#ifdef TIDESDB_WITH_S3
+    if (strcmp(backend, "s3") == 0)
+    {
+        return tidesdb_objstore_s3_create(env_or("TIDESDB_S3_ENDPOINT", "localhost:9000"),
+                                          env_or("TIDESDB_S3_BUCKET", "tidesdb-test"), "",
+                                          env_or("TIDESDB_S3_ACCESS_KEY", "minioadmin"),
+                                          env_or("TIDESDB_S3_SECRET_KEY", "minioadmin"), 0, 1);
+    }
+#endif
+    node_log("unsupported TDB_NODE_BACKEND");
+    return NULL;
+}
+
+/* open the database and ensure the column family exists (a fresh primary creates it; a replica
+ * lets cold-start discovery pull it from the bucket, so a missing CF is not fatal there) */
+static int node_open(void)
+{
+    tidesdb_objstore_t *store = node_make_store();
+    if (!store) return -1;
+
+    int replica = atoi(env_or("TDB_NODE_REPLICA", "0"));
+
+    static tidesdb_objstore_config_t os_cfg;
+    os_cfg = tidesdb_objstore_default_config();
+    os_cfg.replica_mode = replica;
+    os_cfg.replicate_wal = 1;
+    os_cfg.wal_sync_on_commit = atoi(env_or("TDB_NODE_WAL_SYNC_ON_COMMIT", "1"));
+    os_cfg.replica_sync_interval_us =
+        (uint64_t)strtoull(env_or("TDB_NODE_REPLICA_SYNC_US", "500000"), NULL, 10);
+
+    tidesdb_config_t config = tidesdb_default_config();
+    config.db_path = (char *)getenv("TDB_NODE_DATA_DIR");
+    config.object_store = store;
+    config.object_store_config = &os_cfg;
+
+    /* a small write buffer lets a modest test workload roll over many memtables, so the bucket
+     * accrues many sstables and WAL generations to fence and replay (0 = library default) */
+    size_t wb = (size_t)strtoull(env_or("TDB_NODE_WRITE_BUFFER", "0"), NULL, 10);
+    if (wb > 0) config.unified_memtable_write_buffer_size = wb;
+
+    if (tidesdb_open(&config, &g_db) != 0)
+    {
+        node_log("tidesdb_open failed");
+        return -1;
+    }
+
+    if (!replica)
+    {
+        tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
+        if (tidesdb_get_column_family(g_db, g_cf_name) == NULL)
+            tidesdb_create_column_family(g_db, g_cf_name, &cf_config);
+    }
+    return 0;
+}
+
+static void reply(int fd, const char *s)
+{
+    size_t len = strlen(s);
+    (void)write(fd, s, len);
+    (void)write(fd, "\n", 1);
+}
+
+static void handle_put(int fd, char *args)
+{
+    char *sp = strchr(args, ' ');
+    if (!sp)
+    {
+        reply(fd, "ERR -2");
+        return;
+    }
+    *sp = '\0';
+    const char *key = args;
+    const char *val = sp + 1;
+
+    tidesdb_column_family_t *cf = tidesdb_get_column_family(g_db, g_cf_name);
+    if (!cf)
+    {
+        reply(fd, "ERR -3");
+        return;
+    }
+
+    tidesdb_txn_t *txn = NULL;
+    if (tidesdb_txn_begin(g_db, &txn) != 0)
+    {
+        reply(fd, "ERR -11");
+        return;
+    }
+    int rc = tidesdb_txn_put(txn, cf, (const uint8_t *)key, strlen(key) + 1, (const uint8_t *)val,
+                             strlen(val) + 1, 0);
+    if (rc == 0) rc = tidesdb_txn_commit(txn);
+    tidesdb_txn_free(txn);
+
+    if (rc == 0)
+        reply(fd, "OK");
+    else
+    {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "ERR %d", rc);
+        reply(fd, buf);
+    }
+}
+
+static void handle_get(int fd, const char *key)
+{
+    tidesdb_column_family_t *cf = tidesdb_get_column_family(g_db, g_cf_name);
+    if (!cf)
+    {
+        reply(fd, "ERR -3");
+        return;
+    }
+
+    tidesdb_txn_t *txn = NULL;
+    if (tidesdb_txn_begin(g_db, &txn) != 0)
+    {
+        reply(fd, "ERR -11");
+        return;
+    }
+    uint8_t *val = NULL;
+    size_t val_size = 0;
+    int rc = tidesdb_txn_get(txn, cf, (const uint8_t *)key, strlen(key) + 1, &val, &val_size);
+    tidesdb_txn_free(txn);
+
+    if (rc == 0 && val)
+    {
+        char *line = malloc(val_size + 8);
+        if (line)
+        {
+            snprintf(line, val_size + 8, "VAL %s", (char *)val);
+            reply(fd, line);
+            free(line);
+        }
+        else
+            reply(fd, "ERR -1");
+        free(val);
+    }
+    else if (rc == TDB_ERR_NOT_FOUND)
+        reply(fd, "NF");
+    else
+    {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "ERR %d", rc);
+        reply(fd, buf);
+    }
+}
+
+static void handle_del(int fd, const char *key)
+{
+    tidesdb_column_family_t *cf = tidesdb_get_column_family(g_db, g_cf_name);
+    if (!cf)
+    {
+        reply(fd, "ERR -3");
+        return;
+    }
+    tidesdb_txn_t *txn = NULL;
+    if (tidesdb_txn_begin(g_db, &txn) != 0)
+    {
+        reply(fd, "ERR -11");
+        return;
+    }
+    int rc = tidesdb_txn_delete(txn, cf, (const uint8_t *)key, strlen(key) + 1);
+    if (rc == 0) rc = tidesdb_txn_commit(txn);
+    tidesdb_txn_free(txn);
+
+    if (rc == 0)
+        reply(fd, "OK");
+    else
+    {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "ERR %d", rc);
+        reply(fd, buf);
+    }
+}
+
+/* flush the memtable into a new sstable, which also publishes the fenced manifest. compaction is
+ * left to the background engine -- forcing a full compact here only slows the harness. */
+static void handle_flush(int fd)
+{
+    tidesdb_column_family_t *cf = tidesdb_get_column_family(g_db, g_cf_name);
+    if (!cf)
+    {
+        reply(fd, "ERR -3");
+        return;
+    }
+    int rc = tidesdb_flush_memtable(cf);
+    if (rc == 0)
+        reply(fd, "OK");
+    else
+    {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "ERR %d", rc);
+        reply(fd, buf);
+    }
+}
+
+static void handle_promote(int fd)
+{
+    int rc = tidesdb_promote_to_primary(g_db);
+    if (rc == 0)
+    {
+        /* a promoted node creates the CF locally if cold-start has not surfaced it yet */
+        tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
+        if (tidesdb_get_column_family(g_db, g_cf_name) == NULL)
+            tidesdb_create_column_family(g_db, g_cf_name, &cf_config);
+
+        tidesdb_db_stats_t st;
+        char buf[64];
+        if (tidesdb_get_db_stats(g_db, &st) == 0)
+            snprintf(buf, sizeof(buf), "OK %llu", (unsigned long long)st.primary_epoch);
+        else
+            snprintf(buf, sizeof(buf), "OK 0");
+        reply(fd, buf);
+    }
+    else
+    {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "ERR %d", rc);
+        reply(fd, buf);
+    }
+}
+
+static void handle_stat(int fd)
+{
+    tidesdb_db_stats_t st;
+    if (tidesdb_get_db_stats(g_db, &st) != 0)
+    {
+        reply(fd, "ERR -1");
+        return;
+    }
+    char buf[192];
+    snprintf(buf, sizeof(buf),
+             "replica_mode=%d primary_epoch=%llu seq=%llu sstables=%d walgen=%llu", st.replica_mode,
+             (unsigned long long)st.primary_epoch, (unsigned long long)st.global_seq,
+             st.total_sstable_count, (unsigned long long)st.unified_wal_generation);
+    reply(fd, buf);
+}
+
+static void *conn_thread(void *arg)
+{
+    int fd = (int)(intptr_t)arg;
+    char *line = malloc(NODE_LINE_MAX);
+    if (!line)
+    {
+        close(fd);
+        return NULL;
+    }
+
+    size_t used = 0;
+    char rbuf[4096];
+    for (;;)
+    {
+        ssize_t n = read(fd, rbuf, sizeof(rbuf));
+        if (n <= 0) break;
+        for (ssize_t i = 0; i < n; i++)
+        {
+            char c = rbuf[i];
+            if (c == '\n' || used == NODE_LINE_MAX - 1)
+            {
+                line[used] = '\0';
+                used = 0;
+
+                /* strip a trailing CR so CRLF clients work */
+                size_t L = strlen(line);
+                if (L && line[L - 1] == '\r') line[L - 1] = '\0';
+
+                char *args = strchr(line, ' ');
+                if (args) *args++ = '\0';
+
+                if (strcmp(line, "PING") == 0)
+                    reply(fd, "PONG");
+                else if (strcmp(line, "PUT") == 0 && args)
+                    handle_put(fd, args);
+                else if (strcmp(line, "GET") == 0 && args)
+                    handle_get(fd, args);
+                else if (strcmp(line, "DEL") == 0 && args)
+                    handle_del(fd, args);
+                else if (strcmp(line, "FLUSH") == 0)
+                    handle_flush(fd);
+                else if (strcmp(line, "PROMOTE") == 0)
+                    handle_promote(fd);
+                else if (strcmp(line, "STAT") == 0)
+                    handle_stat(fd);
+                else if (strcmp(line, "QUIT") == 0)
+                    goto done;
+                else
+                    reply(fd, "ERR -2");
+            }
+            else if (c != '\r')
+            {
+                line[used++] = c;
+            }
+        }
+    }
+done:
+    free(line);
+    close(fd);
+    return NULL;
+}
+
+static void on_signal(int sig)
+{
+    (void)sig;
+    g_running = 0;
+}
+
+int main(void)
+{
+    signal(SIGPIPE, SIG_IGN);
+    signal(SIGINT, on_signal);
+    signal(SIGTERM, on_signal);
+
+    g_cf_name = env_or("TDB_NODE_CF", "data");
+    const char *port_s = getenv("TDB_NODE_PORT");
+    if (!port_s)
+    {
+        fprintf(stderr, "TDB_NODE_PORT is required\n");
+        return 2;
+    }
+    g_node_id = env_or("TDB_NODE_ID", port_s);
+
+    if (node_open() != 0) return 1;
+    node_log("opened");
+
+    int srv = socket(AF_INET, SOCK_STREAM, 0);
+    if (srv < 0)
+    {
+        node_log("socket failed");
+        return 1;
+    }
+    int yes = 1;
+    setsockopt(srv, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
+
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = INADDR_ANY;
+    addr.sin_port = htons((uint16_t)atoi(port_s));
+
+    if (bind(srv, (struct sockaddr *)&addr, sizeof(addr)) != 0)
+    {
+        node_log("bind failed");
+        return 1;
+    }
+    if (listen(srv, 64) != 0)
+    {
+        node_log("listen failed");
+        return 1;
+    }
+    node_log("listening");
+
+    while (g_running)
+    {
+        int fd = accept(srv, NULL, NULL);
+        if (fd < 0) continue;
+        pthread_t t;
+        if (pthread_create(&t, NULL, conn_thread, (void *)(intptr_t)fd) == 0)
+            pthread_detach(t);
+        else
+            close(fd);
+    }
+
+    close(srv);
+    tidesdb_close(g_db);
+    node_log("closed");
+    return 0;
+}

--- a/test/failover/tidesdb_node.c
+++ b/test/failover/tidesdb_node.c
@@ -28,9 +28,9 @@
  *   PUT <key> <value>   -> OK | ERR <code>          (value is the rest of the line)
  *   GET <key>           -> VAL <value> | NF | ERR <code>
  *   DEL <key>           -> OK | ERR <code>
- *   FLUSH               -> OK | ERR <code>          (flush + compact, forces a manifest publish)
+ *   FLUSH               -> OK | ERR <code>          (flush the memtable, publishing a manifest)
  *   PROMOTE             -> OK <epoch> | ERR <code>
- *   STAT                -> replica_mode=<0|1> primary_epoch=<n> fencing=<0|1> seq=<n>
+ *   STAT                -> replica_mode=<0|1> primary_epoch=<n> seq=<n> sstables=<n> walgen=<n>
  *   QUIT                -> closes the connection
  *
  * configuration is via environment:

--- a/test/objstore__tests.c
+++ b/test/objstore__tests.c
@@ -385,6 +385,13 @@ void test_objstore_fs_put_if_head_fence(void)
     ASSERT_EQ(store->put_if(store->ctx, key, body, TDB_PUT_IF_MATCH, etag1, 1, NULL, 0),
               TDB_ERR_PRECONDITION);
 
+    /* delete clears the sidecars, so a create-only on the same key succeeds again */
+    ASSERT_EQ(store->delete_object(store->ctx, key), 0);
+    ASSERT_EQ(store->head(store->ctx, key, NULL, 0, &epoch), 0);
+    ASSERT_EQ(store->put_if(store->ctx, key, body, TDB_PUT_IF_NONE_MATCH, NULL, 7, NULL, 0), 0);
+    ASSERT_EQ(store->head(store->ctx, key, NULL, 0, &epoch), 1);
+    ASSERT_EQ((int)epoch, 7);
+
     store->destroy(store->ctx);
     free(store);
     cleanup_dirs();

--- a/test/objstore__tests.c
+++ b/test/objstore__tests.c
@@ -323,6 +323,103 @@ void test_objstore_fs_overwrite(void)
     cleanup_dirs();
 }
 
+/* the conditional-put + head primitives that single-writer fencing rests on:
+ * create-only, If-Match success/failure, and epoch metadata readback */
+void test_objstore_fs_put_if_head_fence(void)
+{
+    cleanup_dirs();
+    mkdir(TEST_OBJSTORE_DIR2, 0755);
+
+    tidesdb_objstore_t *store = tidesdb_objstore_fs_create(TEST_OBJSTORE_DIR);
+    ASSERT_TRUE(store != NULL);
+    ASSERT_TRUE(store->put_if != NULL);
+    ASSERT_TRUE(store->head != NULL);
+
+    char body[256];
+    snprintf(body, sizeof(body), "%s" PATH_SEPARATOR "lease_body.dat", TEST_OBJSTORE_DIR2);
+    create_test_file(body, "epoch1", 6);
+
+    const char *key = "_tdb_primary_lease";
+
+    /* head on a missing object reports absence with empty etag and epoch 0 */
+    char etag[TDB_OBJSTORE_ETAG_MAX];
+    uint64_t epoch = 12345;
+    snprintf(etag, sizeof(etag), "sentinel");
+    ASSERT_EQ(store->head(store->ctx, key, etag, sizeof(etag), &epoch), 0);
+    ASSERT_EQ(etag[0], '\0');
+    ASSERT_EQ((int)epoch, 0);
+
+    /* create-only succeeds on an absent key, stamps epoch 1, returns a non-empty etag */
+    char etag1[TDB_OBJSTORE_ETAG_MAX] = {0};
+    ASSERT_EQ(
+        store->put_if(store->ctx, key, body, TDB_PUT_IF_NONE_MATCH, NULL, 1, etag1, sizeof(etag1)),
+        0);
+    ASSERT_TRUE(etag1[0] != '\0');
+
+    /* create-only on an existing key fails the precondition */
+    ASSERT_EQ(store->put_if(store->ctx, key, body, TDB_PUT_IF_NONE_MATCH, NULL, 2, NULL, 0),
+              TDB_ERR_PRECONDITION);
+
+    /* head returns the stored etag + epoch */
+    ASSERT_EQ(store->head(store->ctx, key, etag, sizeof(etag), &epoch), 1);
+    ASSERT_EQ(strcmp(etag, etag1), 0);
+    ASSERT_EQ((int)epoch, 1);
+
+    /* If-Match with a stale etag fails and leaves the object untouched */
+    ASSERT_EQ(store->put_if(store->ctx, key, body, TDB_PUT_IF_MATCH, "stale", 9, NULL, 0),
+              TDB_ERR_PRECONDITION);
+    ASSERT_EQ(store->head(store->ctx, key, etag, sizeof(etag), &epoch), 1);
+    ASSERT_EQ(strcmp(etag, etag1), 0);
+    ASSERT_EQ((int)epoch, 1);
+
+    /* If-Match with the current etag succeeds, advances the epoch, and rotates the etag */
+    char etag2[TDB_OBJSTORE_ETAG_MAX] = {0};
+    ASSERT_EQ(
+        store->put_if(store->ctx, key, body, TDB_PUT_IF_MATCH, etag1, 2, etag2, sizeof(etag2)), 0);
+    ASSERT_TRUE(strcmp(etag2, etag1) != 0);
+    ASSERT_EQ(store->head(store->ctx, key, etag, sizeof(etag), &epoch), 1);
+    ASSERT_EQ(strcmp(etag, etag2), 0);
+    ASSERT_EQ((int)epoch, 2);
+
+    /* the superseded holder's old etag is now stale -- its renew is fenced out */
+    ASSERT_EQ(store->put_if(store->ctx, key, body, TDB_PUT_IF_MATCH, etag1, 1, NULL, 0),
+              TDB_ERR_PRECONDITION);
+
+    store->destroy(store->ctx);
+    free(store);
+    cleanup_dirs();
+}
+
+/* the fence sidecars must stay invisible to list() so manifest/WAL discovery is unaffected */
+void test_objstore_fs_put_if_sidecars_hidden(void)
+{
+    cleanup_dirs();
+    mkdir(TEST_OBJSTORE_DIR2, 0755);
+
+    tidesdb_objstore_t *store = tidesdb_objstore_fs_create(TEST_OBJSTORE_DIR);
+    ASSERT_TRUE(store != NULL);
+
+    char body[256];
+    snprintf(body, sizeof(body), "%s" PATH_SEPARATOR "obj.dat", TEST_OBJSTORE_DIR2);
+    create_test_file(body, "data", 4);
+
+    /* a fenced (epoch-tagged) put writes etag/epoch sidecars under the hood */
+    ASSERT_EQ(store->put_if(store->ctx, "cf/MANIFEST", body, TDB_PUT_OVERWRITE, NULL, 5, NULL, 0),
+              0);
+
+    /* list under the data prefix sees exactly the one object, not its sidecars */
+    list_ctx_t lctx;
+    memset(&lctx, 0, sizeof(lctx));
+    int n = store->list(store->ctx, "cf/", list_callback, &lctx);
+    ASSERT_EQ(n, 1);
+    ASSERT_EQ(lctx.count, 1);
+    ASSERT_EQ(strcmp(lctx.keys[0], "cf/MANIFEST"), 0);
+
+    store->destroy(store->ctx);
+    free(store);
+    cleanup_dirs();
+}
+
 void test_objstore_fs_nested_keys(void)
 {
     cleanup_dirs();
@@ -511,6 +608,8 @@ int main(int argc, char **argv)
     RUN_TEST(test_objstore_fs_list, tests_passed);
     RUN_TEST(test_objstore_fs_put_get_nonexistent, tests_passed);
     RUN_TEST(test_objstore_fs_overwrite, tests_passed);
+    RUN_TEST(test_objstore_fs_put_if_head_fence, tests_passed);
+    RUN_TEST(test_objstore_fs_put_if_sidecars_hidden, tests_passed);
     RUN_TEST(test_objstore_fs_nested_keys, tests_passed);
 #ifdef TIDESDB_WITH_S3
     RUN_TEST(test_objstore_s3_create_config, tests_passed);

--- a/test/objstore__tests.c
+++ b/test/objstore__tests.c
@@ -351,13 +351,13 @@ void test_objstore_fs_put_if_head_fence(void)
 
     /* create-only succeeds on an absent key, stamps epoch 1, returns a non-empty etag */
     char etag1[TDB_OBJSTORE_ETAG_MAX] = {0};
-    ASSERT_EQ(
-        store->put_if(store->ctx, key, body, TDB_PUT_IF_NONE_MATCH, NULL, 1, etag1, sizeof(etag1)),
-        0);
+    ASSERT_EQ(store->put_if(store->ctx, key, body, TDB_PUT_IF_NONE_MATCH, NULL, 1, etag1,
+                            sizeof(etag1), 0),
+              0);
     ASSERT_TRUE(etag1[0] != '\0');
 
     /* create-only on an existing key fails the precondition */
-    ASSERT_EQ(store->put_if(store->ctx, key, body, TDB_PUT_IF_NONE_MATCH, NULL, 2, NULL, 0),
+    ASSERT_EQ(store->put_if(store->ctx, key, body, TDB_PUT_IF_NONE_MATCH, NULL, 2, NULL, 0, 0),
               TDB_ERR_PRECONDITION);
 
     /* head returns the stored etag + epoch */
@@ -366,7 +366,7 @@ void test_objstore_fs_put_if_head_fence(void)
     ASSERT_EQ((int)epoch, 1);
 
     /* If-Match with a stale etag fails and leaves the object untouched */
-    ASSERT_EQ(store->put_if(store->ctx, key, body, TDB_PUT_IF_MATCH, "stale", 9, NULL, 0),
+    ASSERT_EQ(store->put_if(store->ctx, key, body, TDB_PUT_IF_MATCH, "stale", 9, NULL, 0, 0),
               TDB_ERR_PRECONDITION);
     ASSERT_EQ(store->head(store->ctx, key, etag, sizeof(etag), &epoch), 1);
     ASSERT_EQ(strcmp(etag, etag1), 0);
@@ -375,20 +375,21 @@ void test_objstore_fs_put_if_head_fence(void)
     /* If-Match with the current etag succeeds, advances the epoch, and rotates the etag */
     char etag2[TDB_OBJSTORE_ETAG_MAX] = {0};
     ASSERT_EQ(
-        store->put_if(store->ctx, key, body, TDB_PUT_IF_MATCH, etag1, 2, etag2, sizeof(etag2)), 0);
+        store->put_if(store->ctx, key, body, TDB_PUT_IF_MATCH, etag1, 2, etag2, sizeof(etag2), 0),
+        0);
     ASSERT_TRUE(strcmp(etag2, etag1) != 0);
     ASSERT_EQ(store->head(store->ctx, key, etag, sizeof(etag), &epoch), 1);
     ASSERT_EQ(strcmp(etag, etag2), 0);
     ASSERT_EQ((int)epoch, 2);
 
     /* the superseded holder's old etag is now stale -- its renew is fenced out */
-    ASSERT_EQ(store->put_if(store->ctx, key, body, TDB_PUT_IF_MATCH, etag1, 1, NULL, 0),
+    ASSERT_EQ(store->put_if(store->ctx, key, body, TDB_PUT_IF_MATCH, etag1, 1, NULL, 0, 0),
               TDB_ERR_PRECONDITION);
 
     /* delete clears the sidecars, so a create-only on the same key succeeds again */
     ASSERT_EQ(store->delete_object(store->ctx, key), 0);
     ASSERT_EQ(store->head(store->ctx, key, NULL, 0, &epoch), 0);
-    ASSERT_EQ(store->put_if(store->ctx, key, body, TDB_PUT_IF_NONE_MATCH, NULL, 7, NULL, 0), 0);
+    ASSERT_EQ(store->put_if(store->ctx, key, body, TDB_PUT_IF_NONE_MATCH, NULL, 7, NULL, 0, 0), 0);
     ASSERT_EQ(store->head(store->ctx, key, NULL, 0, &epoch), 1);
     ASSERT_EQ((int)epoch, 7);
 
@@ -411,8 +412,8 @@ void test_objstore_fs_put_if_sidecars_hidden(void)
     create_test_file(body, "data", 4);
 
     /* a fenced (epoch-tagged) put writes etag/epoch sidecars under the hood */
-    ASSERT_EQ(store->put_if(store->ctx, "cf/MANIFEST", body, TDB_PUT_OVERWRITE, NULL, 5, NULL, 0),
-              0);
+    ASSERT_EQ(
+        store->put_if(store->ctx, "cf/MANIFEST", body, TDB_PUT_OVERWRITE, NULL, 5, NULL, 0, 0), 0);
 
     /* list under the data prefix sees exactly the one object, not its sidecars */
     list_ctx_t lctx;
@@ -421,6 +422,41 @@ void test_objstore_fs_put_if_sidecars_hidden(void)
     ASSERT_EQ(n, 1);
     ASSERT_EQ(lctx.count, 1);
     ASSERT_EQ(strcmp(lctx.keys[0], "cf/MANIFEST"), 0);
+
+    store->destroy(store->ctx);
+    free(store);
+    cleanup_dirs();
+}
+
+/* put_if max_bytes uploads only the logical prefix -- the fix that stops a WAL's preallocated
+ * zero tail from being shipped on every commit */
+void test_objstore_fs_put_if_partial(void)
+{
+    cleanup_dirs();
+    mkdir(TEST_OBJSTORE_DIR2, 0755);
+
+    tidesdb_objstore_t *store = tidesdb_objstore_fs_create(TEST_OBJSTORE_DIR);
+    ASSERT_TRUE(store != NULL);
+
+    /* a 1000-byte source (mimicking a preallocated WAL) of which only 10 bytes are "live" */
+    char body[256];
+    snprintf(body, sizeof(body), "%s" PATH_SEPARATOR "wal.dat", TEST_OBJSTORE_DIR2);
+    char big[1000];
+    memset(big, 'x', sizeof(big));
+    create_test_file(body, big, sizeof(big));
+
+    /* upload only the first 10 bytes */
+    ASSERT_EQ(store->put_if(store->ctx, "cf/wal", body, TDB_PUT_OVERWRITE, NULL, 3, NULL, 0, 10),
+              0);
+
+    size_t size_out = 0;
+    ASSERT_EQ(store->exists(store->ctx, "cf/wal", &size_out), 1);
+    ASSERT_EQ(size_out, 10);
+
+    /* max_bytes 0 ships the whole file */
+    ASSERT_EQ(store->put_if(store->ctx, "cf/wal", body, TDB_PUT_OVERWRITE, NULL, 3, NULL, 0, 0), 0);
+    ASSERT_EQ(store->exists(store->ctx, "cf/wal", &size_out), 1);
+    ASSERT_EQ(size_out, 1000);
 
     store->destroy(store->ctx);
     free(store);
@@ -617,6 +653,7 @@ int main(int argc, char **argv)
     RUN_TEST(test_objstore_fs_overwrite, tests_passed);
     RUN_TEST(test_objstore_fs_put_if_head_fence, tests_passed);
     RUN_TEST(test_objstore_fs_put_if_sidecars_hidden, tests_passed);
+    RUN_TEST(test_objstore_fs_put_if_partial, tests_passed);
     RUN_TEST(test_objstore_fs_nested_keys, tests_passed);
 #ifdef TIDESDB_WITH_S3
     RUN_TEST(test_objstore_s3_create_config, tests_passed);

--- a/test/queue__tests.c
+++ b/test/queue__tests.c
@@ -952,7 +952,7 @@ typedef struct
     queue_t *queue;
     int num_ops;
     int thread_id;
-    struct timespec *start_time;
+    _Atomic int *start_flag;
 } benchmark_producer_args_t;
 
 typedef struct
@@ -967,7 +967,7 @@ static void *benchmark_producer(void *arg)
     benchmark_producer_args_t *args = (benchmark_producer_args_t *)arg;
 
     /* wait for all threads to be ready */
-    while (args->start_time->tv_sec == 0)
+    while (atomic_load(args->start_flag) == 0)
     {
         usleep(100);
     }
@@ -1028,7 +1028,7 @@ void benchmark_queue_concurrent_producers_consumers()
         malloc(num_consumers * sizeof(benchmark_consumer_args_t));
 
     _Atomic int items_consumed = 0;
-    struct timespec start_time = {0, 0};
+    _Atomic int start_flag = 0;
 
     /* create producers */
     for (int i = 0; i < num_producers; i++)
@@ -1036,7 +1036,7 @@ void benchmark_queue_concurrent_producers_consumers()
         producer_args[i].queue = queue;
         producer_args[i].num_ops = ops_per_producer;
         producer_args[i].thread_id = i;
-        producer_args[i].start_time = &start_time;
+        producer_args[i].start_flag = &start_flag;
         pthread_create(&producers[i], NULL, benchmark_producer, &producer_args[i]);
     }
 
@@ -1052,7 +1052,7 @@ void benchmark_queue_concurrent_producers_consumers()
     /* start timing */
     struct timespec start, end;
     clock_gettime(CLOCK_MONOTONIC, &start);
-    start_time = start; /* signal threads to start */
+    atomic_store(&start_flag, 1); /* signal threads to start */
 
     /* wait for all producers */
     for (int i = 0; i < num_producers; i++)
@@ -1086,7 +1086,7 @@ typedef struct
 {
     queue_t *queue;
     int num_ops;
-    struct timespec *start_time;
+    _Atomic int *start_flag;
 } benchmark_mixed_args_t;
 
 static void *benchmark_mixed_thread(void *arg)
@@ -1094,7 +1094,7 @@ static void *benchmark_mixed_thread(void *arg)
     benchmark_mixed_args_t *args = (benchmark_mixed_args_t *)arg;
 
     /* wait for start signal */
-    while (args->start_time->tv_sec == 0)
+    while (atomic_load(args->start_flag) == 0)
     {
         usleep(100);
     }
@@ -1128,19 +1128,19 @@ void benchmark_queue_mixed_operations()
 
     pthread_t *threads = malloc(num_threads * sizeof(pthread_t));
     benchmark_mixed_args_t *args = malloc(num_threads * sizeof(benchmark_mixed_args_t));
-    struct timespec start_time = {0, 0};
+    _Atomic int start_flag = 0;
 
     for (int i = 0; i < num_threads; i++)
     {
         args[i].queue = queue;
         args[i].num_ops = ops_per_thread;
-        args[i].start_time = &start_time;
+        args[i].start_flag = &start_flag;
         pthread_create(&threads[i], NULL, benchmark_mixed_thread, &args[i]);
     }
 
     struct timespec start, end;
     clock_gettime(CLOCK_MONOTONIC, &start);
-    start_time = start;
+    atomic_store(&start_flag, 1);
 
     for (int i = 0; i < num_threads; i++)
     {
@@ -1181,20 +1181,20 @@ void benchmark_queue_scaling()
 
         pthread_t *threads = malloc(num_threads * sizeof(pthread_t));
         benchmark_producer_args_t *args = malloc(num_threads * sizeof(benchmark_producer_args_t));
-        struct timespec start_time = {0, 0};
+        _Atomic int start_flag = 0;
 
         for (int i = 0; i < num_threads; i++)
         {
             args[i].queue = queue;
             args[i].num_ops = ops_per_thread;
             args[i].thread_id = i;
-            args[i].start_time = &start_time;
+            args[i].start_flag = &start_flag;
             pthread_create(&threads[i], NULL, benchmark_producer, &args[i]);
         }
 
         struct timespec start, end;
         clock_gettime(CLOCK_MONOTONIC, &start);
-        start_time = start;
+        atomic_store(&start_flag, 1);
 
         for (int i = 0; i < num_threads; i++)
         {

--- a/test/skip_list__tests.c
+++ b/test/skip_list__tests.c
@@ -3073,6 +3073,351 @@ void benchmark_skip_list_rw_contention()
     run_rw_contention_suite(total_threads, ops_per_thread, num_unique_keys, 1);
 }
 
+static int vis_seq_le(void *ctx, uint64_t seq)
+{
+    return seq <= *(uint64_t *)ctx;
+}
+
+void test_skip_list_get_with_seq_ref()
+{
+    skip_list_t *list = NULL;
+    ASSERT_EQ(skip_list_new(&list, 12, 0.24f), 0);
+
+    uint8_t key[] = "mvcc_key";
+    ASSERT_EQ(skip_list_put_with_seq(list, key, sizeof(key), (uint8_t *)"v1", 3, -1, 1, 0), 0);
+    ASSERT_EQ(skip_list_put_with_seq(list, key, sizeof(key), (uint8_t *)"v5", 3, -1, 5, 0), 0);
+    ASSERT_EQ(skip_list_put_with_seq(list, key, sizeof(key), (uint8_t *)"v9", 3, -1, 9, 0), 0);
+
+    const uint8_t *val = NULL;
+    size_t vs = 0;
+    int64_t ttl;
+    uint8_t deleted;
+    uint64_t seq;
+
+    /* UINT64_MAX reads the latest version with no snapshot filtering */
+    ASSERT_EQ(skip_list_get_with_seq_ref(list, key, sizeof(key), &val, &vs, &ttl, &deleted, &seq,
+                                         UINT64_MAX, NULL, NULL),
+              0);
+    ASSERT_EQ(seq, 9);
+    ASSERT_EQ(memcmp(val, "v9", 3), 0);
+
+    /* snapshot reads the newest version with seq <= snapshot_seq */
+    ASSERT_EQ(skip_list_get_with_seq_ref(list, key, sizeof(key), &val, &vs, &ttl, &deleted, &seq, 5,
+                                         NULL, NULL),
+              0);
+    ASSERT_EQ(seq, 5);
+    ASSERT_EQ(memcmp(val, "v5", 3), 0);
+
+    ASSERT_EQ(skip_list_get_with_seq_ref(list, key, sizeof(key), &val, &vs, &ttl, &deleted, &seq, 4,
+                                         NULL, NULL),
+              0);
+    ASSERT_EQ(seq, 1);
+    ASSERT_EQ(memcmp(val, "v1", 3), 0);
+
+    /* seq 0 matches nothing because sequence numbers start at 1 */
+    ASSERT_EQ(skip_list_get_with_seq_ref(list, key, sizeof(key), &val, &vs, &ttl, &deleted, &seq, 0,
+                                         NULL, NULL),
+              -1);
+
+    /* visibility check skips a version newer than the committed threshold */
+    uint64_t committed = 5;
+    ASSERT_EQ(skip_list_get_with_seq_ref(list, key, sizeof(key), &val, &vs, &ttl, &deleted, &seq, 9,
+                                         vis_seq_le, &committed),
+              0);
+    ASSERT_EQ(seq, 5);
+    ASSERT_EQ(memcmp(val, "v5", 3), 0);
+
+    uint8_t bad[] = "absent";
+    ASSERT_EQ(skip_list_get_with_seq_ref(list, bad, sizeof(bad), &val, &vs, &ttl, &deleted, &seq,
+                                         UINT64_MAX, NULL, NULL),
+              -1);
+
+    skip_list_free(list);
+}
+
+void test_skip_list_out_of_order_versions()
+{
+    skip_list_t *list = NULL;
+    ASSERT_EQ(skip_list_new(&list, 12, 0.24f), 0);
+
+    uint8_t key[] = "ooo";
+    /* versions arrive out of seq order -- the chain must stay descending: 10 -> 6 -> 2 */
+    ASSERT_EQ(skip_list_put_with_seq(list, key, sizeof(key), (uint8_t *)"v10", 4, -1, 10, 0), 0);
+    ASSERT_EQ(skip_list_put_with_seq(list, key, sizeof(key), (uint8_t *)"v2", 3, -1, 2, 0), 0);
+    ASSERT_EQ(skip_list_put_with_seq(list, key, sizeof(key), (uint8_t *)"v6", 3, -1, 6, 0), 0);
+
+    /* a duplicate seq is rejected */
+    ASSERT_EQ(skip_list_put_with_seq(list, key, sizeof(key), (uint8_t *)"dup", 4, -1, 6, 0), -1);
+
+    skip_list_cursor_t *cursor = NULL;
+    ASSERT_EQ(skip_list_cursor_init(&cursor, list), 0);
+    ASSERT_EQ(skip_list_cursor_goto_first(cursor), 0);
+
+    uint8_t *k, *v;
+    size_t ks, vsz;
+    int64_t ttl;
+    uint8_t deleted;
+    uint64_t seq;
+
+    ASSERT_EQ(skip_list_cursor_get_with_seq(cursor, &k, &ks, &v, &vsz, &ttl, &deleted, &seq), 0);
+    ASSERT_EQ(seq, 10);
+    ASSERT_EQ(skip_list_cursor_advance_in_node(cursor), 0);
+    ASSERT_EQ(skip_list_cursor_get_with_seq(cursor, &k, &ks, &v, &vsz, &ttl, &deleted, &seq), 0);
+    ASSERT_EQ(seq, 6);
+    ASSERT_EQ(skip_list_cursor_advance_in_node(cursor), 0);
+    ASSERT_EQ(skip_list_cursor_get_with_seq(cursor, &k, &ks, &v, &vsz, &ttl, &deleted, &seq), 0);
+    ASSERT_EQ(seq, 2);
+    ASSERT_EQ(skip_list_cursor_advance_in_node(cursor), -1);
+
+    /* a snapshot resolves to the right version across the reordered chain */
+    uint8_t *val = NULL;
+    size_t val_size = 0;
+    ASSERT_EQ(skip_list_get_with_seq(list, key, sizeof(key), &val, &val_size, &ttl, &deleted, &seq,
+                                     5, NULL, NULL),
+              0);
+    ASSERT_EQ(seq, 2);
+    ASSERT_EQ(memcmp(val, "v2", 3), 0);
+    free(val);
+
+    skip_list_cursor_free(cursor);
+    skip_list_free(list);
+}
+
+void test_skip_list_min_max_seq()
+{
+    skip_list_t *list = NULL;
+    ASSERT_EQ(skip_list_new(&list, 12, 0.24f), 0);
+
+    ASSERT_EQ(skip_list_get_min_seq(list), UINT64_MAX);
+
+    uint64_t out = 123;
+    uint8_t miss[] = "miss";
+    ASSERT_EQ(skip_list_get_max_seq(list, miss, sizeof(miss), &out), -1);
+    ASSERT_EQ(out, 0);
+
+    uint8_t key[] = "k";
+    ASSERT_EQ(skip_list_put_with_seq(list, key, sizeof(key), (uint8_t *)"a", 2, -1, 5, 0), 0);
+    ASSERT_EQ(skip_list_get_min_seq(list), 5);
+
+    ASSERT_EQ(skip_list_put_with_seq(list, key, sizeof(key), (uint8_t *)"b", 2, -1, 9, 0), 0);
+    ASSERT_EQ(skip_list_put_with_seq(list, key, sizeof(key), (uint8_t *)"c", 2, -1, 3, 0), 0);
+
+    /* max seq is the newest version, min seq is the smallest ever inserted */
+    ASSERT_EQ(skip_list_get_max_seq(list, key, sizeof(key), &out), 0);
+    ASSERT_EQ(out, 9);
+    ASSERT_EQ(skip_list_get_min_seq(list), 3);
+
+    /* clear resets the min seq floor */
+    ASSERT_EQ(skip_list_clear(list), 0);
+    ASSERT_EQ(skip_list_get_min_seq(list), UINT64_MAX);
+
+    /* a tombstone is tracked by min seq too */
+    ASSERT_EQ(skip_list_put_with_seq(list, key, sizeof(key), (uint8_t *)"d", 2, -1, 20, 0), 0);
+    ASSERT_EQ(skip_list_get_min_seq(list), 20);
+    ASSERT_EQ(skip_list_delete(list, key, sizeof(key), 4), 0);
+    ASSERT_EQ(skip_list_get_min_seq(list), 4);
+
+    skip_list_free(list);
+}
+
+void test_skip_list_single_delete_flag()
+{
+    skip_list_t *list = NULL;
+    ASSERT_EQ(skip_list_new(&list, 12, 0.24f), 0);
+
+    uint8_t key[] = "sd";
+    ASSERT_EQ(skip_list_put_with_seq(list, key, sizeof(key), (uint8_t *)"v", 2, -1, 1, 0), 0);
+    ASSERT_EQ(skip_list_put_with_seq(list, key, sizeof(key), NULL, 0, -1, 2,
+                                     SKIP_LIST_FLAG_DELETED | SKIP_LIST_FLAG_SINGLE_DELETE),
+              0);
+
+    skip_list_cursor_t *cursor = NULL;
+    ASSERT_EQ(skip_list_cursor_init(&cursor, list), 0);
+    ASSERT_EQ(skip_list_cursor_goto_first(cursor), 0);
+
+    uint8_t *k, *v;
+    size_t ks, vs;
+    int64_t ttl;
+    uint8_t deleted;
+    uint64_t seq;
+    ASSERT_EQ(skip_list_cursor_get_with_seq(cursor, &k, &ks, &v, &vs, &ttl, &deleted, &seq), 0);
+    ASSERT_EQ(seq, 2);
+    ASSERT_TRUE(deleted & SKIP_LIST_FLAG_DELETED);
+    ASSERT_TRUE(deleted & SKIP_LIST_FLAG_SINGLE_DELETE);
+
+    skip_list_cursor_free(cursor);
+    skip_list_free(list);
+}
+
+void test_skip_list_put_batch_partial()
+{
+    skip_list_t *list = NULL;
+    ASSERT_EQ(skip_list_new(&list, 12, 0.24f), 0);
+
+    /* entries[1] duplicates the (key, seq) of entries[0] and is skipped */
+    skip_list_batch_entry_t entries[3];
+    entries[0].key = (const uint8_t *)"K";
+    entries[0].key_size = 2;
+    entries[0].value = (const uint8_t *)"a";
+    entries[0].value_size = 2;
+    entries[0].seq = 1;
+    entries[0].ttl = -1;
+    entries[0].flags = 0;
+    entries[1] = entries[0];
+    entries[1].value = (const uint8_t *)"b";
+    entries[2].key = (const uint8_t *)"L";
+    entries[2].key_size = 2;
+    entries[2].value = (const uint8_t *)"c";
+    entries[2].value_size = 2;
+    entries[2].seq = 2;
+    entries[2].ttl = -1;
+    entries[2].flags = 0;
+
+    ASSERT_EQ(skip_list_put_batch(list, entries, 3), 2);
+    ASSERT_EQ(skip_list_count_entries(list), 2);
+
+    skip_list_free(list);
+}
+
+void test_skip_list_tall_heap_update()
+{
+    /* max_level == SKIP_LIST_STACK_UPDATE_SIZE (64) forces the heap update[] path in put/batch */
+    skip_list_t *list = NULL;
+    ASSERT_EQ(skip_list_new(&list, 64, 0.5f), 0);
+
+    skip_list_batch_entry_t entries[64];
+    char keys[64][16];
+    for (int i = 0; i < 64; i++)
+    {
+        snprintf(keys[i], sizeof(keys[i]), "tall_%03d", i);
+        entries[i].key = (const uint8_t *)keys[i];
+        entries[i].key_size = strlen(keys[i]) + 1;
+        entries[i].value = (const uint8_t *)keys[i];
+        entries[i].value_size = strlen(keys[i]) + 1;
+        entries[i].seq = (uint64_t)(i + 1);
+        entries[i].ttl = -1;
+        entries[i].flags = 0;
+    }
+    ASSERT_EQ(skip_list_put_batch(list, entries, 64), 64);
+
+    uint8_t k[] = "tall_single";
+    uint8_t v[] = "x";
+    ASSERT_EQ(skip_list_put_with_seq(list, k, sizeof(k), v, sizeof(v), -1, 100, 0), 0);
+    ASSERT_EQ(skip_list_count_entries(list), 65);
+
+    for (int i = 0; i < 64; i++)
+    {
+        uint8_t *rv = NULL;
+        size_t rvs = 0;
+        int64_t ttl;
+        uint8_t del;
+        ASSERT_EQ(
+            skip_list_get(list, (uint8_t *)keys[i], strlen(keys[i]) + 1, &rv, &rvs, &ttl, &del), 0);
+        ASSERT_EQ(strcmp((char *)rv, keys[i]), 0);
+        free(rv);
+    }
+
+    skip_list_free(list);
+}
+
+void test_skip_list_cached_time_ttl()
+{
+    _Atomic(time_t) clock_val;
+    skip_list_t *list = NULL;
+    ASSERT_EQ(skip_list_new_with_comparator_and_cached_time(
+                  &list, 12, 0.24f, skip_list_comparator_memcmp, NULL, &clock_val),
+              0);
+
+    time_t base = atomic_load_explicit(&clock_val, memory_order_relaxed);
+
+    uint8_t key[] = "ttlk";
+    uint8_t value[] = "v";
+    ASSERT_EQ(skip_list_put_with_seq(list, key, sizeof(key), value, sizeof(value), base + 10, 1, 0),
+              0);
+
+    uint8_t *rv = NULL;
+    size_t rvs = 0;
+    int64_t ttl;
+    uint8_t deleted = 0;
+    ASSERT_EQ(skip_list_get(list, key, sizeof(key), &rv, &rvs, &ttl, &deleted), 0);
+    ASSERT_EQ(deleted, 0);
+    free(rv);
+
+#if defined(__MINGW32__) && !defined(__MINGW64__)
+    /* cached time is not honored on MinGW x86 -- the lib reads the clock directly there */
+    (void)base;
+#else
+    /* advance the injected clock past the ttl without sleeping */
+    atomic_store_explicit(&clock_val, base + 20, memory_order_relaxed);
+    rv = NULL;
+    ASSERT_EQ(skip_list_get(list, key, sizeof(key), &rv, &rvs, &ttl, &deleted), 0);
+    ASSERT_EQ(deleted, 1);
+    free(rv);
+#endif
+
+    skip_list_free(list);
+}
+
+void test_skip_list_cursor_seek_ge()
+{
+    skip_list_t *list = NULL;
+    ASSERT_EQ(skip_list_new(&list, 12, 0.24f), 0);
+
+    for (int i = 0; i <= 90; i += 10)
+    {
+        char key[16], value[16];
+        snprintf(key, sizeof(key), "key_%02d", i);
+        snprintf(value, sizeof(value), "val_%02d", i);
+        ASSERT_EQ(skip_list_put_with_seq(list, (uint8_t *)key, strlen(key), (uint8_t *)value,
+                                         strlen(value), -1, (i / 10) + 1, 0),
+                  0);
+    }
+
+    skip_list_cursor_t *cursor = NULL;
+    ASSERT_EQ(skip_list_cursor_init(&cursor, list), 0);
+
+    uint8_t *key = NULL;
+    size_t key_size = 0;
+    uint8_t *value = NULL;
+    size_t value_size = 0;
+    int64_t ttl = 0;
+    uint8_t deleted = 0;
+
+    /* exact match lands directly on the key, no separate next */
+    ASSERT_EQ(skip_list_cursor_seek_ge(cursor, (uint8_t *)"key_50", 6), 0);
+    ASSERT_EQ(skip_list_cursor_get(cursor, &key, &key_size, &value, &value_size, &ttl, &deleted),
+              0);
+    ASSERT_EQ(memcmp(key, "key_50", 6), 0);
+
+    /* a missing key lands on the next greater key */
+    ASSERT_EQ(skip_list_cursor_seek_ge(cursor, (uint8_t *)"key_55", 6), 0);
+    ASSERT_EQ(skip_list_cursor_get(cursor, &key, &key_size, &value, &value_size, &ttl, &deleted),
+              0);
+    ASSERT_EQ(memcmp(key, "key_60", 6), 0);
+
+    /* a key before all keys lands on the first */
+    ASSERT_EQ(skip_list_cursor_seek_ge(cursor, (uint8_t *)"key_", 4), 0);
+    ASSERT_EQ(skip_list_cursor_get(cursor, &key, &key_size, &value, &value_size, &ttl, &deleted),
+              0);
+    ASSERT_EQ(memcmp(key, "key_00", 6), 0);
+
+    /* a key past all keys returns -1 with the cursor at end */
+    ASSERT_EQ(skip_list_cursor_seek_ge(cursor, (uint8_t *)"key_99", 6), -1);
+
+    skip_list_cursor_free(cursor);
+    skip_list_free(list);
+}
+
+void test_skip_list_new_validation()
+{
+    skip_list_t *list = NULL;
+    ASSERT_EQ(skip_list_new(&list, 0, 0.25f), -1);
+    ASSERT_EQ(skip_list_new(&list, -1, 0.25f), -1);
+    ASSERT_EQ(skip_list_new(&list, 12, 0.0f), -1);
+    ASSERT_EQ(skip_list_new(&list, 12, 1.0f), -1);
+    ASSERT_EQ(skip_list_new(&list, 12, 1.5f), -1);
+}
+
 int main(int argc, char **argv)
 {
     INIT_TEST_FILTER(argc, argv);
@@ -3118,6 +3463,15 @@ int main(int argc, char **argv)
     RUN_TEST(test_skip_list_cursor_next_get, tests_passed);
     RUN_TEST(test_skip_list_cursor_advance_in_node, tests_passed);
     RUN_TEST(test_skip_list_arena_aba, tests_passed);
+    RUN_TEST(test_skip_list_get_with_seq_ref, tests_passed);
+    RUN_TEST(test_skip_list_out_of_order_versions, tests_passed);
+    RUN_TEST(test_skip_list_min_max_seq, tests_passed);
+    RUN_TEST(test_skip_list_single_delete_flag, tests_passed);
+    RUN_TEST(test_skip_list_put_batch_partial, tests_passed);
+    RUN_TEST(test_skip_list_tall_heap_update, tests_passed);
+    RUN_TEST(test_skip_list_cached_time_ttl, tests_passed);
+    RUN_TEST(test_skip_list_cursor_seek_ge, tests_passed);
+    RUN_TEST(test_skip_list_new_validation, tests_passed);
 
     RUN_TEST(benchmark_skip_list, tests_passed);
     RUN_TEST(benchmark_skip_list_sequential, tests_passed);

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tidesdb",
-  "version-string": "9.3.7",
+  "version-string": "9.3.8",
   "description": "TidesDB is a high-performance durable, transactional embeddable storage engine designed for flash and RAM optimization with optional object storage support for unlimited data scaling.",
   "dependencies": ["zstd", "snappy", "lz4", "pthreads", "curl"],
   "features": {


### PR DESCRIPTION
drop the cursor block index field which was only ever written and never read, along with its stale doc comment.

make sync full cached atomic so a runtime sync mode change cannot race the read on the write path.

only scan the trailing region for zeros in strict validation, the permissive crash recovery path truncates either way and never needs it. guard the batch write size tally against overflow on 32 bit.

add tests for large block reads across the read ahead boundary and for the memory budget refusal path.