### PR TITLE
guard worker thread creation in the unified concurrent test

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -1487,18 +1487,48 @@ static inline unsigned __stdcall tdb_win_thread_trampoline(void *p)
     t->retval = t->fn(t->arg);
     return 0;
 }
+
+/* thread attributes -- only the stack size is honored (the one attribute the engine and tests set),
+ * passed through to _beginthreadex. everything else is a no-op. a zero stack size means default. */
+typedef struct
+{
+    size_t stacksize;
+} pthread_attr_t;
+static inline int pthread_attr_init(pthread_attr_t *a)
+{
+    if (a) a->stacksize = 0;
+    return 0;
+}
+static inline int pthread_attr_destroy(pthread_attr_t *a)
+{
+    (void)a;
+    return 0;
+}
+static inline int pthread_attr_setstacksize(pthread_attr_t *a, size_t stacksize)
+{
+    if (!a) return EINVAL;
+    a->stacksize = stacksize;
+    return 0;
+}
+static inline int pthread_attr_getstacksize(const pthread_attr_t *a, size_t *stacksize)
+{
+    if (!a || !stacksize) return EINVAL;
+    *stacksize = a->stacksize;
+    return 0;
+}
+
 static inline int pthread_create(pthread_t *th, const void *attr, void *(*fn)(void *), void *arg)
 {
     tdb_win_thread_t *t;
     uintptr_t h;
+    unsigned stacksize = attr ? (unsigned)((const pthread_attr_t *)attr)->stacksize : 0;
 
-    (void)attr;
     t = (tdb_win_thread_t *)malloc(sizeof(*t));
     if (!t) return EAGAIN;
     t->fn = fn;
     t->arg = arg;
     t->retval = NULL;
-    h = _beginthreadex(NULL, 0, tdb_win_thread_trampoline, t, 0, NULL);
+    h = _beginthreadex(NULL, stacksize, tdb_win_thread_trampoline, t, 0, NULL);
     if (h == 0)
     {
         free(t);

--- a/test/failover/Dockerfile
+++ b/test/failover/Dockerfile
@@ -14,8 +14,8 @@ RUN cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DTIDESDB_WITH_SANITIZER=OFF 
     && cmake --build build --target tidesdb tidesdb_node -j"$(nproc)"
 
 FROM ubuntu:24.04
-# bash: the scenario driver speaks the node's TCP protocol via kubectl exec.
-# iptables: the partition scenario severs this pod's egress to MinIO from inside its own netns
+# the scenario driver speaks the node's TCP protocol via kubectl exec.
+# iptables-- the partition scenario severs this pod's egress to MinIO from inside its own netns
 # (needs the NET_ADMIN capability, set on the pod), so no CNI NetworkPolicy support is required.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash iptables libcurl4 liblz4-1 libzstd1 libsnappy1v5 \

--- a/test/failover/run_k8s.sh
+++ b/test/failover/run_k8s.sh
@@ -159,14 +159,14 @@ scenario_cascading_failover() {
     kexec tdb-primary FLUSH >/dev/null
     wait_all_converge 40 c "${REPLICAS[@]}"
 
-    # first failover: primary -> replica-0 (epoch 2)
+    # first failover primary -> replica-0 (epoch 2)
     kubectl delete pod tdb-primary --wait=true >/dev/null 2>&1
     check "first promote (epoch 2)" "$(kexec tdb-replica-0 PROMOTE)" "OK 2"
     kbulk_put tdb-replica-0 1 20 d
     kexec tdb-replica-0 FLUSH >/dev/null
     wait_all_converge 20 d tdb-replica-1
 
-    # second failover: replica-0 -> replica-1 (epoch 3)
+    # second failover replica-0 -> replica-1 (epoch 3)
     kubectl delete pod tdb-replica-0 --wait=true >/dev/null 2>&1
     check "second promote (epoch 3)" "$(kexec tdb-replica-1 PROMOTE)" "OK 3"
     check "data from before both failovers" "$(kverify tdb-replica-1 1 40 c)" 40
@@ -190,7 +190,7 @@ scenario_partition_zombie() {
     # promote a replica while the primary is isolated and oblivious
     check "promote replica-0" "$(kexec tdb-replica-0 PROMOTE)" "OK 2"
 
-    # the isolated primary keeps taking writes: they commit locally but cannot reach the bucket
+    # the isolated primary keeps taking writes, they commit locally but cannot reach the bucket
     # (each blocks on the WAL-upload retry, so keep the count small)
     kbulk_put tdb-primary 1 3 q
 

--- a/test/failover/run_local.sh
+++ b/test/failover/run_local.sh
@@ -102,8 +102,34 @@ wait_val() {
     return 1
 }
 
+# block until the node's async upload pipeline has drained -- every rotated WAL generation, sstable
+# and manifest is in the bucket. under wal_sync=0 the uploads are asynchronous, so killing the
+# primary before this drains leaves the newest WAL generation only on local disk (lost on crash),
+# and the failover catch-up can then only reach what actually made it to the bucket.
+#
+# upload_queue alone is not enough, a job the worker has dequeued is off the queue but still
+# in-flight (not yet in the bucket), so the queue reads 0 while an upload is mid-transfer. we gate
+# on completions instead -- the queue must be empty AND total_uploads (a completion counter) must
+# stop advancing for several consecutive polls, i.e. no queued and no in-flight work remains.
+wait_uploads_drained() { # wait_uploads_drained port
+    local port=$1 i last=-1 stable=0 q t
+    for i in $(seq 1 300); do # up to ~30s
+        q=$(stat_field "$port" upload_queue)
+        t=$(stat_field "$port" total_uploads)
+        if [ "$q" = "0" ] && [ "$t" = "$last" ]; then
+            stable=$((stable + 1))
+            [ "$stable" -ge 3 ] && return 0
+        else
+            stable=0
+        fi
+        last="$t"
+        sleep 0.1
+    done
+    return 1
+}
+
 start_node() { # start_node port replica data_dir bucket sync_us id [wal_sync_on_commit]
-    # wal_sync defaults off: the failover/zombie scenarios get durability from flushed sstables +
+    # wal_sync defaults off, the failover/zombie scenarios get durability from flushed sstables +
     # the fenced manifest, so they avoid a synchronous WAL upload per put. the rpo_zero scenario
     # passes 1 to require that acked-but-unflushed writes reach the bucket and survive a crash.
     local wal_sync="${7:-0}"
@@ -128,7 +154,7 @@ scenario_failover_catchup() {
     pids=()
 
     start_node "$PORT_P" 0 "$dp" "$bucket" 500000 fc_primary
-    # replica with a 1h sync interval: it must rely on the promotion catch-up, not polling
+    # replica with a 1h sync interval, it must rely on the promotion catch-up, not polling
     start_node "$PORT_R" 1 "$dr" "$bucket" 3600000000 fc_replica
     wait_ready "$PORT_P" || { echo "  FAIL primary not ready"; fail=1; return; }
     wait_ready "$PORT_R" || { echo "  FAIL replica not ready"; fail=1; return; }
@@ -141,6 +167,12 @@ scenario_failover_catchup() {
 
     # the replica never polled (huge interval), so it should have none of the data
     check "replica behind before failover" "$(verify_range "$PORT_R" 1 "$VOLUME" k)" 0
+
+    # simulate a graceful-enough failover -- let the primary finish uploading so the bucket holds
+    # every committed write before it "crashes". without this the newest WAL generation is still
+    # in flight and the catch-up correctly recovers only what reached the bucket (a wal_sync=0
+    # RPO>0 crash), which is a harness race, not an engine fault
+    wait_uploads_drained "$PORT_P" || { echo "  FAIL primary uploads did not drain in time"; fail=1; }
 
     kill -9 "${pids[0]}" 2>/dev/null
     check "promote replica" "$(cmd "$PORT_R" PROMOTE)" "OK 2"
@@ -216,7 +248,7 @@ scenario_rpo_zero() {
     kill -9 "${pids[0]}" 2>/dev/null
     check "promote replica" "$(cmd "$PORT_R" PROMOTE)" "OK 2"
 
-    # RPO=0: the unflushed-but-acked writes must survive via WAL replay in the catch-up
+    # RPO=0 the unflushed-but-acked writes must survive via WAL replay in the catch-up
     check "unflushed acked writes survived (rpo=0)" "$(verify_range "$PORT_R" 1 40 rpo)" 40
     check "baseline preserved" "$(verify_range "$PORT_R" 1 20 base)" 20
     cleanup; pids=()

--- a/test/failover/tidesdb_node.c
+++ b/test/failover/tidesdb_node.c
@@ -31,7 +31,7 @@
  *   FLUSH               -> OK | ERR <code>          (flush the memtable, publishing a manifest)
  *   PROMOTE             -> OK <epoch> | ERR <code>
  *   STAT                -> replica_mode=<0|1> primary_epoch=<n> seq=<n> sstables=<n> walgen=<n>
- *   QUIT                -> closes the connection
+ * upload_queue=<n> total_uploads=<n> QUIT                -> closes the connection
  *
  * configuration is via environment:
  *   TDB_NODE_PORT                 TCP listen port (required)
@@ -323,11 +323,14 @@ static void handle_stat(int fd)
         reply(fd, "ERR -1");
         return;
     }
-    char buf[192];
-    snprintf(buf, sizeof(buf),
-             "replica_mode=%d primary_epoch=%llu seq=%llu sstables=%d walgen=%llu", st.replica_mode,
-             (unsigned long long)st.primary_epoch, (unsigned long long)st.global_seq,
-             st.total_sstable_count, (unsigned long long)st.unified_wal_generation);
+    char buf[256];
+    snprintf(
+        buf, sizeof(buf),
+        "replica_mode=%d primary_epoch=%llu seq=%llu sstables=%d walgen=%llu upload_queue=%llu "
+        "total_uploads=%llu",
+        st.replica_mode, (unsigned long long)st.primary_epoch, (unsigned long long)st.global_seq,
+        st.total_sstable_count, (unsigned long long)st.unified_wal_generation,
+        (unsigned long long)st.upload_queue_depth, (unsigned long long)st.total_uploads);
     reply(fd, buf);
 }
 

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -28026,26 +28026,51 @@ static void test_unified_concurrent_multi_cf_read_write(void)
     _Atomic(int) commits_ok = 0, commits_fail = 0, go = 0, stop = 0;
 
     pthread_t writers[4], readers[4];
+    int w_started[4] = {0}, r_started[4] = {0};
     unified_concurrent_data_t w_data[4], r_data[4];
+
+    /* cap the worker stacks well below the 8MB default -- on a 32-bit ASan runner the default
+     * stacks for these eight threads, on top of the db's own worker/compaction/reaper threads and
+     * ASan's shadow region, can exhaust the address space and make pthread_create fail (EAGAIN),
+     * leaving a zero handle that trips ASan's join check. a short retry rides out a transient
+     * failure, and the started flags ensure we never join a thread that was not created. */
+    pthread_attr_t tattr;
+    pthread_attr_init(&tattr);
+    pthread_attr_setstacksize(&tattr, 1024 * 1024);
 
     for (int i = 0; i < NUM_WRITERS; i++)
     {
         w_data[i] = (unified_concurrent_data_t){db,          cfs,           NUM_CFS, i,    W_OPS,
                                                 &commits_ok, &commits_fail, &go,     &stop};
-        pthread_create(&writers[i], NULL, unified_concurrent_writer, &w_data[i]);
+        for (int a = 0; a < 50 && !w_started[i]; a++)
+        {
+            if (pthread_create(&writers[i], &tattr, unified_concurrent_writer, &w_data[i]) == 0)
+                w_started[i] = 1;
+            else
+                usleep(10000);
+        }
     }
     for (int i = 0; i < NUM_READERS; i++)
     {
         r_data[i] = (unified_concurrent_data_t){db,          cfs,           NUM_CFS, 10 + i, R_OPS,
                                                 &commits_ok, &commits_fail, &go,     &stop};
-        pthread_create(&readers[i], NULL, unified_concurrent_reader, &r_data[i]);
+        for (int a = 0; a < 50 && !r_started[i]; a++)
+        {
+            if (pthread_create(&readers[i], &tattr, unified_concurrent_reader, &r_data[i]) == 0)
+                r_started[i] = 1;
+            else
+                usleep(10000);
+        }
     }
+    pthread_attr_destroy(&tattr);
 
     atomic_store(&go, 1);
 
-    for (int i = 0; i < NUM_WRITERS; i++) pthread_join(writers[i], NULL);
+    for (int i = 0; i < NUM_WRITERS; i++)
+        if (w_started[i]) pthread_join(writers[i], NULL);
     atomic_store(&stop, 1);
-    for (int i = 0; i < NUM_READERS; i++) pthread_join(readers[i], NULL);
+    for (int i = 0; i < NUM_READERS; i++)
+        if (r_started[i]) pthread_join(readers[i], NULL);
 
     int final_ok = atomic_load(&commits_ok);
     int final_fail = atomic_load(&commits_fail);


### PR DESCRIPTION
test_unified_concurrent_multi_cf_read_write created eight worker threads with unchecked pthread_create and then joined them unconditionally. on the 32-bit i386 ASan runner the default 8MB stacks for those threads, on top of the database's own worker/compaction/reaper threads and ASan's shadow region, exhausted the address space and made a pthread_create fail with EAGAIN. that left a zero pthread_t in the array, and joining the zero handle tripped ASan's thread-registry assertion (CHECK failed '((t)) != (0)'), aborting the run intermittently.

give the workers 1MB stacks so creation fits within the constrained address space, retry a transient EAGAIN briefly, and track which threads actually started so the join loops skip any slot that was never created -- so a failed create can never turn into a join on an uninitialized handle.