### PR TITLE
Add wrapper around pwrite() call to handle partial writes

### DIFF
--- a/src/block_manager.c
+++ b/src/block_manager.c
@@ -160,23 +160,21 @@ static uint8_t *bm_get_read_buf(const size_t needed)
  * @param nbyte number of bytes that "must" be written for the call to be successful
  * @return 0 on success (all bytes written), -1 on failure with errno set appropriately.
  */
-static inline int pwrite_all(
-    int fd,
-    const void *buf,
-    size_t nbyte,
-    off_t offset
-){
+static inline int pwrite_all(int fd, const void *buf, size_t nbyte, off_t offset)
+{
     size_t total = 0;
-    while(total < nbyte){
-        ssize_t written = pwrite(fd, (const uint8_t*)buf + total,
-                                nbyte - total, offset + total);
+    while (total < nbyte)
+    {
+        ssize_t written = pwrite(fd, (const uint8_t *)buf + total, nbyte - total, offset + total);
 
-        if (BM_UNLIKELY(written < 0)){
+        if (BM_UNLIKELY(written == -1))
+        {
             if (errno == EINTR) continue;
             return -1;
         }
 
-        if(BM_UNLIKELY(written == 0)){
+        if (BM_UNLIKELY(written == 0))
+        {
             errno = EIO;
             return -1;
         }
@@ -855,7 +853,7 @@ int block_manager_write_at(block_manager_t *bm, const int64_t offset, const uint
      * grow the file without advancing current_file_size, desyncing the two */
     if ((uint64_t)offset + size > atomic_load(&bm->current_file_size)) return -1;
 
-    if(pwrite_all(bm->fd, data, size, offset) != 0)
+    if (pwrite_all(bm->fd, data, size, offset) != 0)
     {
         return -1;
     }

--- a/src/block_manager.c
+++ b/src/block_manager.c
@@ -143,6 +143,49 @@ static uint8_t *bm_get_read_buf(const size_t needed)
     return new_buf;
 }
 
+/*
+ * pwrite_all
+ * Writes exactly nbyte bytes from buf to fd at the specified offset.
+ *
+ * This is a wrapper around pwrite(2) that handles partial writes and
+ * EINTR interruptions by retrying until either:
+ *   - all nbyte bytes have been written, or
+ *   - an unrecoverable error occurs.
+ * The caller is responsible for ensuring that buf points to at least nbyte
+ * bytes of valid memory. Because only a pointer is passed, this function
+ * cannot determine the size of the object referenced by buf.
+ *
+ * @param fd the file descriptor
+ * @param buf buffer to write from
+ * @param nbyte number of bytes that "must" be written for the call to be successful
+ * @return 0 on success (all bytes written), -1 on failure with errno set appropriately.
+ */
+static inline int pwrite_all(
+    int fd,
+    const void *buf,
+    size_t nbyte,
+    off_t offset
+){
+    size_t total = 0;
+    while(total < nbyte){
+        ssize_t written = pwrite(fd, (const uint8_t*)buf + total,
+                                nbyte - total, offset + total);
+
+        if (BM_UNLIKELY(written < 0)){
+            if (errno == EINTR) continue;
+            return -1;
+        }
+
+        if(BM_UNLIKELY(written == 0)){
+            errno = EIO;
+            return -1;
+        }
+        total += (size_t)written;
+    }
+
+    return 0;
+}
+
 /**
  * odsync_available
  * check if O_DSYNC is available on the specific platform
@@ -307,8 +350,7 @@ static int write_header(const int fd)
     encode_uint32_le_compat(header + BLOCK_MANAGER_MAGIC_SIZE + BLOCK_MANAGER_VERSION_SIZE,
                             padding);
 
-    const ssize_t written = pwrite(fd, header, BLOCK_MANAGER_HEADER_SIZE, 0);
-    return (written == BLOCK_MANAGER_HEADER_SIZE) ? 0 : -1;
+    return pwrite_all(fd, header, BLOCK_MANAGER_HEADER_SIZE, 0);
 }
 
 /**
@@ -813,8 +855,7 @@ int block_manager_write_at(block_manager_t *bm, const int64_t offset, const uint
      * grow the file without advancing current_file_size, desyncing the two */
     if ((uint64_t)offset + size > atomic_load(&bm->current_file_size)) return -1;
 
-    const ssize_t written = pwrite(bm->fd, data, size, offset);
-    if (written != (ssize_t)size)
+    if(pwrite_all(bm->fd, data, size, offset) != 0)
     {
         return -1;
     }
@@ -861,8 +902,7 @@ int block_manager_update_checksum(block_manager_t *bm, const int64_t block_offse
     encode_uint32_le_compat(checksum_buf, new_checksum);
 
     const off_t checksum_offset = block_offset + BLOCK_MANAGER_SIZE_FIELD_SIZE;
-    if (pwrite(bm->fd, checksum_buf, BLOCK_MANAGER_CHECKSUM_LENGTH, checksum_offset) !=
-        BLOCK_MANAGER_CHECKSUM_LENGTH)
+    if (pwrite_all(bm->fd, checksum_buf, BLOCK_MANAGER_CHECKSUM_LENGTH, checksum_offset) != 0)
     {
         return -1;
     }


### PR DESCRIPTION
This PR addresses issue #645 where a short write to the WAL/SSTable pair produced inclomplete records. This would hinder recovery from advancing past an incomplete write because validation would fail at startup when the recovery thread can't advance past the incomplete record leading to truncation of already commited data, hence data loss. This is quite similar to the PR #591 that addressed the WAL hole problem.