### PR TITLE
TidesDB 9 PATCH (v9.3.9)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ if(TIDESDB_WITH_MIMALLOC)
 endif()
 
 project(tidesdb
-	VERSION 9.3.8
+	VERSION 9.3.9
 	LANGUAGES C)
 
 set(CMAKE_C_STANDARD 11)

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -747,12 +747,21 @@ struct tidesdb_kv_pair_t
 #define TDB_COMMIT_STATUS_IN_PROGRESS 0
 #define TDB_COMMIT_STATUS_COMMITTED   1
 
+/* write-write reservation slots for first-committer-wins under snapshot/serializable. fixed
+ * and large so hash collisions are rare, and a collision only ever costs a spurious conflict
+ * (a retry), never a missed one. lives in memory only and is empty after recovery, so it
+ * changes no on-disk format. */
+#define TDB_WRITE_RESERVATION_SLOTS (1u << 20)
+#define TDB_WRITE_RESERVATION_MASK  (TDB_WRITE_RESERVATION_SLOTS - 1)
+
 /**
  * tidesdb_commit_status_t
  * @param status array of commit statuses (0=in-progress, 1=committed)
  * @param min_seq minimum sequence number tracked in this buffer
  * @param max_seq maximum sequence number tracked in this buffer
  * @param capacity size of the status array
+ * @param write_res per-key reservation slots holding the latest commit_seq that claimed each
+ *                  slot, used by the commit-time write-write conflict check
  */
 struct tidesdb_commit_status_t
 {
@@ -760,6 +769,7 @@ struct tidesdb_commit_status_t
     _Atomic(uint64_t) min_seq;
     _Atomic(uint64_t) max_seq;
     size_t capacity;
+    _Atomic(uint64_t) *write_res;
 };
 
 /**
@@ -1307,6 +1317,15 @@ static tidesdb_commit_status_t *tidesdb_commit_status_create()
         atomic_init(&cs->status[i], TDB_COMMIT_STATUS_IN_PROGRESS);
     }
 
+    /* write-write reservation slots all start unclaimed (0 == no committer) */
+    cs->write_res = calloc(TDB_WRITE_RESERVATION_SLOTS, sizeof(_Atomic(uint64_t)));
+    if (!cs->write_res)
+    {
+        free((void *)cs->status);
+        free(cs);
+        return NULL;
+    }
+
     atomic_init(&cs->min_seq, 1);
     atomic_init(&cs->max_seq, 0);
     cs->capacity = TDB_COMMIT_STATUS_BUFFER_SIZE;
@@ -1323,6 +1342,7 @@ static void tidesdb_commit_status_destroy(tidesdb_commit_status_t *cs)
 {
     if (!cs) return;
     free((void *)cs->status);
+    free((void *)cs->write_res);
     free(cs);
 }
 
@@ -25719,13 +25739,17 @@ static void tidesdb_txn_remove_from_active_list(tidesdb_txn_t *txn)
  */
 static int tidesdb_txn_add_to_read_set(tidesdb_txn_t *txn, tidesdb_column_family_t *cf,
                                        const uint8_t *key, const size_t key_size,
-                                       const uint64_t seq)
+                                       const uint64_t seq, const int point_read)
 {
-    /*** we skip read tracking for isolation levels that dont need conflict detection
-     **  SNAPSHOT only needs write-write conflict detection (no read set tracking)
-     *   only REPEATABLE_READ and SERIALIZABLE need read tracking */
+    /*** REPEATABLE_READ and SERIALIZABLE track every read for read-write conflict detection.
+     **  SNAPSHOT does no read-write conflict detection, but it records point reads so the
+     **  write-write reservation can validate a write against the version actually read, not
+     **  just the snapshot start -- this closes the window where a writer becomes visible
+     **  between our read and our commit. range-scan reads are not recorded for SNAPSHOT,
+     *   they would grow a read set it never consults. */
     if (txn->isolation_level != TDB_ISOLATION_REPEATABLE_READ &&
-        txn->isolation_level != TDB_ISOLATION_SERIALIZABLE)
+        txn->isolation_level != TDB_ISOLATION_SERIALIZABLE &&
+        !(txn->isolation_level == TDB_ISOLATION_SNAPSHOT && point_read))
     {
         return 0;
     }
@@ -26404,7 +26428,7 @@ int tidesdb_txn_get(tidesdb_txn_t *txn, tidesdb_column_family_t *cf, const uint8
                     *value_size = temp_val_size;
                     tidesdb_immutable_memtable_unref(umt);
                     PROFILE_INC(txn->db, memtable_hits);
-                    tidesdb_txn_add_to_read_set(txn, cf, key, key_size, found_seq_u);
+                    tidesdb_txn_add_to_read_set(txn, cf, key, key_size, found_seq_u, 1);
                     unified_rc = TDB_SUCCESS;
                     goto unified_memtable_done;
                 }
@@ -26480,7 +26504,7 @@ int tidesdb_txn_get(tidesdb_txn_t *txn, tidesdb_column_family_t *cf, const uint8
                             memcpy(*value, temp_val, temp_val_size);
                             *value_size = temp_val_size;
                             PROFILE_INC(txn->db, immutable_hits);
-                            tidesdb_txn_add_to_read_set(txn, cf, key, key_size, found_seq_u);
+                            tidesdb_txn_add_to_read_set(txn, cf, key, key_size, found_seq_u, 1);
                             unified_rc = TDB_SUCCESS;
                         }
                     }
@@ -26537,6 +26561,11 @@ int tidesdb_txn_get(tidesdb_txn_t *txn, tidesdb_column_family_t *cf, const uint8
         if (deleted)
         {
             if (active_mt_refed) tidesdb_immutable_memtable_unref(active_mt_struct);
+            /* record the absent read at the tombstone we saw so the reservation rejects a
+             * concurrent re-insert of this key (insert-insert is also a same-key write race).
+             * snapshot/serializable only -- repeatable read must not gain phantom detection */
+            if (txn->isolation_level >= TDB_ISOLATION_SNAPSHOT)
+                tidesdb_txn_add_to_read_set(txn, cf, key, key_size, found_seq, 1);
             return TDB_ERR_NOT_FOUND;
         }
 
@@ -26554,11 +26583,13 @@ int tidesdb_txn_get(tidesdb_txn_t *txn, tidesdb_column_family_t *cf, const uint8
             if (active_mt_refed) tidesdb_immutable_memtable_unref(active_mt_struct);
 
             PROFILE_INC(txn->db, memtable_hits);
-            tidesdb_txn_add_to_read_set(txn, cf, key, key_size, found_seq);
+            tidesdb_txn_add_to_read_set(txn, cf, key, key_size, found_seq, 1);
             return TDB_SUCCESS;
         }
 
         if (active_mt_refed) tidesdb_immutable_memtable_unref(active_mt_struct);
+        if (txn->isolation_level >= TDB_ISOLATION_SNAPSHOT)
+            tidesdb_txn_add_to_read_set(txn, cf, key, key_size, found_seq, 1);
         return TDB_ERR_NOT_FOUND;
     }
 
@@ -26612,7 +26643,7 @@ int tidesdb_txn_get(tidesdb_txn_t *txn, tidesdb_column_family_t *cf, const uint8
                         memcpy(*value, temp_value, temp_value_size);
                         *value_size = temp_value_size;
                         PROFILE_INC(txn->db, immutable_hits);
-                        tidesdb_txn_add_to_read_set(txn, cf, key, key_size, found_seq);
+                        tidesdb_txn_add_to_read_set(txn, cf, key, key_size, found_seq, 1);
                         result = TDB_SUCCESS;
                         break;
                     }
@@ -26863,12 +26894,17 @@ unified_sst_search:;
             {
                 *value = best_value;
                 *value_size = best_value_size;
-                tidesdb_txn_add_to_read_set(txn, cf, key, key_size, best_seq);
+                tidesdb_txn_add_to_read_set(txn, cf, key, key_size, best_seq, 1);
                 return TDB_SUCCESS;
             }
 
             if (best_value) free(best_value);
-            return (!best_is_dead) ? TDB_ERR_MEMORY : TDB_ERR_NOT_FOUND;
+            if (!best_is_dead) return TDB_ERR_MEMORY;
+            /* absent because the newest version in range is a tombstone -- record it so the
+             * reservation rejects a concurrent re-insert at the same key (snapshot/serializable) */
+            if (txn->isolation_level >= TDB_ISOLATION_SNAPSHOT)
+                tidesdb_txn_add_to_read_set(txn, cf, key, key_size, best_seq, 1);
+            return TDB_ERR_NOT_FOUND;
         }
     }
 
@@ -26887,6 +26923,10 @@ unified_sst_search:;
         return TDB_ERR_BUSY;
     }
 
+    /* nothing existed for this key in our snapshot -- record the absent read at seq 0 so the
+     * reservation rejects a concurrent first insert of the same key (snapshot/serializable) */
+    if (txn->isolation_level >= TDB_ISOLATION_SNAPSHOT)
+        tidesdb_txn_add_to_read_set(txn, cf, key, key_size, 0, 1);
     return TDB_ERR_NOT_FOUND;
 }
 
