### PR TITLE
consolidate small sstables in preemptive merge; descend shallow trees…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ if(TIDESDB_WITH_MIMALLOC)
 endif()
 
 project(tidesdb
-	VERSION 9.3.11
+	VERSION 9.3.12
 	LANGUAGES C)
 
 set(CMAKE_C_STANDARD 11)

--- a/src/block_manager.c
+++ b/src/block_manager.c
@@ -320,12 +320,15 @@ static inline void maybe_extend_allocation(block_manager_t *bm, const uint64_t r
     {
         const uint64_t prealloc =
             atomic_load_explicit(&bm->preallocated_size, memory_order_acquire);
-        if (BM_LIKELY(reservation_end + BLOCK_MANAGER_PREALLOC_LOWWATER <= prealloc)) return;
+        /* chunk is per-instance (block_manager_open_pre); lowwater derives as chunk >> 4 so the
+         * default 64 MB chunk keeps its 4 MB lowwater while a small manifest chunk scales down */
+        const uint64_t chunk = atomic_load_explicit(&bm->prealloc_chunk, memory_order_relaxed);
+        if (chunk == 0) return; /* preallocation disabled -- writes extend the file exactly */
+        const uint64_t lowwater = chunk >> BLOCK_MANAGER_PREALLOC_LOWWATER_SHIFT;
+        if (BM_LIKELY(reservation_end + lowwater <= prealloc)) return;
 
         /* we round up to the next CHUNK boundary so successive extends stay aligned */
-        const uint64_t target =
-            ((reservation_end + BLOCK_MANAGER_PREALLOC_CHUNK - 1) / BLOCK_MANAGER_PREALLOC_CHUNK) *
-            BLOCK_MANAGER_PREALLOC_CHUNK;
+        const uint64_t target = ((reservation_end + chunk - 1) / chunk) * chunk;
         if (target <= prealloc) return; /* another writer already extended past us */
 
         if (tdb_preallocate_extent(bm->fd, (off_t)prealloc, (off_t)(target - prealloc)) != 0)
@@ -469,7 +472,8 @@ static int truncate_to_header(block_manager_t *bm)
  * @return 0 if successful, -1 if not
  */
 static int block_manager_open_internal(block_manager_t **bm, const char *file_path,
-                                       const block_manager_sync_mode_t sync_mode)
+                                       const block_manager_sync_mode_t sync_mode,
+                                       const uint64_t prealloc_chunk)
 {
     block_manager_t *new_bm = malloc(sizeof(block_manager_t));
     if (!new_bm)
@@ -481,6 +485,10 @@ static int block_manager_open_internal(block_manager_t **bm, const char *file_pa
     /* we initialize atomic variable to prevent reading uninitialized memory */
     atomic_init(&new_bm->current_file_size, 0);
     atomic_init(&new_bm->preallocated_size, 0);
+    /* prealloc_chunk 0 disables preallocation -- the file grows to exactly what is written, so a
+     * copy of a live file carries no trailing reserved zeros. tiny append logs (the manifest) use
+     * this. block_manager_open always passes the non-zero default. */
+    atomic_init(&new_bm->prealloc_chunk, prealloc_chunk);
     atomic_init(&new_bm->group_durable_size, 0);
     atomic_init(&new_bm->group_sync_active, 0);
 
@@ -1984,5 +1992,13 @@ int block_manager_read_block_data_at_offset(block_manager_t *bm, const uint64_t 
 int block_manager_open(block_manager_t **bm, const char *file_path, const int sync_mode)
 {
     if (!bm || !file_path) return -1;
-    return block_manager_open_internal(bm, file_path, convert_sync_mode(sync_mode));
+    return block_manager_open_internal(bm, file_path, convert_sync_mode(sync_mode),
+                                       BLOCK_MANAGER_PREALLOC_CHUNK);
+}
+
+int block_manager_open_pre(block_manager_t **bm, const char *file_path, const int sync_mode,
+                           const uint64_t prealloc_chunk)
+{
+    if (!bm || !file_path) return -1;
+    return block_manager_open_internal(bm, file_path, convert_sync_mode(sync_mode), prealloc_chunk);
 }

--- a/src/block_manager.h
+++ b/src/block_manager.h
@@ -62,6 +62,9 @@
  * of disjoint offsets, so we preallocate in chunks and let pwrites land in-place. */
 #define BLOCK_MANAGER_PREALLOC_CHUNK    (64ull * 1024 * 1024) /* extend by 64 MB at a time */
 #define BLOCK_MANAGER_PREALLOC_LOWWATER (4ull * 1024 * 1024)  /* trigger extend when 4 MB left */
+/* the per-instance lowwater derives from the chunk by this shift (chunk >> 4 = chunk / 16), which
+ * reproduces the default 64 MB chunk / 4 MB lowwater ratio for any chunk size */
+#define BLOCK_MANAGER_PREALLOC_LOWWATER_SHIFT 4
 
 /* sstable-construction writeback pacing-- when smoothing is enabled, start async writeback
  * of the file each time this many bytes accumulate since the last hint, so the final
@@ -111,6 +114,12 @@ typedef struct
     /* explicit alignment for atomic uint64_t to avoid ABI issues on 32-bit platforms */
     ATOMIC_ALIGN(8) _Atomic uint64_t current_file_size;
     ATOMIC_ALIGN(8) _Atomic uint64_t preallocated_size;
+    /* per-instance preallocation chunk -- the on-disk extent grows by this many bytes at a time.
+     * block_manager_open uses BLOCK_MANAGER_PREALLOC_CHUNK; block_manager_open_pre may set a
+     * smaller value, or 0 to disable preallocation entirely (tiny append logs like the manifest, so
+     * a copy of the live file carries no trailing reserved zeros). lowwater derives as chunk >> 4
+     */
+    ATOMIC_ALIGN(8) _Atomic uint64_t prealloc_chunk;
     ATOMIC_ALIGN(8) _Atomic uint64_t group_durable_size;
     /* atomic so concurrent group-commit leaders don't race on this flag */
     _Atomic int group_sync_active;
@@ -159,6 +168,21 @@ typedef struct
  * @return 0 if successful, -1 if not
  */
 int block_manager_open(block_manager_t **bm, const char *file_path, int sync_mode);
+
+/**
+ * block_manager_open_pre
+ * like block_manager_open but with a caller-chosen preallocation chunk. pass a small chunk for a
+ * tiny file, or 0 to disable preallocation entirely so the file grows to exactly what is written
+ * (tiny append logs like the manifest, so a copy of the live file carries no trailing reserved
+ * zeros) rather than reserve a full BLOCK_MANAGER_PREALLOC_CHUNK extent.
+ * @param bm the block manager to open
+ * @param file_path the path of the file
+ * @param sync_mode the sync mode (BLOCK_MANAGER_SYNC_NONE, BLOCK_MANAGER_SYNC_FULL)
+ * @param prealloc_chunk bytes to extend the on-disk extent by at a time; 0 disables preallocation
+ * @return 0 if successful, -1 if not
+ */
+int block_manager_open_pre(block_manager_t **bm, const char *file_path, int sync_mode,
+                           uint64_t prealloc_chunk);
 
 /**
  * block_manager_close

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -19,6 +19,7 @@
 
 #include "manifest.h"
 
+#include <ctype.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <stdio.h>
@@ -30,314 +31,44 @@
 #define MANIFEST_TMP_EXT     ".tmp."
 #define MANIFEST_TMP_EXT_LEN (sizeof(MANIFEST_TMP_EXT) - 1)
 
-/* forward declaration; documented at the definition below */
+static inline void manifest_put_u32(uint8_t *p, const uint32_t v)
+{
+    p[0] = (uint8_t)(v >> 24);
+    p[1] = (uint8_t)(v >> 16);
+    p[2] = (uint8_t)(v >> 8);
+    p[3] = (uint8_t)v;
+}
+
+static inline void manifest_put_u64(uint8_t *p, uint64_t v)
+{
+    for (int i = 7; i >= 0; i--)
+    {
+        p[i] = (uint8_t)v;
+        v >>= 8;
+    }
+}
+
+static inline uint32_t manifest_get_u32(const uint8_t *p)
+{
+    return ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16) | ((uint32_t)p[2] << 8) | (uint32_t)p[3];
+}
+
+static inline uint64_t manifest_get_u64(const uint8_t *p)
+{
+    uint64_t v = 0;
+    for (int i = 0; i < 8; i++) v = (v << 8) | (uint64_t)p[i];
+    return v;
+}
+
+/* forward declarations; documented at their definitions */
 static int tidesdb_manifest_add_sstable_unlocked(tidesdb_manifest_t *manifest, int level,
                                                  uint64_t id, uint64_t num_entries,
                                                  uint64_t size_bytes);
-
-/**
- * manifest_body_append
- * append a raw manifest line's bytes to the growable body buffer used to verify the version 8
- * checksum on read. grows the buffer by doubling.
- * @param body pointer to the buffer pointer (grown in place)
- * @param len pointer to the current byte length
- * @param cap pointer to the current allocated capacity
- * @param line the NUL-terminated line to append (its bytes, excluding the NUL)
- * @return 0 on success, -1 on allocation failure
- */
-static int manifest_body_append(char **body, size_t *len, size_t *cap, const char *line)
-{
-    const size_t ll = strlen(line);
-    if (*len + ll > *cap)
-    {
-        size_t new_cap = *cap ? *cap : MANIFEST_BODY_INIT_CAP;
-        while (new_cap < *len + ll) new_cap *= 2;
-        char *new_body = realloc(*body, new_cap);
-        if (!new_body) return -1;
-        *body = new_body;
-        *cap = new_cap;
-    }
-    memcpy(*body + *len, line, ll);
-    *len += ll;
-    return 0;
-}
-
-tidesdb_manifest_t *tidesdb_manifest_open(const char *path)
-{
-    if (!path) return NULL;
-
-    tidesdb_manifest_t *manifest = malloc(sizeof(tidesdb_manifest_t));
-    if (!manifest) return NULL;
-
-    manifest->entries = malloc(sizeof(tidesdb_manifest_entry_t) * MANIFEST_INITIAL_CAPACITY);
-    if (!manifest->entries)
-    {
-        free(manifest);
-        return NULL;
-    }
-
-    manifest->num_entries = 0;
-    manifest->capacity = MANIFEST_INITIAL_CAPACITY;
-    atomic_init(&manifest->sequence, 0);
-    manifest->fp = NULL;
-    atomic_init(&manifest->active_ops, 0);
-    strncpy(manifest->path, path, MANIFEST_PATH_LEN - 1);
-    manifest->path[MANIFEST_PATH_LEN - 1] = '\0';
-
-    if (pthread_rwlock_init(&manifest->lock, NULL) != 0)
-    {
-        free(manifest->entries);
-        free(manifest);
-        return NULL;
-    }
-
-    /* we clean up orphaned temp files from incomplete commits
-     * temp files are named -- <path>MANIFEST_TMP_EXT<thread_id>.<pid>
-     * if main manifest exists, temp files are stale and can be removed */
-    char dir_path[MANIFEST_PATH_LEN];
-    const char *last_sep = strrchr(path, PATH_SEPARATOR[0]);
-    if (last_sep)
-    {
-        const size_t dir_len = last_sep - path;
-        if (dir_len < sizeof(dir_path))
-        {
-            memcpy(dir_path, path, dir_len);
-            dir_path[dir_len] = '\0';
-        }
-        else
-        {
-            strcpy(dir_path, ".");
-        }
-    }
-    else
-    {
-        strcpy(dir_path, ".");
-    }
-
-    /* base filename for pattern matching */
-    const char *base_name = last_sep ? last_sep + 1 : path;
-    const size_t base_len = strlen(base_name);
-
-    /* we scan directory looking for orphaned temp files */
-    DIR *dir = opendir(dir_path);
-    if (dir)
-    {
-        const size_t dir_path_len = strlen(dir_path);
-        const size_t sep_len = strlen(PATH_SEPARATOR);
-        struct dirent *entry;
-        while ((entry = readdir(dir)) != NULL)
-        {
-            /* we check if filename matches pattern -- <base_name>MANIFEST_TMP_EXT* */
-            const size_t entry_len = strlen(entry->d_name);
-            if (entry_len > base_len + MANIFEST_TMP_EXT_LEN &&
-                strncmp(entry->d_name, base_name, base_len) == 0 &&
-                strncmp(entry->d_name + base_len, MANIFEST_TMP_EXT, MANIFEST_TMP_EXT_LEN) == 0)
-            {
-                /* found orphaned temp file, we remove it */
-                char temp_full_path[MANIFEST_PATH_LEN];
-                /* we check if combined path fits in buffer (dir + separator + entry + null) */
-                if (dir_path_len + sep_len + entry_len + 1 <= MANIFEST_PATH_LEN)
-                {
-                    size_t offset = 0;
-                    memcpy(temp_full_path + offset, dir_path, dir_path_len);
-                    offset += dir_path_len;
-                    memcpy(temp_full_path + offset, PATH_SEPARATOR, sep_len);
-                    offset += sep_len;
-                    memcpy(temp_full_path + offset, entry->d_name, entry_len);
-                    offset += entry_len;
-                    temp_full_path[offset] = '\0';
-                    remove(temp_full_path);
-                }
-            }
-        }
-        closedir(dir);
-    }
-
-    FILE *fp = tdb_fopen(path, "r");
-    if (!fp)
-    {
-        /* the file doesnt exist, return empty manifest */
-        if (errno == ENOENT) return manifest;
-        /* other error */
-        pthread_rwlock_destroy(&manifest->lock);
-        free(manifest->entries);
-        free(manifest);
-        return NULL;
-    }
-
-    char line[MANIFEST_MAX_LINE_LEN];
-
-    int is_v8 = 0;
-    if (fgets(line, sizeof(line), fp))
-    {
-        char *endptr;
-        const long version = strtol(line, &endptr, 10);
-        if (endptr == line || (version != MANIFEST_VERSION && version != MANIFEST_VERSION_LEGACY))
-        {
-            fclose(fp);
-            pthread_rwlock_destroy(&manifest->lock);
-            free(manifest->entries);
-            free(manifest);
-            return NULL;
-        }
-        is_v8 = (version == MANIFEST_VERSION);
-    }
-    else
-    {
-        /* empty file, keep it open */
-        manifest->fp = fp;
-        return manifest;
-    }
-
-    /* version 8 carries an xxhash64 of the body (sequence + entries) on the next line. read it
-     * here, then accumulate the raw body bytes as we parse so we can verify at end of file and
-     * refuse to open a corrupted manifest rather than silently dropping entries. */
-    uint64_t expected_checksum = 0;
-    char *body = NULL;
-    size_t body_len = 0;
-    size_t body_cap = 0;
-    if (is_v8)
-    {
-        char *cs_endptr;
-        if (!fgets(line, sizeof(line), fp) ||
-            (expected_checksum = strtoull(line, &cs_endptr, 16), cs_endptr == line))
-        {
-            fclose(fp);
-            pthread_rwlock_destroy(&manifest->lock);
-            free(manifest->entries);
-            free(manifest);
-            return NULL;
-        }
-    }
-
-    if (fgets(line, sizeof(line), fp))
-    {
-        if (is_v8 && manifest_body_append(&body, &body_len, &body_cap, line) != 0)
-        {
-            free(body);
-            fclose(fp);
-            pthread_rwlock_destroy(&manifest->lock);
-            free(manifest->entries);
-            free(manifest);
-            return NULL;
-        }
-
-        char *seq_endptr;
-        const unsigned long long seq = strtoull(line, &seq_endptr, 10);
-        /* the sequence line must be a number terminated by end-of-line. reject junk
-         * (e.g. "123abc") rather than silently truncating it -- an under-parsed
-         * sequence under-seeds next_sstable_id on recovery and risks id collisions */
-        if (seq_endptr == line ||
-            (*seq_endptr != '\0' && *seq_endptr != '\n' && *seq_endptr != '\r'))
-        {
-            free(body);
-            fclose(fp);
-            pthread_rwlock_destroy(&manifest->lock);
-            free(manifest->entries);
-            free(manifest);
-            return NULL;
-        }
-        atomic_store(&manifest->sequence, seq);
-    }
-
-    int skipped_lines = 0;
-    while (fgets(line, sizeof(line), fp))
-    {
-        if (is_v8 && manifest_body_append(&body, &body_len, &body_cap, line) != 0)
-        {
-            free(body);
-            fclose(fp);
-            pthread_rwlock_destroy(&manifest->lock);
-            free(manifest->entries);
-            free(manifest);
-            return NULL;
-        }
-
-        const char *ptr = line;
-        char *endptr;
-
-        /* parse level */
-        const long level_val = strtol(ptr, &endptr, 10);
-        if (endptr == ptr || *endptr != ',')
-        {
-            skipped_lines++;
-            continue;
-        }
-        const int level = (int)level_val;
-        ptr = endptr + 1;
-
-        /* parse id */
-        const uint64_t id = strtoull(ptr, &endptr, 10);
-        if (endptr == ptr || *endptr != ',')
-        {
-            skipped_lines++;
-            continue;
-        }
-        ptr = endptr + 1;
-
-        /* parse num_entries */
-        const uint64_t num_entries = strtoull(ptr, &endptr, 10);
-        if (endptr == ptr || *endptr != ',')
-        {
-            skipped_lines++;
-            continue;
-        }
-        ptr = endptr + 1;
-
-        /* parse size_bytes */
-        const uint64_t size_bytes = strtoull(ptr, &endptr, 10);
-        if (endptr == ptr)
-        {
-            skipped_lines++;
-            continue;
-        }
-
-        tidesdb_manifest_add_sstable_unlocked(manifest, level, id, num_entries, size_bytes);
-    }
-
-    /* version 8 -- verify the body checksum and refuse to open on a mismatch. a checksum-valid
-     * body has no corrupt lines to drop, so this replaces the silent line-skip with a hard fail
-     * that lets the operator restore the manifest instead of serving a damaged tree. */
-    if (is_v8)
-    {
-        const uint64_t actual_checksum = XXH64(body, body_len, 0);
-        free(body);
-        body = NULL;
-        if (actual_checksum != expected_checksum)
-        {
-            fprintf(stderr, "tidesdb manifest: checksum mismatch loading %s, refusing to open\n",
-                    manifest->path[0] ? manifest->path : "(unknown)");
-            fclose(fp);
-            pthread_rwlock_destroy(&manifest->lock);
-            free(manifest->entries);
-            free(manifest);
-            return NULL;
-        }
-    }
-
-    /* surface silent data loss, malformed entry lines were dropped. this leaf module has
-     * no access to the db log, so a single stderr line is the best signal available. */
-    if (skipped_lines > 0)
-    {
-        fprintf(stderr, "tidesdb manifest: skipped %d malformed entry line(s) while loading %s\n",
-                skipped_lines, manifest->path[0] ? manifest->path : "(unknown)");
-    }
-
-    /* we keep file open for future use */
-    manifest->fp = fp;
-
-    return manifest;
-}
+static int manifest_rollover_locked(tidesdb_manifest_t *manifest, int durable_sync);
 
 /**
  * tidesdb_manifest_add_sstable_unlocked
- * adds an sstable to the manifest
- * @param manifest manifest to add sstable to
- * @param level level of sstable
- * @param id id of sstable
- * @param num_entries number of entries in sstable
- * @param size_bytes size of sstable in bytes
- * @return 0 on success, -1 on error
+ * upsert an sstable into the in-memory entry array. updates in place on a matching (level,id).
  */
 static int tidesdb_manifest_add_sstable_unlocked(tidesdb_manifest_t *manifest, const int level,
                                                  const uint64_t id, const uint64_t num_entries,
@@ -358,11 +89,7 @@ static int tidesdb_manifest_add_sstable_unlocked(tidesdb_manifest_t *manifest, c
         const int new_capacity = manifest->capacity * 2;
         tidesdb_manifest_entry_t *new_entries =
             realloc(manifest->entries, sizeof(tidesdb_manifest_entry_t) * new_capacity);
-        if (!new_entries)
-        {
-            return -1;
-        }
-
+        if (!new_entries) return -1;
         manifest->entries = new_entries;
         manifest->capacity = new_capacity;
     }
@@ -372,8 +99,646 @@ static int tidesdb_manifest_add_sstable_unlocked(tidesdb_manifest_t *manifest, c
     manifest->entries[manifest->num_entries].num_entries = num_entries;
     manifest->entries[manifest->num_entries].size_bytes = size_bytes;
     manifest->num_entries++;
-
     return 0;
+}
+
+/**
+ * manifest_remove_entry_unlocked
+ * remove a matching (level,id) from the array with an O(1) swap. returns 1 if removed, 0 if absent.
+ */
+static int manifest_remove_entry_unlocked(tidesdb_manifest_t *manifest, const int level,
+                                          const uint64_t id)
+{
+    for (int i = 0; i < manifest->num_entries; i++)
+    {
+        if (manifest->entries[i].level == level && manifest->entries[i].id == id)
+        {
+            manifest->entries[i] = manifest->entries[manifest->num_entries - 1];
+            manifest->num_entries--;
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/**
+ * manifest_pending_reset
+ * reset the pending buffer to a fresh batch containing only the format byte. allocates the buffer
+ * on first use. returns 0 on success, -1 on allocation failure.
+ */
+static int manifest_pending_reset(tidesdb_manifest_t *manifest)
+{
+    if (!manifest->pending)
+    {
+        manifest->pending = malloc(MANIFEST_BODY_INIT_CAP);
+        if (!manifest->pending) return -1;
+        manifest->pending_cap = MANIFEST_BODY_INIT_CAP;
+    }
+    manifest->pending[0] = (uint8_t)MANIFEST_BATCH_FORMAT;
+    manifest->pending_len = MANIFEST_BATCH_HDR_SIZE;
+    return 0;
+}
+
+/**
+ * manifest_pending_add_record
+ * append one record to the pending batch. for MANIFEST_OP_SEQ the sequence is passed in id. grows
+ * the buffer by doubling. returns 0 on success, -1 on allocation failure.
+ */
+static int manifest_pending_add_record(tidesdb_manifest_t *manifest, const uint8_t op,
+                                       const int level, const uint64_t id,
+                                       const uint64_t num_entries, const uint64_t size_bytes)
+{
+    size_t need;
+    switch (op)
+    {
+        case MANIFEST_OP_ADD:
+            need = MANIFEST_REC_ADD_SIZE;
+            break;
+        case MANIFEST_OP_REMOVE:
+            need = MANIFEST_REC_REMOVE_SIZE;
+            break;
+        case MANIFEST_OP_SEQ:
+            need = MANIFEST_REC_SEQ_SIZE;
+            break;
+        default:
+            return -1;
+    }
+
+    if (!manifest->pending && manifest_pending_reset(manifest) != 0) return -1;
+
+    if (manifest->pending_len + need > manifest->pending_cap)
+    {
+        size_t new_cap = manifest->pending_cap ? manifest->pending_cap : MANIFEST_BODY_INIT_CAP;
+        while (new_cap < manifest->pending_len + need) new_cap *= 2;
+        uint8_t *nb = realloc(manifest->pending, new_cap);
+        if (!nb) return -1;
+        manifest->pending = nb;
+        manifest->pending_cap = new_cap;
+    }
+
+    uint8_t *p = manifest->pending + manifest->pending_len;
+    *p++ = op;
+    if (op == MANIFEST_OP_SEQ)
+    {
+        manifest_put_u64(p, id);
+    }
+    else
+    {
+        manifest_put_u32(p, (uint32_t)level);
+        p += 4;
+        manifest_put_u64(p, id);
+        p += 8;
+        if (op == MANIFEST_OP_ADD)
+        {
+            manifest_put_u64(p, num_entries);
+            p += 8;
+            manifest_put_u64(p, size_bytes);
+        }
+    }
+    manifest->pending_len += need;
+    return 0;
+}
+
+/**
+ * manifest_apply_batch
+ * decode one committed block payload (format byte then self-delimiting records) and apply each
+ * record to the in-memory set. a record whose fields would overrun the payload marks the batch
+ * truncated. returns 0 on a clean batch, -1 if the batch was truncated (a torn final commit).
+ */
+static int manifest_apply_batch(tidesdb_manifest_t *manifest, const uint8_t *data,
+                                const size_t size)
+{
+    if (size < MANIFEST_BATCH_HDR_SIZE) return -1;
+    /* data[0] is the batch format byte; unknown formats are refused rather than misread */
+    if (data[0] != (uint8_t)MANIFEST_BATCH_FORMAT) return -1;
+
+    size_t off = MANIFEST_BATCH_HDR_SIZE;
+    while (off < size)
+    {
+        const uint8_t op = data[off];
+        switch (op)
+        {
+            case MANIFEST_OP_ADD:
+            {
+                if (off + MANIFEST_REC_ADD_SIZE > size) return -1;
+                const int level = (int)manifest_get_u32(data + off + 1);
+                const uint64_t id = manifest_get_u64(data + off + 5);
+                const uint64_t ne = manifest_get_u64(data + off + 13);
+                const uint64_t sz = manifest_get_u64(data + off + 21);
+                tidesdb_manifest_add_sstable_unlocked(manifest, level, id, ne, sz);
+                off += MANIFEST_REC_ADD_SIZE;
+                break;
+            }
+            case MANIFEST_OP_REMOVE:
+            {
+                if (off + MANIFEST_REC_REMOVE_SIZE > size) return -1;
+                const int level = (int)manifest_get_u32(data + off + 1);
+                const uint64_t id = manifest_get_u64(data + off + 5);
+                manifest_remove_entry_unlocked(manifest, level, id);
+                off += MANIFEST_REC_REMOVE_SIZE;
+                break;
+            }
+            case MANIFEST_OP_SEQ:
+            {
+                if (off + MANIFEST_REC_SEQ_SIZE > size) return -1;
+                const uint64_t seq = manifest_get_u64(data + off + 1);
+                atomic_store(&manifest->sequence, seq);
+                off += MANIFEST_REC_SEQ_SIZE;
+                break;
+            }
+            default:
+                return -1; /* unknown opcode -- we treat as corruption */
+        }
+    }
+    return 0;
+}
+
+/**
+ * manifest_replay_locked
+ * replay every committed block in the open log into the in-memory set. a torn tail (a crash mid
+ * append leaves the last block unreadable) is skipped so the last durable commit wins, but a
+ * corrupt block that is followed by valid blocks is genuine mid-file corruption -- an append-only
+ * log never writes past a torn tail -- so it fails loud rather than silently dropping entries. a
+ * batch payload that will not decode under a valid block frame is corruption too. returns 0 on a
+ * clean replay, -1 on mid-file corruption (the caller must refuse to open).
+ */
+static int manifest_replay_locked(tidesdb_manifest_t *manifest)
+{
+    block_manager_cursor_t *cursor = NULL;
+    if (block_manager_cursor_init(&cursor, manifest->bm) != 0) return 0;
+
+    int rc = 0;
+    int skipped = 0; /* we skipped an unreadable block; a later valid block means mid-file rot */
+    if (block_manager_cursor_goto_first(cursor) == 0)
+    {
+        while (1)
+        {
+            block_manager_block_t *block = block_manager_cursor_read(cursor);
+            if (!block)
+            {
+                if (block_manager_cursor_skip_corrupt(cursor) == 0)
+                {
+                    skipped = 1;
+                    continue;
+                }
+                if (block_manager_cursor_resync_past_hole(cursor) == 0)
+                {
+                    skipped = 1;
+                    continue;
+                }
+                break; /* nothing valid follows -- torn tail, tolerated */
+            }
+            if (skipped || manifest_apply_batch(manifest, (const uint8_t *)block->data,
+                                                (size_t)block->size) != 0)
+            {
+                block_manager_block_free(block);
+                rc = -1;
+                break;
+            }
+            block_manager_block_free(block);
+            if (block_manager_cursor_next(cursor) != 0) break;
+        }
+    }
+
+    block_manager_cursor_free(cursor);
+    return rc;
+}
+
+/**
+ * manifest_rollover_locked
+ * write the current set as one snapshot block (all live ADDs then the final SEQ) to a temp log,
+ * fsync it when durable, atomically rename it over the manifest path, and reopen the log handle.
+ * this bounds recovery replay and, on a path change, re-points the manifest to the new path.
+ * caller holds the write lock. returns 0 on success, -1 on error.
+ */
+static int manifest_rollover_locked(tidesdb_manifest_t *manifest, const int durable_sync)
+{
+    const size_t need = MANIFEST_BATCH_HDR_SIZE +
+                        (size_t)manifest->num_entries * MANIFEST_REC_ADD_SIZE +
+                        MANIFEST_REC_SEQ_SIZE;
+    uint8_t *buf = malloc(need);
+    if (!buf) return -1;
+
+    size_t off = 0;
+    buf[off++] = (uint8_t)MANIFEST_BATCH_FORMAT;
+    for (int i = 0; i < manifest->num_entries; i++)
+    {
+        buf[off] = MANIFEST_OP_ADD;
+        manifest_put_u32(buf + off + 1, (uint32_t)manifest->entries[i].level);
+        manifest_put_u64(buf + off + 5, manifest->entries[i].id);
+        manifest_put_u64(buf + off + 13, manifest->entries[i].num_entries);
+        manifest_put_u64(buf + off + 21, manifest->entries[i].size_bytes);
+        off += MANIFEST_REC_ADD_SIZE;
+    }
+    buf[off] = MANIFEST_OP_SEQ;
+    manifest_put_u64(buf + off + 1, atomic_load(&manifest->sequence));
+    off += MANIFEST_REC_SEQ_SIZE;
+
+    /* temp path is the manifest path plus a per-thread/pid suffix. a truncated temp path would
+     * rename over the wrong file, so bail if it would not fit rather than proceed with a clipped
+     * name */
+    char temp_path[MANIFEST_PATH_LEN + 64];
+    const int tp_written = snprintf(temp_path, sizeof(temp_path), "%s" MANIFEST_TMP_EXT "%lu.%d",
+                                    manifest->path, (unsigned long)TDB_THREAD_ID(), TDB_GETPID());
+    if (tp_written < 0 || (size_t)tp_written >= sizeof(temp_path)) return -1;
+
+    /* the log is opened SYNC_NONE and made durable by an explicit fdatasync so a non-durable commit
+     * pays no fsync; the snapshot uses the same discipline */
+    block_manager_t *tbm = NULL;
+    if (block_manager_open_pre(&tbm, temp_path, BLOCK_MANAGER_SYNC_NONE,
+                               0 /* preallocation disabled */) != 0)
+    {
+        free(buf);
+        return -1;
+    }
+
+    block_manager_block_t *blk = block_manager_block_create(off, buf);
+    free(buf);
+    if (!blk)
+    {
+        block_manager_close(tbm);
+        remove(temp_path);
+        return -1;
+    }
+    const int64_t woff = block_manager_block_write(tbm, blk);
+    block_manager_block_free(blk);
+    if (woff < 0)
+    {
+        block_manager_close(tbm);
+        remove(temp_path);
+        return -1;
+    }
+    if (durable_sync) block_manager_escalate_fsync(tbm);
+    block_manager_close(tbm);
+
+    if (atomic_rename_file(temp_path, manifest->path) != 0)
+    {
+        remove(temp_path);
+        return -1;
+    }
+
+    if (durable_sync)
+    {
+        char dir_buf[MANIFEST_PATH_LEN];
+        strncpy(dir_buf, manifest->path, sizeof(dir_buf) - 1);
+        dir_buf[sizeof(dir_buf) - 1] = '\0';
+        char *last_sep = strrchr(dir_buf, '/');
+#ifdef _WIN32
+        if (!last_sep) last_sep = strrchr(dir_buf, '\\');
+#endif
+        if (last_sep)
+        {
+            *last_sep = '\0';
+            tdb_sync_directory(dir_buf);
+        }
+    }
+
+    /* reopen the log on the (possibly new) path so subsequent commits append to the snapshot */
+    if (manifest->bm)
+    {
+        block_manager_close(manifest->bm);
+        manifest->bm = NULL;
+    }
+    if (block_manager_open_pre(&manifest->bm, manifest->path, BLOCK_MANAGER_SYNC_NONE,
+                               0 /* preallocation disabled */) != 0)
+    {
+        manifest->bm = NULL;
+        return -1;
+    }
+
+    manifest->records_since_snapshot = 0;
+    return manifest_pending_reset(manifest);
+}
+
+/**
+ * manifest_body_append
+ * append a raw text line's bytes to the growable body buffer used to verify the version 8 checksum.
+ */
+static int manifest_body_append(char **body, size_t *len, size_t *cap, const char *line)
+{
+    const size_t ll = strlen(line);
+    if (*len + ll > *cap)
+    {
+        size_t new_cap = *cap ? *cap : MANIFEST_BODY_INIT_CAP;
+        while (new_cap < *len + ll) new_cap *= 2;
+        char *new_body = realloc(*body, new_cap);
+        if (!new_body) return -1;
+        *body = new_body;
+        *cap = new_cap;
+    }
+    memcpy(*body + *len, line, ll);
+    *len += ll;
+    return 0;
+}
+
+/**
+ * manifest_parse_legacy_text
+ * parse an old text manifest (version 7 without a checksum, version 8 with an xxhash64 body
+ * checksum) into the in-memory set. returns 0 on success, -1 on a bad version or checksum mismatch.
+ */
+static int manifest_parse_legacy_text(tidesdb_manifest_t *manifest, FILE *fp)
+{
+    char line[MANIFEST_MAX_LINE_LEN];
+
+    int is_v8 = 0;
+    if (fgets(line, sizeof(line), fp))
+    {
+        char *endptr;
+        const long version = strtol(line, &endptr, 10);
+        if (endptr == line || (version != MANIFEST_VERSION && version != MANIFEST_VERSION_LEGACY))
+            return -1;
+        is_v8 = (version == MANIFEST_VERSION);
+    }
+    else
+    {
+        return 0; /* empty file -- empty set */
+    }
+
+    uint64_t expected_checksum = 0;
+    char *body = NULL;
+    size_t body_len = 0;
+    size_t body_cap = 0;
+    if (is_v8)
+    {
+        char *cs_endptr;
+        if (!fgets(line, sizeof(line), fp) ||
+            (expected_checksum = strtoull(line, &cs_endptr, 16), cs_endptr == line))
+            return -1;
+    }
+
+    if (fgets(line, sizeof(line), fp))
+    {
+        if (is_v8 && manifest_body_append(&body, &body_len, &body_cap, line) != 0)
+        {
+            free(body);
+            return -1;
+        }
+        char *seq_endptr;
+        const unsigned long long seq = strtoull(line, &seq_endptr, 10);
+        if (seq_endptr == line ||
+            (*seq_endptr != '\0' && *seq_endptr != '\n' && *seq_endptr != '\r'))
+        {
+            free(body);
+            return -1;
+        }
+        atomic_store(&manifest->sequence, seq);
+    }
+
+    int skipped_lines = 0;
+    while (fgets(line, sizeof(line), fp))
+    {
+        if (is_v8 && manifest_body_append(&body, &body_len, &body_cap, line) != 0)
+        {
+            free(body);
+            return -1;
+        }
+
+        const char *ptr = line;
+        char *endptr;
+        const long level_val = strtol(ptr, &endptr, 10);
+        if (endptr == ptr || *endptr != ',')
+        {
+            skipped_lines++;
+            continue;
+        }
+        const int level = (int)level_val;
+        ptr = endptr + 1;
+
+        const uint64_t id = strtoull(ptr, &endptr, 10);
+        if (endptr == ptr || *endptr != ',')
+        {
+            skipped_lines++;
+            continue;
+        }
+        ptr = endptr + 1;
+
+        const uint64_t num_entries = strtoull(ptr, &endptr, 10);
+        if (endptr == ptr || *endptr != ',')
+        {
+            skipped_lines++;
+            continue;
+        }
+        ptr = endptr + 1;
+
+        const uint64_t size_bytes = strtoull(ptr, &endptr, 10);
+        if (endptr == ptr)
+        {
+            skipped_lines++;
+            continue;
+        }
+
+        tidesdb_manifest_add_sstable_unlocked(manifest, level, id, num_entries, size_bytes);
+    }
+
+    if (is_v8)
+    {
+        const uint64_t actual_checksum = XXH64(body, body_len, 0);
+        free(body);
+        if (actual_checksum != expected_checksum)
+        {
+            fprintf(stderr, "tidesdb manifest: checksum mismatch loading %s, refusing to open\n",
+                    manifest->path[0] ? manifest->path : "(unknown)");
+            return -1;
+        }
+    }
+
+    if (skipped_lines > 0)
+    {
+        fprintf(stderr, "tidesdb manifest: skipped %d malformed entry line(s) while loading %s\n",
+                skipped_lines, manifest->path[0] ? manifest->path : "(unknown)");
+    }
+    return 0;
+}
+
+/**
+ * manifest_cleanup_orphaned_temps
+ * remove leftover temp files from an interrupted commit/rollover -- if the main manifest exists,
+ * any <base>.tmp.* is stale.
+ */
+static void manifest_cleanup_orphaned_temps(const char *path)
+{
+    char dir_path[MANIFEST_PATH_LEN];
+    const char *last_sep = strrchr(path, PATH_SEPARATOR[0]);
+    if (last_sep)
+    {
+        const size_t dir_len = last_sep - path;
+        if (dir_len < sizeof(dir_path))
+        {
+            memcpy(dir_path, path, dir_len);
+            dir_path[dir_len] = '\0';
+        }
+        else
+        {
+            strcpy(dir_path, ".");
+        }
+    }
+    else
+    {
+        strcpy(dir_path, ".");
+    }
+
+    const char *base_name = last_sep ? last_sep + 1 : path;
+    const size_t base_len = strlen(base_name);
+
+    DIR *dir = opendir(dir_path);
+    if (!dir) return;
+    const size_t dir_path_len = strlen(dir_path);
+    const size_t sep_len = strlen(PATH_SEPARATOR);
+    struct dirent *entry;
+    while ((entry = readdir(dir)) != NULL)
+    {
+        const size_t entry_len = strlen(entry->d_name);
+        if (entry_len > base_len + MANIFEST_TMP_EXT_LEN &&
+            strncmp(entry->d_name, base_name, base_len) == 0 &&
+            strncmp(entry->d_name + base_len, MANIFEST_TMP_EXT, MANIFEST_TMP_EXT_LEN) == 0)
+        {
+            char temp_full_path[MANIFEST_PATH_LEN];
+            if (dir_path_len + sep_len + entry_len + 1 <= MANIFEST_PATH_LEN)
+            {
+                size_t offset = 0;
+                memcpy(temp_full_path + offset, dir_path, dir_path_len);
+                offset += dir_path_len;
+                memcpy(temp_full_path + offset, PATH_SEPARATOR, sep_len);
+                offset += sep_len;
+                memcpy(temp_full_path + offset, entry->d_name, entry_len);
+                offset += entry_len;
+                temp_full_path[offset] = '\0';
+                remove(temp_full_path);
+            }
+        }
+    }
+    closedir(dir);
+}
+
+tidesdb_manifest_t *tidesdb_manifest_open(const char *path)
+{
+    if (!path) return NULL;
+
+    tidesdb_manifest_t *manifest = malloc(sizeof(tidesdb_manifest_t));
+    if (!manifest) return NULL;
+
+    manifest->entries = malloc(sizeof(tidesdb_manifest_entry_t) * MANIFEST_INITIAL_CAPACITY);
+    if (!manifest->entries)
+    {
+        free(manifest);
+        return NULL;
+    }
+
+    manifest->num_entries = 0;
+    manifest->capacity = MANIFEST_INITIAL_CAPACITY;
+    atomic_init(&manifest->sequence, 0);
+    manifest->bm = NULL;
+    manifest->pending = NULL;
+    manifest->pending_len = 0;
+    manifest->pending_cap = 0;
+    manifest->records_since_snapshot = 0;
+    manifest->self_healed = 0;
+    atomic_init(&manifest->active_ops, 0);
+    strncpy(manifest->path, path, MANIFEST_PATH_LEN - 1);
+    manifest->path[MANIFEST_PATH_LEN - 1] = '\0';
+
+    if (pthread_rwlock_init(&manifest->lock, NULL) != 0)
+    {
+        free(manifest->entries);
+        free(manifest);
+        return NULL;
+    }
+
+    manifest_cleanup_orphaned_temps(path);
+
+    /* format detection -- a legacy text manifest starts with its version digit ('7' or '8'); a
+     * new-format log starts with the block manager header magic (a non-digit byte). */
+    unsigned char sniff = 0;
+    int have_sniff = 0;
+    int file_empty = 0;
+    FILE *sf = tdb_fopen(path, "rb");
+    if (sf)
+    {
+        const size_t got = fread(&sniff, 1, 1, sf);
+        have_sniff = (got == 1);
+        file_empty = (got == 0); /* exists but has no bytes -- a stale zero-length file */
+        fclose(sf);
+    }
+
+    if (!sf && errno != ENOENT)
+    {
+        pthread_rwlock_destroy(&manifest->lock);
+        free(manifest->entries);
+        free(manifest);
+        return NULL;
+    }
+
+    /* an empty existing file has no block manager header, so drop it and let the log be created
+     * fresh below (matches the legacy behavior of opening an empty manifest as an empty set) */
+    if (file_empty) remove(path);
+
+    if (have_sniff && (sniff == '7' || sniff == '8'))
+    {
+        /* legacy text -- we parse then convert forward to the append-only format */
+        FILE *fp = tdb_fopen(path, "r");
+        if (!fp || manifest_parse_legacy_text(manifest, fp) != 0)
+        {
+            if (fp) fclose(fp);
+            pthread_rwlock_destroy(&manifest->lock);
+            free(manifest->entries);
+            free(manifest);
+            return NULL;
+        }
+        fclose(fp);
+        if (manifest_pending_reset(manifest) != 0 || manifest_rollover_locked(manifest, 1) != 0)
+        {
+            tidesdb_manifest_close(manifest);
+            return NULL;
+        }
+        return manifest;
+    }
+
+    /* new format (or a fresh/empty database) -- open the log and replay it */
+    if (block_manager_open_pre(&manifest->bm, path, BLOCK_MANAGER_SYNC_NONE,
+                               0 /* preallocation disabled */) != 0)
+    {
+        /* the file exists but its header will not validate (garbage / truncated header). the
+         * sstable files on disk are the ground truth that recovery reloads, so self-heal by
+         * discarding the unreadable manifest and starting a fresh log rather than failing the open
+         */
+        manifest->bm = NULL;
+        manifest->self_healed = 1;
+        fprintf(stderr, "tidesdb manifest: unreadable header in %s, self-healing to a fresh log\n",
+                path[0] ? path : "(unknown)");
+        remove(path);
+        if (block_manager_open_pre(&manifest->bm, path, BLOCK_MANAGER_SYNC_NONE,
+                                   0 /* preallocation disabled */) != 0)
+        {
+            manifest->bm = NULL;
+            pthread_rwlock_destroy(&manifest->lock);
+            free(manifest->entries);
+            free(manifest);
+            return NULL;
+        }
+    }
+    const int replay_rc = manifest_replay_locked(manifest);
+    if (manifest_pending_reset(manifest) != 0)
+    {
+        tidesdb_manifest_close(manifest);
+        return NULL;
+    }
+    if (replay_rc != 0)
+    {
+        /* mid-file corruption -- self-heal rather than refuse. the sstable files on disk are the
+         * ground truth and recovery reloads them, so keep the good prefix we replayed and rewrite
+         * the log as a clean snapshot, discarding the unreadable remainder */
+        manifest->self_healed = 1;
+        fprintf(stderr,
+                "tidesdb manifest: corruption in %s, self-healing from the recovered prefix\n",
+                manifest->path[0] ? manifest->path : "(unknown)");
+        if (manifest_rollover_locked(manifest, 1) != 0)
+        {
+            tidesdb_manifest_close(manifest);
+            return NULL;
+        }
+        return manifest;
+    }
+    return manifest;
 }
 
 int tidesdb_manifest_add_sstable(tidesdb_manifest_t *manifest, const int level, const uint64_t id,
@@ -383,8 +748,14 @@ int tidesdb_manifest_add_sstable(tidesdb_manifest_t *manifest, const int level, 
 
     atomic_fetch_add(&manifest->active_ops, 1);
     pthread_rwlock_wrlock(&manifest->lock);
-    const int result =
+    int result =
         tidesdb_manifest_add_sstable_unlocked(manifest, level, id, num_entries, size_bytes);
+    if (result == 0)
+    {
+        result = manifest_pending_add_record(manifest, MANIFEST_OP_ADD, level, id, num_entries,
+                                             size_bytes);
+        if (result == 0) manifest->records_since_snapshot++;
+    }
     pthread_rwlock_unlock(&manifest->lock);
     atomic_fetch_sub(&manifest->active_ops, 1);
     return result;
@@ -397,23 +768,15 @@ int tidesdb_manifest_remove_sstable(tidesdb_manifest_t *manifest, const int leve
 
     atomic_fetch_add(&manifest->active_ops, 1);
     pthread_rwlock_wrlock(&manifest->lock);
-
-    for (int i = 0; i < manifest->num_entries; i++)
+    int result = -1;
+    if (manifest_remove_entry_unlocked(manifest, level, id))
     {
-        if (manifest->entries[i].level == level && manifest->entries[i].id == id)
-        {
-            /* we swap with last element for O(1) removal (order not required) */
-            manifest->entries[i] = manifest->entries[manifest->num_entries - 1];
-            manifest->num_entries--;
-            pthread_rwlock_unlock(&manifest->lock);
-            atomic_fetch_sub(&manifest->active_ops, 1);
-            return 0;
-        }
+        result = manifest_pending_add_record(manifest, MANIFEST_OP_REMOVE, level, id, 0, 0);
+        if (result == 0) manifest->records_since_snapshot++;
     }
-
     pthread_rwlock_unlock(&manifest->lock);
     atomic_fetch_sub(&manifest->active_ops, 1);
-    return -1;
+    return result;
 }
 
 int tidesdb_manifest_has_sstable(tidesdb_manifest_t *manifest, const int level, const uint64_t id)
@@ -422,29 +785,27 @@ int tidesdb_manifest_has_sstable(tidesdb_manifest_t *manifest, const int level, 
 
     atomic_fetch_add(&manifest->active_ops, 1);
     pthread_rwlock_rdlock(&manifest->lock);
-
+    int found = 0;
     for (int i = 0; i < manifest->num_entries; i++)
     {
         if (manifest->entries[i].level == level && manifest->entries[i].id == id)
         {
-            pthread_rwlock_unlock(&manifest->lock);
-            atomic_fetch_sub(&manifest->active_ops, 1);
-            return 1;
+            found = 1;
+            break;
         }
     }
-
     pthread_rwlock_unlock(&manifest->lock);
     atomic_fetch_sub(&manifest->active_ops, 1);
-    return 0;
+    return found;
 }
 
 void tidesdb_manifest_update_sequence(tidesdb_manifest_t *manifest, uint64_t sequence)
 {
     if (!manifest) return;
 
-    /* monotonic guard, the sequence seeds next_sstable_id on recovery, so it must never
-     * regress or recovery would re-hand-out live sstable ids and collide. cas loop so a
-     * concurrent larger store is never clobbered by a smaller one. */
+    /* monotonic guard -- the sequence seeds next_sstable_id on recovery, so it must never regress
+     * or recovery would re-hand-out live sstable ids and collide. the value is persisted by the
+     * next commit, which appends a SEQ record for the current sequence. */
     uint64_t cur = atomic_load(&manifest->sequence);
     while (sequence > cur && !atomic_compare_exchange_weak(&manifest->sequence, &cur, sequence))
     {
@@ -459,154 +820,79 @@ int tidesdb_manifest_commit(tidesdb_manifest_t *manifest, const char *path, cons
     atomic_fetch_add(&manifest->active_ops, 1);
     pthread_rwlock_wrlock(&manifest->lock);
 
-    /* we update stored path if it changed */
+    int result = 0;
+
+    /* a path change re-points the manifest and persists the whole set at the new path via a
+     * rollover, which reopens the log there */
     if (strcmp(manifest->path, path) != 0)
     {
         strncpy(manifest->path, path, MANIFEST_PATH_LEN - 1);
         manifest->path[MANIFEST_PATH_LEN - 1] = '\0';
-    }
-
-    if (manifest->fp)
-    {
-        fclose(manifest->fp);
-        manifest->fp = NULL;
-    }
-
-    char temp_path[MANIFEST_PATH_LEN];
-    snprintf(temp_path, sizeof(temp_path), "%s" MANIFEST_TMP_EXT "%lu.%d", path,
-             (unsigned long)TDB_THREAD_ID(), TDB_GETPID());
-
-    FILE *fp = tdb_fopen(temp_path, "w");
-    if (!fp)
-    {
+        result = manifest_rollover_locked(manifest, durable_sync);
         pthread_rwlock_unlock(&manifest->lock);
         atomic_fetch_sub(&manifest->active_ops, 1);
-        return -1;
+        return result;
     }
 
-    /* build the body (sequence then entries) in memory so we can checksum it before writing the
-     * header. each line is well under MANIFEST_BODY_LINE_MAX, so this buffer never has to grow. */
-    const size_t body_cap = (size_t)(manifest->num_entries + 2) * MANIFEST_BODY_LINE_MAX;
-    char *body = malloc(body_cap);
-    if (!body)
+    if (!manifest->bm)
     {
-        fclose(fp);
-        remove(temp_path);
-        pthread_rwlock_unlock(&manifest->lock);
-        atomic_fetch_sub(&manifest->active_ops, 1);
-        return -1;
-    }
-
-    size_t body_len = 0;
-    int n = snprintf(body, body_cap, "%" PRIu64 "\n", atomic_load(&manifest->sequence));
-    int body_ok = (n > 0 && (size_t)n < body_cap);
-    if (body_ok) body_len = (size_t)n;
-
-    for (int i = 0; body_ok && i < manifest->num_entries; i++)
-    {
-        n = snprintf(body + body_len, body_cap - body_len,
-                     "%d,%" PRIu64 ",%" PRIu64 ",%" PRIu64 "\n", manifest->entries[i].level,
-                     manifest->entries[i].id, manifest->entries[i].num_entries,
-                     manifest->entries[i].size_bytes);
-        if (n <= 0 || (size_t)n >= body_cap - body_len)
+        if (block_manager_open_pre(&manifest->bm, manifest->path, BLOCK_MANAGER_SYNC_NONE,
+                                   0 /* preallocation disabled */) != 0)
         {
-            body_ok = 0;
-            break;
-        }
-        body_len += (size_t)n;
-    }
-
-    if (!body_ok)
-    {
-        free(body);
-        fclose(fp);
-        remove(temp_path);
-        pthread_rwlock_unlock(&manifest->lock);
-        atomic_fetch_sub(&manifest->active_ops, 1);
-        return -1;
-    }
-
-    /* header is the version then the xxhash64 of the body, then the body it covers */
-    const uint64_t body_checksum = XXH64(body, body_len, 0);
-    fprintf(fp, "%d\n", MANIFEST_VERSION);
-    fprintf(fp, "%016" PRIx64 "\n", body_checksum);
-    fwrite(body, 1, body_len, fp);
-    free(body);
-
-    if (fflush(fp) != 0)
-    {
-        fclose(fp);
-        remove(temp_path);
-        pthread_rwlock_unlock(&manifest->lock);
-        atomic_fetch_sub(&manifest->active_ops, 1);
-        return -1;
-    }
-
-    if (durable_sync)
-    {
-        const int fd = tdb_fileno(fp);
-        if (fd >= 0)
-        {
-            if (tdb_fsync(fd) != 0)
-            {
-                fclose(fp);
-                remove(temp_path);
-                pthread_rwlock_unlock(&manifest->lock);
-                atomic_fetch_sub(&manifest->active_ops, 1);
-                return -1;
-            }
+            manifest->bm = NULL;
+            pthread_rwlock_unlock(&manifest->lock);
+            atomic_fetch_sub(&manifest->active_ops, 1);
+            return -1;
         }
     }
 
-    fclose(fp);
+    /* close the batch with a SEQ record carrying the current sequence so replay's last SEQ wins */
+    if (manifest_pending_add_record(manifest, MANIFEST_OP_SEQ, 0, atomic_load(&manifest->sequence),
+                                    0, 0) != 0)
+        result = -1;
 
-    /* atomic rename -- this is the commit point */
-    if (atomic_rename_file(temp_path, path) != 0)
+    if (result == 0)
     {
-        remove(temp_path);
-        pthread_rwlock_unlock(&manifest->lock);
-        atomic_fetch_sub(&manifest->active_ops, 1);
-        return -1;
-    }
-
-    /* we sync the parent directory to ensure the rename is durable.
-     * without this, a crash after rename could lose the directory entry
-     * on POSIX systems that don't flush directory metadata automatically.
-     * skipped under TDB_SYNC_NONE (durable_sync clear) along with the file fsync above. */
-    if (durable_sync)
-    {
-        /* sized to the full manifest path length -- a 1024-byte buffer silently truncated
-         * paths > 1023 chars and synced the wrong directory */
-        char dir_buf[MANIFEST_PATH_LEN];
-        strncpy(dir_buf, path, sizeof(dir_buf) - 1);
-        dir_buf[sizeof(dir_buf) - 1] = '\0';
-        char *last_sep = strrchr(dir_buf, '/');
-#ifdef _WIN32
-        if (!last_sep) last_sep = strrchr(dir_buf, '\\');
-#endif
-        if (last_sep)
+        block_manager_block_t *blk =
+            block_manager_block_create(manifest->pending_len, manifest->pending);
+        if (!blk)
         {
-            *last_sep = '\0';
-            tdb_sync_directory(dir_buf);
+            result = -1;
+        }
+        else
+        {
+            const int64_t off = block_manager_block_write(manifest->bm, blk);
+            block_manager_block_free(blk);
+            if (off < 0)
+                result = -1;
+            else if (durable_sync)
+                block_manager_escalate_fsync(manifest->bm);
         }
     }
 
-    /* we reopen for reading */
-    manifest->fp = tdb_fopen(path, "r");
+    /* the SEQ record is one more log record regardless of whether the batch carried changes */
+    manifest->records_since_snapshot++;
+    manifest_pending_reset(manifest);
+
+    /* roll the log over once it grows past a small multiple of the live set, keeping replay bounded
+     */
+    if (result == 0)
+    {
+        int bound = manifest->num_entries * MANIFEST_ROLLOVER_LIVE_MULTIPLE;
+        if (bound < MANIFEST_ROLLOVER_MIN_RECORDS) bound = MANIFEST_ROLLOVER_MIN_RECORDS;
+        if (manifest->records_since_snapshot > bound)
+            result = manifest_rollover_locked(manifest, durable_sync);
+    }
 
     pthread_rwlock_unlock(&manifest->lock);
     atomic_fetch_sub(&manifest->active_ops, 1);
-    return 0;
+    return result;
 }
 
 void tidesdb_manifest_close(tidesdb_manifest_t *manifest)
 {
     if (!manifest) return;
 
-    /* the caller is expected to have quiesced all manifest users before closing. tidesdb_close
-     * joins every flush, compaction, sync, and reaper thread before the owning column family is
-     * freed, so active_ops is normally already zero here. the bounded wait is a backstop for a
-     * caller that has not fully quiesced. */
     int wait_count = 0;
     while (atomic_load(&manifest->active_ops) > 0 && wait_count < MANIFEST_CLOSE_MAX_WAITS)
     {
@@ -614,10 +900,6 @@ void tidesdb_manifest_close(tidesdb_manifest_t *manifest)
         wait_count++;
     }
 
-    /* if the drain expired with operations still in flight the close proceeds anyway rather than
-     * leaking the manifest on every shutdown, but that means a caller freed the manifest without
-     * quiescing its users -- a contract violation that risks a use-after-free, so surface it loudly
-     * rather than tearing down the lock and struct silently underneath a live operation. */
     if (atomic_load(&manifest->active_ops) > 0)
     {
         fprintf(stderr,
@@ -628,15 +910,14 @@ void tidesdb_manifest_close(tidesdb_manifest_t *manifest)
     }
 
     pthread_rwlock_wrlock(&manifest->lock);
-
-    if (manifest->fp)
+    if (manifest->bm)
     {
-        fclose(manifest->fp);
-        manifest->fp = NULL;
+        block_manager_close(manifest->bm);
+        manifest->bm = NULL;
     }
-
     pthread_rwlock_unlock(&manifest->lock);
     pthread_rwlock_destroy(&manifest->lock);
+    free(manifest->pending);
     free(manifest->entries);
     free(manifest);
 }

--- a/src/manifest.h
+++ b/src/manifest.h
@@ -37,6 +37,28 @@
 /* max iterations (10000 × 100μs = 1 second) */
 #define MANIFEST_CLOSE_MAX_WAITS 10000
 
+/* the manifest is an append-only block-manager log. every commit appends one
+ * framed block holding a batch of these records, replayed on open to rebuild the set. a snapshot
+ * batch (all live ADDs then the final SEQ) is written when the log is rolled over so replay stays
+ * bounded. legacy text versions 7 and 8 are read once on open and converted forward. */
+#define MANIFEST_OP_ADD       0x01
+#define MANIFEST_OP_REMOVE    0x02
+#define MANIFEST_OP_SEQ       0x03
+#define MANIFEST_BATCH_FORMAT 1
+/* on-disk record sizes (opcode byte + fields); a batch is a single format byte then self-delimiting
+ * records (each record's opcode fixes its length, so no count is needed). all integers big-endian
+ */
+#define MANIFEST_BATCH_HDR_SIZE  1  /* u8 format */
+#define MANIFEST_REC_ADD_SIZE    29 /* u8 op + i32 level + u64 id + u64 num_entries + u64 size */
+#define MANIFEST_REC_REMOVE_SIZE 13 /* u8 op + i32 level + u64 id */
+#define MANIFEST_REC_SEQ_SIZE    9  /* u8 op + u64 sequence */
+/* roll the log over into a fresh single snapshot block when records since the last snapshot exceed
+ * max(MIN_RECORDS, LIVE_MULTIPLE * live entries) -- bounds recovery replay to a small multiple of
+ * the live set and amortizes the O(N) snapshot to O(1) per commit */
+#define MANIFEST_ROLLOVER_MIN_RECORDS   512
+#define MANIFEST_ROLLOVER_LIVE_MULTIPLE 2
+
+#include "block_manager.h"
 #include "compat.h"
 
 /**
@@ -63,9 +85,17 @@ typedef struct
  * @param capacity capacity of entries array
  * @param sequence current global sequence number
  * @param path path to manifest file
- * @param fp read-mode handle to the manifest file; opened when the manifest is parsed and
- *           reopened after each commit. commits write a temp file and atomically rename it into
- *           place, so they never write through this handle
+ * @param bm append-only block-manager log handle. a commit appends one framed block of pending
+ *           records and (durably) fdatasyncs it -- no full rewrite, no rename, no reopen. only a
+ *           rollover writes a fresh file and renames it into place
+ * @param pending records buffered by add/remove/update_sequence since the last commit
+ * @param pending_len bytes used in the pending buffer
+ * @param pending_cap allocated capacity of the pending buffer
+ * @param records_since_snapshot records appended since the last snapshot; drives rollover
+ * @param self_healed set when open recovered a corrupt or unreadable manifest. the recovered set
+ *                    may be incomplete, so recovery must trust the on-disk sstables over this
+ *                    manifest -- keep every sstable it finds and rebuild the manifest from them,
+ *                    rather than deleting sstables it thinks are unreferenced
  * @param lock reader-writer lock for thread safety
  * @param active_ops count of active operations (for safe shutdown)
  */
@@ -76,7 +106,12 @@ typedef struct
     int capacity;
     _Atomic(uint64_t) sequence;
     char path[MANIFEST_PATH_LEN];
-    FILE *fp;
+    block_manager_t *bm;
+    uint8_t *pending;
+    size_t pending_len;
+    size_t pending_cap;
+    int records_since_snapshot;
+    int self_healed;
     pthread_rwlock_t lock;
     _Atomic(int) active_ops;
 } tidesdb_manifest_t;

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -24481,14 +24481,15 @@ int tidesdb_rename_column_family(tidesdb_t *db, const char *old_name, const char
         }
     }
 
-    /* we close manifest file handle before rename (required on Windows) */
+    /* we close the manifest log handle before rename (required on Windows). the next commit at the
+     * new path reopens it -- the path is re-pointed and re-committed after the directory rename */
     if (cf->manifest)
     {
         pthread_rwlock_wrlock(&cf->manifest->lock);
-        if (cf->manifest->fp)
+        if (cf->manifest->bm)
         {
-            fclose(cf->manifest->fp);
-            cf->manifest->fp = NULL;
+            block_manager_close(cf->manifest->bm);
+            cf->manifest->bm = NULL;
         }
         pthread_rwlock_unlock(&cf->manifest->lock);
     }
@@ -33743,10 +33744,13 @@ static void tidesdb_recover_single_sstable(tidesdb_column_family_t *cf, const st
 
     const uint64_t sst_id = (uint64_t)sst_id_ull;
 
-    /* we check manifest to see if this sstable is complete */
+    /* we check manifest to see if this sstable is complete. a self-healed manifest recovered from
+     * corruption may be missing legitimately committed sstables, so we must not use it to decide a
+     * file is an orphan -- when it self-healed we keep every sstable on disk and rebuild the
+     * manifest from them below instead of deleting. */
     const int in_manifest = tidesdb_manifest_has_sstable(cf->manifest, level_num, sst_id);
 
-    if (!in_manifest)
+    if (!in_manifest && !cf->manifest->self_healed)
     {
         TDB_DEBUG_LOG(TDB_LOG_WARN,
                       "CF '%s' SSTable %" PRIu64
@@ -33808,6 +33812,13 @@ static void tidesdb_recover_single_sstable(tidesdb_column_family_t *cf, const st
     {
         tidesdb_level_add_sstable(cf->levels[level_num - 1], sst);
         tidesdb_bump_sstable_layout_version(cf);
+        if (!in_manifest)
+        {
+            /* self-heal -- this sstable was on disk but missing from the recovered manifest, so add
+             * it back so the rebuilt manifest reflects the on-disk set */
+            tidesdb_manifest_add_sstable(cf->manifest, level_num, sst_id, sst->num_entries,
+                                         sst->klog_size + sst->vlog_size);
+        }
     }
     else
     {
@@ -33866,6 +33877,18 @@ static int tidesdb_recover_sstables(tidesdb_column_family_t *cf)
         }
     }
     closedir(dir);
+
+    /* a manifest that self-healed from corruption was rebuilt above from the on-disk sstables --
+     * persist that reconstructed set and clear the flag so the manifest is authoritative again */
+    if (cf->manifest && cf->manifest->self_healed)
+    {
+        TDB_DEBUG_LOG(TDB_LOG_INFO,
+                      "CF '%s' rebuilt manifest from %d on-disk SSTables after self-heal", cf->name,
+                      cf->manifest->num_entries);
+        tidesdb_manifest_commit(cf->manifest, cf->manifest->path,
+                                cf->config.sync_mode != TDB_SYNC_NONE);
+        cf->manifest->self_healed = 0;
+    }
 
     /*** if no local .klog files were found but the MANIFEST
      **  has sstable entries, we reconstruct sstable structs from MANIFEST metadata.

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -1884,8 +1884,12 @@ static inline size_t tdb_cf_effective_stall(const tidesdb_column_family_t *cf)
     if (stall < 1) stall = 1;
     if (cf->db)
     {
-        /* unified mode has a single shared immutable queue, so the per-CF
-         * memory-budget split below does not apply -- use the configured value */
+        /* unified mode has a single shared immutable queue, so the per-CF memory-budget split
+         * below does not apply -- use the configured value. its memory is unified_wbuf x depth
+         * regardless of CF count, so no division is needed. note apply_backpressure runs per
+         * committing CF, so this shared queue is paced by whichever CF is committing -- per-CF
+         * thresholds that differ pace it inconsistently (the depth is bounded by the largest of
+         * them); with the default threshold across CFs it stalls coherently at one depth. */
         if (cf->db->unified_mt.enabled) return stall;
 
         const int num_cfs = cf->db->num_column_families;

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -17713,6 +17713,74 @@ static int tidesdb_partitioned_merge(tidesdb_column_family_t *cf, const int star
     }
     free(ssts_array);
 
+    /* spooky seamless adaptation (the merge half) -- when merging into the largest level, coalesce
+     * a run of adjacent under-full partitions into one sub-merge so their combined data lands as a
+     * single ~file_max sstable instead of several small ones. this is the lower-bound counterpart
+     * to the file_max split, which only bounds output size from above; together they keep the
+     * largest level's files near-equal-sized (between ~file_max/2 and file_max) under skewed
+     * deletes. a skipped (cold) partition stays its own group so its untouched file is preserved,
+     * and the driver's per-file skip accounting above keeps using the original partition arrays --
+     * only the sub-compaction dispatch below sees this coalesced view. disabled when file_max is 0
+     * (not targeting the largest level, where output stays partitioned by L for future alignment).
+     * the group boundaries alias the original boundary keys, so only the group container arrays are
+     * freed here. */
+    uint8_t **grp_boundaries = boundaries;
+    size_t *grp_boundary_sizes = boundary_sizes;
+    int *grp_skipped = partition_skipped;
+    int grp_num = num_partitions;
+    int grp_owned = 0;
+    if (file_max > 0 && num_partitions > 1)
+    {
+        uint8_t **gb = malloc((size_t)num_partitions * sizeof(uint8_t *));
+        size_t *gbs = malloc((size_t)num_partitions * sizeof(size_t));
+        int *gs = malloc((size_t)num_partitions * sizeof(int));
+        if (gb && gbs && gs)
+        {
+            int g = 0;
+            int i = 0;
+            while (i < num_partitions)
+            {
+                const int start = i;
+                const int start_skipped = (partition_skipped && partition_skipped[start]) ? 1 : 0;
+                if (start_skipped)
+                {
+                    i++; /* a skipped partition is always its own group -- file left in place */
+                }
+                else
+                {
+                    uint64_t acc = 0;
+                    /* accumulate adjacent non-skipped partitions until the next would push the
+                     * group past file_max; the first file is always taken so a single oversized
+                     * file still forms a group (the file_max split handles its output). */
+                    while (i < num_partitions && !(partition_skipped && partition_skipped[i]))
+                    {
+                        uint64_t sz = largest_sstables[i] ? largest_sstables[i]->klog_size +
+                                                                largest_sstables[i]->vlog_size
+                                                          : 0;
+                        if (acc != 0 && acc + sz > file_max) break;
+                        acc += sz;
+                        i++;
+                    }
+                }
+                gb[g] = boundaries[start]; /* alias -- owned by the original boundaries array */
+                gbs[g] = boundary_sizes[start];
+                gs[g] = start_skipped;
+                g++;
+            }
+            grp_boundaries = gb;
+            grp_boundary_sizes = gbs;
+            grp_skipped = gs;
+            grp_num = g;
+            grp_owned = 1;
+        }
+        else
+        {
+            free(gb);
+            free(gbs);
+            free(gs);
+        }
+    }
+
     int aborted = 0;
 
     tidesdb_partitioned_merge_ctx_t pctx;
@@ -17720,10 +17788,10 @@ static int tidesdb_partitioned_merge(tidesdb_column_family_t *cf, const int star
     pctx.start_idx = start_idx;
     pctx.end_idx = end_idx;
     pctx.end_level = end_level;
-    pctx.num_partitions = num_partitions;
-    pctx.boundaries = boundaries;
-    pctx.boundary_sizes = boundary_sizes;
-    pctx.partition_skipped = partition_skipped;
+    pctx.num_partitions = grp_num;
+    pctx.boundaries = grp_boundaries;
+    pctx.boundary_sizes = grp_boundary_sizes;
+    pctx.partition_skipped = grp_skipped;
     pctx.file_max = file_max;
     pctx.reap_tombstones = reap_tombstones;
     pctx.oldest_unflushed_seq = pm_oldest_unflushed;
@@ -17731,9 +17799,19 @@ static int tidesdb_partitioned_merge(tidesdb_column_family_t *cf, const int star
 
     /* run the partition sub-merges across the sub-compaction helper pool (calling thread works
      * too); each partition commits its output(s) under cf->compaction_commit_lock */
-    tidesdb_run_subcompactions(cf->db, &pctx, tidesdb_partitioned_merge_partition, num_partitions);
+    tidesdb_run_subcompactions(cf->db, &pctx, tidesdb_partitioned_merge_partition, grp_num);
 
     if (atomic_load_explicit(&pctx.aborted, memory_order_acquire)) aborted = 1;
+
+    /* the group view was only needed for dispatch; the original boundary/skip arrays are freed by
+     * the cleanup paths below. the group boundaries alias the originals, so free containers only.
+     */
+    if (grp_owned)
+    {
+        free(grp_boundaries);
+        free(grp_boundary_sizes);
+        free(grp_skipped);
+    }
 
     if (aborted)
     {

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -14736,6 +14736,55 @@ typedef struct
 static int tidesdb_full_preemptive_shard(void *vctx, int shard);
 
 /**
+ * tidesdb_coarsen_boundaries
+ * reduce a monotonic shard-boundary set so a merge writes roughly one output sstable per
+ * target_bytes of input rather than one per output level file. without this a merge of many small
+ * sstables rewrites them into just as many small sstables and the file count never shrinks, so
+ * every later round pays fixed per-output cost over a count that never drops. a strided subset of
+ * a monotonic tiling is still monotonic and still covers the whole key range (shard 0 starts
+ * unbounded and the last shard ends unbounded), so no key range is dropped. dropped boundary keys
+ * are freed here, the retained ones stay compacted in the prefix for the caller to free.
+ * @param boundaries malloc'd boundary keys, compacted in place
+ * @param boundary_sizes matching sizes, compacted in place
+ * @param num_boundaries current boundary count
+ * @param total_bytes total on-disk bytes of the merge inputs
+ * @param target_bytes desired output sstable size
+ * @return retained boundary count
+ */
+static int tidesdb_coarsen_boundaries(uint8_t **boundaries, size_t *boundary_sizes,
+                                      int num_boundaries, uint64_t total_bytes, size_t target_bytes)
+{
+    if (num_boundaries <= 0 || target_bytes == 0) return num_boundaries;
+
+    /* one output shard per target_bytes of input, at least one. shards = boundaries + 1, so we
+     * want want_shards - 1 boundaries; if we already have that few, keep them all */
+    uint64_t want_shards = total_bytes / target_bytes;
+    if (want_shards < 1) want_shards = 1;
+    if (want_shards >= (uint64_t)num_boundaries + 1) return num_boundaries;
+    const int want_boundaries = (int)(want_shards - 1);
+
+    int kept = 0;
+    for (int i = 0; i < num_boundaries; i++)
+    {
+        /* keep want_boundaries evenly spaced across the range, free the rest */
+        const int keep =
+            kept < want_boundaries &&
+            i >= (int)(((uint64_t)(kept + 1) * (uint64_t)num_boundaries) / want_shards);
+        if (keep)
+        {
+            boundaries[kept] = boundaries[i];
+            boundary_sizes[kept] = boundary_sizes[i];
+            kept++;
+        }
+        else
+        {
+            free(boundaries[i]);
+        }
+    }
+    return kept;
+}
+
+/**
  * tidesdb_full_preemptive_merge
  * perform a full preemptive merge on the column family
  * @param cf the column family
@@ -14891,6 +14940,19 @@ static int tidesdb_full_preemptive_merge(tidesdb_column_family_t *cf, int start_
             }
         }
         atomic_fetch_sub_explicit(&out_lvl->array_readers, 1, memory_order_release);
+    }
+
+    /* coarsen the shard boundaries so the merge emits roughly one output sstable per
+     * write_buffer_size of input instead of one per output level file -- otherwise a merge of many
+     * small sstables reproduces the same file count and compaction never reduces it */
+    {
+        uint64_t fp_total_bytes = 0;
+        for (size_t i = 0; i < fp_del_n; i++)
+            if (fp_del_snap[i])
+                fp_total_bytes += fp_del_snap[i]->klog_size + fp_del_snap[i]->vlog_size;
+        fp_num_boundaries =
+            tidesdb_coarsen_boundaries(fp_boundaries, fp_boundary_sizes, fp_num_boundaries,
+                                       fp_total_bytes, cf->config.write_buffer_size);
     }
 
     tidesdb_full_preemptive_ctx_t fctx;
@@ -18661,9 +18723,12 @@ int tidesdb_trigger_compaction(tidesdb_column_family_t *cf, int full_compaction)
         return result;
     }
 
-    /* we calculate X (dividing level) */
-    int X = num_levels - 1 - cf->config.dividing_level_offset;
-    if (X < 1) X = 1;
+    /* we calculate X (dividing level). a raw value below 1 means the tree is too shallow to carve
+     * a dividing level beneath the largest one, so x_clamped records that the floor fired and the
+     * dispatch below descends instead of rewriting the top level in place */
+    int x_raw = num_levels - 1 - cf->config.dividing_level_offset;
+    int x_clamped = x_raw < 1;
+    int X = x_clamped ? 1 : x_raw;
 
     int target_lvl = X; /* default to X if no suitable level found */
 
@@ -18714,8 +18779,27 @@ int tidesdb_trigger_compaction(tidesdb_column_family_t *cf, int full_compaction)
     }
     else if (target_lvl == X)
     {
-        TDB_DEBUG_LOG(TDB_LOG_INFO, "Dividing merge at level %d", X);
-        result = tidesdb_dividing_merge(cf, X - 1); /* convert to 0-indexed */
+        if (x_clamped)
+        {
+            /* the tree is too shallow to carve a dividing level, so a dividing merge at level 1
+             * would rewrite the top level in place without descending. ensure a level exists
+             * beneath the top and merge every level into the largest one so data moves down and the
+             * tree deepens, the same shape a full compaction uses. once the tree is deep enough for
+             * a real dividing level this branch is not taken and normal spooky resumes */
+            if (atomic_load_explicit(&cf->num_active_levels, memory_order_acquire) < 2)
+                tidesdb_add_level(cf);
+            int nl = atomic_load_explicit(&cf->num_active_levels, memory_order_acquire);
+            TDB_DEBUG_LOG(TDB_LOG_INFO,
+                          "CF '%s' tree too shallow for a dividing level, full preemptive merge "
+                          "into largest level %d",
+                          cf->name, nl);
+            result = tidesdb_full_preemptive_merge(cf, 0, nl - 1, nl - 1);
+        }
+        else
+        {
+            TDB_DEBUG_LOG(TDB_LOG_INFO, "Dividing merge at level %d", X);
+            result = tidesdb_dividing_merge(cf, X - 1); /* convert to 0-indexed */
+        }
     }
     else
     {

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -16399,38 +16399,44 @@ static int tidesdb_dividing_merge(tidesdb_column_family_t *cf, int target_level)
     }
 
     tidesdb_level_t *target = cf->levels[target_level];
-    /** dividing merge
-     * we use boundaries from target_level+1 (the level we're merging into) */
-    tidesdb_level_t *next_level = cf->levels[target_level + 1];
+    /* spooky algorithm 2 -- a dividing merge partitions its output by the file boundaries at the
+     * largest level, not the adjacent level, so each output file overlaps at most one largest-level
+     * file and the later partitioned merge across levels X..L draws perfectly overlapping groups.
+     * the merge inputs are levels 0..target_level; the largest level is only the boundary source
+     * and is left untouched. (target_level < num_levels-1 is guaranteed by the largest-level branch
+     * above, so the largest level is always strictly below the merge target.) */
+    tidesdb_level_t *largest_level = cf->levels[num_levels - 1];
 
-    /* the boundaries come from next_level's per-sstable min_keys and the merge assumes they ascend
-     * so the partition ranges tile the key space. parallel sub-compaction commits can leave the
-     * level out of ascending order, which makes the boundaries non-monotonic, opens gaps between
-     * partitions, and silently drops every key in a gap. sort first; if the sort cannot run, fall
-     * back to the full merge, which does not partition by these boundaries. */
+    /* the boundaries come from the largest level's per-sstable min_keys and the merge assumes they
+     * ascend so the partition ranges tile the key space. parallel sub-compaction commits can leave
+     * the level out of ascending order, which makes the boundaries non-monotonic, opens gaps
+     * between partitions, and silently drops every key in a gap. sort first; if the sort cannot
+     * run, fall back to the full merge, which does not partition by these boundaries. */
     {
         skip_list_comparator_fn dm_cmp = NULL;
         void *dm_cmp_ctx = NULL;
         tidesdb_resolve_comparator(cf->db, &cf->config, &dm_cmp, &dm_cmp_ctx);
         if (!dm_cmp ||
-            tidesdb_level_sort_by_min_key(cf->db, next_level, dm_cmp, dm_cmp_ctx) != TDB_SUCCESS)
+            tidesdb_level_sort_by_min_key(cf->db, largest_level, dm_cmp, dm_cmp_ctx) != TDB_SUCCESS)
             return tidesdb_full_preemptive_merge(cf, 0, target_level, target_level);
     }
 
-    tidesdb_level_update_boundaries(target, next_level);
+    tidesdb_level_update_boundaries(target, largest_level);
 
-    int next_level_num_ssts = atomic_load_explicit(&next_level->num_sstables, memory_order_acquire);
-    TDB_DEBUG_LOG(TDB_LOG_INFO, "Next level (L%d) has %d SSTables", next_level->level_num,
-                  next_level_num_ssts);
-    tidesdb_sstable_t **next_level_ssts =
-        atomic_load_explicit(&next_level->sstables, memory_order_acquire);
-    for (int i = 0; i < next_level_num_ssts; i++)
+    int boundary_src_num_ssts =
+        atomic_load_explicit(&largest_level->num_sstables, memory_order_acquire);
+    TDB_DEBUG_LOG(TDB_LOG_INFO, "Boundary source largest level (L%d) has %d SSTables",
+                  largest_level->level_num, boundary_src_num_ssts);
+    tidesdb_sstable_t **boundary_src_ssts =
+        atomic_load_explicit(&largest_level->sstables, memory_order_acquire);
+    for (int i = 0; i < boundary_src_num_ssts; i++)
     {
-        const tidesdb_sstable_t *sst = next_level_ssts[i];
+        const tidesdb_sstable_t *sst = boundary_src_ssts[i];
         if (sst)
         {
             TDB_DEBUG_LOG(TDB_LOG_INFO,
-                          "Next level SSTable %" PRIu64 " (min_key_size=%zu, max_key_size=%zu)",
+                          "Boundary source SSTable %" PRIu64
+                          " (min_key_size=%zu, max_key_size=%zu)",
                           sst->id, sst->min_key_size, sst->max_key_size);
         }
     }
@@ -17605,10 +17611,12 @@ static int tidesdb_partitioned_merge(tidesdb_column_family_t *cf, const int star
         }
     }
 
-    /**** spooky paper algorithm 2 -- when merging into the largest level,
-     ***  cap output sstable size at file_max = C_X (capacity of the dividing level).
-     **   this bounds transient space-amp to 1/T. when not targeting the largest level,
-     *    file_max is 0 which disables splitting. */
+    /**** spooky paper algorithm 2 -- when merging into the largest level, cap output sstable size
+     *at
+     ***  file_max = C_X (capacity of the dividing level). this restricts the partitioned merge's
+     **   transient space-amp to file_max/N_L = 1/T^(L-X) (which is 1/T in the 2L case X=L-1, and
+     *    tighter for a deeper dividing level). when not targeting the largest level, file_max is 0
+     *    which disables splitting. */
     const int targeting_largest = (end_idx == num_levels - 1);
 
     /* a tombstone may be reaped only when no older version of its key can survive outside this

--- a/test/block_manager__tests.c
+++ b/test/block_manager__tests.c
@@ -2969,7 +2969,7 @@ void test_write_raw_hole_stops_replay(void)
     ASSERT_EQ(block_manager_cursor_next(cursor), 0);
 
     /*
-     * cursor_read at B's offset now reads the size field: 0x00000000.
+     * cursor_read at B's offset now reads the size field-- 0x00000000.
      * block_manager_read_block_at_offset treats size=0 as invalid and returns
      * NULL.  This is the point where WAL replay must stop since it cannot
      * distinguish the hole from a genuine write boundary.
@@ -3012,8 +3012,8 @@ void test_write_raw_hole_stops_replay(void)
  * two zero-filled holes.  replay stops at the first hole, compounding data
  * loss for every block written after it.
  *
- * file layout:  [A (valid)] [hole B] [hole D] [E (valid)]
- * expected:     cursor reads A, cursor_next returns -1 at hole B, E is lost.
+ * file layout      [A (valid)] [hole B] [hole D] [E (valid)]
+ * expected         cursor reads A, cursor_next returns -1 at hole B, E is lost.
  */
 void test_write_raw_multiple_holes_stop_replay(void)
 {

--- a/test/bloom_filter__tests.c
+++ b/test/bloom_filter__tests.c
@@ -360,7 +360,7 @@ void test_bloom_filter_large_capacity_random_keys()
     }
     printf("All %d keys added.\n", n);
 
-    /* sanity check: count how many bits are set in bloom filter */
+    /* count how many bits are set in bloom filter */
     unsigned int bits_set = 0;
     for (unsigned int i = 0; i < bf->size_in_words; i++)
     {
@@ -582,7 +582,7 @@ void test_bloom_filter_deserialize_oob_index(void)
     uint8_t *data = bloom_filter_serialize(bf, &size);
     ASSERT_TRUE(data != NULL);
 
-    /* we craft a malicious payload: valid header but OOB word index
+    /* we craft a malicious payload -- valid header but OOB word index
      * first we deserialize to get baseline, then we'll manually build one */
     bloom_filter_free(bf);
 
@@ -767,14 +767,14 @@ void test_bloom_filter_deserialize_overflow_m(void)
     ASSERT_TRUE(bf == NULL);
 }
 
-/* exercises the hash-version logic: new filters are v2 and carry the sentinel;
+/* exercises the hash-version logic -- new filters are v2 and carry the sentinel;
  * a legacy v1 filter (no sentinel) round-trips back as v1 and stays correct,
  * proving a filter is always queried with the hash that built it (no FN). */
 void test_bloom_filter_hash_versioning()
 {
     const char *keys[] = {"alpha", "beta", "gamma", "delta", "epsilon"};
 
-    /* v2: a freshly built filter uses the current hash and serializes with the
+    /* v2 -- a freshly built filter uses the current hash and serializes with the
      * 0x00 version sentinel */
     bloom_filter_t *v2;
     (void)bloom_filter_new(&v2, 0.01, 1000);
@@ -795,7 +795,7 @@ void test_bloom_filter_hash_versioning()
     for (int i = 0; i < 5; i++)
         ASSERT_EQ(bloom_filter_contains(v2_rt, (const uint8_t *)keys[i], strlen(keys[i])), 1);
 
-    /* legacy v1: simulate an on-disk filter built with the old hash. force the
+    /* legacy v1 -- simulate an on-disk filter built with the old hash. force the
      * version to 1 before adding so the bits are set with the v1 hash. */
     bloom_filter_t *v1;
     (void)bloom_filter_new(&v1, 0.01, 1000);
@@ -806,7 +806,7 @@ void test_bloom_filter_hash_versioning()
     size_t v1_size;
     uint8_t *v1_blob = bloom_filter_serialize(v1, &v1_size);
     ASSERT_TRUE(v1_blob != NULL);
-    ASSERT_TRUE(v1_blob[0] != 0x00); /* legacy format: first byte is varint(m), never 0 */
+    ASSERT_TRUE(v1_blob[0] != 0x00); /* legacy format -- first byte is varint(m), never 0 */
 
     /* the legacy blob must come back as v1 and still find every key -- a
      * regression that queried v1 bits with the v2 hash would false-negative here */
@@ -844,12 +844,12 @@ void test_bloom_filter_hash_versioning()
  * post-malloc failure paths did free(*bf) without nulling, leaving callers
  * with a dangling pointer that produced a general protection fault inside
  * bloom_filter_add when subsequently used). exercises every post-malloc
- * failure path: m-overflow, h-overflow, size_in_words-overflow are covered
+ * failure path -- m-overflow, h-overflow, size_in_words-overflow are covered
  * by extreme parameter values
  */
 static void test_bloom_filter_new_failure_nulls_out(void)
 {
-    /* h_double > BF_MAX_HASH_FUNCTIONS (100): tiny p forces a very large h.
+    /* h_double > BF_MAX_HASH_FUNCTIONS (100) -- tiny p forces a very large h.
      * bloom_filter_new malloc()s the struct first then hits the h validator
      * and free()s it -- pre-fix this returned -1 with *bf pointing at the
      * freed struct */
@@ -858,7 +858,7 @@ static void test_bloom_filter_new_failure_nulls_out(void)
     ASSERT_EQ(rc, -1);
     ASSERT_EQ(bf, NULL);
 
-    /* size_in_words overflow path: very small p combined with n large enough
+    /* size_in_words overflow path -- very small p combined with n large enough
      * to push m past UINT32_MAX */
     bf = (bloom_filter_t *)(uintptr_t)0xdeadbeef;
     rc = bloom_filter_new(&bf, 1e-9, INT_MAX);
@@ -884,7 +884,7 @@ static void test_bloom_filter_new_failure_nulls_out(void)
 }
 
 /* a densely filled filter (almost every 64-bit word non-zero) must serialize with
- * the dense encoding: smaller than the raw bitset plus a small header, never the
+ * the dense encoding -- smaller than the raw bitset plus a small header, never the
  * sparse bloat it used to produce. format byte high nibble == 1 marks dense. */
 void test_bloom_filter_dense_encoding(void)
 {
@@ -951,7 +951,7 @@ void test_bloom_filter_sparse_encoding_unchanged(void)
     bloom_filter_free(rt);
 }
 
-/* deserialize must reject malformed buffers without over-reading: a buffer ending
+/* deserialize must reject malformed buffers without over-reading, a buffer ending
  * mid-varint, a lone sentinel, an unknown hash version, an unknown encoding, and
  * a header that promises more bitset words than the buffer holds */
 void test_bloom_filter_deserialize_malformed(void)
@@ -972,7 +972,7 @@ void test_bloom_filter_deserialize_malformed(void)
     uint8_t bad_encoding[2] = {0x00, 0x22};
     ASSERT_TRUE(bloom_filter_deserialize(bad_encoding, 2) == NULL);
 
-    /* sparse: count claims 3 words but only one is present */
+    /* sparse -- count claims 3 words but only one is present */
     uint8_t trunc_sparse[16];
     uint8_t *p = trunc_sparse;
     p = encode_varint32(p, 128);  /* m = 128 -> 2 words */
@@ -982,7 +982,7 @@ void test_bloom_filter_deserialize_malformed(void)
     p = encode_varint64(p, 0xFF); /* value -- and then nothing more */
     ASSERT_TRUE(bloom_filter_deserialize(trunc_sparse, (size_t)(p - trunc_sparse)) == NULL);
 
-    /* dense: header says 2 words but the raw body is missing */
+    /* dense-- header says 2 words but the raw body is missing */
     uint8_t trunc_dense[8];
     p = trunc_dense;
     *p++ = 0x00;                    /* sentinel */
@@ -992,7 +992,7 @@ void test_bloom_filter_deserialize_malformed(void)
     ASSERT_TRUE(bloom_filter_deserialize(trunc_dense, (size_t)(p - trunc_dense)) == NULL);
 }
 
-/* is_full over a multi-word filter: the all-words-set return-1 path and both the
+/* is_full over a multi-word filter the all-words-set return-1 path and both the
  * partial-last-word (remaining_bits != 0) and exact-multiple (== 0) branches */
 void test_bloom_filter_is_full_multiword(void)
 {

--- a/test/btree__tests.c
+++ b/test/btree__tests.c
@@ -949,7 +949,7 @@ void test_btree_seek_edge_cases()
     btree_builder_t *builder = NULL;
     ASSERT_TRUE(btree_builder_new(&builder, bm, &config) == 0);
 
-    /* we add keys with gaps: key10, key20, key30, key40, key50 */
+    /* we add keys with gaps key10, key20, key30, key40, key50 */
     for (int i = 1; i <= 5; i++)
     {
         char key[32];
@@ -1245,7 +1245,7 @@ void test_btree_cursor_seek_for_prev(void)
     btree_builder_t *builder = NULL;
     ASSERT_TRUE(btree_builder_new(&builder, bm, &config) == 0);
 
-    /* keys with gaps: key10, key20, key30, key40, key50 */
+    /* keys with gaps key10, key20, key30, key40, key50 */
     for (int i = 1; i <= 5; i++)
     {
         char key[32];
@@ -1319,7 +1319,7 @@ void test_btree_cursor_has_next_has_prev(void)
     btree_cursor_t *cursor = NULL;
     ASSERT_TRUE(btree_cursor_init(&cursor, tree) == 0);
 
-    /* at first entry: has_prev=0, has_next=1 */
+    /* at first entry has_prev=0, has_next=1 */
     ASSERT_EQ(btree_cursor_has_prev(cursor), 0);
     ASSERT_EQ(btree_cursor_has_next(cursor), 1);
 

--- a/test/clock_cache__tests.c
+++ b/test/clock_cache__tests.c
@@ -2459,9 +2459,9 @@ void test_realistic_oltp_concurrent(void)
  * test_realistic_working_set_shift
  * simulates a workload where the hot working set shifts over time
  * (e.g., time-series ingestion where recent partitions are hot):
- *   -- epoch 0: blocks 0-999 are hot
- *   -- epoch 1: blocks 1000-1999 become hot, 0-999 cool off
- *   -- epoch 2: blocks 2000-2999 become hot
+ *   -- epoch 0   blocks 0-999 are hot
+ *   -- epoch 1   blocks 1000-1999 become hot, 0-999 cool off
+ *   -- epoch 2   blocks 2000-2999 become hot
  * after each epoch shift, verifies:
  *   -- new hot blocks achieve high hit rates after warm-up
  *   -- old cold blocks are mostly evicted

--- a/test/manifest__tests.c
+++ b/test/manifest__tests.c
@@ -601,14 +601,17 @@ void test_manifest_corrupted_recovery()
 {
     const char *test_path = "." PATH_SEPARATOR "test_corrupted_manifest";
 
-    /* test invalid version */
+    /* an unrecognized version is neither the legacy text format nor a valid binary header, so open
+     * self-heals to a fresh empty log rather than failing (the sstables on disk are the truth) */
     FILE *f = tdb_fopen(test_path, "w");
     ASSERT_TRUE(f != NULL);
     fprintf(f, "999\n1000\n1,100,1000,65536\n");
     fclose(f);
 
     tidesdb_manifest_t *m1 = tidesdb_manifest_open(test_path);
-    ASSERT_TRUE(m1 == NULL);
+    ASSERT_TRUE(m1 != NULL);
+    ASSERT_EQ(m1->num_entries, 0);
+    tidesdb_manifest_close(m1);
     remove(test_path);
 
     /* test malformed entry (missing comma) */
@@ -856,9 +859,12 @@ void test_manifest_corrupted_version_nonnumeric(void)
     fprintf(f, "abc\n1000\n1,100,1000,65536\n");
     fclose(f);
 
-    /* non-numeric version should fail to parse (endptr == line) */
+    /* a non-numeric version is not the legacy text format nor a valid binary header, so open
+     * self-heals to a fresh empty log rather than failing */
     tidesdb_manifest_t *m = tidesdb_manifest_open(test_path);
-    ASSERT_TRUE(m == NULL);
+    ASSERT_TRUE(m != NULL);
+    ASSERT_EQ(m->num_entries, 0);
+    tidesdb_manifest_close(m);
 
     remove(test_path);
 }
@@ -951,18 +957,16 @@ void test_manifest_v8_checksum_roundtrip(void)
     ASSERT_EQ(tidesdb_manifest_commit(manifest, test_path, 1), 0);
     tidesdb_manifest_close(manifest);
 
-    /* the committed file must carry the current version and a 16-hex checksum on the next line */
-    FILE *f = tdb_fopen(test_path, "r");
+    /* the committed file is the append-only block-manager log, not the old text format -- it must
+     * not start with a legacy version digit, and per-block xxhash checksums give it integrity */
+    FILE *f = tdb_fopen(test_path, "rb");
     ASSERT_TRUE(f != NULL);
-    char vline[64];
-    char csline[64];
-    ASSERT_TRUE(fgets(vline, sizeof(vline), f) != NULL);
-    ASSERT_TRUE(fgets(csline, sizeof(csline), f) != NULL);
-    ASSERT_EQ(atoi(vline), MANIFEST_VERSION);
-    ASSERT_EQ((int)strlen(csline), 17); /* 16 hex digits plus a newline */
+    unsigned char first = 0;
+    ASSERT_TRUE(fread(&first, 1, 1, f) == 1);
+    ASSERT_FALSE(first == '7' || first == '8');
     fclose(f);
 
-    /* the checksum-verified reload must reproduce every field */
+    /* the reload must reproduce every field */
     tidesdb_manifest_t *m2 = tidesdb_manifest_open(test_path);
     ASSERT_TRUE(m2 != NULL);
     ASSERT_EQ(m2->sequence, 4242);
@@ -973,47 +977,61 @@ void test_manifest_v8_checksum_roundtrip(void)
     remove(test_path);
 }
 
-void test_manifest_v8_detects_body_corruption(void)
+void test_manifest_self_heals_on_corruption(void)
 {
-    const char *test_path = "." PATH_SEPARATOR "test_v8_corrupt_manifest";
+    const char *test_path = "." PATH_SEPARATOR "test_corrupt_manifest_bin";
 
+    /* build a two-commit log so there is a non-final block to corrupt */
     tidesdb_manifest_t *manifest = tidesdb_manifest_open(test_path);
     ASSERT_TRUE(manifest != NULL);
     tidesdb_manifest_add_sstable(manifest, 1, 100, 1000, 65536);
-    tidesdb_manifest_update_sequence(manifest, 7777);
+    ASSERT_EQ(tidesdb_manifest_commit(manifest, test_path, 1), 0);
+    tidesdb_manifest_add_sstable(manifest, 2, 200, 2000, 131072);
     ASSERT_EQ(tidesdb_manifest_commit(manifest, test_path, 1), 0);
     tidesdb_manifest_close(manifest);
 
-    /* read the whole file, flip the first byte of the body (start of the sequence line, which
-     * sits just past the version and checksum lines) and write it back. the stored checksum no
-     * longer matches the body, so the manifest must refuse to open rather than serve stale data. */
+    unsigned char buf[1024];
     FILE *f = tdb_fopen(test_path, "rb");
     ASSERT_TRUE(f != NULL);
-    char buf[512];
     const size_t n = fread(buf, 1, sizeof(buf), f);
     fclose(f);
-    ASSERT_TRUE(n > 0);
+    ASSERT_TRUE(n > 24);
 
-    int newlines = 0;
-    size_t body_start = 0;
-    for (size_t i = 0; i < n; i++)
+    /* torn tail -- a crash mid-append leaves the final block truncated. open must not fail; the
+     * sstable files (not tested here) are the ground truth that recovery reloads. */
     {
-        if (buf[i] == '\n' && ++newlines == 2)
-        {
-            body_start = i + 1;
-            break;
-        }
+        FILE *w = tdb_fopen(test_path, "wb");
+        ASSERT_TRUE(w != NULL);
+        ASSERT_EQ(fwrite(buf, 1, n - 6, w), n - 6); /* cut into the last block */
+        fclose(w);
+
+        tidesdb_manifest_t *mt = tidesdb_manifest_open(test_path);
+        ASSERT_TRUE(mt != NULL);
+        tidesdb_manifest_close(mt);
     }
-    ASSERT_TRUE(body_start > 0 && body_start < n);
-    buf[body_start] = (char)('0' + (((buf[body_start] - '0') + 1) % 10));
 
-    f = tdb_fopen(test_path, "wb");
-    ASSERT_TRUE(f != NULL);
-    ASSERT_EQ(fwrite(buf, 1, n, f), n);
-    fclose(f);
+    /* unreadable manifest -- overwrite it with garbage (a corrupt header). open must self-heal to a
+     * fresh usable log rather than fail (the sstable files, not tested here, are the ground truth
+     * recovery reloads), and an add + commit + reopen must round-trip cleanly afterward. */
+    {
+        FILE *w = tdb_fopen(test_path, "wb");
+        ASSERT_TRUE(w != NULL);
+        const char garbage[] = "not a manifest at all -- pure garbage bytes \x01\x02\x03";
+        ASSERT_EQ(fwrite(garbage, 1, sizeof(garbage), w), sizeof(garbage));
+        fclose(w);
 
-    tidesdb_manifest_t *m2 = tidesdb_manifest_open(test_path);
-    ASSERT_TRUE(m2 == NULL);
+        tidesdb_manifest_t *mc = tidesdb_manifest_open(test_path);
+        ASSERT_TRUE(mc != NULL);
+        ASSERT_EQ(tidesdb_manifest_add_sstable(mc, 5, 500, 5000, 4096), 0);
+        ASSERT_EQ(tidesdb_manifest_commit(mc, test_path, 1), 0);
+        tidesdb_manifest_close(mc);
+
+        tidesdb_manifest_t *mc2 = tidesdb_manifest_open(test_path);
+        ASSERT_TRUE(mc2 != NULL);
+        ASSERT_TRUE(tidesdb_manifest_has_sstable(mc2, 5, 500));
+        tidesdb_manifest_close(mc2);
+    }
+
     remove(test_path);
 }
 
@@ -1021,8 +1039,8 @@ void test_manifest_v7_legacy_opens(void)
 {
     const char *test_path = "." PATH_SEPARATOR "test_v7_legacy_manifest";
 
-    /* a version 7 file has no checksum line and must still open. after a commit it is rewritten
-     * as the current version and gains a checksum. */
+    /* a legacy version 7 text file must still open, and open converts it forward to the append-only
+     * block-manager format -- so after the open the file is no longer text */
     FILE *f = tdb_fopen(test_path, "w");
     ASSERT_TRUE(f != NULL);
     fprintf(f, "7\n5000\n1,100,1000,65536\n2,200,2000,131072\n");
@@ -1035,11 +1053,12 @@ void test_manifest_v7_legacy_opens(void)
     ASSERT_EQ(tidesdb_manifest_commit(m, test_path, 1), 0);
     tidesdb_manifest_close(m);
 
-    FILE *vf = tdb_fopen(test_path, "r");
+    /* the converted file is the binary log now, not a text version line */
+    FILE *vf = tdb_fopen(test_path, "rb");
     ASSERT_TRUE(vf != NULL);
-    char vline[64];
-    ASSERT_TRUE(fgets(vline, sizeof(vline), vf) != NULL);
-    ASSERT_EQ(atoi(vline), MANIFEST_VERSION);
+    unsigned char first = 0;
+    ASSERT_TRUE(fread(&first, 1, 1, vf) == 1);
+    ASSERT_FALSE(first == '7' || first == '8');
     fclose(vf);
 
     tidesdb_manifest_t *m2 = tidesdb_manifest_open(test_path);
@@ -1078,7 +1097,7 @@ int main(int argc, char **argv)
     RUN_TEST(test_manifest_commit_empty, tests_passed);
     RUN_TEST(test_manifest_large_uint64_roundtrip, tests_passed);
     RUN_TEST(test_manifest_v8_checksum_roundtrip, tests_passed);
-    RUN_TEST(test_manifest_v8_detects_body_corruption, tests_passed);
+    RUN_TEST(test_manifest_self_heals_on_corruption, tests_passed);
     RUN_TEST(test_manifest_v7_legacy_opens, tests_passed);
 
     PRINT_TEST_RESULTS(tests_passed, tests_failed);

--- a/test/queue__tests.c
+++ b/test/queue__tests.c
@@ -863,7 +863,7 @@ void test_queue_remove_if_callback_invoked(void)
 
 void test_queue_remove_if_tail_match(void)
 {
-    /* exercise the tail-pointer fix-up path: remove the last item, ensure subsequent
+    /* exercise the tail-pointer fix-up path, we remove the last item, ensure subsequent
      * enqueues still land at the end */
     queue_t *queue = queue_new();
     int a = 1, b = 2, c = 3;

--- a/test/skip_list__tests.c
+++ b/test/skip_list__tests.c
@@ -726,7 +726,7 @@ void *concurrent_writer(void *arg)
         snprintf(key_buf, sizeof(key_buf), "key%d", i % 10);
         snprintf(value_buf, sizeof(value_buf), "thread%d_value%d", ctx->thread_id, i);
 
-        /* retry loop: if write fails due to sequence conflict, get new seq and retry */
+        /* if write fails due to sequence conflict, get new seq and retry */
         int result = -1;
         int retry_count = 0;
         while (result != 0 && retry_count < 100)
@@ -1177,7 +1177,7 @@ void *lockfree_stress_writer(void *arg)
         snprintf(key_buf, sizeof(key_buf), "key%d", key_id);
         snprintf(value_buf, sizeof(value_buf), "t%d_v%d", ctx->thread_id, i);
 
-        /* retry loop: if write fails due to sequence conflict, get new seq and retry */
+        /* if write fails due to sequence conflict, get new seq and retry */
         int result = -1;
         int retry_count = 0;
         while (result != 0 && retry_count < 100)
@@ -1430,7 +1430,7 @@ void test_skip_list_lockfree_stress()
 
 static uint64_t zipfian_next(uint64_t *state, uint64_t n)
 {
-    /* simple zipfian approximation: 80% of accesses go to 20% of keys */
+    /* simple zipfian approximation at 80% of accesses go to 20% of keys */
     *state = (*state * 1103515245 + 12345) & 0x7fffffff;
     if ((*state % 100) < 80)
     {
@@ -1927,8 +1927,8 @@ static int reverse_memcmp_comparator(const uint8_t *key1, size_t key1_size, cons
     size_t min_size = key1_size < key2_size ? key1_size : key2_size;
     int result = memcmp(key1, key2, min_size);
     if (result != 0) return -result;      /* negate to reverse */
-    if (key1_size < key2_size) return 1;  /* reverse: shorter is greater */
-    if (key1_size > key2_size) return -1; /* reverse: longer is smaller */
+    if (key1_size < key2_size) return 1;  /* reverse shorter is greater */
+    if (key1_size > key2_size) return -1; /* reverse longer is smaller */
     return 0;
 }
 
@@ -1988,7 +1988,7 @@ void test_skip_list_prefix_seek_behavior()
     skip_list_t *list = NULL;
     ASSERT_EQ(skip_list_new(&list, 12, 0.25f), 0);
 
-    /* common prefixes: user:100, user:200, user:300, user:400, user:500 */
+    /* common prefixes user:100, user:200, user:300, user:400, user:500 */
     const char *keys[] = {"user:100", "user:200", "user:300", "user:400", "user:500"};
     const char *values[] = {"alice", "bob", "charlie", "david", "eve"};
     const int num_keys = 5;
@@ -3141,7 +3141,7 @@ void test_skip_list_out_of_order_versions()
     ASSERT_EQ(skip_list_new(&list, 12, 0.24f), 0);
 
     uint8_t key[] = "ooo";
-    /* versions arrive out of seq order -- the chain must stay descending: 10 -> 6 -> 2 */
+    /* versions arrive out of seq order -- the chain must stay descending 10 -> 6 -> 2 */
     ASSERT_EQ(skip_list_put_with_seq(list, key, sizeof(key), (uint8_t *)"v10", 4, -1, 10, 0), 0);
     ASSERT_EQ(skip_list_put_with_seq(list, key, sizeof(key), (uint8_t *)"v2", 3, -1, 2, 0), 0);
     ASSERT_EQ(skip_list_put_with_seq(list, key, sizeof(key), (uint8_t *)"v6", 3, -1, 6, 0), 0);

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -32273,6 +32273,87 @@ static void test_burst_quiescence_default_pool_readback(void)
     cleanup_test_dir();
 }
 
+/* Manifest self-heal at the recovery layer. If a CF's MANIFEST is destroyed, reopening must NOT
+ * treat the on-disk sstables as orphans and delete them -- recovery rebuilds the manifest from the
+ * sstables, so every committed key survives. Guards the append-only manifest's self-heal against
+ * the recovery orphan-deletion path. */
+static void test_manifest_corruption_recovers_from_sstables(void)
+{
+    if (is_running_under_qemu())
+    {
+        printf("  SKIPPED (QEMU emulation)\n");
+        return;
+    }
+
+    cleanup_test_dir();
+
+    tidesdb_config_t config = tidesdb_default_config();
+    config.db_path = TEST_DB_PATH;
+
+    tidesdb_t *db = NULL;
+    ASSERT_EQ(tidesdb_open(&config, &db), 0);
+
+    tidesdb_column_family_config_t cc = tidesdb_default_column_family_config();
+    cc.write_buffer_size = 8192; /* small, so the writes land in real sstables */
+    ASSERT_EQ(tidesdb_create_column_family(db, "heal_cf", &cc), 0);
+    tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "heal_cf");
+    ASSERT_TRUE(cf != NULL);
+
+    const int N = 400;
+    for (int i = 0; i < N; i++)
+    {
+        tidesdb_txn_t *txn = NULL;
+        ASSERT_EQ(tidesdb_txn_begin(db, &txn), 0);
+        char key[32], val[64];
+        snprintf(key, sizeof(key), "hk_%05d", i);
+        snprintf(val, sizeof(val), "hv_%05d", i);
+        ASSERT_EQ(tidesdb_txn_put(txn, cf, (uint8_t *)key, strlen(key) + 1, (uint8_t *)val,
+                                  strlen(val) + 1, 0),
+                  0);
+        ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+        tidesdb_txn_free(txn);
+    }
+    /* push everything to disk so the manifest is load-bearing for recovery */
+    ASSERT_EQ(tidesdb_flush_memtable(cf), 0);
+    wait_for_flush(db);
+    wait_for_compaction_idle(db, cf);
+    ASSERT_EQ(tidesdb_close(db), 0);
+
+    /* destroy the manifest -- overwrite it with garbage */
+    char manifest_path[512];
+    snprintf(manifest_path, sizeof(manifest_path), "%s%sheal_cf%sMANIFEST", TEST_DB_PATH,
+             PATH_SEPARATOR, PATH_SEPARATOR);
+    FILE *mf = fopen(manifest_path, "wb");
+    ASSERT_TRUE(mf != NULL);
+    const char junk[] = "total garbage, not a manifest at all \x01\x02\x03\x04";
+    ASSERT_EQ(fwrite(junk, 1, sizeof(junk), mf), sizeof(junk));
+    fclose(mf);
+
+    /* reopen -- recovery must rebuild the manifest from the on-disk sstables, not delete them */
+    db = NULL;
+    ASSERT_EQ(tidesdb_open(&config, &db), 0);
+    cf = tidesdb_get_column_family(db, "heal_cf");
+    ASSERT_TRUE(cf != NULL);
+
+    for (int i = 0; i < N; i++)
+    {
+        tidesdb_txn_t *txn = NULL;
+        ASSERT_EQ(tidesdb_txn_begin(db, &txn), 0);
+        char key[32], exp[64];
+        snprintf(key, sizeof(key), "hk_%05d", i);
+        snprintf(exp, sizeof(exp), "hv_%05d", i);
+        uint8_t *rv = NULL;
+        size_t rs = 0;
+        ASSERT_EQ(tdb_test_get_with_retry(txn, cf, (uint8_t *)key, strlen(key) + 1, &rv, &rs), 0);
+        ASSERT_TRUE(rv != NULL && rs == strlen(exp) + 1 && memcmp(rv, exp, rs) == 0);
+        free(rv);
+        tidesdb_txn_free(txn);
+    }
+
+    ASSERT_EQ(tidesdb_close(db), 0);
+    cleanup_test_dir();
+}
+
 int main(int argc, char **argv)
 {
     g_test_argv0 = argv[0];
@@ -32335,6 +32416,7 @@ int main(int argc, char **argv)
     RUN_TEST(test_unified_stats_per_cf_key_attribution, tests_passed);
     RUN_TEST(test_burst_then_quiescence_compaction_tail, tests_passed);
     RUN_TEST(test_burst_quiescence_default_pool_readback, tests_passed);
+    RUN_TEST(test_manifest_corruption_recovers_from_sstables, tests_passed);
     RUN_TEST(test_iterator_snapshot_complete_under_flush_compaction, tests_passed);
     RUN_TEST(test_get_stats_multi_cf_concurrent_under_flush, tests_passed);
     RUN_TEST(test_iterator_multi_cf_snapshot_under_churn, tests_passed);

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -18172,77 +18172,85 @@ static void test_database_lock_multi_process(void)
     tidesdb_config_t config = tidesdb_default_config();
     config.db_path = TEST_DB_PATH;
 
-    char signal_file[256];
-    snprintf(signal_file, sizeof(signal_file), "%s/.parent_ready", TEST_DB_PATH);
+    /* both children are forked from this pristine, single-threaded parent -- before it opens (and
+     * so before it spawns and later joins the flush/compaction/sync/reaper threads of) any
+     * database. forking a child that then opens a database from a parent that has already run
+     * threads is the fork-without-exec hazard macOS aborts on intermittently; forking both children
+     * up front removes the threaded-parent fork entirely. the two signal files coordinate ordering
+     * and live outside the db directory so they never appear in the directory the db scans. */
+    char ready_file[256];
+    char closed_file[256];
+    snprintf(ready_file, sizeof(ready_file), "%s_lockmp_ready", TEST_DB_PATH);
+    snprintf(closed_file, sizeof(closed_file), "%s_lockmp_closed", TEST_DB_PATH);
+    remove(ready_file); /* clear any stragglers from a crashed prior run */
+    remove(closed_file);
 
-    pid_t pid = fork();
-    ASSERT_TRUE(pid >= 0);
-
-    if (pid == 0)
+    /* child 1 -- opens while the parent holds the lock, expects TDB_ERR_LOCKED */
+    pid_t pid1 = fork();
+    ASSERT_TRUE(pid1 >= 0);
+    if (pid1 == 0)
     {
-        /* child process -- wait for parent to signal it has opened the database */
         int wait_count = 0;
-        while (access(signal_file, F_OK) != 0 && wait_count < 100)
+        while (access(ready_file, F_OK) != 0 && wait_count < 1000)
         {
             usleep(10000); /* 10ms */
             wait_count++;
         }
+        if (wait_count >= 1000) _exit(2); /* timeout waiting for the parent to open */
 
-        if (wait_count >= 100)
-        {
-            _exit(2); /* timeout waiting for parent */
-        }
-
-        /* we now try to open the locked database -- should fail */
         tidesdb_t *child_db = NULL;
         const int result = tidesdb_open(&config, &child_db);
         _exit(result == TDB_ERR_LOCKED ? 0 : 1);
     }
 
-    /* parent process -- open database first */
-    tidesdb_t *db = NULL;
-    ASSERT_EQ(tidesdb_open(&config, &db), TDB_SUCCESS);
-    ASSERT_TRUE(db != NULL);
-
-    /* signal child that database is open */
-    FILE *f = fopen(signal_file, "w");
-    ASSERT_TRUE(f != NULL);
-    fclose(f);
-
-    /* we wait for child */
-    int status;
-    waitpid(pid, &status, 0);
-    ASSERT_TRUE(WIFEXITED(status));
-    ASSERT_EQ(WEXITSTATUS(status), 0); /* child got TDB_ERR_LOCKED as expected */
-
-    /* remove signal file */
-    remove(signal_file);
-
-    /* parent closes database */
-    ASSERT_EQ(tidesdb_close(db), TDB_SUCCESS);
-
-    /* we test that a new process can now open the database */
-    pid = fork();
-    ASSERT_TRUE(pid >= 0);
-
-    if (pid == 0)
+    /* child 2 -- opens after the parent releases the lock, expects success */
+    pid_t pid2 = fork();
+    ASSERT_TRUE(pid2 >= 0);
+    if (pid2 == 0)
     {
-        /* child process -- should succeed now that parent released lock */
-        tidesdb_t *child_db = NULL;
-        int result = tidesdb_open(&config, &child_db);
-        if (result != TDB_SUCCESS || child_db == NULL)
+        int wait_count = 0;
+        while (access(closed_file, F_OK) != 0 && wait_count < 1000)
         {
-            _exit(1);
+            usleep(10000); /* 10ms */
+            wait_count++;
         }
+        if (wait_count >= 1000) _exit(2); /* timeout waiting for the parent to close */
+
+        tidesdb_t *child_db = NULL;
+        const int result = tidesdb_open(&config, &child_db);
+        if (result != TDB_SUCCESS || child_db == NULL) _exit(1);
         tidesdb_close(child_db);
         _exit(0);
     }
 
-    /* parent waits for child */
-    waitpid(pid, &status, 0);
-    ASSERT_TRUE(WIFEXITED(status));
-    ASSERT_EQ(WEXITSTATUS(status), 0); /* child opened successfully */
+    /* parent -- open the database first, then signal child 1 */
+    tidesdb_t *db = NULL;
+    ASSERT_EQ(tidesdb_open(&config, &db), TDB_SUCCESS);
+    ASSERT_TRUE(db != NULL);
 
+    FILE *rf = fopen(ready_file, "w");
+    ASSERT_TRUE(rf != NULL);
+    fclose(rf);
+
+    int status1 = 0;
+    waitpid(pid1, &status1, 0);
+    ASSERT_TRUE(WIFEXITED(status1));
+    ASSERT_EQ(WEXITSTATUS(status1), 0); /* child 1 got TDB_ERR_LOCKED as expected */
+
+    /* release the lock, then signal child 2 that it may open */
+    ASSERT_EQ(tidesdb_close(db), TDB_SUCCESS);
+
+    FILE *cf = fopen(closed_file, "w");
+    ASSERT_TRUE(cf != NULL);
+    fclose(cf);
+
+    int status2 = 0;
+    waitpid(pid2, &status2, 0);
+    ASSERT_TRUE(WIFEXITED(status2));
+    ASSERT_EQ(WEXITSTATUS(status2), 0); /* child 2 opened the released database successfully */
+
+    remove(ready_file);
+    remove(closed_file);
     cleanup_test_dir();
 }
 #endif

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -32034,6 +32034,245 @@ static void test_unified_stats_per_cf_key_attribution(void)
     cleanup_test_dir();
 }
 
+/* monotonic milliseconds, for measuring how long the engine takes to go quiet */
+static uint64_t test_monotonic_ms(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000ULL + (uint64_t)ts.tv_nsec / 1000000ULL;
+}
+
+/* poll until every cf's compaction has fully drained (pending==0 && !is_compacting) and the shared
+ * compaction queue is empty, or cap_ms elapses. compaction_pending_count is the reliable signal --
+ * it is bumped before the work item is enqueued and dropped only after the worker finishes, so it
+ * has no TOCTOU gap. returns elapsed ms, or cap_ms if it never quiesced. */
+static uint64_t wait_for_all_compaction_idle_ms(tidesdb_t *db, tidesdb_column_family_t **cfs, int n,
+                                                uint64_t cap_ms)
+{
+    const uint64_t start = test_monotonic_ms();
+    for (;;)
+    {
+        int busy = 0;
+        for (int i = 0; i < n; i++)
+        {
+            if (atomic_load_explicit(&cfs[i]->compaction_pending_count, memory_order_acquire) !=
+                    0 ||
+                atomic_load_explicit(&cfs[i]->is_compacting, memory_order_acquire))
+            {
+                busy = 1;
+                break;
+            }
+        }
+        tidesdb_db_stats_t st;
+        if (!busy && tidesdb_get_db_stats(db, &st) == 0 && st.compaction_queue_size == 0)
+            return test_monotonic_ms() - start;
+        if (test_monotonic_ms() - start >= cap_ms) return cap_ms;
+        usleep(20000);
+    }
+}
+
+/* run one burst-then-settle cycle with a given compaction pool size and return the compaction
+ * settle time. tiny write buffers are the trick -- a modest, unique key burst rotates the shared
+ * unified memtable many times, so it lands as many small per-cf L1 sstables (a large compaction
+ * debt) while the on-disk and memory footprint stays ~1.5 MB. after the burst the flush side is
+ * drained first, so what we time is purely the compaction tail. */
+static uint64_t burst_then_measure_compaction_settle(int num_compaction_threads, int report)
+{
+    cleanup_test_dir();
+
+    tidesdb_config_t config = tidesdb_default_config();
+    config.db_path = TEST_DB_PATH;
+    config.unified_memtable = 1;
+    config.unified_memtable_write_buffer_size = 16384; /* tiny -> many small flushes -> debt */
+    config.num_compaction_threads = num_compaction_threads;
+
+    tidesdb_t *db = NULL;
+    ASSERT_EQ(tidesdb_open(&config, &db), 0);
+    ASSERT_TRUE(db != NULL);
+
+    const int NCF = 8;
+    tidesdb_column_family_t *cfs[8];
+    for (int c = 0; c < NCF; c++)
+    {
+        char name[32];
+        snprintf(name, sizeof(name), "burst_cf_%d", c);
+        tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
+        cf_config.write_buffer_size = 16384;
+        ASSERT_EQ(tidesdb_create_column_family(db, name, &cf_config), 0);
+        cfs[c] = tidesdb_get_column_family(db, name);
+        ASSERT_TRUE(cfs[c] != NULL);
+    }
+
+    /* the write burst -- unique keys across every cf, small padded values */
+    const int PER_CF = 1500;
+    for (int i = 0; i < PER_CF; i++)
+    {
+        tidesdb_txn_t *txn = NULL;
+        ASSERT_EQ(tidesdb_txn_begin(db, &txn), 0);
+        for (int c = 0; c < NCF; c++)
+        {
+            char key[32], val[64];
+            snprintf(key, sizeof(key), "k_%d_%06d", c, i);
+            snprintf(val, sizeof(val), "v_%06d_padding_bytes_to_bulk_sstables", i);
+            ASSERT_EQ(tidesdb_txn_put(txn, cfs[c], (uint8_t *)key, strlen(key) + 1, (uint8_t *)val,
+                                      strlen(val) + 1, 0),
+                      0);
+        }
+        ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+        tidesdb_txn_free(txn);
+    }
+
+    /* writes have stopped. drain the flush side first so what remains is only compaction --
+     * this mirrors the observed shape where flush finishes fast and compaction is the long pole. */
+    for (int c = 0; c < NCF; c++) wait_for_cf_flush_idle(db, cfs[c]);
+
+    tidesdb_db_stats_t at_flush_idle;
+    ASSERT_EQ(tidesdb_get_db_stats(db, &at_flush_idle), 0);
+    uint64_t comp_before = 0;
+    for (int c = 0; c < NCF; c++)
+        comp_before += atomic_load_explicit(&cfs[c]->compaction_count, memory_order_relaxed);
+
+    /* now time how long compaction takes to fully quiesce */
+    const uint64_t cap_ms = 60000;
+    const uint64_t settle_ms = wait_for_all_compaction_idle_ms(db, cfs, NCF, cap_ms);
+
+    uint64_t comp_after = 0;
+    for (int c = 0; c < NCF; c++)
+        comp_after += atomic_load_explicit(&cfs[c]->compaction_count, memory_order_relaxed);
+
+    if (report)
+        printf(
+            "\n    [compaction_threads=%d] sstables_after_flush=%d "
+            "compactions_after_flush_idle=%" PRIu64 " compaction_settle=%" PRIu64 "ms%s\n",
+            num_compaction_threads, at_flush_idle.total_sstable_count, comp_after - comp_before,
+            settle_ms, settle_ms >= cap_ms ? "  <-- NEVER QUIESCED (hit 60s cap)" : "");
+
+    /* the burst must actually have created a compaction backlog, otherwise the test proves
+     * nothing about the settle tail */
+    ASSERT_TRUE(at_flush_idle.total_sstable_count > NCF);
+    ASSERT_TRUE(comp_after >= comp_before);
+    /* and the engine must return to a quiet state -- hitting the cap here reproduces the
+     * non-terminating end of the spectrum */
+    ASSERT_TRUE(settle_ms < cap_ms);
+
+    ASSERT_EQ(tidesdb_close(db), 0);
+    cleanup_test_dir();
+    return settle_ms;
+}
+
+static void test_burst_then_quiescence_compaction_tail(void)
+{
+    if (is_running_under_qemu())
+    {
+        printf("  SKIPPED (QEMU emulation)\n");
+        return;
+    }
+
+    const uint64_t settle_default =
+        burst_then_measure_compaction_settle(2, 1); /* library default */
+    const uint64_t settle_wide = burst_then_measure_compaction_settle(8, 1);
+
+    printf("    compaction settle: 2 threads=%" PRIu64 "ms  8 threads=%" PRIu64 "ms\n",
+           settle_default, settle_wide);
+
+    /* the tail is throughput-bound, so a wider pool must not make it slower. one-sided and
+     * generous because absolute timings are runner-dependent; the printed numbers are the signal.
+     */
+    ASSERT_TRUE(settle_wide <= settle_default + 2000);
+}
+
+static void test_burst_quiescence_default_pool_readback(void)
+{
+    if (is_running_under_qemu())
+    {
+        printf("  SKIPPED (QEMU emulation)\n");
+        return;
+    }
+
+    cleanup_test_dir();
+
+    tidesdb_config_t config = tidesdb_default_config();
+    config.db_path = TEST_DB_PATH;
+    config.unified_memtable = 1;
+    config.unified_memtable_write_buffer_size = 16384;
+    /* deliberately leaves num_compaction_threads at its default -- tamed compaction must keep pace
+     * without any thread tuning */
+
+    tidesdb_t *db = NULL;
+    ASSERT_EQ(tidesdb_open(&config, &db), 0);
+    ASSERT_TRUE(db != NULL);
+
+    const int NCF = 8;
+    const int PER_CF = 1500;
+    tidesdb_column_family_t *cfs[8];
+    for (int c = 0; c < NCF; c++)
+    {
+        char name[32];
+        snprintf(name, sizeof(name), "rb_cf_%d", c);
+        tidesdb_column_family_config_t cc = tidesdb_default_column_family_config();
+        cc.write_buffer_size = 16384;
+        ASSERT_EQ(tidesdb_create_column_family(db, name, &cc), 0);
+        cfs[c] = tidesdb_get_column_family(db, name);
+        ASSERT_TRUE(cfs[c] != NULL);
+    }
+
+    /* burst -- deterministic keys and values so every one can be read back after settle */
+    for (int i = 0; i < PER_CF; i++)
+    {
+        tidesdb_txn_t *txn = NULL;
+        ASSERT_EQ(tidesdb_txn_begin(db, &txn), 0);
+        for (int c = 0; c < NCF; c++)
+        {
+            char key[32], val[64];
+            snprintf(key, sizeof(key), "k_%d_%06d", c, i);
+            snprintf(val, sizeof(val), "v_%d_%06d", c, i);
+            ASSERT_EQ(tidesdb_txn_put(txn, cfs[c], (uint8_t *)key, strlen(key) + 1, (uint8_t *)val,
+                                      strlen(val) + 1, 0),
+                      0);
+        }
+        ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+        tidesdb_txn_free(txn);
+    }
+
+    for (int c = 0; c < NCF; c++) wait_for_cf_flush_idle(db, cfs[c]);
+
+    const uint64_t settle_ms = wait_for_all_compaction_idle_ms(db, cfs, NCF, 60000);
+
+    tidesdb_db_stats_t st;
+    ASSERT_EQ(tidesdb_get_db_stats(db, &st), 0);
+    printf("\n    default-pool settle=%" PRIu64 "ms  final_sstables=%d%s\n", settle_ms,
+           st.total_sstable_count, settle_ms >= 60000 ? "  <-- DID NOT QUIESCE" : "");
+
+    /* correctness gate -- every committed key must read back with its exact value after all the
+     * compaction merges. a size-bounded merge that mis-tiled a shard would drop a key here. */
+    for (int c = 0; c < NCF; c++)
+    {
+        for (int i = 0; i < PER_CF; i++)
+        {
+            tidesdb_txn_t *txn = NULL;
+            ASSERT_EQ(tidesdb_txn_begin(db, &txn), 0);
+            char key[32], exp[64];
+            snprintf(key, sizeof(key), "k_%d_%06d", c, i);
+            snprintf(exp, sizeof(exp), "v_%d_%06d", c, i);
+            uint8_t *rv = NULL;
+            size_t rs = 0;
+            ASSERT_EQ(
+                tdb_test_get_with_retry(txn, cfs[c], (uint8_t *)key, strlen(key) + 1, &rv, &rs), 0);
+            ASSERT_EQ(rs, strlen(exp) + 1);
+            ASSERT_TRUE(rv != NULL && memcmp(rv, exp, rs) == 0);
+            free(rv);
+            tidesdb_txn_free(txn);
+        }
+    }
+
+    /* the engine must return to a quiet state at the default pool -- a cap hit means compaction is
+     * still lagging and the fix did not tame it */
+    ASSERT_TRUE(settle_ms < 60000);
+
+    tidesdb_close(db);
+    cleanup_test_dir();
+}
+
 int main(int argc, char **argv)
 {
     g_test_argv0 = argv[0];
@@ -32094,6 +32333,8 @@ int main(int argc, char **argv)
     RUN_TEST(test_sstable_distinct_key_cardinality, tests_passed);
     RUN_TEST(test_distinct_key_count_collapses_versions, tests_passed);
     RUN_TEST(test_unified_stats_per_cf_key_attribution, tests_passed);
+    RUN_TEST(test_burst_then_quiescence_compaction_tail, tests_passed);
+    RUN_TEST(test_burst_quiescence_default_pool_readback, tests_passed);
     RUN_TEST(test_iterator_snapshot_complete_under_flush_compaction, tests_passed);
     RUN_TEST(test_get_stats_multi_cf_concurrent_under_flush, tests_passed);
     RUN_TEST(test_iterator_multi_cf_snapshot_under_churn, tests_passed);

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -32071,6 +32071,74 @@ static uint64_t wait_for_all_compaction_idle_ms(tidesdb_t *db, tidesdb_column_fa
     }
 }
 
+/* the per-cf stats fold caches each frozen unified immutable's key/byte breakdown so repeated polls
+ * skip the prefix walk. a tiny write buffer rotates the shared memtable into many frozen
+ * immutables, and hammering get_stats while they drain builds, publishes, reads back and (on free)
+ * releases the cache -- the path ASan would fault on if the lifecycle were wrong. the transient
+ * total cannot be pinned, unified flush adds a cf's sstable before clearing the immutable's flushed
+ * flag, so a key is briefly counted in both, and other windows undercount. so we only ceiling the
+ * transient against gross corruption and assert exact per-cf conservation once everything has
+ * settled onto disk. */
+static void test_unified_stats_immutable_count_cache(void)
+{
+    cleanup_test_dir();
+    tidesdb_config_t config = tidesdb_default_config();
+    config.db_path = TEST_DB_PATH;
+    config.unified_memtable = 1;
+    config.unified_memtable_write_buffer_size = 16384; /* tiny -> rotate into many immutables */
+    tidesdb_t *db = NULL;
+    ASSERT_EQ(tidesdb_open(&config, &db), 0);
+    ASSERT_TRUE(db != NULL);
+
+    tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
+    cf_config.compression_algorithm = TDB_COMPRESS_NONE;
+    ASSERT_EQ(tidesdb_create_column_family(db, "uicc_a", &cf_config), 0);
+    ASSERT_EQ(tidesdb_create_column_family(db, "uicc_b", &cf_config), 0);
+    tidesdb_column_family_t *cfa = tidesdb_get_column_family(db, "uicc_a");
+    tidesdb_column_family_t *cfb = tidesdb_get_column_family(db, "uicc_b");
+    ASSERT_TRUE(cfa != NULL && cfb != NULL);
+
+    const int NA = 600, NB = 250;
+    put_n_keys(db, cfa, "ka", NA);
+    put_n_keys(db, cfb, "kb", NB);
+
+    /* poll hard while the immutables drain -- this is where the cache builds and is read back */
+    for (int r = 0; r < 300; r++)
+    {
+        tidesdb_stats_t *sa = NULL, *sb = NULL;
+        ASSERT_EQ(tidesdb_get_stats(cfa, &sa), TDB_SUCCESS);
+        ASSERT_EQ(tidesdb_get_stats(cfb, &sb), TDB_SUCCESS);
+        /* a garbage cache pointer or a mis-sized breakdown would return wild counts; a sane cache
+         * stays within a small multiple of the true totals through every flush window */
+        ASSERT_TRUE(sa->total_keys <= (uint64_t)(2 * (NA + NB)));
+        ASSERT_TRUE(sb->total_keys <= (uint64_t)(2 * (NA + NB)));
+        tidesdb_free_stats(sa);
+        tidesdb_free_stats(sb);
+    }
+
+    /* let flush and compaction settle to disk, then the counts are exact and cache-independent */
+    wait_for_flush(db);
+    tidesdb_column_family_t *cfs[2] = {cfa, cfb};
+    wait_for_all_compaction_idle_ms(db, cfs, 2, 10000);
+
+    tidesdb_stats_t *sa = NULL, *sb = NULL;
+    ASSERT_EQ(tidesdb_get_stats(cfa, &sa), TDB_SUCCESS);
+    ASSERT_EQ(tidesdb_get_stats(cfb, &sb), TDB_SUCCESS);
+    ASSERT_EQ(sa->total_keys, (uint64_t)NA);
+    ASSERT_EQ(sb->total_keys, (uint64_t)NB);
+    tidesdb_free_stats(sa);
+    tidesdb_free_stats(sb);
+
+    uint64_t ea = 0, eb = 0;
+    ASSERT_EQ(tidesdb_cf_estimate_cardinality(cfa, &ea), TDB_SUCCESS);
+    ASSERT_EQ(tidesdb_cf_estimate_cardinality(cfb, &eb), TDB_SUCCESS);
+    ASSERT_EQ(ea, (uint64_t)NA);
+    ASSERT_EQ(eb, (uint64_t)NB);
+
+    ASSERT_EQ(tidesdb_close(db), 0);
+    cleanup_test_dir();
+}
+
 /* run one burst-then-settle cycle with a given compaction pool size and return the compaction
  * settle time. tiny write buffers are the trick -- a modest, unique key burst rotates the shared
  * unified memtable many times, so it lands as many small per-cf L1 sstables (a large compaction
@@ -32147,10 +32215,10 @@ static uint64_t burst_then_measure_compaction_settle(int num_compaction_threads,
             num_compaction_threads, at_flush_idle.total_sstable_count, comp_after - comp_before,
             settle_ms, settle_ms >= cap_ms ? "  <-- NEVER QUIESCED (hit 60s cap)" : "");
 
-    /* the burst must have flushed sstables (at least one per cf) and exercised compaction, otherwise
-     * the test proves nothing. we do NOT require sstable_count > NCF at flush-idle -- with fast
-     * consolidation compaction can already have merged each cf down to a single sstable by then,
-     * which is the fix working, not a failure. */
+    /* the burst must have flushed sstables (at least one per cf) and exercised compaction,
+     * otherwise the test proves nothing. we do NOT require sstable_count > NCF at flush-idle --
+     * with fast consolidation compaction can already have merged each cf down to a single sstable
+     * by then, which is the fix working, not a failure. */
     ASSERT_TRUE(at_flush_idle.total_sstable_count >= NCF);
     ASSERT_TRUE(comp_after > 0);
     /* and the engine must return to a quiet state -- hitting the cap here reproduces the
@@ -32416,6 +32484,7 @@ int main(int argc, char **argv)
     RUN_TEST(test_sstable_distinct_key_cardinality, tests_passed);
     RUN_TEST(test_distinct_key_count_collapses_versions, tests_passed);
     RUN_TEST(test_unified_stats_per_cf_key_attribution, tests_passed);
+    RUN_TEST(test_unified_stats_immutable_count_cache, tests_passed);
     RUN_TEST(test_burst_then_quiescence_compaction_tail, tests_passed);
     RUN_TEST(test_burst_quiescence_default_pool_readback, tests_passed);
     RUN_TEST(test_manifest_corruption_recovers_from_sstables, tests_passed);

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -32147,10 +32147,12 @@ static uint64_t burst_then_measure_compaction_settle(int num_compaction_threads,
             num_compaction_threads, at_flush_idle.total_sstable_count, comp_after - comp_before,
             settle_ms, settle_ms >= cap_ms ? "  <-- NEVER QUIESCED (hit 60s cap)" : "");
 
-    /* the burst must actually have created a compaction backlog, otherwise the test proves
-     * nothing about the settle tail */
-    ASSERT_TRUE(at_flush_idle.total_sstable_count > NCF);
-    ASSERT_TRUE(comp_after >= comp_before);
+    /* the burst must have flushed sstables (at least one per cf) and exercised compaction, otherwise
+     * the test proves nothing. we do NOT require sstable_count > NCF at flush-idle -- with fast
+     * consolidation compaction can already have merged each cf down to a single sstable by then,
+     * which is the fix working, not a failure. */
+    ASSERT_TRUE(at_flush_idle.total_sstable_count >= NCF);
+    ASSERT_TRUE(comp_after > 0);
     /* and the engine must return to a quiet state -- hitting the cap here reproduces the
      * non-terminating end of the spectrum */
     ASSERT_TRUE(settle_ms < cap_ms);

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tidesdb",
-  "version-string": "9.3.11",
+  "version-string": "9.3.12",
   "description": "TidesDB is a high-performance durable, transactional embeddable storage engine designed for flash and RAM optimization with optional object storage support for unlimited data scaling.",
   "dependencies": ["zstd", "snappy", "lz4", "pthreads", "curl"],
   "features": {


### PR DESCRIPTION
… instead of self-merging (thanks jeb)

compaction was not reducing sstable count. a full preemptive merge emitted one output per output-level file, so many small sstables rewrote into just as many small sstables and every later round paid fixed per-output cost over a count that never dropped -- a write burst could leave compaction churning for minutes. and when the tree had too few levels the dividing level clamped to 1, so the dividing merge rewrote level 1 in place rather than moving data down.

coarsen the full-preemptive shard boundaries to roughly one output sstable per write_buffer_size of input. a strided subset of the monotonic boundary tiling is still monotonic and still covers the whole key range (shard 0 unbounded below, the last shard unbounded above), so no key range is dropped. and when X clamps, merge into the largest level so data descends and the tree deepens instead of self-merging the top level.