### PR TITLE
park object store uploads that fail the fast retries and have the rea…

### DIFF
--- a/src/skip_list.c
+++ b/src/skip_list.c
@@ -2669,6 +2669,89 @@ int skip_list_get_max_seq(skip_list_t *list, const uint8_t *key, const size_t ke
     return 0;
 }
 
+/**
+ * skip_list_find_node
+ * locates the node holding an exact key. shared traversal for the conflict scan and the abort
+ * marker, mirroring the descent in skip_list_get_max_seq.
+ * @param list skip list
+ * @param key key data
+ * @param key_size size of key
+ * @return the node for key, or NULL when the key is absent
+ */
+static skip_list_node_t *skip_list_find_node(skip_list_t *list, const uint8_t *key, size_t key_size)
+{
+    skip_list_node_t *current = atomic_load_explicit(&list->header, memory_order_acquire);
+    const int max_level = atomic_load_explicit(&list->level, memory_order_acquire);
+    const skip_list_cmp_type_t cmp_type = list->cmp_type;
+
+    for (int i = max_level; i >= 0; i--)
+    {
+        skip_list_node_t *next = atomic_load_explicit(&current->forward[i], memory_order_acquire);
+        while (next != NULL && !NODE_IS_SENTINEL(next))
+        {
+            if (skip_list_compare_keys_with_type(cmp_type, list, next->key, next->key_size, key,
+                                                 key_size) >= 0)
+                break;
+            current = next;
+            next = atomic_load_explicit(&current->forward[i], memory_order_acquire);
+        }
+    }
+
+    skip_list_node_t *target = atomic_load_explicit(&current->forward[0], memory_order_acquire);
+    if (target == NULL || NODE_IS_SENTINEL(target)) return NULL;
+    if (skip_list_compare_keys_with_type(cmp_type, list, target->key, target->key_size, key,
+                                         key_size) != 0)
+        return NULL;
+    return target;
+}
+
+int skip_list_has_write_conflict(skip_list_t *list, const uint8_t *key, const size_t key_size,
+                                 const uint64_t threshold_seq, const uint64_t exclude_seq)
+{
+    if (list == NULL || key == NULL || key_size == 0) return 0;
+
+    skip_list_node_t *target = skip_list_find_node(list, key, key_size);
+    if (target == NULL) return 0;
+
+    /* versions descend by seq, so stop once at or below the snapshot since every version past it is
+     * older still. the version at exclude_seq is the scanner's own freshly applied write, and an
+     * aborted version belongs to a transaction that already lost, so neither counts as a conflict.
+     */
+    for (skip_list_version_t *v = atomic_load_explicit(&target->versions, memory_order_acquire);
+         v != NULL; v = atomic_load_explicit(&v->next, memory_order_acquire))
+    {
+        const uint64_t seq = atomic_load_explicit(&v->seq, memory_order_acquire);
+        if (seq <= threshold_seq) break;
+        if (seq == exclude_seq) continue;
+        if (atomic_load_explicit(&v->flags, memory_order_acquire) & SKIP_LIST_FLAG_ABORTED)
+            continue;
+        return 1;
+    }
+    return 0;
+}
+
+int skip_list_mark_aborted(skip_list_t *list, const uint8_t *key, const size_t key_size,
+                           const uint64_t seq)
+{
+    if (list == NULL || key == NULL || key_size == 0) return -1;
+
+    skip_list_node_t *target = skip_list_find_node(list, key, key_size);
+    if (target == NULL) return -1;
+
+    for (skip_list_version_t *v = atomic_load_explicit(&target->versions, memory_order_acquire);
+         v != NULL; v = atomic_load_explicit(&v->next, memory_order_acquire))
+    {
+        const uint64_t vseq = atomic_load_explicit(&v->seq, memory_order_acquire);
+        if (vseq == seq)
+        {
+            atomic_fetch_or_explicit(&v->flags, SKIP_LIST_FLAG_ABORTED, memory_order_release);
+            return 0;
+        }
+        if (vseq < seq) break;
+    }
+    return -1;
+}
+
 int skip_list_get_with_seq(skip_list_t *list, const uint8_t *key, const size_t key_size,
                            uint8_t **value, size_t *value_size, int64_t *ttl, uint8_t *deleted,
                            uint64_t *seq, uint64_t snapshot_seq,
@@ -2721,6 +2804,9 @@ int skip_list_get_with_seq(skip_list_t *list, const uint8_t *key, const size_t k
 
     if (snapshot_seq == UINT64_MAX)
     {
+        /* an aborted version is invisible to every reader, so we descend to the first live one */
+        while (version != NULL && VERSION_IS_ABORTED(version))
+            version = atomic_load_explicit(&version->next, memory_order_acquire);
         if (version == NULL) return -1;
     }
     else
@@ -2731,6 +2817,11 @@ int skip_list_get_with_seq(skip_list_t *list, const uint8_t *key, const size_t k
          * version that passes both checks. */
         while (version != NULL)
         {
+            if (VERSION_IS_ABORTED(version))
+            {
+                version = atomic_load_explicit(&version->next, memory_order_acquire);
+                continue;
+            }
             uint64_t version_seq = atomic_load_explicit(&version->seq, memory_order_acquire);
 
             /* we check if version is within snapshot range */
@@ -2845,12 +2936,21 @@ int skip_list_get_with_seq_ref(skip_list_t *list, const uint8_t *key, const size
 
     if (snapshot_seq == UINT64_MAX)
     {
+        /* an aborted version belongs to a transaction that lost its conflict check and is invisible
+         * to every reader, so we descend to the first live version */
+        while (version != NULL && VERSION_IS_ABORTED(version))
+            version = atomic_load_explicit(&version->next, memory_order_acquire);
         if (version == NULL) return -1;
     }
     else
     {
         while (version != NULL)
         {
+            if (VERSION_IS_ABORTED(version))
+            {
+                version = atomic_load_explicit(&version->next, memory_order_acquire);
+                continue;
+            }
             uint64_t version_seq = atomic_load_explicit(&version->seq, memory_order_acquire);
 
             if (version_seq <= snapshot_seq)

--- a/src/skip_list.h
+++ b/src/skip_list.h
@@ -92,6 +92,11 @@ struct skip_list_arena_t
           * has been put at most once since the last         \
           * single-delete or start, so put+single-delete can \
           * be reaped together at compaction. */
+#define SKIP_LIST_FLAG_ABORTED                               \
+    0x04 /* version belongs to a transaction that failed its \
+          * write-write conflict check after applying. it is \
+          * invisible to reads and skipped by flush and by   \
+          * later conflict scans, then reclaimed by gc. */
 
 /**
  * skip_list_cmp_type_t
@@ -113,6 +118,9 @@ typedef enum
 /* helper macros for flag access */
 #define VERSION_IS_DELETED(version) \
     (atomic_load_explicit(&(version)->flags, memory_order_acquire) & SKIP_LIST_FLAG_DELETED)
+
+#define VERSION_IS_ABORTED(version) \
+    (atomic_load_explicit(&(version)->flags, memory_order_acquire) & SKIP_LIST_FLAG_ABORTED)
 
 #define NODE_IS_SENTINEL(node) ((node)->node_flags & SKIP_LIST_NODE_FLAG_SENTINEL)
 
@@ -557,6 +565,33 @@ int skip_list_get_with_seq_ref(skip_list_t *list, const uint8_t *key, size_t key
  */
 int skip_list_get_max_seq(skip_list_t *list, const uint8_t *key, size_t key_size,
                           uint64_t *out_seq);
+
+/**
+ * skip_list_has_write_conflict
+ * reports whether the key carries a version newer than threshold_seq that was written by another
+ * transaction, used by apply-before-validate write-write detection. the committer scans after
+ * inserting its own version, so its own seq and any aborted version are excluded.
+ * @param list skip list
+ * @param key key data
+ * @param key_size size of key
+ * @param threshold_seq the committing transaction's snapshot sequence
+ * @param exclude_seq the committing transaction's own commit sequence
+ * @return 1 if a conflicting version exists, 0 otherwise
+ */
+int skip_list_has_write_conflict(skip_list_t *list, const uint8_t *key, size_t key_size,
+                                 uint64_t threshold_seq, uint64_t exclude_seq);
+
+/**
+ * skip_list_mark_aborted
+ * flags the version with the given seq as aborted so reads, flush and later conflict scans skip it.
+ * called when a transaction loses its post-apply conflict check.
+ * @param list skip list
+ * @param key key data
+ * @param key_size size of key
+ * @param seq sequence number of the version to abort
+ * @return 0 if the version was found and flagged, -1 otherwise
+ */
+int skip_list_mark_aborted(skip_list_t *list, const uint8_t *key, size_t key_size, uint64_t seq);
 
 /**
  * skip_list_get_min_seq

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -496,9 +496,16 @@ typedef tidesdb_memtable_t tidesdb_immutable_memtable_t;
 #define TDB_NO_CF_SYNC_SLEEP_US                 100000
 
 /* object store retry constants */
-#define TDB_UPLOAD_MAX_RETRIES          3
-#define TDB_UPLOAD_INITIAL_BACKOFF_US   100000 /* 100ms */
-#define TDB_UPLOAD_BACKOFF_MULTIPLIER   4      /* 100ms -> 400ms -> 1600ms */
+#define TDB_UPLOAD_MAX_RETRIES        3
+#define TDB_UPLOAD_INITIAL_BACKOFF_US 100000 /* 100ms */
+#define TDB_UPLOAD_BACKOFF_MULTIPLIER 4      /* 100ms -> 400ms -> 1600ms */
+/* an upload that exhausts the fast inner retries above is parked in a backlog rather than dropped,
+ * and the reaper re-attempts it on a slow outer backoff so a multi-minute object store outage still
+ * delivers eventually instead of giving up after half a second */
+#define TDB_UPLOAD_DEFER_MAX            256 /* cap on parked uploads; over this the oldest is dropped */
+#define TDB_UPLOAD_DEFER_INITIAL_SEC    2  /* first outer-retry delay; doubles each miss */
+#define TDB_UPLOAD_DEFER_MAX_SEC        60 /* outer-retry backoff ceiling */
+#define TDB_UPLOAD_DEFER_MAX_SHIFT      6  /* clamp on the doubling exponent (2<<6 already > 60s) */
 #define TDB_DOWNLOAD_MAX_RETRIES        3
 #define TDB_DOWNLOAD_INITIAL_BACKOFF_US 50000 /* 50ms */
 #define TDB_DOWNLOAD_BACKOFF_MULTIPLIER 4     /* 50ms -> 200ms -> 800ms */
@@ -4854,6 +4861,8 @@ static void tdb_path_to_object_key(const tidesdb_t *db, const char *local_path, 
  * @param local_path local file path of the file to upload
  * @param object_key object store key derived from local_path
  * @param wal_generation WAL generation to fence after upload (0 = no fence)
+ * @param track_in_cache register the file with the local cache once the upload confirms (sstable
+ *        files stay untracked -- and therefore unevictable -- until they are safely remote)
  */
 typedef struct
 {
@@ -4862,7 +4871,296 @@ typedef struct
     uint64_t wal_generation;   /* WAL gen to fence after upload (0 = no fence) */
     uint64_t meta_epoch;       /* single-writer lease epoch to tag the object with (0 = untagged) */
     uint64_t upload_max_bytes; /* logical length to upload (0 = whole file) */
+    int track_in_cache;        /* 1 = cache-track local_path on success (sstable) */
 } tdb_upload_job_t;
+
+/**
+ * tdb_deferred_upload_t
+ * a parked upload that exhausted the fast inner retries, awaiting slow outer retry by the reaper
+ * @param job the original upload job (local_path, object_key, fence/epoch/size, track flag)
+ * @param outer_attempts number of slow retries already spent (drives the backoff)
+ * @param next_retry_sec earliest cached_current_time (seconds) at which to retry again
+ */
+typedef struct
+{
+    tdb_upload_job_t job;
+    unsigned int outer_attempts;
+    time_t next_retry_sec;
+} tdb_deferred_upload_t;
+
+/**
+ * tdb_objstore_put_once
+ * attempts a single upload and confirms it. an epoch-tagged or partial upload goes through put_if,
+ * anything else through a plain put, and the object is then verified to have landed at the size we
+ * expect.
+ * @param db database
+ * @param job upload job describing the object
+ * @return 0 if the object landed and verified, -1 otherwise
+ */
+static int tdb_objstore_put_once(tidesdb_t *db, const tdb_upload_job_t *job)
+{
+    int rc;
+    /* use put_if when the object is epoch-tagged (WAL fencing) or a partial upload is requested
+     * (active WAL's logical length, skipping its preallocated tail) -- both need put_if, which
+     * also works untagged (epoch 0). otherwise a plain put. */
+    if ((job->meta_epoch || job->upload_max_bytes) && db->object_store->put_if)
+        rc = db->object_store->put_if(db->object_store->ctx, job->object_key, job->local_path,
+                                      TDB_PUT_OVERWRITE, NULL, job->meta_epoch, NULL, 0,
+                                      (size_t)job->upload_max_bytes);
+    else
+        rc = db->object_store->put(db->object_store->ctx, job->object_key, job->local_path);
+    if (rc != 0) return -1;
+
+    /* verify the upload landed with the correct size. MANIFEST is skipped -- it is mutable and may
+     * grow between upload and the exists check due to concurrent flushes. */
+    if (!strstr(job->object_key, TDB_COLUMN_FAMILY_MANIFEST_NAME))
+    {
+        struct stat local_st;
+        if (stat(job->local_path, &local_st) == 0)
+        {
+            /* a partial WAL upload's remote size is the logical length, not the preallocated file
+             */
+            size_t expected =
+                job->upload_max_bytes ? (size_t)job->upload_max_bytes : (size_t)local_st.st_size;
+            size_t remote_size = 0;
+            const int verify =
+                db->object_store->exists(db->object_store->ctx, job->object_key, &remote_size);
+            if (verify != 1 || remote_size != expected)
+            {
+                TDB_DEBUG_LOG(TDB_LOG_ERROR,
+                              "Upload verification failed for %s (expected=%zu, remote=%zu, "
+                              "exists=%d)",
+                              job->object_key, expected, remote_size, verify);
+                return -1;
+            }
+        }
+    }
+    return 0;
+}
+
+/**
+ * tdb_objstore_cancel_deferred
+ * drop any parked retry whose object_key matches -- a fresh successful upload of a key retires a
+ * stale pending retry for it (e.g. a newer MANIFEST supersedes an older failed one).
+ * @param db database
+ * @param object_key key to cancel
+ */
+static void tdb_objstore_cancel_deferred(tidesdb_t *db, const char *object_key)
+{
+    pthread_mutex_lock(&db->pending_upload_lock);
+    tdb_deferred_upload_t *arr = db->pending_uploads;
+    for (size_t i = 0; i < db->pending_upload_count;)
+    {
+        if (strcmp(arr[i].job.object_key, object_key) == 0)
+            arr[i] = arr[--db->pending_upload_count]; /* swap-remove */
+        else
+            i++;
+    }
+    pthread_mutex_unlock(&db->pending_upload_lock);
+}
+
+/**
+ * tdb_objstore_on_upload_success
+ * runs the shared bookkeeping once an object has been delivered. it counts the upload, and for a
+ * rotated WAL advances the fence and deletes the now-redundant local copy. an sstable file stays
+ * untracked (and so unevictable) until it is proven remote, so it is registered with the local
+ * cache here. any retry still parked for the same key is cancelled.
+ * @param db database
+ * @param job the delivered upload job
+ */
+static void tdb_objstore_on_upload_success(tidesdb_t *db, const tdb_upload_job_t *job)
+{
+    atomic_fetch_add_explicit(&db->total_uploads, 1, memory_order_relaxed);
+
+    /* we advance the WAL fence if this upload advances it */
+    if (job->wal_generation > 0)
+    {
+        uint64_t cur = atomic_load_explicit(&db->last_uploaded_gen, memory_order_relaxed);
+        while (job->wal_generation > cur)
+        {
+            if (atomic_compare_exchange_weak_explicit(&db->last_uploaded_gen, &cur,
+                                                      job->wal_generation, memory_order_release,
+                                                      memory_order_relaxed))
+                break;
+        }
+        /* the rotated WAL is confirmed present (exists + size verify above), so the local copy is
+         * deleted here. recovery replays the WAL from the object store if the node restarts before
+         * the immutable has flushed. */
+        tdb_unlink(job->local_path);
+    }
+
+    /* an sstable file stayed untracked (and so unevictable) until it was safely remote -- track it
+     * now so the local cache can reclaim it */
+    if (job->track_in_cache && db->local_cache)
+        tdb_local_cache_track(db->local_cache, job->local_path);
+
+    tdb_objstore_cancel_deferred(db, job->object_key);
+}
+
+/**
+ * tdb_objstore_park_locked
+ * insert or replace a deferred entry for job->object_key. caller holds pending_upload_lock. dedups
+ * by key (a later attempt supersedes an earlier one), grows the backlog, and enforces the cap by
+ * dropping the oldest entry (its file persists locally for the next startup to re-upload).
+ * @param db database
+ * @param job upload job to park
+ * @param attempts outer retries already spent (drives the next backoff)
+ * @param next_retry_sec earliest time (seconds) to retry
+ */
+static void tdb_objstore_park_locked(tidesdb_t *db, const tdb_upload_job_t *job,
+                                     unsigned int attempts, time_t next_retry_sec)
+{
+    tdb_deferred_upload_t *arr = db->pending_uploads;
+    for (size_t i = 0; i < db->pending_upload_count; i++)
+    {
+        if (strcmp(arr[i].job.object_key, job->object_key) == 0)
+        {
+            arr[i].job = *job;
+            arr[i].outer_attempts = attempts;
+            arr[i].next_retry_sec = next_retry_sec;
+            return;
+        }
+    }
+
+    if (db->pending_upload_count == db->pending_upload_capacity)
+    {
+        size_t new_cap = db->pending_upload_capacity ? db->pending_upload_capacity * 2 : 16;
+        if (new_cap > TDB_UPLOAD_DEFER_MAX) new_cap = TDB_UPLOAD_DEFER_MAX;
+        if (new_cap > db->pending_upload_capacity)
+        {
+            tdb_deferred_upload_t *grown = realloc(arr, new_cap * sizeof(*grown));
+            if (grown)
+            {
+                db->pending_uploads = arr = grown;
+                db->pending_upload_capacity = new_cap;
+            }
+        }
+    }
+
+    if (db->pending_upload_count == db->pending_upload_capacity)
+    {
+        if (db->pending_upload_count == 0) return; /* cap pinned at 0 -- nothing to park into */
+        TDB_DEBUG_LOG(TDB_LOG_WARN, "Deferred-upload backlog full (%d) dropping oldest to park %s",
+                      TDB_UPLOAD_DEFER_MAX, job->object_key);
+        memmove(&arr[0], &arr[1], (db->pending_upload_count - 1) * sizeof(*arr));
+        db->pending_upload_count--;
+    }
+
+    arr[db->pending_upload_count].job = *job;
+    arr[db->pending_upload_count].outer_attempts = attempts;
+    arr[db->pending_upload_count].next_retry_sec = next_retry_sec;
+    db->pending_upload_count++;
+}
+
+/**
+ * tdb_objstore_defer_upload
+ * park an upload that exhausted its fast inner retries for slow outer retry by the reaper.
+ * @param db database
+ * @param job upload job to park
+ */
+static void tdb_objstore_defer_upload(tidesdb_t *db, const tdb_upload_job_t *job)
+{
+    const time_t now = atomic_load_explicit(&db->cached_current_time, memory_order_relaxed);
+    pthread_mutex_lock(&db->pending_upload_lock);
+    tdb_objstore_park_locked(db, job, 0, now + TDB_UPLOAD_DEFER_INITIAL_SEC);
+    pthread_mutex_unlock(&db->pending_upload_lock);
+}
+
+/**
+ * tdb_objstore_retry_deferred
+ * the reaper's sweep over the deferred-upload backlog. it re-attempts each parked upload whose
+ * backoff has elapsed. a vanished local file (compaction replaced the sstable, a rotation deleted
+ * the WAL) is dropped without counting a failure, since its data is durable elsewhere. a delivered
+ * upload runs the shared success bookkeeping, while a still-failing one is re-parked with a longer,
+ * capped backoff. the network put runs with the lock released so writers can keep parking failures
+ * meanwhile.
+ * @param db database
+ */
+static void tdb_objstore_retry_deferred(tidesdb_t *db)
+{
+    if (!db->object_store || !db->object_store->put) return;
+    const time_t now = atomic_load_explicit(&db->cached_current_time, memory_order_relaxed);
+
+    while (1)
+    {
+        tdb_upload_job_t job;
+        unsigned int attempts = 0;
+        int found = 0;
+
+        pthread_mutex_lock(&db->pending_upload_lock);
+        tdb_deferred_upload_t *arr = db->pending_uploads;
+        for (size_t i = 0; i < db->pending_upload_count; i++)
+        {
+            if (arr[i].next_retry_sec <= now)
+            {
+                job = arr[i].job;
+                attempts = arr[i].outer_attempts;
+                arr[i] =
+                    arr[--db->pending_upload_count]; /* swap-remove; re-parked below on failure */
+                found = 1;
+                break;
+            }
+        }
+        pthread_mutex_unlock(&db->pending_upload_lock);
+        if (!found) break;
+
+        struct stat st;
+        if (stat(job.local_path, &st) != 0)
+        {
+            TDB_DEBUG_LOG(TDB_LOG_DEBUG, "Deferred upload local file gone dropping %s",
+                          job.object_key);
+            continue;
+        }
+
+        if (tdb_objstore_put_once(db, &job) == 0)
+        {
+            tdb_objstore_on_upload_success(db, &job);
+            continue;
+        }
+
+        /* still failing -- re-park with a doubled, capped outer backoff */
+        unsigned int next_attempts = attempts + 1;
+        unsigned int shift =
+            next_attempts < TDB_UPLOAD_DEFER_MAX_SHIFT ? next_attempts : TDB_UPLOAD_DEFER_MAX_SHIFT;
+        time_t delay = (time_t)TDB_UPLOAD_DEFER_INITIAL_SEC << shift;
+        if (delay > TDB_UPLOAD_DEFER_MAX_SEC) delay = TDB_UPLOAD_DEFER_MAX_SEC;
+
+        pthread_mutex_lock(&db->pending_upload_lock);
+        tdb_objstore_park_locked(db, &job, next_attempts, now + delay);
+        pthread_mutex_unlock(&db->pending_upload_lock);
+    }
+}
+
+/**
+ * tdb_objstore_drain_deferred
+ * one final pass over the deferred backlog at close (reaper stopped, workers joined -- single
+ * threaded), then free it. anything still undelivered persists on local disk for the next startup.
+ * @param db database
+ */
+static void tdb_objstore_drain_deferred(tidesdb_t *db)
+{
+    pthread_mutex_lock(&db->pending_upload_lock);
+    tdb_deferred_upload_t *arr = db->pending_uploads;
+    size_t n = db->pending_upload_count;
+    db->pending_uploads = NULL; /* detach so on_upload_success -> cancel is a noop while draining */
+    db->pending_upload_count = 0;
+    db->pending_upload_capacity = 0;
+    pthread_mutex_unlock(&db->pending_upload_lock);
+
+    for (size_t i = 0; i < n; i++)
+    {
+        struct stat st;
+        if (db->object_store && db->object_store->put && stat(arr[i].job.local_path, &st) == 0 &&
+            tdb_objstore_put_once(db, &arr[i].job) == 0)
+        {
+            tdb_objstore_on_upload_success(db, &arr[i].job);
+            continue;
+        }
+        TDB_DEBUG_LOG(TDB_LOG_WARN, "Deferred upload undelivered at close persists locally %s",
+                      arr[i].job.object_key);
+    }
+    free(arr);
+}
 
 /**
  * tdb_upload_worker_thread
@@ -4885,51 +5183,10 @@ static void *tdb_upload_worker_thread(void *arg)
             unsigned int backoff_us = TDB_UPLOAD_INITIAL_BACKOFF_US;
             for (int attempt = 0; attempt < TDB_UPLOAD_MAX_RETRIES; attempt++)
             {
-                /* use put_if when the object is epoch-tagged (WAL fencing) or a partial upload is
-                 * requested (active WAL's logical length, skipping its preallocated tail) -- both
-                 * need put_if, which also works untagged (epoch 0). otherwise a plain put. */
-                if ((job->meta_epoch || job->upload_max_bytes) && db->object_store->put_if)
-                    rc = db->object_store->put_if(
-                        db->object_store->ctx, job->object_key, job->local_path, TDB_PUT_OVERWRITE,
-                        NULL, job->meta_epoch, NULL, 0, (size_t)job->upload_max_bytes);
-                else
-                    rc = db->object_store->put(db->object_store->ctx, job->object_key,
-                                               job->local_path);
-                if (rc != 0)
-                {
-                    TDB_DEBUG_LOG(TDB_LOG_WARN, "Upload attempt %d/%d failed: %s", attempt + 1,
-                                  TDB_UPLOAD_MAX_RETRIES, job->object_key);
-                }
-                else if (!strstr(job->object_key, TDB_COLUMN_FAMILY_MANIFEST_NAME))
-                {
-                    /* verify the upload landed with the correct size. MANIFEST is skipped --
-                     * it is mutable and may grow between upload and the exists check due to
-                     * concurrent flushes. a verify mismatch now retries the put (rc=-1 below)
-                     * instead of being a permanent failure with no re-upload. */
-                    struct stat local_st;
-                    if (stat(job->local_path, &local_st) == 0)
-                    {
-                        /* a partial WAL upload's remote size is the logical length, not the
-                         * preallocated local file size */
-                        size_t expected = job->upload_max_bytes ? (size_t)job->upload_max_bytes
-                                                                : (size_t)local_st.st_size;
-                        size_t remote_size = 0;
-                        const int verify = db->object_store->exists(db->object_store->ctx,
-                                                                    job->object_key, &remote_size);
-                        if (verify != 1 || remote_size != expected)
-                        {
-                            TDB_DEBUG_LOG(
-                                TDB_LOG_ERROR,
-                                "Upload verification failed for %s (expected=%zu, remote=%zu, "
-                                "exists=%d)",
-                                job->object_key, expected, remote_size, verify);
-                            rc = -1;
-                        }
-                    }
-                }
-
+                rc = tdb_objstore_put_once(db, job);
                 if (rc == 0) break;
-
+                TDB_DEBUG_LOG(TDB_LOG_WARN, "Upload attempt %d/%d failed: %s", attempt + 1,
+                              TDB_UPLOAD_MAX_RETRIES, job->object_key);
                 if (attempt + 1 < TDB_UPLOAD_MAX_RETRIES)
                 {
                     usleep(backoff_us);
@@ -4939,35 +5196,27 @@ static void *tdb_upload_worker_thread(void *arg)
 
             if (rc == 0)
             {
-                atomic_fetch_add_explicit(&db->total_uploads, 1, memory_order_relaxed);
-
-                /* we update WAL fence if this upload advances it */
-                if (job->wal_generation > 0)
-                {
-                    uint64_t cur =
-                        atomic_load_explicit(&db->last_uploaded_gen, memory_order_relaxed);
-                    while (job->wal_generation > cur)
-                    {
-                        if (atomic_compare_exchange_weak_explicit(
-                                &db->last_uploaded_gen, &cur, job->wal_generation,
-                                memory_order_release, memory_order_relaxed))
-                            break;
-                    }
-
-                    /* the rotated WAL is now confirmed present on the object
-                     * store (the exists + size verify above proved it), so the
-                     * upload worker deletes the local copy here. this replaces
-                     * the reaper's old synchronous per-generation exists() sweep.
-                     * recovery can replay the WAL from the object store if the
-                     * node restarts before the immutable has flushed. */
-                    tdb_unlink(job->local_path);
-                }
+                tdb_objstore_on_upload_success(db, job);
             }
             else
             {
                 atomic_fetch_add_explicit(&db->total_upload_failures, 1, memory_order_relaxed);
-                TDB_DEBUG_LOG(TDB_LOG_ERROR, "Upload permanently failed after %d attempts: %s",
-                              TDB_UPLOAD_MAX_RETRIES, job->object_key);
+                /* an active-WAL snapshot (generation 0, partial length) is re-shipped to the same
+                 * key every sync interval, so the periodic resync is its own retry and parking it
+                 * would only risk a stale shorter snapshot overwriting a newer one. everything else
+                 * is parked for the reaper so a longer object store outage still delivers instead
+                 * of dropping the upload here. */
+                if (job->wal_generation == 0 && job->upload_max_bytes > 0)
+                {
+                    TDB_DEBUG_LOG(TDB_LOG_WARN, "WAL snapshot upload failed after %d attempts %s",
+                                  TDB_UPLOAD_MAX_RETRIES, job->object_key);
+                }
+                else
+                {
+                    TDB_DEBUG_LOG(TDB_LOG_WARN, "Upload failed after %d attempts parking %s",
+                                  TDB_UPLOAD_MAX_RETRIES, job->object_key);
+                    tdb_objstore_defer_upload(db, job);
+                }
             }
         }
 
@@ -5000,6 +5249,8 @@ static void tdb_objstore_enqueue_upload(const tidesdb_t *db, const char *local_p
     job->wal_generation = wal_generation;
     job->meta_epoch = meta_epoch;
     job->upload_max_bytes = max_bytes;
+    job->track_in_cache =
+        0; /* async path serves WAL/manifest/config, never sstable cache tracking */
 
     if (queue_enqueue(db->upload_queue, job) != 0)
     {
@@ -5009,86 +5260,102 @@ static void tdb_objstore_enqueue_upload(const tidesdb_t *db, const char *local_p
 }
 
 /**
- * tdb_objstore_upload_file_sync
- * upload a local file synchronously (blocks until complete).
- * used for small metadata files (config.ini, MANIFEST) that must be
- * visible immediately after the call returns.
- * @param db database instance
- * @param local_path local file path to upload
+ * tdb_objstore_upload_job_sync
+ * the synchronous sibling of the async worker. it runs the same fast inner retries and, on success,
+ * the shared bookkeeping. on failure it parks the job for the reaper's slow outer retry when
+ * defer_on_fail is set, and otherwise only records the failure for a caller that retries by other
+ * means (an active WAL snapshot is re-shipped every sync interval, so it needs no parking).
+ * @param db database
+ * @param job upload job describing the object
+ * @param defer_on_fail park the job for deferred retry once the inner retries are exhausted
+ * @return 0 on success, -1 otherwise
  */
-static void tdb_objstore_upload_file_sync(tidesdb_t *db, const char *local_path)
+static int tdb_objstore_upload_job_sync(tidesdb_t *db, const tdb_upload_job_t *job,
+                                        int defer_on_fail)
 {
-    if (!db->object_store || !local_path) return;
-    char key[TDB_MAX_PATH_LEN];
-    tdb_path_to_object_key(db, local_path, key, sizeof(key));
-
-    /* we retry with exponential backoff matching the async upload worker. the upload counters
-     * cover both paths, so the sync sstable/config/wal uploads count alongside the async
-     * manifest/wal ones. */
     unsigned int delay_us = TDB_UPLOAD_INITIAL_BACKOFF_US;
     for (int attempt = 0; attempt < TDB_UPLOAD_MAX_RETRIES; attempt++)
     {
-        if (db->object_store->put(db->object_store->ctx, key, local_path) == 0)
+        if (tdb_objstore_put_once(db, job) == 0)
         {
-            atomic_fetch_add_explicit(&db->total_uploads, 1, memory_order_relaxed);
-            return;
+            tdb_objstore_on_upload_success(db, job);
+            return 0;
         }
-
         TDB_DEBUG_LOG(TDB_LOG_WARN, "Object store sync upload attempt %d/%d failed: %s",
-                      attempt + 1, TDB_UPLOAD_MAX_RETRIES, key);
+                      attempt + 1, TDB_UPLOAD_MAX_RETRIES, job->object_key);
         if (attempt + 1 < TDB_UPLOAD_MAX_RETRIES) usleep(delay_us);
         delay_us *= TDB_UPLOAD_BACKOFF_MULTIPLIER;
     }
+
     atomic_fetch_add_explicit(&db->total_upload_failures, 1, memory_order_relaxed);
-    TDB_DEBUG_LOG(TDB_LOG_ERROR, "Object store sync upload failed after %d attempts: %s",
-                  TDB_UPLOAD_MAX_RETRIES, key);
+    if (defer_on_fail)
+    {
+        TDB_DEBUG_LOG(TDB_LOG_WARN, "Object store sync upload failed after %d attempts parking %s",
+                      TDB_UPLOAD_MAX_RETRIES, job->object_key);
+        tdb_objstore_defer_upload(db, job);
+    }
+    else
+    {
+        TDB_DEBUG_LOG(TDB_LOG_WARN, "Object store sync upload failed after %d attempts %s",
+                      TDB_UPLOAD_MAX_RETRIES, job->object_key);
+    }
+    return -1;
+}
+
+/**
+ * tdb_objstore_upload_file_sync
+ * upload a local file synchronously, blocking until it lands. used for the small metadata files
+ * (config.ini, MANIFEST, the cf-index map) and for sstable data files, which must be on the store
+ * before the local cache is allowed to evict them. a failed upload is parked for deferred retry.
+ * @param db database
+ * @param local_path local file path to upload
+ * @param track_in_cache register the file with the local cache once it is confirmed remote
+ * (sstable)
+ * @return 0 on success, -1 otherwise
+ */
+static int tdb_objstore_upload_file_sync(tidesdb_t *db, const char *local_path, int track_in_cache)
+{
+    if (!db->object_store || !local_path) return -1;
+
+    tdb_upload_job_t job;
+    snprintf(job.local_path, sizeof(job.local_path), "%s", local_path);
+    tdb_path_to_object_key(db, local_path, job.object_key, sizeof(job.object_key));
+    job.wal_generation = 0;
+    job.meta_epoch = 0;
+    job.upload_max_bytes = 0;
+    job.track_in_cache = track_in_cache;
+    return tdb_objstore_upload_job_sync(db, &job, 1);
 }
 
 /**
  * tdb_objstore_upload_wal_sync
- * synchronous WAL upload that tags the object with the current lease epoch so a replica can
- * skip a superseded primary's segments. falls back to the plain sync upload when fencing is off.
- * @param db database instance
+ * synchronous WAL upload that tags the object with the current lease epoch so a replica can skip a
+ * superseded primary's segments. a rotated WAL (wal_generation > 0) advances the upload fence and
+ * has its local copy deleted on success, and is parked for deferred retry on failure. an active-WAL
+ * snapshot (generation 0, partial length) is re-shipped every sync interval, so it is not parked.
+ * put_once routes through put_if whenever the connector has it so the snapshot honors max_bytes and
+ * ships the WAL's logical length rather than its preallocated extent.
+ * @param db database
  * @param local_path WAL file path to upload
  * @param max_bytes logical WAL length to upload (0 = whole file); the active WAL is preallocated
  *                  far past its data, so shipping the whole file would copy a huge zero tail
+ * @param wal_generation rotated-WAL generation to fence on success (0 = active WAL, no fence)
+ * @return 0 on success, -1 otherwise
  */
-static void tdb_objstore_upload_wal_sync(tidesdb_t *db, const char *local_path, uint64_t max_bytes)
+static int tdb_objstore_upload_wal_sync(tidesdb_t *db, const char *local_path, uint64_t max_bytes,
+                                        uint64_t wal_generation)
 {
-    if (!db->object_store || !local_path) return;
+    if (!db->object_store || !local_path) return -1;
 
-    /* route through put_if whenever the connector has it, even before a lease is held (epoch 0):
-     * it is the only upload that honors max_bytes, so it ships the active WAL's logical length
-     * rather than its 64MB preallocated extent. an untagged (epoch 0) WAL is fine -- a reader
-     * treats epoch 0 as never-stale. only a legacy connector lacking put_if falls back. */
-    if (!db->object_store->put_if)
-    {
-        tdb_objstore_upload_file_sync(db, local_path);
-        return;
-    }
+    tdb_upload_job_t job;
+    snprintf(job.local_path, sizeof(job.local_path), "%s", local_path);
+    tdb_path_to_object_key(db, local_path, job.object_key, sizeof(job.object_key));
+    job.wal_generation = wal_generation;
+    job.meta_epoch = atomic_load_explicit(&db->primary_epoch, memory_order_acquire);
+    job.upload_max_bytes = max_bytes;
+    job.track_in_cache = 0;
 
-    uint64_t epoch = atomic_load_explicit(&db->primary_epoch, memory_order_acquire);
-
-    char key[TDB_MAX_PATH_LEN];
-    tdb_path_to_object_key(db, local_path, key, sizeof(key));
-
-    unsigned int delay_us = TDB_UPLOAD_INITIAL_BACKOFF_US;
-    for (int attempt = 0; attempt < TDB_UPLOAD_MAX_RETRIES; attempt++)
-    {
-        if (db->object_store->put_if(db->object_store->ctx, key, local_path, TDB_PUT_OVERWRITE,
-                                     NULL, epoch, NULL, 0, (size_t)max_bytes) == 0)
-        {
-            atomic_fetch_add_explicit(&db->total_uploads, 1, memory_order_relaxed);
-            return;
-        }
-        TDB_DEBUG_LOG(TDB_LOG_WARN, "Object store sync WAL upload attempt %d/%d failed: %s",
-                      attempt + 1, TDB_UPLOAD_MAX_RETRIES, key);
-        if (attempt + 1 < TDB_UPLOAD_MAX_RETRIES) usleep(delay_us);
-        delay_us *= TDB_UPLOAD_BACKOFF_MULTIPLIER;
-    }
-    atomic_fetch_add_explicit(&db->total_upload_failures, 1, memory_order_relaxed);
-    TDB_DEBUG_LOG(TDB_LOG_ERROR, "Object store sync WAL upload failed after %d attempts: %s",
-                  TDB_UPLOAD_MAX_RETRIES, key);
+    return tdb_objstore_upload_job_sync(db, &job, wal_generation > 0);
 }
 
 /**
@@ -5110,7 +5377,7 @@ static void tdb_objstore_upload_file(tidesdb_t *db, const char *local_path)
     }
 
     /* we fallback to synchronous upload (retries and counts via the sync helper) */
-    tdb_objstore_upload_file_sync(db, local_path);
+    tdb_objstore_upload_file_sync(db, local_path, 0);
 }
 
 /**
@@ -5412,7 +5679,7 @@ static int tdb_objstore_fencing_enabled(const tidesdb_t *db)
 }
 
 /* tdb_objstore_verify_conditional_writes
- * probe whether the backend actually enforces conditional puts: a create-only put on a fresh
+ * probe whether the backend actually enforces conditional puts, a create-only put on a fresh
  * key must succeed and an immediate second create-only on the same key must fail the
  * precondition. a store that ignores If-None-Match returns success twice, so fencing would be
  * false safety -- callers disable it in that case. uses a node-unique key to avoid cross-node
@@ -10525,21 +10792,22 @@ static int64_t tidesdb_sstable_aux_memory_bytes(const tidesdb_sstable_t *sst)
  */
 static int tidesdb_level_add_sstable(tidesdb_level_t *level, tidesdb_sstable_t *sst)
 {
-    /* we upload sstable files synchronously before tracking in the local cache.
-     * this ensures the object store has a copy before cache eviction can delete
-     * the local file (the eviction path unlinks cold files from disk).
-     * a replica never creates sstables -- its adds come from sync/cold-start and
-     * already exist remotely, so re-uploading wastes bandwidth and, on an incomplete
-     * local copy, could clobber good remote data. it can also always re-fetch on
-     * eviction, so only primaries push to the store. */
+    /* a primary uploads each sstable file synchronously and only marks it cache-trackable -- and
+     * so evictable -- once the upload confirms, since the eviction path unlinks cold files from
+     * disk and must never reclaim a file that is not yet on the store. an upload that exhausts the
+     * fast retries is parked for deferred retry and the file stays untracked (pinned on disk) until
+     * the reaper delivers it. a replica never creates sstables -- its adds come from
+     * sync/cold-start and already exist remotely, so it tracks them for eviction directly and can
+     * re-fetch on a miss, never pushing to the store (re-uploading an incomplete local copy could
+     * clobber good remote data). */
     if (sst->db && sst->db->object_store)
     {
         if (!atomic_load_explicit(&sst->db->replica_mode, memory_order_acquire))
         {
-            tdb_objstore_upload_file_sync(sst->db, sst->klog_path);
-            tdb_objstore_upload_file_sync(sst->db, sst->vlog_path);
+            tdb_objstore_upload_file_sync(sst->db, sst->klog_path, 1);
+            tdb_objstore_upload_file_sync(sst->db, sst->vlog_path, 1);
         }
-        if (sst->db->local_cache)
+        else if (sst->db->local_cache)
         {
             tdb_local_cache_track(sst->db->local_cache, sst->klog_path);
             tdb_local_cache_track(sst->db->local_cache, sst->vlog_path);
@@ -20394,6 +20662,10 @@ static void *tidesdb_reaper_thread(void *arg)
             }
         }
 
+        /* re-attempt any uploads parked by a failed put, now that some time has passed and the
+         * object store may have recovered */
+        tdb_objstore_retry_deferred(db);
+
         int current_open = atomic_load(&db->num_open_sstables);
         int max_open = (int)db->config.max_open_sstables;
         /* evict down to the reader budget, not max_open, keeping num_open at/below the budget
@@ -21735,6 +22007,12 @@ int tidesdb_open(const tidesdb_config_t *config, tidesdb_t **db)
     }
 
     pthread_mutex_init(&(*db)->reaper_thread_mutex, NULL);
+    /* deferred-upload backlog -- initialized unconditionally so close can always destroy it,
+     * even for non-object-store databases that never populate it */
+    (*db)->pending_uploads = NULL;
+    (*db)->pending_upload_count = 0;
+    (*db)->pending_upload_capacity = 0;
+    pthread_mutex_init(&(*db)->pending_upload_lock, NULL);
 #if defined(__linux__)
     {
         pthread_condattr_t cattr;
@@ -22255,10 +22533,16 @@ int tidesdb_close(tidesdb_t *db)
         queue_free(db->upload_queue);
         db->upload_queue = NULL;
 
+        /* one best-effort pass over the deferred backlog -- the reaper is already stopped and the
+         * workers are joined, so this is single-threaded. anything still undelivered persists on
+         * local disk for the next startup to re-upload */
+        tdb_objstore_drain_deferred(db);
+
         TDB_DEBUG_LOG(TDB_LOG_INFO,
                       "Upload pipeline stopped (%" PRIu64 " uploads, %" PRIu64 " failures)",
                       atomic_load(&db->total_uploads), atomic_load(&db->total_upload_failures));
     }
+    pthread_mutex_destroy(&db->pending_upload_lock);
 
     /* we clean up unified memtable state if enabled */
     if (db->unified_mt.enabled)
@@ -22591,7 +22875,7 @@ static int tidesdb_unimap_persist(tidesdb_t *db)
      * MANIFEST so replicas reconstruct cf indexes the same way the primary did */
     if (db->object_store)
     {
-        tdb_objstore_upload_file_sync(db, final_path);
+        tdb_objstore_upload_file_sync(db, final_path, 0);
     }
 
     return TDB_SUCCESS;
@@ -23440,14 +23724,14 @@ int tidesdb_create_column_family(tidesdb_t *db, const char *name,
     /* we upload config.ini to object store (sync -- small file, must be visible immediately) */
     if (db->object_store && save_result == TDB_SUCCESS)
     {
-        tdb_objstore_upload_file_sync(db, config_path);
+        tdb_objstore_upload_file_sync(db, config_path, 0);
 
         /* commit + upload the empty MANIFEST so replicas can discover this CF
          * before its first flush -- discovery keys off <cf>/MANIFEST */
         if (tidesdb_manifest_commit(cf->manifest, cf->manifest->path,
                                     cf->config.sync_mode != TDB_SYNC_NONE) == 0)
         {
-            tdb_objstore_upload_file_sync(db, cf->manifest->path);
+            tdb_objstore_upload_file_sync(db, cf->manifest->path, 0);
         }
     }
 
@@ -28149,11 +28433,13 @@ static void tidesdb_unified_close_wal(tidesdb_t *db, tidesdb_memtable_t *umt_imm
     {
         if (db->config.object_store_config->wal_upload_sync)
         {
-            /* the WAL was closed above, so it is already trimmed to its data -- ship the whole
-             * file */
-            tdb_objstore_upload_wal_sync(db, wal_path, 0);
-            tdb_unlink(wal_path);
-            tdb_sync_directory(db->db_path);
+            /* the WAL was closed above and is trimmed to its data, so the whole file ships. on
+             * success the upload helper advances the fence and deletes the local copy, so the
+             * directory sync just persists that deletion. on failure the WAL is parked for the
+             * reaper and the local file is kept for that retry and for recovery to replay if we
+             * restart first. */
+            if (tdb_objstore_upload_wal_sync(db, wal_path, 0, imm_gen) == 0)
+                tdb_sync_directory(db->db_path);
         }
         else
         {
@@ -28904,7 +29190,7 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
         {
             uint64_t wal_len = 0;
             block_manager_get_size(umt->wal, &wal_len);
-            tdb_objstore_upload_wal_sync(txn->db, umt->wal->file_path, wal_len);
+            tdb_objstore_upload_wal_sync(txn->db, umt->wal->file_path, wal_len, 0);
         }
 
         /* we apply ops to unified skip list with prefixed keys */

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -746,6 +746,9 @@ struct tidesdb_kv_pair_t
 
 #define TDB_COMMIT_STATUS_IN_PROGRESS 0
 #define TDB_COMMIT_STATUS_COMMITTED   1
+#define TDB_COMMIT_STATUS_ABORTED                                \
+    2 /* lost its post-apply write-write check; lets the visible \
+       * watermark advance past it and keeps its versions unseen */
 
 /**
  * tidesdb_commit_status_t
@@ -1353,6 +1356,53 @@ static void tidesdb_commit_status_mark(tidesdb_commit_status_t *cs, uint64_t seq
 }
 
 /**
+ * tidesdb_visible_seq_advance
+ * pushes db->visible_seq forward over every contiguous decided commit (committed or aborted), so a
+ * snapshot taken from visible_seq never names an in-flight commit. called once a commit reaches its
+ * fate. the walk stops at the first undecided seq and never crosses global_seq, since a slot past
+ * the highest allocated seq may still hold a stale status from a wrapped-around earlier seq.
+ * @param db database
+ */
+static void tidesdb_visible_seq_advance(tidesdb_t *db)
+{
+    tidesdb_commit_status_t *cs = db->commit_status;
+    if (!cs) return;
+
+    uint64_t v = atomic_load_explicit(&db->visible_seq, memory_order_acquire);
+    while (1)
+    {
+        const uint64_t next = v + 1;
+        if (next >= atomic_load_explicit(&db->global_seq, memory_order_acquire)) break;
+        const uint8_t st =
+            atomic_load_explicit(&cs->status[next % cs->capacity], memory_order_acquire);
+        if (st != TDB_COMMIT_STATUS_COMMITTED && st != TDB_COMMIT_STATUS_ABORTED) break;
+        if (atomic_compare_exchange_weak_explicit(&db->visible_seq, &v, next, memory_order_release,
+                                                  memory_order_acquire))
+            v = next; /* claimed next; keep walking */
+        /* CAS failure reloaded v into the new watermark; retest next against it */
+    }
+}
+
+/**
+ * tidesdb_commit_status_is_aborted
+ * whether seq belongs to a transaction that lost its post-apply conflict check. an aborted seq is
+ * recent -- it lives only in a memtable until flush skips it -- so the global_seq window guards a
+ * wrapped circular-buffer slot (a much older committed sstable seq) from being misread as aborted.
+ * @param cs commit status tracker
+ * @param seq sequence number to test
+ * @param global_seq the current global sequence
+ * @return 1 if seq is a recent aborted transaction, 0 otherwise
+ */
+static int tidesdb_commit_status_is_aborted(tidesdb_commit_status_t *cs, uint64_t seq,
+                                            uint64_t global_seq)
+{
+    if (!cs || seq == 0 || seq == UINT64_MAX) return 0;
+    if (seq + cs->capacity <= global_seq) return 0;
+    return atomic_load_explicit(&cs->status[seq % cs->capacity], memory_order_acquire) ==
+           TDB_COMMIT_STATUS_ABORTED;
+}
+
+/**
  * tidesdb_visibility_check_callback
  * callback for skip list to check if a sequence is committed
  * used by skip_list_get_with_seq for visibility determination
@@ -1719,7 +1769,9 @@ static int tidesdb_partitioned_merge(tidesdb_column_family_t *cf, const int star
                                      const int end_level);
 static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t **inputs,
                                   int input_count, int min_input_level, int max_input_level,
-                                  int target_level);
+                                  int target_level, const uint8_t *drop_range_start,
+                                  size_t drop_range_start_size, const uint8_t *drop_range_end,
+                                  size_t drop_range_end_size);
 static int tidesdb_compact_range_internal(tidesdb_column_family_t *cf, const uint8_t *start_key,
                                           size_t start_key_size, const uint8_t *end_key,
                                           size_t end_key_size, int target_level_override);
@@ -1739,7 +1791,7 @@ static int tidesdb_sstable_write_from_heap_btree(tidesdb_column_family_t *cf,
                                                  bloom_filter_t *bloom, queue_t *sstables_to_delete,
                                                  int is_largest_level, const uint8_t *range_start,
                                                  size_t range_start_size, const uint8_t *range_end,
-                                                 size_t range_end_size,
+                                                 size_t range_end_size, int keep_out_of_range,
                                                  uint64_t oldest_unflushed_seq);
 static int tidesdb_trigger_compaction(tidesdb_column_family_t *cf, int full_compaction);
 static int tidesdb_enqueue_compaction(tidesdb_column_family_t *cf, int full_compaction);
@@ -6514,13 +6566,15 @@ static void tdb_objstore_replay_remote_wals(tidesdb_t *db, int cold_start, uint6
 
     /* max_seq is the highest seq applied; global_seq is the next seq to assign, so it
      * must reach max_seq + 1. comparing max_seq directly leaves a replica that is one
-     * step behind stuck, global_seq never advances, the read snapshot (global_seq - 1)
-     * stays below the newest entry, and just-replayed rows stay invisible while the
-     * replay re-applies the same tail every tick. */
+     * step behind stuck, global_seq never advances, the read snapshot stays below the
+     * newest entry, and just-replayed rows stay invisible while the replay re-applies
+     * the same tail every tick. replayed entries are all committed, so the visible
+     * watermark advances with global_seq. */
     const uint64_t next_seq = max_seq + 1;
     if (next_seq > atomic_load_explicit(&db->global_seq, memory_order_acquire))
     {
         atomic_store_explicit(&db->global_seq, next_seq, memory_order_release);
+        atomic_store_explicit(&db->visible_seq, max_seq, memory_order_release);
     }
 
     /* the boundary entry at seq == start_max_seq is re-applied every tick (idempotent), so
@@ -8496,6 +8550,16 @@ static int tidesdb_sstable_write_from_memtable_btree_ex(tidesdb_t *db, tidesdb_c
                 key_size -= seg_prefix_len;
             }
 
+            /* an aborted version lost its conflict check and is invisible, so it must never reach
+             * the sstable. skip it, stopping the chain walk once below the snapshot floor where
+             * older versions are dominated anyway. */
+            if (deleted & SKIP_LIST_FLAG_ABORTED)
+            {
+                if (seq <= min_snapshot_seq) break;
+                if (skip_list_cursor_advance_in_node(cursor) != 0) break;
+                continue;
+            }
+
             /* we write value to vlog if it exceeds the threshold, matching the
              * compaction merge path. small values are stored inline in the btree. */
             uint64_t vlog_offset = 0;
@@ -8699,6 +8763,33 @@ static uint64_t tidesdb_cf_oldest_unflushed_seq(tidesdb_column_family_t *cf)
 }
 
 /**
+ * tdb_key_in_drop_range
+ * whether key lies in [range_start, range_end), a NULL bound being unbounded on that side. a
+ * key-range targeted merge collects whole sstables that overhang the range, so it may only GC a
+ * tombstone for a key inside the range it fully covers -- an out-of-range overhang key can have an
+ * older put in a deeper sstable that did not overlap the range and so was never collected, and
+ * dropping its tombstone would resurrect it.
+ * @param cmp_fn comparator
+ * @param cmp_ctx comparator context
+ * @param key candidate key
+ * @param key_size size of key
+ * @param range_start inclusive lower bound (NULL = unbounded)
+ * @param range_start_size size of range_start
+ * @param range_end exclusive upper bound (NULL = unbounded)
+ * @param range_end_size size of range_end
+ * @return 1 if in range, 0 otherwise
+ */
+static int tdb_key_in_drop_range(skip_list_comparator_fn cmp_fn, void *cmp_ctx, const uint8_t *key,
+                                 size_t key_size, const uint8_t *range_start,
+                                 size_t range_start_size, const uint8_t *range_end,
+                                 size_t range_end_size)
+{
+    if (range_start && cmp_fn(key, key_size, range_start, range_start_size, cmp_ctx) < 0) return 0;
+    if (range_end && cmp_fn(key, key_size, range_end, range_end_size, cmp_ctx) >= 0) return 0;
+    return 1;
+}
+
+/**
  * tidesdb_sstable_write_from_heap_btree
  * write merged entries from a heap to an sstable using B+tree format
  * @param cf column family
@@ -8709,13 +8800,17 @@ static uint64_t tidesdb_cf_oldest_unflushed_seq(tidesdb_column_family_t *cf)
  * @param bloom bloom filter (optional, may be NULL)
  * @param sstables_to_delete queue for corrupted sstables
  * @param is_largest_level whether this is the largest level
+ * @param keep_out_of_range when set, keys outside [range_start, range_end) are still written rather
+ *        than skipped (a single-output targeted merge must not drop the overhang of a boundary
+ *        sstable); their tombstones are never GC'd regardless. when clear a partition writer skips
+ *        them, since the other partitions cover them.
  * @return 0 on success, error code on failure
  */
 static int tidesdb_sstable_write_from_heap_btree(
     tidesdb_column_family_t *cf, tidesdb_sstable_t *sst, tidesdb_merge_heap_t *heap,
     block_manager_t *klog_bm, block_manager_t *vlog_bm, bloom_filter_t *bloom,
     queue_t *sstables_to_delete, const int is_largest_level, const uint8_t *range_start,
-    size_t range_start_size, const uint8_t *range_end, size_t range_end_size,
+    size_t range_start_size, const uint8_t *range_end, size_t range_end_size, int keep_out_of_range,
     uint64_t oldest_unflushed_seq)
 {
     if (!cf || !sst || !heap || !klog_bm || !vlog_bm) return TDB_ERR_INVALID_ARGS;
@@ -8801,11 +8896,12 @@ static int tidesdb_sstable_write_from_heap_btree(
          * partition output must contain only keys in [range_start, range_end). without this the
          * btree partition writer wrote out-of-range keys and, worse, processed (and at the largest
          * level GC'd) tombstones for keys owned by other partitions whose puts then resurfaced.
-         * all versions of a key share the key, so skipping by key is safe. */
-        if (kv && ((range_start && comparator_fn(kv->key, kv->entry.key_size, range_start,
-                                                 range_start_size, comparator_ctx) < 0) ||
-                   (range_end && comparator_fn(kv->key, kv->entry.key_size, range_end,
-                                               range_end_size, comparator_ctx) >= 0)))
+         * all versions of a key share the key, so skipping by key is safe. a single-output targeted
+         * merge instead keeps the overhang (keep_out_of_range) and relies on the GC gate below, as
+         * skipping there would drop a boundary sstable's out-of-range keys with nowhere to land. */
+        if (!keep_out_of_range && kv &&
+            !tdb_key_in_drop_range(comparator_fn, comparator_ctx, kv->key, kv->entry.key_size,
+                                   range_start, range_start_size, range_end, range_end_size))
         {
             tidesdb_kv_pair_free(kv);
             continue;
@@ -8832,10 +8928,16 @@ static int tidesdb_sstable_write_from_heap_btree(
         {
             const int sd_pair_drop = pending_is_single_delete && pending_sd_paired_with_put;
             /* never reap a tombstone newer than the oldest write still unflushed in a memtable --
-             * that older version is off the merge's snapshot and would resurface once it flushes */
-            const int tombstone_drop = (pending->entry.flags & TDB_KV_FLAG_TOMBSTONE) &&
-                                       is_largest_level && pending->entry.seq <= min_snapshot_seq &&
-                                       pending->entry.seq < oldest_unflushed_seq;
+             * that older version is off the merge's snapshot and would resurface once it flushes.
+             * an out-of-range overhang key is never reaped here either -- its older versions may
+             * sit in sstables that did not overlap the merge range and so were not collected. */
+            const int tombstone_drop =
+                (pending->entry.flags & TDB_KV_FLAG_TOMBSTONE) && is_largest_level &&
+                pending->entry.seq <= min_snapshot_seq &&
+                pending->entry.seq < oldest_unflushed_seq &&
+                tdb_key_in_drop_range(comparator_fn, comparator_ctx, pending->key,
+                                      pending->entry.key_size, range_start, range_start_size,
+                                      range_end, range_end_size);
             const int ttl_drop =
                 pending->entry.ttl > 0 &&
                 pending->entry.ttl <
@@ -9182,6 +9284,16 @@ static int tidesdb_sstable_write_from_memtable_ex(tidesdb_t *db, tidesdb_column_
                     }
                     key += seg_prefix_len;
                     key_size -= seg_prefix_len;
+                }
+
+                /* an aborted version lost its conflict check and is invisible, so it must never
+                 * reach the sstable. skip it, stopping the chain walk once below the snapshot floor
+                 * where older versions are dominated anyway. */
+                if (deleted & SKIP_LIST_FLAG_ABORTED)
+                {
+                    if (seq <= min_snapshot_seq) break;
+                    if (skip_list_cursor_advance_in_node(cursor) != 0) break;
+                    continue;
                 }
 
                 /* we populate stack-allocated KV pair (no malloc needed) */
@@ -14920,7 +15032,8 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
         {
             int btree_result = tidesdb_sstable_write_from_heap_btree(
                 cf, new_sst, heap, klog_bm, vlog_bm, bloom, sstables_to_delete, is_largest_level,
-                range_start, range_start_size, range_end, range_end_size, c->oldest_unflushed_seq);
+                range_start, range_start_size, range_end, range_end_size, 0,
+                c->oldest_unflushed_seq);
             block_manager_close(klog_bm);
             block_manager_close(vlog_bm);
             tidesdb_merge_heap_free(heap);
@@ -15467,11 +15580,19 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
  * @param min_input_level smallest 0-indexed level any input lives in
  * @param max_input_level largest 0-indexed level any input lives in
  * @param target_level 0-indexed level to write output to
+ * @param drop_range_start lower bound of the range this merge fully covers (NULL = unbounded); a
+ *        tombstone is only GC'd for a key inside [drop_range_start, drop_range_end), since an
+ *        overhang key of a boundary input sstable may have older versions that were not collected
+ * @param drop_range_start_size size of drop_range_start
+ * @param drop_range_end upper bound, exclusive (NULL = unbounded)
+ * @param drop_range_end_size size of drop_range_end
  * @return TDB_SUCCESS on success, error code on failure
  */
 static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t **inputs,
                                   int input_count, int min_input_level, int max_input_level,
-                                  int target_level)
+                                  int target_level, const uint8_t *drop_range_start,
+                                  size_t drop_range_start_size, const uint8_t *drop_range_end,
+                                  size_t drop_range_end_size)
 {
     if (!cf || !inputs || input_count <= 0) return TDB_ERR_INVALID_ARGS;
     if (min_input_level < 0 || max_input_level < min_input_level) return TDB_ERR_INVALID_ARGS;
@@ -15588,8 +15709,9 @@ static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t
     if (cf->config.use_btree)
     {
         int btree_result = tidesdb_sstable_write_from_heap_btree(
-            cf, new_sst, heap, klog_bm, vlog_bm, bloom, sstables_to_delete, is_largest_level, NULL,
-            0, NULL, 0, oldest_unflushed_seq);
+            cf, new_sst, heap, klog_bm, vlog_bm, bloom, sstables_to_delete, is_largest_level,
+            drop_range_start, drop_range_start_size, drop_range_end, drop_range_end_size, 1,
+            oldest_unflushed_seq);
         block_manager_close(klog_bm);
         block_manager_close(vlog_bm);
         tidesdb_merge_heap_free(heap);
@@ -15675,9 +15797,15 @@ static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t
         if (pending)
         {
             const int sd_pair_drop = pending_is_single_delete && pending_sd_paired_with_put;
-            const int tombstone_drop = (pending->entry.flags & TDB_KV_FLAG_TOMBSTONE) &&
-                                       is_largest_level && pending->entry.seq <= min_snapshot_seq &&
-                                       pending->entry.seq < oldest_unflushed_seq;
+            /* an out-of-range overhang key of a boundary input is written but never reaped -- its
+             * older versions may live in sstables that did not overlap the merge range */
+            const int tombstone_drop =
+                (pending->entry.flags & TDB_KV_FLAG_TOMBSTONE) && is_largest_level &&
+                pending->entry.seq <= min_snapshot_seq &&
+                pending->entry.seq < oldest_unflushed_seq &&
+                tdb_key_in_drop_range(comparator_fn, comparator_ctx, pending->key,
+                                      pending->entry.key_size, drop_range_start,
+                                      drop_range_start_size, drop_range_end, drop_range_end_size);
             const int ttl_drop =
                 pending->entry.ttl > 0 &&
                 pending->entry.ttl <
@@ -16547,7 +16675,8 @@ static int tidesdb_dividing_merge_partition(void *vctx, int partition)
 
             int btree_result = tidesdb_sstable_write_from_heap_btree(
                 cf, new_sst, partition_heap, klog_bm, vlog_bm, bloom, NULL, is_largest_level,
-                range_start, range_start_size, range_end, range_end_size, c->oldest_unflushed_seq);
+                range_start, range_start_size, range_end, range_end_size, 0,
+                c->oldest_unflushed_seq);
             block_manager_close(klog_bm);
             block_manager_close(vlog_bm);
             tidesdb_merge_heap_free(partition_heap);
@@ -17719,7 +17848,7 @@ static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
             {
                 int btree_result = tidesdb_sstable_write_from_heap_btree(
                     cf, new_sst, heap, klog_bm, vlog_bm, bloom, NULL, reap_tombstones, range_start,
-                    range_start_size, range_end, range_end_size, c->oldest_unflushed_seq);
+                    range_start_size, range_end, range_end_size, 0, c->oldest_unflushed_seq);
                 block_manager_close(klog_bm);
                 block_manager_close(vlog_bm);
                 tidesdb_merge_heap_free(heap);
@@ -21412,6 +21541,7 @@ int tidesdb_open(const tidesdb_config_t *config, tidesdb_t **db)
 
     atomic_init(&(*db)->next_txn_id, 1);
     atomic_init(&(*db)->global_seq, 1);
+    atomic_init(&(*db)->visible_seq, 0);
     atomic_init(&(*db)->num_open_sstables, 0);
 
     (*db)->commit_status = tidesdb_commit_status_create();
@@ -25263,8 +25393,13 @@ static int tidesdb_compact_range_internal(tidesdb_column_family_t *cf, const uin
         if (target_level < min_input_level) target_level = min_input_level;
     }
 
-    const int merge_result = tidesdb_targeted_merge(cf, inputs, input_count, min_input_level,
-                                                    max_input_level, target_level);
+    /* the merge fully covers [start_key, end_key) -- it collected every sstable overlapping that
+     * range, so only there is a key guaranteed to have all its versions in this merge and its
+     * tombstone safe to reap. boundary inputs overhang the range and their overhang keys are kept
+     * but never reaped. */
+    const int merge_result =
+        tidesdb_targeted_merge(cf, inputs, input_count, min_input_level, max_input_level,
+                               target_level, start_key, start_key_size, end_key, end_key_size);
     free(inputs);
 
     atomic_store_explicit(&cf->is_compacting, 0, memory_order_release);
@@ -25936,9 +26071,10 @@ int tidesdb_txn_begin_with_isolation(tidesdb_t *db, const tidesdb_isolation_leve
     else
     {
         /** REPEATABLE_READ, SNAPSHOT, SERIALIZABLE = consistent snapshot
-         *  we capture global_seq -- 1 to see only transactions committed before we started */
-        uint64_t current_seq = atomic_load_explicit(&db->global_seq, memory_order_acquire);
-        (*txn)->snapshot_seq = (current_seq > 0) ? current_seq - 1 : 0;
+         *  we read visible_seq, the highest seq with no in-flight predecessor, so the snapshot can
+         *  never name a commit that is still applying -- such a commit is invisible to reads and
+         *  would otherwise also slip past the post-apply write-write scan */
+        (*txn)->snapshot_seq = atomic_load_explicit(&db->visible_seq, memory_order_acquire);
     }
 
     (*txn)->commit_seq = 0;
@@ -27154,8 +27290,7 @@ int tidesdb_txn_reset(tidesdb_txn_t *txn, const tidesdb_isolation_level_t isolat
     }
     else
     {
-        uint64_t current_seq = atomic_load_explicit(&txn->db->global_seq, memory_order_acquire);
-        txn->snapshot_seq = (current_seq > 0) ? current_seq - 1 : 0;
+        txn->snapshot_seq = atomic_load_explicit(&txn->db->visible_seq, memory_order_acquire);
     }
 
     txn->commit_seq = 0;
@@ -27433,46 +27568,30 @@ static int tidesdb_txn_check_read_conflicts(const tidesdb_txn_t *txn)
     tidesdb_immutable_memtable_t **imm_refs = NULL;
     size_t imm_count = 0;
 
+    /* serializable also runs the post-apply write-write check, which already serializes any key it
+     * writes; re-validating such a key as a read here is redundant and turns a hot
+     * read-modify-write key into a livelock. repeatable_read has no write-write check, so it must
+     * validate every read. */
+    const int skip_written = (txn->isolation_level == TDB_ISOLATION_SERIALIZABLE);
+
     for (int r = 0; r < txn->read_set_count; r++)
     {
+        if (skip_written)
+        {
+            int in_write_set = 0;
+            for (int w = 0; w < txn->num_ops && !in_write_set; w++)
+            {
+                const tidesdb_txn_op_t *op = &txn->ops[w];
+                if (op->cf == txn->read_cfs[r] && op->key_size == txn->read_key_sizes[r] &&
+                    memcmp(op->key, txn->read_keys[r], op->key_size) == 0)
+                    in_write_set = 1;
+            }
+            if (in_write_set) continue;
+        }
+
         const int result = tidesdb_txn_check_key_conflict(txn, txn->read_cfs[r], txn->read_keys[r],
                                                           txn->read_key_sizes[r], txn->read_seqs[r],
                                                           &imm_refs, &imm_count, &last_cf);
-
-        if (result != TDB_SUCCESS)
-        {
-            if (imm_refs) tidesdb_txn_cleanup_imm_snapshot(imm_refs, imm_count);
-            return result;
-        }
-    }
-
-    if (imm_refs) tidesdb_txn_cleanup_imm_snapshot(imm_refs, imm_count);
-    return TDB_SUCCESS;
-}
-
-/**
- * tidesdb_txn_check_write_conflicts
- * check write-set for conflicts (snapshot isolation and higher)
- * @param txn transaction to check
- * @return TDB_SUCCESS if no conflicts, TDB_ERR_CONFLICT otherwise
- */
-static int tidesdb_txn_check_write_conflicts(const tidesdb_txn_t *txn)
-{
-    if (txn->isolation_level < TDB_ISOLATION_SNAPSHOT || txn->num_ops == 0)
-    {
-        return TDB_SUCCESS;
-    }
-
-    tidesdb_column_family_t *last_cf = NULL;
-    tidesdb_immutable_memtable_t **imm_refs = NULL;
-    size_t imm_count = 0;
-
-    for (int w = 0; w < txn->num_ops; w++)
-    {
-        const tidesdb_txn_op_t *op = &txn->ops[w];
-
-        const int result = tidesdb_txn_check_key_conflict(
-            txn, op->cf, op->key, op->key_size, txn->snapshot_seq, &imm_refs, &imm_count, &last_cf);
 
         if (result != TDB_SUCCESS)
         {
@@ -29082,16 +29201,14 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
         return TDB_SUCCESS;
     }
 
-    /*** we skip all conflict checks for READ_UNCOMMITTED and READ_COMMITTED
-     **  read conflicts require REPEATABLE_READ+, write conflicts require SNAPSHOT+,
-     *   SSI conflicts require SERIALIZABLE -- none apply at lower isolation levels */
+    /*** we skip read and ssi checks for READ_UNCOMMITTED and READ_COMMITTED
+     **  read conflicts require REPEATABLE_READ+, ssi conflicts require SERIALIZABLE. write-write is
+     *   detected after apply below, so a concurrent committer's version is already on the chain
+     *   when we scan and cannot be missed by both of us. */
     int result;
     if (txn->isolation_level > TDB_ISOLATION_READ_COMMITTED)
     {
         result = tidesdb_txn_check_read_conflicts(txn);
-        if (result != TDB_SUCCESS) return result;
-
-        result = tidesdb_txn_check_write_conflicts(txn);
         if (result != TDB_SUCCESS) return result;
 
         result = tidesdb_txn_check_ssi_conflicts(txn);
@@ -29202,6 +29319,52 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
             return result;
         }
 
+        /* apply-before-validate write-write detection, mirroring the per-cf path but over the
+         * shared chain with prefixed keys, run while writers are still held. a concurrent committer
+         * of the same key cannot be missed by both of us; on a conflict we flag our applied
+         * versions aborted so reads, flush and later scans skip them, then abort. */
+        if (txn->isolation_level >= TDB_ISOLATION_SNAPSHOT)
+        {
+            int conflict = 0;
+            for (int op_idx = 0; op_idx < txn->num_ops && !conflict; op_idx++)
+            {
+                const tidesdb_txn_op_t *op = &txn->ops[op_idx];
+                if (!op->cf) continue;
+                uint8_t pk_stack[TDB_PREFIXED_KEY_STACK_MAX];
+                const size_t pk_total = TDB_UNIFIED_CF_PREFIX_SIZE + op->key_size;
+                uint8_t *pk = pk_total <= sizeof(pk_stack) ? pk_stack : malloc(pk_total);
+                if (!pk) continue;
+                const size_t pk_size =
+                    tdb_build_prefixed_key(op->cf->unified_cf_index, op->key, op->key_size, pk);
+                if (skip_list_has_write_conflict(umt->skip_list, pk, pk_size, txn->snapshot_seq,
+                                                 txn->commit_seq))
+                    conflict = 1;
+                if (pk != pk_stack) free(pk);
+            }
+            if (conflict)
+            {
+                for (int op_idx = 0; op_idx < txn->num_ops; op_idx++)
+                {
+                    const tidesdb_txn_op_t *op = &txn->ops[op_idx];
+                    if (!op->cf) continue;
+                    uint8_t pk_stack[TDB_PREFIXED_KEY_STACK_MAX];
+                    const size_t pk_total = TDB_UNIFIED_CF_PREFIX_SIZE + op->key_size;
+                    uint8_t *pk = pk_total <= sizeof(pk_stack) ? pk_stack : malloc(pk_total);
+                    if (!pk) continue;
+                    const size_t pk_size =
+                        tdb_build_prefixed_key(op->cf->unified_cf_index, op->key, op->key_size, pk);
+                    skip_list_mark_aborted(umt->skip_list, pk, pk_size, txn->commit_seq);
+                    if (pk != pk_stack) free(pk);
+                }
+                tidesdb_commit_status_mark(txn->db->commit_status, txn->commit_seq,
+                                           TDB_COMMIT_STATUS_ABORTED);
+                tidesdb_visible_seq_advance(txn->db);
+                atomic_fetch_sub_explicit(&umt->writers, 1, memory_order_release);
+                atomic_fetch_sub_explicit(&umt->refcount, 1, memory_order_release);
+                return TDB_ERR_CONFLICT;
+            }
+        }
+
         /* we check if unified memtable needs rotation */
         const size_t umt_size = (size_t)skip_list_get_size(umt->skip_list);
         atomic_fetch_sub_explicit(&umt->writers, 1, memory_order_release);
@@ -29247,6 +29410,7 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
         atomic_thread_fence(memory_order_seq_cst);
         tidesdb_commit_status_mark(txn->db->commit_status, txn->commit_seq,
                                    TDB_COMMIT_STATUS_COMMITTED);
+        tidesdb_visible_seq_advance(txn->db);
         tidesdb_txn_remove_from_active_list(txn);
 
         /* we invoke commit hooks */
@@ -29440,6 +29604,48 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
         }
     }
 
+    /* apply-before-validate write-write detection, run while writers are still held so a flush
+     * cannot snapshot the memtable until our fate is sealed. our writes are on the version chains,
+     * so a concurrent committer that wrote the same key was either inserted before our scan (we see
+     * it and abort) or inserts after and sees us, never both. on a conflict we flag every applied
+     * version aborted so reads, flush and later scans skip it, then release refs via cleanup. */
+    if (txn->isolation_level >= TDB_ISOLATION_SNAPSHOT)
+    {
+        int conflict = 0;
+        for (int op_idx = 0; op_idx < txn->num_ops && !conflict; op_idx++)
+        {
+            const tidesdb_txn_op_t *op = &txn->ops[op_idx];
+            if (!op->cf) continue;
+            for (int c = 0; c < txn->num_cfs; c++)
+            {
+                if (txn->cfs[c] != op->cf || !cf_skiplists[c]) continue;
+                if (skip_list_has_write_conflict(cf_skiplists[c], op->key, op->key_size,
+                                                 txn->snapshot_seq, txn->commit_seq))
+                    conflict = 1;
+                break;
+            }
+        }
+        if (conflict)
+        {
+            for (int op_idx = 0; op_idx < txn->num_ops; op_idx++)
+            {
+                const tidesdb_txn_op_t *op = &txn->ops[op_idx];
+                if (!op->cf) continue;
+                for (int c = 0; c < txn->num_cfs; c++)
+                {
+                    if (txn->cfs[c] != op->cf || !cf_skiplists[c]) continue;
+                    skip_list_mark_aborted(cf_skiplists[c], op->key, op->key_size, txn->commit_seq);
+                    break;
+                }
+            }
+            tidesdb_commit_status_mark(txn->db->commit_status, txn->commit_seq,
+                                       TDB_COMMIT_STATUS_ABORTED);
+            tidesdb_visible_seq_advance(txn->db);
+            result = TDB_ERR_CONFLICT;
+            goto cleanup;
+        }
+    }
+
     /**** second pass is we release refs and trigger flushes. deferred from the first loop
      ***  because flush can block on backpressure and we don't want to hold refs
      **   to other CFs' memtables while waiting. */
@@ -29516,6 +29722,7 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
     atomic_thread_fence(memory_order_seq_cst);
     tidesdb_commit_status_mark(txn->db->commit_status, txn->commit_seq,
                                TDB_COMMIT_STATUS_COMMITTED);
+    tidesdb_visible_seq_advance(txn->db);
     tidesdb_txn_remove_from_active_list(txn);
 
     /*** we invoke commit hooks for each CF that has one registered
@@ -29779,6 +29986,17 @@ static int tidesdb_iter_kv_visible(tidesdb_iter_t *iter, tidesdb_kv_pair_t *kv)
     if (!seq_visible)
     {
         return 0; /* not visible due to isolation level */
+    }
+
+    /* an aborted version is invisible regardless of isolation -- the point-get path skips it via
+     * the skip-list flag, and the iterator path skips it here so the conflict loser never surfaces
+     */
+    tidesdb_t *db = iter->cf->db;
+    if (tidesdb_commit_status_is_aborted(
+            db->commit_status, kv->entry.seq,
+            atomic_load_explicit(&db->global_seq, memory_order_acquire)))
+    {
+        return 0;
     }
 
     /** we now check if it's a tombstone -- if visible tombstone, return -1 to signal
@@ -33577,6 +33795,7 @@ static int tidesdb_recover_column_family(tidesdb_column_family_t *cf)
     if (global_max_seq >= current_seq)
     {
         atomic_store(&cf->db->global_seq, global_max_seq + 1);
+        atomic_store(&cf->db->visible_seq, global_max_seq);
         TDB_DEBUG_LOG(TDB_LOG_INFO, "CF '%s' has updated global_seq from %" PRIu64 " to %" PRIu64,
                       cf->name, current_seq, global_max_seq + 1);
     }
@@ -33898,6 +34117,7 @@ static int tidesdb_unified_wal_recover(tidesdb_t *db)
         if (max_seq >= current_seq)
         {
             atomic_store_explicit(&db->global_seq, max_seq + 1, memory_order_release);
+            atomic_store_explicit(&db->visible_seq, max_seq, memory_order_release);
         }
     }
 

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -893,6 +893,11 @@ struct tidesdb_t
     _Atomic(time_t) last_open_fail_log_sec;
     _Atomic(uint64_t) next_txn_id;
     _Atomic(uint64_t) global_seq;
+    /* highest seq all of whose predecessors have a decided fate (committed or aborted). snapshots
+     * read from here rather than global_seq - 1 so a snapshot never names an in-flight commit,
+     * which would otherwise be both invisible to reads and missed by the post-apply write-write
+     * scan. */
+    _Atomic(uint64_t) visible_seq;
     tidesdb_commit_status_t *commit_status;
     pthread_rwlock_t active_txns_lock;
     tidesdb_txn_t **active_txns;

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -958,8 +958,15 @@ struct tidesdb_t
     _Atomic(uint64_t) last_uploaded_gen;     /* highest WAL gen confirmed uploaded */
     _Atomic(uint64_t) total_uploads;         /* lifetime upload count */
     _Atomic(uint64_t) total_upload_failures; /* lifetime failed upload count */
-    _Atomic(uint64_t) last_wal_sync_size;    /* WAL file size at last object store sync;
-                                              * _Atomic -- reaper writes it, open seeds it */
+    /* uploads that exhausted the fast inner retries are parked here and re-attempted by the reaper
+     * on a slow outer backoff so a long object store outage still delivers eventually. the backlog
+     * is a dynamic array of tdb_deferred_upload_t guarded by pending_upload_lock */
+    void *pending_uploads; /* tdb_deferred_upload_t[], void* to avoid a fwd decl */
+    size_t pending_upload_count;
+    size_t pending_upload_capacity;
+    pthread_mutex_t pending_upload_lock;
+    _Atomic(uint64_t) last_wal_sync_size; /* WAL file size at last object store sync;
+                                           * _Atomic -- reaper writes it, open seeds it */
 
     /* replica mode runtime state */
     _Atomic(int) replica_mode;               /* 1 = read-only replica, 0 = primary */

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -8287,6 +8287,259 @@ static void test_snapshot_write_write_conflict_still_works(void)
     cleanup_test_dir();
 }
 
+/* ***** concurrent write-write conflict (lost-update / stale-index) repros *****
+ * the sequential write-write test above passes because t1 fully commits (and applies) before t2
+ * validates. the defect is in the CONCURRENT path -- two committers both validate before either
+ * applies, so neither sees the other and both commit. these threaded tests pin first-committer-wins
+ * under contention; they fail on the current engine and pass once validate+apply is serialized. */
+
+#define OCC_THREADS  8
+#define OCC_INCRS    500
+#define OCC_IDX_ROWS 64
+#define OCC_IDX_OPS  1000
+
+static int occ_rc_retryable(int rc)
+{
+    return rc == TDB_ERR_BUSY || rc == TDB_ERR_MEMORY_LIMIT || rc == TDB_ERR_CONFLICT;
+}
+
+typedef struct
+{
+    tidesdb_t *db;
+    tidesdb_column_family_t *cf;
+    int incrs;
+    tidesdb_isolation_level_t iso;
+} occ_counter_arg_t;
+
+/* increment a single shared counter, retrying until each increment commits. with correct
+ * first-committer-wins every successful commit advances the counter by exactly one. */
+static void *occ_counter_worker(void *vp)
+{
+    occ_counter_arg_t *a = (occ_counter_arg_t *)vp;
+    const uint8_t key[] = "counter";
+    for (int i = 0; i < a->incrs; i++)
+    {
+        for (long attempt = 0; attempt < 100000000L; attempt++)
+        {
+            tidesdb_txn_t *t = NULL;
+            if (tidesdb_txn_begin_with_isolation(a->db, a->iso, &t) != 0) continue;
+            uint8_t *val = NULL;
+            size_t vs = 0;
+            uint64_t cur = 0;
+            int rc = tidesdb_txn_get(t, a->cf, key, sizeof(key), &val, &vs);
+            if (rc == 0 && val && vs == sizeof(uint64_t)) memcpy(&cur, val, sizeof(uint64_t));
+            if (val) free(val);
+            uint64_t next = cur + 1;
+            rc = tidesdb_txn_put(t, a->cf, key, sizeof(key), (uint8_t *)&next, sizeof(next), 0);
+            if (rc == 0) rc = tidesdb_txn_commit(t);
+            tidesdb_txn_free(t);
+            if (rc == 0) break;
+            if (!occ_rc_retryable(rc)) break; /* unexpected -- let the final count flag it */
+        }
+    }
+    return NULL;
+}
+
+static void run_concurrent_counter_no_lost_update(tidesdb_isolation_level_t iso, const char *label,
+                                                  int n_threads, int n_incrs)
+{
+    cleanup_test_dir();
+    tidesdb_t *db = create_test_db();
+    tidesdb_column_family_config_t cfg = tidesdb_default_column_family_config();
+    ASSERT_EQ(tidesdb_create_column_family(db, "occ_counter_cf", &cfg), 0);
+    tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "occ_counter_cf");
+    ASSERT_TRUE(cf != NULL);
+
+    const uint8_t key[] = "counter";
+    uint64_t zero = 0;
+    tidesdb_txn_t *t0 = NULL;
+    ASSERT_EQ(tidesdb_txn_begin(db, &t0), 0);
+    ASSERT_EQ(tidesdb_txn_put(t0, cf, key, sizeof(key), (uint8_t *)&zero, sizeof(zero), 0), 0);
+    ASSERT_EQ(tidesdb_txn_commit(t0), 0);
+    tidesdb_txn_free(t0);
+
+    pthread_t th[OCC_THREADS];
+    occ_counter_arg_t args[OCC_THREADS];
+    for (int i = 0; i < n_threads; i++)
+    {
+        args[i] = (occ_counter_arg_t){db, cf, n_incrs, iso};
+        pthread_create(&th[i], NULL, occ_counter_worker, &args[i]);
+    }
+    for (int i = 0; i < n_threads; i++) pthread_join(th[i], NULL);
+
+    tidesdb_txn_t *tr = NULL;
+    ASSERT_EQ(tidesdb_txn_begin(db, &tr), 0);
+    uint8_t *val = NULL;
+    size_t vs = 0;
+    ASSERT_EQ(tidesdb_txn_get(tr, cf, key, sizeof(key), &val, &vs), 0);
+    ASSERT_TRUE(val != NULL && vs == sizeof(uint64_t));
+    uint64_t final_val = 0;
+    memcpy(&final_val, val, sizeof(final_val));
+    free(val);
+    tidesdb_txn_rollback(tr);
+    tidesdb_txn_free(tr);
+
+    printf("  %s counter: expected=%d final=%llu (deficit=%lld = lost updates)\n", label,
+           n_threads * n_incrs, (unsigned long long)final_val,
+           (long long)(n_threads * n_incrs) - (long long)final_val);
+    ASSERT_EQ(final_val, (uint64_t)(n_threads * n_incrs));
+
+    tidesdb_close(db);
+    cleanup_test_dir();
+}
+
+static void test_concurrent_snapshot_no_lost_update(void)
+{
+    run_concurrent_counter_no_lost_update(TDB_ISOLATION_SNAPSHOT, "snapshot", OCC_THREADS,
+                                          OCC_INCRS);
+}
+
+static void test_concurrent_serializable_no_lost_update(void)
+{
+    run_concurrent_counter_no_lost_update(TDB_ISOLATION_SERIALIZABLE, "serializable", OCC_THREADS,
+                                          OCC_INCRS);
+}
+
+static _Atomic uint64_t occ_idx_next_k;
+
+typedef struct
+{
+    tidesdb_t *db;
+    tidesdb_column_family_t *dc;
+    tidesdb_column_family_t *ic;
+    int ops;
+    unsigned seed;
+} occ_idx_arg_t;
+
+static void occ_be64(uint8_t *p, uint64_t v)
+{
+    for (int i = 7; i >= 0; i--)
+    {
+        p[i] = (uint8_t)(v & 0xff);
+        v >>= 8;
+    }
+}
+static uint64_t occ_rb64(const uint8_t *p)
+{
+    uint64_t v = 0;
+    for (int i = 0; i < 8; i++) v = (v << 8) | p[i];
+    return v;
+}
+
+/* mirror the TideSQL secondary-index write path: each update moves a row to a unique new k while
+ * maintaining a separate index CF (delete old idx key, put new). concurrent updates to the same row
+ * that both commit orphan the loser's index entry -- a stale secondary index. */
+static void *occ_idx_worker(void *vp)
+{
+    occ_idx_arg_t *a = (occ_idx_arg_t *)vp;
+    const uint8_t one = 1;
+    for (int i = 0; i < a->ops; i++)
+    {
+        uint64_t id = rand_r(&a->seed) % OCC_IDX_ROWS;
+        for (long attempt = 0; attempt < 100000000L; attempt++)
+        {
+            tidesdb_txn_t *t = NULL;
+            if (tidesdb_txn_begin_with_isolation(a->db, TDB_ISOLATION_SNAPSHOT, &t) != 0) continue;
+            uint8_t dk[8];
+            occ_be64(dk, id);
+            uint8_t *val = NULL;
+            size_t vs = 0;
+            uint64_t curk = 0;
+            int rc = tidesdb_txn_get(t, a->dc, dk, 8, &val, &vs);
+            if (rc == 0 && val && vs == 8) curk = occ_rb64(val);
+            if (val) free(val);
+            uint64_t newk = atomic_fetch_add(&occ_idx_next_k, 1);
+            uint8_t dv[8], ok[16], nk[16];
+            occ_be64(dv, newk);
+            occ_be64(ok, curk);
+            occ_be64(ok + 8, id);
+            occ_be64(nk, newk);
+            occ_be64(nk + 8, id);
+            rc = tidesdb_txn_put(t, a->dc, dk, 8, dv, 8, 0);
+            if (rc == 0) rc = tidesdb_txn_delete(t, a->ic, ok, 16);
+            if (rc == 0) rc = tidesdb_txn_put(t, a->ic, nk, 16, &one, 1, 0);
+            if (rc == 0) rc = tidesdb_txn_commit(t);
+            tidesdb_txn_free(t);
+            if (rc == 0) break;
+            if (!occ_rc_retryable(rc)) break;
+        }
+    }
+    return NULL;
+}
+
+static void test_concurrent_snapshot_secondary_index_consistency(void)
+{
+    cleanup_test_dir();
+    tidesdb_t *db = create_test_db();
+    tidesdb_column_family_config_t cfg = tidesdb_default_column_family_config();
+    ASSERT_EQ(tidesdb_create_column_family(db, "occ_data", &cfg), 0);
+    ASSERT_EQ(tidesdb_create_column_family(db, "occ_idx", &cfg), 0);
+    tidesdb_column_family_t *dc = tidesdb_get_column_family(db, "occ_data");
+    tidesdb_column_family_t *ic = tidesdb_get_column_family(db, "occ_idx");
+    ASSERT_TRUE(dc != NULL && ic != NULL);
+    atomic_store(&occ_idx_next_k, 1ull << 20);
+
+    const uint8_t one = 1;
+    for (uint64_t id = 0; id < OCC_IDX_ROWS; id++)
+    {
+        tidesdb_txn_t *t = NULL;
+        ASSERT_EQ(tidesdb_txn_begin(db, &t), 0);
+        uint8_t dk[8], dv[8], ik[16];
+        occ_be64(dk, id);
+        occ_be64(dv, 0);
+        occ_be64(ik, 0);
+        occ_be64(ik + 8, id);
+        ASSERT_EQ(tidesdb_txn_put(t, dc, dk, 8, dv, 8, 0), 0);
+        ASSERT_EQ(tidesdb_txn_put(t, ic, ik, 16, &one, 1, 0), 0);
+        ASSERT_EQ(tidesdb_txn_commit(t), 0);
+        tidesdb_txn_free(t);
+    }
+
+    pthread_t th[OCC_THREADS];
+    occ_idx_arg_t args[OCC_THREADS];
+    for (int i = 0; i < OCC_THREADS; i++)
+    {
+        args[i] = (occ_idx_arg_t){db, dc, ic, OCC_IDX_OPS, (unsigned)(i * 2654435761u + 1)};
+        pthread_create(&th[i], NULL, occ_idx_worker, &args[i]);
+    }
+    for (int i = 0; i < OCC_THREADS; i++) pthread_join(th[i], NULL);
+
+    /* every live index key (k,id) must resolve to a data row whose stored k equals it */
+    tidesdb_txn_t *t = NULL;
+    ASSERT_EQ(tidesdb_txn_begin(db, &t), 0);
+    tidesdb_iter_t *it = NULL;
+    ASSERT_EQ(tidesdb_iter_new(t, ic, &it), 0);
+    tidesdb_iter_seek_to_first(it);
+    uint64_t idx_keys = 0, stale = 0;
+    while (tidesdb_iter_valid(it))
+    {
+        uint8_t *k = NULL;
+        size_t ks = 0;
+        if (tidesdb_iter_key(it, &k, &ks) != 0 || !k || ks < 16) break;
+        uint64_t ik = occ_rb64(k), id = occ_rb64(k + 8);
+        idx_keys++;
+        uint8_t dk[8];
+        occ_be64(dk, id);
+        uint8_t *val = NULL;
+        size_t vs = 0;
+        int rc = tidesdb_txn_get(t, dc, dk, 8, &val, &vs);
+        uint64_t rowk = (rc == 0 && val && vs == 8) ? occ_rb64(val) : ~0ull;
+        if (val) free(val);
+        if (rowk != ik) stale++;
+        tidesdb_iter_next(it);
+    }
+    tidesdb_iter_free(it);
+    tidesdb_txn_rollback(t);
+    tidesdb_txn_free(t);
+
+    printf("  snapshot secondary index: index_keys=%llu stale=%llu\n", (unsigned long long)idx_keys,
+           (unsigned long long)stale);
+    ASSERT_EQ(stale, (uint64_t)0);
+
+    tidesdb_close(db);
+    cleanup_test_dir();
+}
+
 static void test_serializable_phantom_prevention(void)
 {
     cleanup_test_dir();
@@ -30491,6 +30744,9 @@ int main(int argc, char **argv)
     RUN_TEST(test_snapshot_no_read_conflict, tests_passed);
     RUN_TEST(test_snapshot_allows_write_skew, tests_passed);
     RUN_TEST(test_snapshot_write_write_conflict_still_works, tests_passed);
+    RUN_TEST(test_concurrent_snapshot_no_lost_update, tests_passed);
+    RUN_TEST(test_concurrent_serializable_no_lost_update, tests_passed);
+    RUN_TEST(test_concurrent_snapshot_secondary_index_consistency, tests_passed);
     RUN_TEST(test_serializable_phantom_prevention, tests_passed);
     RUN_TEST(test_transaction_abort_retry, tests_passed);
     RUN_TEST(test_long_running_transaction, tests_passed);


### PR DESCRIPTION
…per redeliver them

uploads that exhaust the three fast inner retries are no longer dropped they go into a deferred backlog the reaper re attempts on a slow capped backoff so a long object store outage still delivers eventually

sstable files stay untracked and so unevictable until the upload confirms so a failed upload can never be reclaimed off local disk before it lands rotated wals and manifests defer too while an active wal snapshot does not since its periodic resync is already its own retry