@@ -29075,6 +29115,122 @@ static int tidesdb_unified_memtable_rotate(tidesdb_t *db)
     return TDB_SUCCESS;
 }
 
+/**
+ * tidesdb_txn_read_seq
+ * look up the sequence this transaction observed when it last read (cf, key). the write-write
+ * reservation validates a write against the version actually read instead of the snapshot
+ * start, so a writer that became visible between our read and our commit is still caught. only
+ * snapshot point reads and RR/SERIALIZABLE reads are recorded, so a key written without a
+ * prior point read is reported not found and the caller falls back to the snapshot start.
+ * @param txn transaction
+ * @param cf column family
+ * @param key key
+ * @param key_size key size
+ * @param out_seq receives the highest observed read seq when found
+ * @return 1 if a read of this key was recorded, 0 otherwise
+ */
+static int tidesdb_txn_read_seq(const tidesdb_txn_t *txn, const tidesdb_column_family_t *cf,
+                                const uint8_t *key, const size_t key_size, uint64_t *out_seq)
+{
+    uint64_t best = 0;
+    int found = 0;
+    for (int i = 0; i < txn->read_set_count; i++)
+    {
+        if (txn->read_cfs[i] == cf && txn->read_key_sizes[i] == key_size &&
+            memcmp(txn->read_keys[i], key, key_size) == 0)
+        {
+            if (!found || txn->read_seqs[i] > best) best = txn->read_seqs[i];
+            found = 1;
+        }
+    }
+    if (found) *out_seq = best;
+    return found;
+}
+
+/**
+ * tidesdb_txn_release_writes
+ * undo this transaction's write-write reservations after a snapshot/serializable commit
+ * loses. each write key's slot is CAS'd from our commit_seq back to unclaimed; a CAS that
+ * fails means a newer committer already owns the slot and we leave it alone. dropping a slot
+ * to unclaimed can only lose a conflict against an already-committed writer, which
+ * tidesdb_txn_check_write_conflicts still catches against the memtable, so it stays safe.
+ * @param txn transaction whose reservations to release
+ */
+static void tidesdb_txn_release_writes(tidesdb_txn_t *txn)
+{
+    _Atomic(uint64_t) *res = txn->db->commit_status ? txn->db->commit_status->write_res : NULL;
+    if (!res || txn->commit_seq == 0) return;
+
+    for (int i = 0; i < txn->num_ops; i++)
+    {
+        const tidesdb_txn_op_t *op = &txn->ops[i];
+        if (!op->cf) continue;
+        const uint32_t slot =
+            tidesdb_write_set_hash_key(op->cf, op->key, op->key_size) & TDB_WRITE_RESERVATION_MASK;
+        uint64_t expect = txn->commit_seq;
+        atomic_compare_exchange_strong_explicit(&res[slot], &expect, 0, memory_order_acq_rel,
+                                                memory_order_acquire);
+    }
+}
+
+/**
+ * tidesdb_txn_reserve_writes
+ * first-committer-wins write-write conflict reservation for snapshot/serializable commits.
+ * each write key claims its reservation slot with this transaction's commit_seq. we lose and
+ * abort if a slot already holds a seq committed after our snapshot, or a seq still in flight
+ * that our snapshot could not have read -- both mean a concurrent writer beat us to the key.
+ * the slot CAS lets exactly one of two racing same-key committers win. this runs before the
+ * WAL write, so a loser aborts having written nothing, and partial claims are undone so an
+ * aborted reservation never poisons a slot. it complements tidesdb_txn_check_write_conflicts,
+ * which only sees writers that already applied and so misses concurrent in-flight committers.
+ * @param txn transaction reserving its write set
+ * @return TDB_SUCCESS with all keys reserved, or TDB_ERR_CONFLICT with partial claims undone
+ */
+static int tidesdb_txn_reserve_writes(tidesdb_txn_t *txn)
+{
+    tidesdb_commit_status_t *cs = txn->db->commit_status;
+    if (!cs || !cs->write_res) return TDB_SUCCESS;
+    _Atomic(uint64_t) *res = cs->write_res;
+    const uint64_t snap = txn->snapshot_seq;
+    const uint64_t myseq = txn->commit_seq;
+
+    for (int i = 0; i < txn->num_ops; i++)
+    {
+        const tidesdb_txn_op_t *op = &txn->ops[i];
+        if (!op->cf) continue;
+        const uint32_t slot =
+            tidesdb_write_set_hash_key(op->cf, op->key, op->key_size) & TDB_WRITE_RESERVATION_MASK;
+
+        /* validate against the version we actually read for this key, falling back to the
+         * snapshot start for a blind write. a writer that landed after our read -- including one
+         * that was in flight when we read and committed before we reached here, whose seq still
+         * sits at or below our snapshot -- pushes the slot past our read seq and is caught */
+        uint64_t base = snap;
+        uint64_t rseq;
+        if (tidesdb_txn_read_seq(txn, op->cf, op->key, op->key_size, &rseq)) base = rseq;
+
+        for (;;)
+        {
+            uint64_t r = atomic_load_explicit(&res[slot], memory_order_acquire);
+            if (r == myseq) break; /* already ours -- a duplicate key or a colliding sibling key */
+
+            /* a committer claimed this key after the version we read, or is committing it right
+             * now and we could not have seen it. visibility_check returns committed (including
+             * evicted) seqs as true, so the second test fires only for a genuinely in-flight one */
+            if (r > base || (r != 0 && !tidesdb_visibility_check_callback(cs, r)))
+            {
+                tidesdb_txn_release_writes(txn);
+                return TDB_ERR_CONFLICT;
+            }
+            if (atomic_compare_exchange_weak_explicit(&res[slot], &r, myseq, memory_order_acq_rel,
+                                                      memory_order_acquire))
+                break;
+            /* CAS lost to a concurrent claimer -- re-read and re-evaluate this slot */
+        }
+    }
+    return TDB_SUCCESS;
+}
+
 int tidesdb_txn_commit(tidesdb_txn_t *txn)
 {
     if (!txn || txn->is_committed || txn->is_aborted) return TDB_ERR_INVALID_ARGS;
@@ -29111,6 +29267,17 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
     txn->commit_seq = atomic_fetch_add_explicit(&txn->db->global_seq, 1, memory_order_relaxed);
     tidesdb_commit_status_mark(txn->db->commit_status, txn->commit_seq,
                                TDB_COMMIT_STATUS_IN_PROGRESS);
+
+    /* first-committer-wins write-write reservation before the WAL write. snapshot and
+     * serializable must not let two concurrent commits to the same key both win; the
+     * check_write_conflicts pass above only sees writers that already applied, so a
+     * concurrent in-flight committer slips past it. reserving here publishes our claim
+     * before anything is written, so a racing committer sees it and exactly one wins */
+    if (txn->isolation_level >= TDB_ISOLATION_SNAPSHOT)
+    {
+        result = tidesdb_txn_reserve_writes(txn);
+        if (result != TDB_SUCCESS) return result;
+    }
 
     /* with the unified path, we do single WAL + single skip list */
     if (txn->db->unified_mt.enabled)
@@ -32708,7 +32875,7 @@ int tidesdb_iter_next(tidesdb_iter_t *iter)
         if (iter->txn->isolation_level >= TDB_ISOLATION_REPEATABLE_READ)
         {
             tidesdb_txn_add_to_read_set(iter->txn, iter->cf, kv->key, kv->entry.key_size,
-                                        kv->entry.seq);
+                                        kv->entry.seq, 0);
         }
 
         tidesdb_kv_pair_free(prev);
@@ -32793,7 +32960,7 @@ int tidesdb_iter_prev(tidesdb_iter_t *iter)
         if (iter->txn->isolation_level >= TDB_ISOLATION_REPEATABLE_READ)
         {
             tidesdb_txn_add_to_read_set(iter->txn, iter->cf, kv->key, kv->entry.key_size,
-                                        kv->entry.seq);
+                                        kv->entry.seq, 0);
         }
 
         tidesdb_kv_pair_free(prev);

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -496,9 +496,16 @@ typedef tidesdb_memtable_t tidesdb_immutable_memtable_t;
 #define TDB_NO_CF_SYNC_SLEEP_US                 100000
 
 /* object store retry constants */
-#define TDB_UPLOAD_MAX_RETRIES          3
-#define TDB_UPLOAD_INITIAL_BACKOFF_US   100000 /* 100ms */
-#define TDB_UPLOAD_BACKOFF_MULTIPLIER   4      /* 100ms -> 400ms -> 1600ms */
+#define TDB_UPLOAD_MAX_RETRIES        3
+#define TDB_UPLOAD_INITIAL_BACKOFF_US 100000 /* 100ms */
+#define TDB_UPLOAD_BACKOFF_MULTIPLIER 4      /* 100ms -> 400ms -> 1600ms */
+/* an upload that exhausts the fast inner retries above is parked in a backlog rather than dropped,
+ * and the reaper re-attempts it on a slow outer backoff so a multi-minute object store outage still
+ * delivers eventually instead of giving up after half a second */
+#define TDB_UPLOAD_DEFER_MAX            256 /* cap on parked uploads; over this the oldest is dropped */
+#define TDB_UPLOAD_DEFER_INITIAL_SEC    2  /* first outer-retry delay; doubles each miss */
+#define TDB_UPLOAD_DEFER_MAX_SEC        60 /* outer-retry backoff ceiling */
+#define TDB_UPLOAD_DEFER_MAX_SHIFT      6  /* clamp on the doubling exponent (2<<6 already > 60s) */
 #define TDB_DOWNLOAD_MAX_RETRIES        3
 #define TDB_DOWNLOAD_INITIAL_BACKOFF_US 50000 /* 50ms */
 #define TDB_DOWNLOAD_BACKOFF_MULTIPLIER 4     /* 50ms -> 200ms -> 800ms */
@@ -4864,6 +4871,8 @@ static void tdb_path_to_object_key(const tidesdb_t *db, const char *local_path, 
  * @param local_path local file path of the file to upload
  * @param object_key object store key derived from local_path
  * @param wal_generation WAL generation to fence after upload (0 = no fence)
+ * @param track_in_cache register the file with the local cache once the upload confirms (sstable
+ *        files stay untracked -- and therefore unevictable -- until they are safely remote)
  */
 typedef struct
 {
@@ -4872,7 +4881,296 @@ typedef struct
     uint64_t wal_generation;   /* WAL gen to fence after upload (0 = no fence) */
     uint64_t meta_epoch;       /* single-writer lease epoch to tag the object with (0 = untagged) */
     uint64_t upload_max_bytes; /* logical length to upload (0 = whole file) */
+    int track_in_cache;        /* 1 = cache-track local_path on success (sstable) */
 } tdb_upload_job_t;
+
+/**
+ * tdb_deferred_upload_t
+ * a parked upload that exhausted the fast inner retries, awaiting slow outer retry by the reaper
+ * @param job the original upload job (local_path, object_key, fence/epoch/size, track flag)
+ * @param outer_attempts number of slow retries already spent (drives the backoff)
+ * @param next_retry_sec earliest cached_current_time (seconds) at which to retry again
+ */
+typedef struct
+{
+    tdb_upload_job_t job;
+    unsigned int outer_attempts;
+    time_t next_retry_sec;
+} tdb_deferred_upload_t;
+
+/**
+ * tdb_objstore_put_once
+ * attempts a single upload and confirms it. an epoch-tagged or partial upload goes through put_if,
+ * anything else through a plain put, and the object is then verified to have landed at the size we
+ * expect.
+ * @param db database
+ * @param job upload job describing the object
+ * @return 0 if the object landed and verified, -1 otherwise
+ */
+static int tdb_objstore_put_once(tidesdb_t *db, const tdb_upload_job_t *job)
+{
+    int rc;
+    /* use put_if when the object is epoch-tagged (WAL fencing) or a partial upload is requested
+     * (active WAL's logical length, skipping its preallocated tail) -- both need put_if, which
+     * also works untagged (epoch 0). otherwise a plain put. */
+    if ((job->meta_epoch || job->upload_max_bytes) && db->object_store->put_if)
+        rc = db->object_store->put_if(db->object_store->ctx, job->object_key, job->local_path,
+                                      TDB_PUT_OVERWRITE, NULL, job->meta_epoch, NULL, 0,
+                                      (size_t)job->upload_max_bytes);
+    else
+        rc = db->object_store->put(db->object_store->ctx, job->object_key, job->local_path);
+    if (rc != 0) return -1;
+
+    /* verify the upload landed with the correct size. MANIFEST is skipped -- it is mutable and may
+     * grow between upload and the exists check due to concurrent flushes. */
+    if (!strstr(job->object_key, TDB_COLUMN_FAMILY_MANIFEST_NAME))
+    {
+        struct stat local_st;
+        if (stat(job->local_path, &local_st) == 0)
+        {
+            /* a partial WAL upload's remote size is the logical length, not the preallocated file
+             */
+            size_t expected =
+                job->upload_max_bytes ? (size_t)job->upload_max_bytes : (size_t)local_st.st_size;
+            size_t remote_size = 0;
+            const int verify =
+                db->object_store->exists(db->object_store->ctx, job->object_key, &remote_size);
+            if (verify != 1 || remote_size != expected)
+            {
+                TDB_DEBUG_LOG(TDB_LOG_ERROR,
+                              "Upload verification failed for %s (expected=%zu, remote=%zu, "
+                              "exists=%d)",
+                              job->object_key, expected, remote_size, verify);
+                return -1;
+            }
+        }
+    }
+    return 0;
+}
+
+/**
+ * tdb_objstore_cancel_deferred
+ * drop any parked retry whose object_key matches -- a fresh successful upload of a key retires a
+ * stale pending retry for it (e.g. a newer MANIFEST supersedes an older failed one).
+ * @param db database
+ * @param object_key key to cancel
+ */
+static void tdb_objstore_cancel_deferred(tidesdb_t *db, const char *object_key)
+{
+    pthread_mutex_lock(&db->pending_upload_lock);
+    tdb_deferred_upload_t *arr = db->pending_uploads;
+    for (size_t i = 0; i < db->pending_upload_count;)
+    {
+        if (strcmp(arr[i].job.object_key, object_key) == 0)
+            arr[i] = arr[--db->pending_upload_count]; /* swap-remove */
+        else
+            i++;
+    }
+    pthread_mutex_unlock(&db->pending_upload_lock);
+}
+
+/**
+ * tdb_objstore_on_upload_success
+ * runs the shared bookkeeping once an object has been delivered. it counts the upload, and for a
+ * rotated WAL advances the fence and deletes the now-redundant local copy. an sstable file stays
+ * untracked (and so unevictable) until it is proven remote, so it is registered with the local
+ * cache here. any retry still parked for the same key is cancelled.
+ * @param db database
+ * @param job the delivered upload job
+ */
+static void tdb_objstore_on_upload_success(tidesdb_t *db, const tdb_upload_job_t *job)
+{
+    atomic_fetch_add_explicit(&db->total_uploads, 1, memory_order_relaxed);
+
+    /* we advance the WAL fence if this upload advances it */
+    if (job->wal_generation > 0)
+    {
+        uint64_t cur = atomic_load_explicit(&db->last_uploaded_gen, memory_order_relaxed);
+        while (job->wal_generation > cur)
+        {
+            if (atomic_compare_exchange_weak_explicit(&db->last_uploaded_gen, &cur,
+                                                      job->wal_generation, memory_order_release,
+                                                      memory_order_relaxed))
+                break;
+        }
+        /* the rotated WAL is confirmed present (exists + size verify above), so the local copy is
+         * deleted here. recovery replays the WAL from the object store if the node restarts before
+         * the immutable has flushed. */
+        tdb_unlink(job->local_path);
+    }
+
+    /* an sstable file stayed untracked (and so unevictable) until it was safely remote -- track it
+     * now so the local cache can reclaim it */
+    if (job->track_in_cache && db->local_cache)
+        tdb_local_cache_track(db->local_cache, job->local_path);
+
+    tdb_objstore_cancel_deferred(db, job->object_key);
+}
+
+/**
+ * tdb_objstore_park_locked
+ * insert or replace a deferred entry for job->object_key. caller holds pending_upload_lock. dedups
+ * by key (a later attempt supersedes an earlier one), grows the backlog, and enforces the cap by
+ * dropping the oldest entry (its file persists locally for the next startup to re-upload).
+ * @param db database
+ * @param job upload job to park
+ * @param attempts outer retries already spent (drives the next backoff)
+ * @param next_retry_sec earliest time (seconds) to retry
+ */
+static void tdb_objstore_park_locked(tidesdb_t *db, const tdb_upload_job_t *job,
+                                     unsigned int attempts, time_t next_retry_sec)
+{
+    tdb_deferred_upload_t *arr = db->pending_uploads;
+    for (size_t i = 0; i < db->pending_upload_count; i++)
+    {
+        if (strcmp(arr[i].job.object_key, job->object_key) == 0)
+        {
+            arr[i].job = *job;
+            arr[i].outer_attempts = attempts;
+            arr[i].next_retry_sec = next_retry_sec;
+            return;
+        }
+    }
+
+    if (db->pending_upload_count == db->pending_upload_capacity)
+    {
+        size_t new_cap = db->pending_upload_capacity ? db->pending_upload_capacity * 2 : 16;
+        if (new_cap > TDB_UPLOAD_DEFER_MAX) new_cap = TDB_UPLOAD_DEFER_MAX;
+        if (new_cap > db->pending_upload_capacity)
+        {
+            tdb_deferred_upload_t *grown = realloc(arr, new_cap * sizeof(*grown));
+            if (grown)
+            {
+                db->pending_uploads = arr = grown;
+                db->pending_upload_capacity = new_cap;
+            }
+        }
+    }
+
+    if (db->pending_upload_count == db->pending_upload_capacity)
+    {
+        if (db->pending_upload_count == 0) return; /* cap pinned at 0 -- nothing to park into */
+        TDB_DEBUG_LOG(TDB_LOG_WARN, "Deferred-upload backlog full (%d) dropping oldest to park %s",
+                      TDB_UPLOAD_DEFER_MAX, job->object_key);
+        memmove(&arr[0], &arr[1], (db->pending_upload_count - 1) * sizeof(*arr));
+        db->pending_upload_count--;
+    }
+
+    arr[db->pending_upload_count].job = *job;
+    arr[db->pending_upload_count].outer_attempts = attempts;
+    arr[db->pending_upload_count].next_retry_sec = next_retry_sec;
+    db->pending_upload_count++;
+}
+
+/**
+ * tdb_objstore_defer_upload
+ * park an upload that exhausted its fast inner retries for slow outer retry by the reaper.
+ * @param db database
+ * @param job upload job to park
+ */
+static void tdb_objstore_defer_upload(tidesdb_t *db, const tdb_upload_job_t *job)
+{
+    const time_t now = atomic_load_explicit(&db->cached_current_time, memory_order_relaxed);
+    pthread_mutex_lock(&db->pending_upload_lock);
+    tdb_objstore_park_locked(db, job, 0, now + TDB_UPLOAD_DEFER_INITIAL_SEC);
+    pthread_mutex_unlock(&db->pending_upload_lock);
+}
+
+/**
+ * tdb_objstore_retry_deferred
+ * the reaper's sweep over the deferred-upload backlog. it re-attempts each parked upload whose
+ * backoff has elapsed. a vanished local file (compaction replaced the sstable, a rotation deleted
+ * the WAL) is dropped without counting a failure, since its data is durable elsewhere. a delivered
+ * upload runs the shared success bookkeeping, while a still-failing one is re-parked with a longer,
+ * capped backoff. the network put runs with the lock released so writers can keep parking failures
+ * meanwhile.
+ * @param db database
+ */
+static void tdb_objstore_retry_deferred(tidesdb_t *db)
+{
+    if (!db->object_store || !db->object_store->put) return;
+    const time_t now = atomic_load_explicit(&db->cached_current_time, memory_order_relaxed);
+
+    while (1)
+    {
+        tdb_upload_job_t job;
+        unsigned int attempts = 0;
+        int found = 0;
+
+        pthread_mutex_lock(&db->pending_upload_lock);
+        tdb_deferred_upload_t *arr = db->pending_uploads;
+        for (size_t i = 0; i < db->pending_upload_count; i++)
+        {
+            if (arr[i].next_retry_sec <= now)
+            {
+                job = arr[i].job;
+                attempts = arr[i].outer_attempts;
+                arr[i] =
+                    arr[--db->pending_upload_count]; /* swap-remove; re-parked below on failure */
+                found = 1;
+                break;
+            }
+        }
+        pthread_mutex_unlock(&db->pending_upload_lock);
+        if (!found) break;
+
+        struct stat st;
+        if (stat(job.local_path, &st) != 0)
+        {
+            TDB_DEBUG_LOG(TDB_LOG_DEBUG, "Deferred upload local file gone dropping %s",
+                          job.object_key);
+            continue;
+        }
+
+        if (tdb_objstore_put_once(db, &job) == 0)
+        {
+            tdb_objstore_on_upload_success(db, &job);
+            continue;
+        }
+
+        /* still failing -- re-park with a doubled, capped outer backoff */
+        unsigned int next_attempts = attempts + 1;
+        unsigned int shift =
+            next_attempts < TDB_UPLOAD_DEFER_MAX_SHIFT ? next_attempts : TDB_UPLOAD_DEFER_MAX_SHIFT;
+        time_t delay = (time_t)TDB_UPLOAD_DEFER_INITIAL_SEC << shift;
+        if (delay > TDB_UPLOAD_DEFER_MAX_SEC) delay = TDB_UPLOAD_DEFER_MAX_SEC;
+
+        pthread_mutex_lock(&db->pending_upload_lock);
+        tdb_objstore_park_locked(db, &job, next_attempts, now + delay);
+        pthread_mutex_unlock(&db->pending_upload_lock);
+    }
+}
+
+/**
+ * tdb_objstore_drain_deferred
+ * one final pass over the deferred backlog at close (reaper stopped, workers joined -- single
+ * threaded), then free it. anything still undelivered persists on local disk for the next startup.
+ * @param db database
+ */
+static void tdb_objstore_drain_deferred(tidesdb_t *db)
+{
+    pthread_mutex_lock(&db->pending_upload_lock);
+    tdb_deferred_upload_t *arr = db->pending_uploads;
+    size_t n = db->pending_upload_count;
+    db->pending_uploads = NULL; /* detach so on_upload_success -> cancel is a noop while draining */
+    db->pending_upload_count = 0;
+    db->pending_upload_capacity = 0;
+    pthread_mutex_unlock(&db->pending_upload_lock);
+
+    for (size_t i = 0; i < n; i++)
+    {
+        struct stat st;
+        if (db->object_store && db->object_store->put && stat(arr[i].job.local_path, &st) == 0 &&
+            tdb_objstore_put_once(db, &arr[i].job) == 0)
+        {
+            tdb_objstore_on_upload_success(db, &arr[i].job);
+            continue;
+        }
+        TDB_DEBUG_LOG(TDB_LOG_WARN, "Deferred upload undelivered at close persists locally %s",
+                      arr[i].job.object_key);
+    }
+    free(arr);
+}
 
 /**
  * tdb_upload_worker_thread
@@ -4895,51 +5193,10 @@ static void *tdb_upload_worker_thread(void *arg)
             unsigned int backoff_us = TDB_UPLOAD_INITIAL_BACKOFF_US;
             for (int attempt = 0; attempt < TDB_UPLOAD_MAX_RETRIES; attempt++)
             {
-                /* use put_if when the object is epoch-tagged (WAL fencing) or a partial upload is
-                 * requested (active WAL's logical length, skipping its preallocated tail) -- both
-                 * need put_if, which also works untagged (epoch 0). otherwise a plain put. */
-                if ((job->meta_epoch || job->upload_max_bytes) && db->object_store->put_if)
-                    rc = db->object_store->put_if(
-                        db->object_store->ctx, job->object_key, job->local_path, TDB_PUT_OVERWRITE,
-                        NULL, job->meta_epoch, NULL, 0, (size_t)job->upload_max_bytes);
-                else
-                    rc = db->object_store->put(db->object_store->ctx, job->object_key,
-                                               job->local_path);
-                if (rc != 0)
-                {
-                    TDB_DEBUG_LOG(TDB_LOG_WARN, "Upload attempt %d/%d failed: %s", attempt + 1,
-                                  TDB_UPLOAD_MAX_RETRIES, job->object_key);
-                }
-                else if (!strstr(job->object_key, TDB_COLUMN_FAMILY_MANIFEST_NAME))
-                {
-                    /* verify the upload landed with the correct size. MANIFEST is skipped --
-                     * it is mutable and may grow between upload and the exists check due to
-                     * concurrent flushes. a verify mismatch now retries the put (rc=-1 below)
-                     * instead of being a permanent failure with no re-upload. */
-                    struct stat local_st;
-                    if (stat(job->local_path, &local_st) == 0)
-                    {
-                        /* a partial WAL upload's remote size is the logical length, not the
-                         * preallocated local file size */
-                        size_t expected = job->upload_max_bytes ? (size_t)job->upload_max_bytes
-                                                                : (size_t)local_st.st_size;
-                        size_t remote_size = 0;
-                        const int verify = db->object_store->exists(db->object_store->ctx,
-                                                                    job->object_key, &remote_size);
-                        if (verify != 1 || remote_size != expected)
-                        {
-                            TDB_DEBUG_LOG(
-                                TDB_LOG_ERROR,
-                                "Upload verification failed for %s (expected=%zu, remote=%zu, "
-                                "exists=%d)",
-                                job->object_key, expected, remote_size, verify);
-                            rc = -1;
-                        }
-                    }
-                }
-
+                rc = tdb_objstore_put_once(db, job);
                 if (rc == 0) break;
-
+                TDB_DEBUG_LOG(TDB_LOG_WARN, "Upload attempt %d/%d failed: %s", attempt + 1,
+                              TDB_UPLOAD_MAX_RETRIES, job->object_key);
                 if (attempt + 1 < TDB_UPLOAD_MAX_RETRIES)
                 {
                     usleep(backoff_us);
@@ -4949,35 +5206,27 @@ static void *tdb_upload_worker_thread(void *arg)
 
             if (rc == 0)
             {
-                atomic_fetch_add_explicit(&db->total_uploads, 1, memory_order_relaxed);
-
-                /* we update WAL fence if this upload advances it */
-                if (job->wal_generation > 0)
-                {
-                    uint64_t cur =
-                        atomic_load_explicit(&db->last_uploaded_gen, memory_order_relaxed);
-                    while (job->wal_generation > cur)
-                    {
-                        if (atomic_compare_exchange_weak_explicit(
-                                &db->last_uploaded_gen, &cur, job->wal_generation,
-                                memory_order_release, memory_order_relaxed))
-                            break;
-                    }
-
-                    /* the rotated WAL is now confirmed present on the object
-                     * store (the exists + size verify above proved it), so the
-                     * upload worker deletes the local copy here. this replaces
-                     * the reaper's old synchronous per-generation exists() sweep.
-                     * recovery can replay the WAL from the object store if the
-                     * node restarts before the immutable has flushed. */
-                    tdb_unlink(job->local_path);
-                }
+                tdb_objstore_on_upload_success(db, job);
             }
             else
             {
                 atomic_fetch_add_explicit(&db->total_upload_failures, 1, memory_order_relaxed);
-                TDB_DEBUG_LOG(TDB_LOG_ERROR, "Upload permanently failed after %d attempts: %s",
-                              TDB_UPLOAD_MAX_RETRIES, job->object_key);
+                /* an active-WAL snapshot (generation 0, partial length) is re-shipped to the same
+                 * key every sync interval, so the periodic resync is its own retry and parking it
+                 * would only risk a stale shorter snapshot overwriting a newer one. everything else
+                 * is parked for the reaper so a longer object store outage still delivers instead
+                 * of dropping the upload here. */
+                if (job->wal_generation == 0 && job->upload_max_bytes > 0)
+                {
+                    TDB_DEBUG_LOG(TDB_LOG_WARN, "WAL snapshot upload failed after %d attempts %s",
+                                  TDB_UPLOAD_MAX_RETRIES, job->object_key);
+                }
+                else
+                {
+                    TDB_DEBUG_LOG(TDB_LOG_WARN, "Upload failed after %d attempts parking %s",
+                                  TDB_UPLOAD_MAX_RETRIES, job->object_key);
+                    tdb_objstore_defer_upload(db, job);
+                }
             }
         }
 
@@ -5010,6 +5259,8 @@ static void tdb_objstore_enqueue_upload(const tidesdb_t *db, const char *local_p
     job->wal_generation = wal_generation;
     job->meta_epoch = meta_epoch;
     job->upload_max_bytes = max_bytes;
+    job->track_in_cache =
+        0; /* async path serves WAL/manifest/config, never sstable cache tracking */
 
     if (queue_enqueue(db->upload_queue, job) != 0)
     {
@@ -5019,86 +5270,102 @@ static void tdb_objstore_enqueue_upload(const tidesdb_t *db, const char *local_p
 }
 
 /**
- * tdb_objstore_upload_file_sync
- * upload a local file synchronously (blocks until complete).
- * used for small metadata files (config.ini, MANIFEST) that must be
- * visible immediately after the call returns.
- * @param db database instance
- * @param local_path local file path to upload
+ * tdb_objstore_upload_job_sync
+ * the synchronous sibling of the async worker. it runs the same fast inner retries and, on success,
+ * the shared bookkeeping. on failure it parks the job for the reaper's slow outer retry when
+ * defer_on_fail is set, and otherwise only records the failure for a caller that retries by other
+ * means (an active WAL snapshot is re-shipped every sync interval, so it needs no parking).
+ * @param db database
+ * @param job upload job describing the object
+ * @param defer_on_fail park the job for deferred retry once the inner retries are exhausted
+ * @return 0 on success, -1 otherwise
  */
-static void tdb_objstore_upload_file_sync(tidesdb_t *db, const char *local_path)
+static int tdb_objstore_upload_job_sync(tidesdb_t *db, const tdb_upload_job_t *job,
+                                        int defer_on_fail)
 {
-    if (!db->object_store || !local_path) return;
-    char key[TDB_MAX_PATH_LEN];
-    tdb_path_to_object_key(db, local_path, key, sizeof(key));
-
-    /* we retry with exponential backoff matching the async upload worker. the upload counters
-     * cover both paths, so the sync sstable/config/wal uploads count alongside the async
-     * manifest/wal ones. */
     unsigned int delay_us = TDB_UPLOAD_INITIAL_BACKOFF_US;
     for (int attempt = 0; attempt < TDB_UPLOAD_MAX_RETRIES; attempt++)
     {
-        if (db->object_store->put(db->object_store->ctx, key, local_path) == 0)
+        if (tdb_objstore_put_once(db, job) == 0)
         {
-            atomic_fetch_add_explicit(&db->total_uploads, 1, memory_order_relaxed);
-            return;
+            tdb_objstore_on_upload_success(db, job);
+            return 0;
         }
-
         TDB_DEBUG_LOG(TDB_LOG_WARN, "Object store sync upload attempt %d/%d failed: %s",
-                      attempt + 1, TDB_UPLOAD_MAX_RETRIES, key);
+                      attempt + 1, TDB_UPLOAD_MAX_RETRIES, job->object_key);
         if (attempt + 1 < TDB_UPLOAD_MAX_RETRIES) usleep(delay_us);
         delay_us *= TDB_UPLOAD_BACKOFF_MULTIPLIER;
     }
+
     atomic_fetch_add_explicit(&db->total_upload_failures, 1, memory_order_relaxed);
-    TDB_DEBUG_LOG(TDB_LOG_ERROR, "Object store sync upload failed after %d attempts: %s",
-                  TDB_UPLOAD_MAX_RETRIES, key);
+    if (defer_on_fail)
+    {
+        TDB_DEBUG_LOG(TDB_LOG_WARN, "Object store sync upload failed after %d attempts parking %s",
+                      TDB_UPLOAD_MAX_RETRIES, job->object_key);
+        tdb_objstore_defer_upload(db, job);
+    }
+    else
+    {
+        TDB_DEBUG_LOG(TDB_LOG_WARN, "Object store sync upload failed after %d attempts %s",
+                      TDB_UPLOAD_MAX_RETRIES, job->object_key);
+    }
+    return -1;
+}
+
+/**
+ * tdb_objstore_upload_file_sync
+ * upload a local file synchronously, blocking until it lands. used for the small metadata files
+ * (config.ini, MANIFEST, the cf-index map) and for sstable data files, which must be on the store
+ * before the local cache is allowed to evict them. a failed upload is parked for deferred retry.
+ * @param db database
+ * @param local_path local file path to upload
+ * @param track_in_cache register the file with the local cache once it is confirmed remote
+ * (sstable)
+ * @return 0 on success, -1 otherwise
+ */
+static int tdb_objstore_upload_file_sync(tidesdb_t *db, const char *local_path, int track_in_cache)
+{
+    if (!db->object_store || !local_path) return -1;
+
+    tdb_upload_job_t job;
+    snprintf(job.local_path, sizeof(job.local_path), "%s", local_path);
+    tdb_path_to_object_key(db, local_path, job.object_key, sizeof(job.object_key));
+    job.wal_generation = 0;
+    job.meta_epoch = 0;
+    job.upload_max_bytes = 0;
+    job.track_in_cache = track_in_cache;
+    return tdb_objstore_upload_job_sync(db, &job, 1);
 }
 
 /**
  * tdb_objstore_upload_wal_sync
- * synchronous WAL upload that tags the object with the current lease epoch so a replica can
- * skip a superseded primary's segments. falls back to the plain sync upload when fencing is off.
- * @param db database instance
+ * synchronous WAL upload that tags the object with the current lease epoch so a replica can skip a
+ * superseded primary's segments. a rotated WAL (wal_generation > 0) advances the upload fence and
+ * has its local copy deleted on success, and is parked for deferred retry on failure. an active-WAL
+ * snapshot (generation 0, partial length) is re-shipped every sync interval, so it is not parked.
+ * put_once routes through put_if whenever the connector has it so the snapshot honors max_bytes and
+ * ships the WAL's logical length rather than its preallocated extent.
+ * @param db database
  * @param local_path WAL file path to upload
  * @param max_bytes logical WAL length to upload (0 = whole file); the active WAL is preallocated
  *                  far past its data, so shipping the whole file would copy a huge zero tail
+ * @param wal_generation rotated-WAL generation to fence on success (0 = active WAL, no fence)
+ * @return 0 on success, -1 otherwise
  */
-static void tdb_objstore_upload_wal_sync(tidesdb_t *db, const char *local_path, uint64_t max_bytes)
+static int tdb_objstore_upload_wal_sync(tidesdb_t *db, const char *local_path, uint64_t max_bytes,
+                                        uint64_t wal_generation)
 {
-    if (!db->object_store || !local_path) return;
+    if (!db->object_store || !local_path) return -1;
 
-    /* route through put_if whenever the connector has it, even before a lease is held (epoch 0):
-     * it is the only upload that honors max_bytes, so it ships the active WAL's logical length
-     * rather than its 64MB preallocated extent. an untagged (epoch 0) WAL is fine -- a reader
-     * treats epoch 0 as never-stale. only a legacy connector lacking put_if falls back. */
-    if (!db->object_store->put_if)
-    {
-        tdb_objstore_upload_file_sync(db, local_path);
-        return;
-    }
+    tdb_upload_job_t job;
+    snprintf(job.local_path, sizeof(job.local_path), "%s", local_path);
+    tdb_path_to_object_key(db, local_path, job.object_key, sizeof(job.object_key));
+    job.wal_generation = wal_generation;
+    job.meta_epoch = atomic_load_explicit(&db->primary_epoch, memory_order_acquire);
+    job.upload_max_bytes = max_bytes;
+    job.track_in_cache = 0;
 
-    uint64_t epoch = atomic_load_explicit(&db->primary_epoch, memory_order_acquire);
-
-    char key[TDB_MAX_PATH_LEN];
-    tdb_path_to_object_key(db, local_path, key, sizeof(key));
-
-    unsigned int delay_us = TDB_UPLOAD_INITIAL_BACKOFF_US;
-    for (int attempt = 0; attempt < TDB_UPLOAD_MAX_RETRIES; attempt++)
-    {
-        if (db->object_store->put_if(db->object_store->ctx, key, local_path, TDB_PUT_OVERWRITE,
-                                     NULL, epoch, NULL, 0, (size_t)max_bytes) == 0)
-        {
-            atomic_fetch_add_explicit(&db->total_uploads, 1, memory_order_relaxed);
-            return;
-        }
-        TDB_DEBUG_LOG(TDB_LOG_WARN, "Object store sync WAL upload attempt %d/%d failed: %s",
-                      attempt + 1, TDB_UPLOAD_MAX_RETRIES, key);
-        if (attempt + 1 < TDB_UPLOAD_MAX_RETRIES) usleep(delay_us);
-        delay_us *= TDB_UPLOAD_BACKOFF_MULTIPLIER;
-    }
-    atomic_fetch_add_explicit(&db->total_upload_failures, 1, memory_order_relaxed);
-    TDB_DEBUG_LOG(TDB_LOG_ERROR, "Object store sync WAL upload failed after %d attempts: %s",
-                  TDB_UPLOAD_MAX_RETRIES, key);
+    return tdb_objstore_upload_job_sync(db, &job, wal_generation > 0);
 }
 
 /**
@@ -5120,7 +5387,7 @@ static void tdb_objstore_upload_file(tidesdb_t *db, const char *local_path)
     }
 
     /* we fallback to synchronous upload (retries and counts via the sync helper) */
-    tdb_objstore_upload_file_sync(db, local_path);
+    tdb_objstore_upload_file_sync(db, local_path, 0);
 }
 
 /**
@@ -5422,7 +5689,7 @@ static int tdb_objstore_fencing_enabled(const tidesdb_t *db)
 }
 
 /* tdb_objstore_verify_conditional_writes
- * probe whether the backend actually enforces conditional puts: a create-only put on a fresh
+ * probe whether the backend actually enforces conditional puts, a create-only put on a fresh
  * key must succeed and an immediate second create-only on the same key must fail the
  * precondition. a store that ignores If-None-Match returns success twice, so fencing would be
  * false safety -- callers disable it in that case. uses a node-unique key to avoid cross-node
@@ -10535,21 +10802,22 @@ static int64_t tidesdb_sstable_aux_memory_bytes(const tidesdb_sstable_t *sst)
  */
 static int tidesdb_level_add_sstable(tidesdb_level_t *level, tidesdb_sstable_t *sst)
 {
-    /* we upload sstable files synchronously before tracking in the local cache.
-     * this ensures the object store has a copy before cache eviction can delete
-     * the local file (the eviction path unlinks cold files from disk).
-     * a replica never creates sstables -- its adds come from sync/cold-start and
-     * already exist remotely, so re-uploading wastes bandwidth and, on an incomplete
-     * local copy, could clobber good remote data. it can also always re-fetch on
-     * eviction, so only primaries push to the store. */
+    /* a primary uploads each sstable file synchronously and only marks it cache-trackable -- and
+     * so evictable -- once the upload confirms, since the eviction path unlinks cold files from
+     * disk and must never reclaim a file that is not yet on the store. an upload that exhausts the
+     * fast retries is parked for deferred retry and the file stays untracked (pinned on disk) until
+     * the reaper delivers it. a replica never creates sstables -- its adds come from
+     * sync/cold-start and already exist remotely, so it tracks them for eviction directly and can
+     * re-fetch on a miss, never pushing to the store (re-uploading an incomplete local copy could
+     * clobber good remote data). */
     if (sst->db && sst->db->object_store)
     {
         if (!atomic_load_explicit(&sst->db->replica_mode, memory_order_acquire))
         {
-            tdb_objstore_upload_file_sync(sst->db, sst->klog_path);
-            tdb_objstore_upload_file_sync(sst->db, sst->vlog_path);
+            tdb_objstore_upload_file_sync(sst->db, sst->klog_path, 1);
+            tdb_objstore_upload_file_sync(sst->db, sst->vlog_path, 1);
         }
-        if (sst->db->local_cache)
+        else if (sst->db->local_cache)
         {
             tdb_local_cache_track(sst->db->local_cache, sst->klog_path);
             tdb_local_cache_track(sst->db->local_cache, sst->vlog_path);
@@ -20404,6 +20672,10 @@ static void *tidesdb_reaper_thread(void *arg)
             }
         }
 
+        /* re-attempt any uploads parked by a failed put, now that some time has passed and the
+         * object store may have recovered */
+        tdb_objstore_retry_deferred(db);
+
         int current_open = atomic_load(&db->num_open_sstables);
         int max_open = (int)db->config.max_open_sstables;
         /* evict down to the reader budget, not max_open, keeping num_open at/below the budget
@@ -21745,6 +22017,12 @@ int tidesdb_open(const tidesdb_config_t *config, tidesdb_t **db)
     }
 
     pthread_mutex_init(&(*db)->reaper_thread_mutex, NULL);
+    /* deferred-upload backlog -- initialized unconditionally so close can always destroy it,
+     * even for non-object-store databases that never populate it */
+    (*db)->pending_uploads = NULL;
+    (*db)->pending_upload_count = 0;
+    (*db)->pending_upload_capacity = 0;
+    pthread_mutex_init(&(*db)->pending_upload_lock, NULL);
 #if defined(__linux__)
     {
         pthread_condattr_t cattr;
@@ -22265,10 +22543,16 @@ int tidesdb_close(tidesdb_t *db)
         queue_free(db->upload_queue);
         db->upload_queue = NULL;
 
+        /* one best-effort pass over the deferred backlog -- the reaper is already stopped and the
+         * workers are joined, so this is single-threaded. anything still undelivered persists on
+         * local disk for the next startup to re-upload */
+        tdb_objstore_drain_deferred(db);
+
         TDB_DEBUG_LOG(TDB_LOG_INFO,
                       "Upload pipeline stopped (%" PRIu64 " uploads, %" PRIu64 " failures)",
                       atomic_load(&db->total_uploads), atomic_load(&db->total_upload_failures));
     }
+    pthread_mutex_destroy(&db->pending_upload_lock);
 
     /* we clean up unified memtable state if enabled */
     if (db->unified_mt.enabled)
@@ -22601,7 +22885,7 @@ static int tidesdb_unimap_persist(tidesdb_t *db)
      * MANIFEST so replicas reconstruct cf indexes the same way the primary did */
     if (db->object_store)
     {
-        tdb_objstore_upload_file_sync(db, final_path);
+        tdb_objstore_upload_file_sync(db, final_path, 0);
     }
 
     return TDB_SUCCESS;
@@ -23450,14 +23734,14 @@ int tidesdb_create_column_family(tidesdb_t *db, const char *name,
     /* we upload config.ini to object store (sync -- small file, must be visible immediately) */
     if (db->object_store && save_result == TDB_SUCCESS)
     {
-        tdb_objstore_upload_file_sync(db, config_path);
+        tdb_objstore_upload_file_sync(db, config_path, 0);
 
         /* commit + upload the empty MANIFEST so replicas can discover this CF
          * before its first flush -- discovery keys off <cf>/MANIFEST */
         if (tidesdb_manifest_commit(cf->manifest, cf->manifest->path,
                                     cf->config.sync_mode != TDB_SYNC_NONE) == 0)
         {
-            tdb_objstore_upload_file_sync(db, cf->manifest->path);
+            tdb_objstore_upload_file_sync(db, cf->manifest->path, 0);
         }
     }
 
@@ -28159,11 +28443,13 @@ static void tidesdb_unified_close_wal(tidesdb_t *db, tidesdb_memtable_t *umt_imm
     {
         if (db->config.object_store_config->wal_upload_sync)
         {
-            /* the WAL was closed above, so it is already trimmed to its data -- ship the whole
-             * file */
-            tdb_objstore_upload_wal_sync(db, wal_path, 0);
-            tdb_unlink(wal_path);
-            tdb_sync_directory(db->db_path);
+            /* the WAL was closed above and is trimmed to its data, so the whole file ships. on
+             * success the upload helper advances the fence and deletes the local copy, so the
+             * directory sync just persists that deletion. on failure the WAL is parked for the
+             * reaper and the local file is kept for that retry and for recovery to replay if we
+             * restart first. */
+            if (tdb_objstore_upload_wal_sync(db, wal_path, 0, imm_gen) == 0)
+                tdb_sync_directory(db->db_path);
         }
         else
         {
@@ -28914,7 +29200,7 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
         {
             uint64_t wal_len = 0;
             block_manager_get_size(umt->wal, &wal_len);
-            tdb_objstore_upload_wal_sync(txn->db, umt->wal->file_path, wal_len);
+            tdb_objstore_upload_wal_sync(txn->db, umt->wal->file_path, wal_len, 0);
         }
 
         /* we apply ops to unified skip list with prefixed keys */

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -1359,6 +1359,16 @@ static int tidesdb_visibility_check_callback(void *opaque_ctx, const uint64_t se
 
     tidesdb_commit_status_t *cs = (tidesdb_commit_status_t *)opaque_ctx;
 
+    /* the ring only distinguishes the last cs->capacity sequence numbers. once a seq falls
+     * more than capacity behind the high-water mark its slot has been recycled by a newer
+     * seq, so the slot no longer describes it. a version reaches a reader only after its
+     * commit applied it to the skip list, and a seq that far back cannot still be in flight,
+     * so an evicted seq is committed -- the same assumption recovery makes when it backfills
+     * the trailing window. without this an old committed version reads its slot as the newer
+     * seq's in-progress status and falls through as a stale snapshot read */
+    const uint64_t max_seq = atomic_load_explicit(&cs->max_seq, memory_order_acquire);
+    if (max_seq >= cs->capacity && seq <= max_seq - cs->capacity) return 1;
+
     /* we map seq to circular buffer index */
     const size_t idx = seq % cs->capacity;
     uint8_t status = atomic_load_explicit(&cs->status[idx], memory_order_acquire);

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -958,8 +958,15 @@ struct tidesdb_t
     _Atomic(uint64_t) last_uploaded_gen;     /* highest WAL gen confirmed uploaded */
     _Atomic(uint64_t) total_uploads;         /* lifetime upload count */
     _Atomic(uint64_t) total_upload_failures; /* lifetime failed upload count */
-    _Atomic(uint64_t) last_wal_sync_size;    /* WAL file size at last object store sync;
-                                              * _Atomic -- reaper writes it, open seeds it */
+    /* uploads that exhausted the fast inner retries are parked here and re-attempted by the reaper
+     * on a slow outer backoff so a long object store outage still delivers eventually. the backlog
+     * is a dynamic array of tdb_deferred_upload_t guarded by pending_upload_lock */
+    void *pending_uploads; /* tdb_deferred_upload_t[], void* to avoid a fwd decl */
+    size_t pending_upload_count;
+    size_t pending_upload_capacity;
+    pthread_mutex_t pending_upload_lock;
+    _Atomic(uint64_t) last_wal_sync_size; /* WAL file size at last object store sync;
+                                           * _Atomic -- reaper writes it, open seeds it */
 
     /* replica mode runtime state */
     _Atomic(int) replica_mode;               /* 1 = read-only replica, 0 = primary */

--- a/test/bloom_filter__tests.c
+++ b/test/bloom_filter__tests.c
@@ -840,26 +840,26 @@ static void test_bloom_filter_new_failure_nulls_out(void)
      * bloom_filter_new malloc()s the struct first then hits the h validator
      * and free()s it -- pre-fix this returned -1 with *bf pointing at the
      * freed struct */
-    bloom_filter_t *bf = (bloom_filter_t *)0xdeadbeef;
+    bloom_filter_t *bf = (bloom_filter_t *)(uintptr_t)0xdeadbeef;
     int rc = bloom_filter_new(&bf, 1e-300, 100);
     ASSERT_EQ(rc, -1);
     ASSERT_EQ(bf, NULL);
 
     /* size_in_words overflow path: very small p combined with n large enough
      * to push m past UINT32_MAX */
-    bf = (bloom_filter_t *)0xdeadbeef;
+    bf = (bloom_filter_t *)(uintptr_t)0xdeadbeef;
     rc = bloom_filter_new(&bf, 1e-9, INT_MAX);
     ASSERT_EQ(rc, -1);
     ASSERT_EQ(bf, NULL);
 
     /* invalid args path (returns before malloc, *bf untouched) -- the
      * sentinel must still be observable */
-    bf = (bloom_filter_t *)0xdeadbeef;
+    bf = (bloom_filter_t *)(uintptr_t)0xdeadbeef;
     rc = bloom_filter_new(&bf, 0.0, 100);
     ASSERT_EQ(rc, -1);
     /* this path does not malloc so it leaves *bf alone -- documented
      * carve-out from the contract above */
-    ASSERT_EQ(bf, (bloom_filter_t *)0xdeadbeef);
+    ASSERT_EQ(bf, (bloom_filter_t *)(uintptr_t)0xdeadbeef);
 
     /* and a caller that ignores the return code must not UAF. with the
      * contract fix bf is NULL after a failed new() and bloom_filter_add

--- a/test/failover/k8s/nodes.yaml
+++ b/test/failover/k8s/nodes.yaml
@@ -1,4 +1,4 @@
-# Cluster nodes for the failover simulation: one primary and three replicas, all pointed at the
+# Cluster nodes for the failover simulation with one primary and three replicas, all pointed at the
 # shared MinIO bucket. the image is built from test/failover/Dockerfile and loaded into kind.
 # restartPolicy Never so deleting a pod is a real node loss. three replicas let the matrix cover
 # fan-out convergence, surviving replicas re-following a newly promoted primary, and cascading

--- a/test/failover/run_k8s.sh
+++ b/test/failover/run_k8s.sh
@@ -1,13 +1,10 @@
 #!/usr/bin/env bash
 #
-# cloud-simulation failover test: real pods on a kind cluster, fencing against a real MinIO
+# cloud-simulation failover test with real pods on a kind cluster, fencing against a real MinIO
 # bucket over the S3 connector's conditional writes (not the fs/flock shortcut). a "node loss" is
 # a real pod deletion and the writers are separate containers. one primary + three replicas let
 # the matrix cover fan-out replication, a failover the surviving replicas re-follow, split-brain
 # fencing of a live zombie, and cascading (sequential) failovers with a monotonic epoch.
-#
-# assumes a working kubectl context (the kind cluster) with the node image loaded as
-# tidesdb-node:ci. test infrastructure only.
 set -u
 
 K8S_DIR="$(cd "$(dirname "$0")/k8s" && pwd)"

--- a/test/failover/run_local.sh
+++ b/test/failover/run_local.sh
@@ -4,12 +4,12 @@
 # starts real tidesdb_node processes against a shared filesystem bucket (the fs backend uses
 # flock, so the fence works across processes on one host) and drives two scenarios:
 #
-#   failover_catchup -- the replica is given a huge sync interval so it never polls; all of the
+#   failover_catchup    the replica is given a huge sync interval so it never polls; all of the
 #                       outgoing primary's data must arrive via the promotion catch-up. proves the
 #                       catch-up gates on the outgoing epoch (the ordering fix) rather than
 #                       skipping it as stale. writes enough through a small write buffer to build
 #                       many sstables and WAL generations.
-#   zombie_fence     -- after a replica is promoted, the old primary keeps writing. its next
+#   zombie_fence        after a replica is promoted, the old primary keeps writing. its next
 #                       publish must fail the lease renew and self-demote, and its post-promotion
 #                       writes must never appear on the new primary.
 #

--- a/test/failover/tidesdb_node.c
+++ b/test/failover/tidesdb_node.c
@@ -43,7 +43,7 @@
  *   TDB_NODE_WAL_SYNC_ON_COMMIT   0 | 1 (default 1, RPO=0)
  *   TDB_NODE_REPLICA_SYNC_US      replica poll interval (default 500000)
  *   TDB_NODE_ID                   label used in log lines (default the port)
- * for the s3 backend: TIDESDB_S3_ENDPOINT, TIDESDB_S3_BUCKET, TIDESDB_S3_ACCESS_KEY,
+ * for the s3 backend TIDESDB_S3_ENDPOINT, TIDESDB_S3_BUCKET, TIDESDB_S3_ACCESS_KEY,
  * TIDESDB_S3_SECRET_KEY (matching the existing object-store CI workflow).
  */
 

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -30422,14 +30422,26 @@ typedef struct
     _Atomic(uint64_t) *commits; /* per-key successful-commit counts */
 } lostupd_arg_t;
 
+/* tiny per-thread xorshift so the test needs no posix rand_r (absent on msvc); the seed is
+ * always non-zero because id*odd + 1 cannot be zero for any thread id in range */
+static inline uint32_t lostupd_rand(uint32_t *s)
+{
+    uint32_t x = *s;
+    x ^= x << 13;
+    x ^= x >> 17;
+    x ^= x << 5;
+    *s = x;
+    return x;
+}
+
 static void *lostupd_increment_worker(void *arg)
 {
     lostupd_arg_t *a = arg;
-    unsigned seed = (unsigned)(a->id * 2654435761u + 1u);
+    uint32_t seed = (uint32_t)(a->id * 2654435761u + 1u);
 
     for (int n = 0; n < LOSTUPD_OPS; n++)
     {
-        const int k = rand_r(&seed) % LOSTUPD_KEYS;
+        const int k = (int)(lostupd_rand(&seed) % LOSTUPD_KEYS);
         uint8_t key[16];
         const int klen = snprintf((char *)key, sizeof(key), "ctr:%d", k);
 

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -17484,7 +17484,7 @@ static void test_unlimited_max_open_no_eviction(void)
 {
     cleanup_test_dir();
 
-    /* max_open_sstables = 0 means unlimited: the reaper must never evict for budget and a reader
+    /* max_open_sstables = 0 means unlimited, the reaper must never evict for budget and a reader
      * must never back off with TDB_ERR_BUSY. this also guards the sentinel itself -- if 0 were
      * treated as a literal budget of zero the reader gate would reject every open and every read
      * would return BUSY. */
@@ -17534,7 +17534,7 @@ static void test_unlimited_max_open_no_eviction(void)
     }
     usleep(200000); /* give the reaper ample time -- under unlimited it must not evict */
 
-    /* every read uses a plain get (no retry): unlimited means no fd-budget backoff, so each read
+    /* every read uses a plain get (no retry), unlimited means no fd-budget backoff, so each read
      * resolves directly with no TDB_ERR_BUSY */
     tidesdb_txn_t *txn = NULL;
     ASSERT_EQ(tidesdb_txn_begin(db, &txn), TDB_SUCCESS);
@@ -24288,7 +24288,7 @@ static void *mcf_atom_compactor_thread(void *arg)
 }
 
 /* a one-sided NOT_FOUND in the verify can be a transient read-vs-compaction miss rather than a real
- * loss: the long-lived verify txn reads while background compaction relocates keys, and the
+ * loss. the long-lived verify txn reads while background compaction relocates keys, and the
  * point-get layout guard only converts some such races to a retryable BUSY. re-read the missing key
  * with fresh txns over ~1s -- if it reappears the pair is durably present (atomicity held); if it
  * stays gone it is a genuine one-sided loss. returns 1 if still gone (durable), 0 if it reappeared.
@@ -30405,6 +30405,121 @@ static void test_crash_recovery_no_clean_close(void)
     (void)remove_directory(CRASH_RECOVERY_DB_PATH);
 }
 
+/* concurrent read-modify-write of a few hot keys -- pins first-committer-wins for snapshot and
+ * serializable. each increment reads the counter and writes value+1, retrying on conflict, so a
+ * correct engine that lets only one of two racing same-key commits win ends with each counter
+ * equal to the number of commits it received. a lost update would leave the counter short. */
+#define LOSTUPD_THREADS 8
+#define LOSTUPD_KEYS    4
+#define LOSTUPD_OPS     500
+
+typedef struct
+{
+    tidesdb_t *db;
+    tidesdb_column_family_t *cf;
+    int isolation;
+    int id;
+    _Atomic(uint64_t) *commits; /* per-key successful-commit counts */
+} lostupd_arg_t;
+
+static void *lostupd_increment_worker(void *arg)
+{
+    lostupd_arg_t *a = arg;
+    unsigned seed = (unsigned)(a->id * 2654435761u + 1u);
+
+    for (int n = 0; n < LOSTUPD_OPS; n++)
+    {
+        const int k = rand_r(&seed) % LOSTUPD_KEYS;
+        uint8_t key[16];
+        const int klen = snprintf((char *)key, sizeof(key), "ctr:%d", k);
+
+        for (;;) /* retry until this increment commits */
+        {
+            tidesdb_txn_t *txn = NULL;
+            if (tidesdb_txn_begin_with_isolation(a->db, a->isolation, &txn) != 0) break;
+
+            uint64_t v = 0;
+            uint8_t *old = NULL;
+            size_t oldn = 0;
+            if (tidesdb_txn_get(txn, a->cf, key, (size_t)klen, &old, &oldn) == 0 && oldn == 8)
+                for (int i = 0; i < 8; i++) v = (v << 8) | old[i];
+            free(old);
+
+            uint64_t nv = v + 1;
+            uint8_t vb[8];
+            for (int i = 0; i < 8; i++) vb[i] = (uint8_t)(nv >> (8 * (7 - i)));
+
+            int rc = tidesdb_txn_put(txn, a->cf, key, (size_t)klen, vb, 8, 0);
+            if (rc == 0) rc = tidesdb_txn_commit(txn);
+            tidesdb_txn_free(txn);
+
+            if (rc == 0)
+            {
+                atomic_fetch_add(&a->commits[k], 1);
+                break;
+            }
+            if (rc != TDB_ERR_CONFLICT && rc != TDB_ERR_BUSY) break;
+        }
+    }
+    return NULL;
+}
+
+static void test_concurrent_increment_no_lost_update(void)
+{
+    const int isos[] = {TDB_ISOLATION_SNAPSHOT, TDB_ISOLATION_SERIALIZABLE};
+
+    for (int ii = 0; ii < 2; ii++)
+    {
+        cleanup_test_dir();
+
+        tidesdb_config_t config = tidesdb_default_config();
+        config.db_path = TEST_DB_PATH;
+        config.unified_memtable = 1;
+
+        tidesdb_t *db = NULL;
+        ASSERT_EQ(tidesdb_open(&config, &db), 0);
+        ASSERT_TRUE(db != NULL);
+
+        tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
+        ASSERT_EQ(tidesdb_create_column_family(db, "ctr_cf", &cf_config), 0);
+        tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "ctr_cf");
+        ASSERT_TRUE(cf != NULL);
+
+        _Atomic(uint64_t) commits[LOSTUPD_KEYS];
+        for (int k = 0; k < LOSTUPD_KEYS; k++) atomic_init(&commits[k], 0);
+
+        pthread_t threads[LOSTUPD_THREADS];
+        lostupd_arg_t args[LOSTUPD_THREADS];
+        for (int t = 0; t < LOSTUPD_THREADS; t++)
+        {
+            args[t] = (lostupd_arg_t){
+                .db = db, .cf = cf, .isolation = isos[ii], .id = t, .commits = commits};
+            pthread_create(&threads[t], NULL, lostupd_increment_worker, &args[t]);
+        }
+        for (int t = 0; t < LOSTUPD_THREADS; t++) pthread_join(threads[t], NULL);
+
+        /* each counter must equal the commits it received -- no lost update */
+        for (int k = 0; k < LOSTUPD_KEYS; k++)
+        {
+            uint8_t key[16];
+            const int klen = snprintf((char *)key, sizeof(key), "ctr:%d", k);
+            tidesdb_txn_t *txn = NULL;
+            ASSERT_EQ(tidesdb_txn_begin(db, &txn), 0);
+            uint8_t *val = NULL;
+            size_t vn = 0;
+            uint64_t v = 0;
+            if (tidesdb_txn_get(txn, cf, key, (size_t)klen, &val, &vn) == 0 && vn == 8)
+                for (int i = 0; i < 8; i++) v = (v << 8) | val[i];
+            free(val);
+            tidesdb_txn_free(txn);
+            ASSERT_EQ(v, atomic_load(&commits[k]));
+        }
+
+        ASSERT_EQ(tidesdb_close(db), 0);
+    }
+    cleanup_test_dir();
+}
+
 int main(int argc, char **argv)
 {
     g_test_argv0 = argv[0];
@@ -30802,6 +30917,7 @@ int main(int argc, char **argv)
     RUN_TEST(test_unified_four_cf_single_txn, tests_passed);
     RUN_TEST(test_unified_iter_unflushed, tests_passed);
     RUN_TEST(test_unified_snapshot_commit, tests_passed);
+    RUN_TEST(test_concurrent_increment_no_lost_update, tests_passed);
     RUN_TEST(test_perf_cached_iter_seek, tests_passed);
     RUN_TEST(test_block_index_shared_prefix, tests_passed);
     RUN_TEST(test_objstore_fs_roundtrip, tests_passed);

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tidesdb",
-  "version-string": "9.3.8",
+  "version-string": "9.3.9",
   "description": "TidesDB is a high-performance durable, transactional embeddable storage engine designed for flash and RAM optimization with optional object storage support for unlimited data scaling.",
   "dependencies": ["zstd", "snappy", "lz4", "pthreads", "curl"],
   "features": {


### PR DESCRIPTION
originally identified through TAF analysis (https://github.com/MariaDB/TAF) and brought up by @JonathanBMiller through heavy concurrent stress config sweeps up to 512 threads and beyond running sysbench with a sigkill soak.

the commit status ring has a fixed 65536 slots indexed by sequence number modulo capacity, with no tag recording which sequence owns a slot. under heavy concurrent commits the global sequence runs more than a full ring ahead of an older committed sequence, and that older sequence slot gets reused by a newer one that is still in progress. the snapshot visibility check read the slot, saw the newer sequence in progress state, and concluded the old committed version was not visible. the read then fell through to an older version and returned stale data.

only snapshot isolation corrupted data. repeatable read and serializable hit the same stale read but their read set tracking turns it into a conflict and retries, so it self heals. snapshot does write write conflict detection only, so it committed a new write on top of the stale value and left secondary index entries pointing at rows that no longer matched. read committed and read uncommitted read the latest sequence and never saw it.

treat any sequence that has fallen more than a full ring behind the high water mark as committed. its slot has already been recycled so it cannot still be in flight, and a version only becomes visible to a reader after its commit applied it to the skip list. this matches what recovery already assumes when it backfills only the trailing ring window.