### PR TITLE
retire chunked aux for blocked partitioned bloom filter and block index

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -708,8 +708,10 @@ if(TIDESDB_BUILD_TESTS) # enable building tests and benchmarks
     add_executable(btree_tests test/btree__tests.c)
     add_executable(local_cache_tests test/local_cache__tests.c)
     add_executable(objstore_tests test/objstore__tests.c)
-    add_executable(sha256_tests test/sha256__tests.c)
-    add_executable(hmac_sha256_tests test/hmac_sha256__tests.c)
+    if(TIDESDB_WITH_S3)
+        add_executable(sha256_tests test/sha256__tests.c)
+        add_executable(hmac_sha256_tests test/hmac_sha256__tests.c)
+    endif()
     add_executable(tidesdb_tests test/tidesdb__tests.c)
     if(TIDESDB_WITH_S3)
         target_compile_definitions(tidesdb_tests PRIVATE TIDESDB_WITH_S3)
@@ -780,7 +782,15 @@ if(TIDESDB_BUILD_TESTS) # enable building tests and benchmarks
     endif()
 
     # add include and link directories for test executables
-    foreach(test_target block_manager_tests skip_list_tests compress_tests bloom_filter_tests blocked_bloom_filter_tests blocked_index_tests manifest_tests clock_cache_tests queue_tests btree_tests local_cache_tests objstore_tests sha256_tests hmac_sha256_tests tidesdb_tests tidesdb_bench)
+    set(TIDESDB_TEST_LINK_TARGETS
+            block_manager_tests skip_list_tests compress_tests bloom_filter_tests
+            blocked_bloom_filter_tests blocked_index_tests
+            manifest_tests clock_cache_tests queue_tests btree_tests local_cache_tests
+            objstore_tests tidesdb_tests tidesdb_bench)
+    if(TIDESDB_WITH_S3)
+        list(APPEND TIDESDB_TEST_LINK_TARGETS sha256_tests hmac_sha256_tests)
+    endif()
+    foreach(test_target ${TIDESDB_TEST_LINK_TARGETS})
         target_link_libraries(${test_target} PRIVATE tidesdb)
         target_include_directories(${test_target} PRIVATE external)
     endforeach()
@@ -797,8 +807,10 @@ if(TIDESDB_BUILD_TESTS) # enable building tests and benchmarks
     add_test(NAME btree_tests COMMAND btree_tests)
     add_test(NAME local_cache_tests COMMAND local_cache_tests)
     add_test(NAME objstore_tests COMMAND objstore_tests)
-    add_test(NAME sha256_tests COMMAND sha256_tests)
-    add_test(NAME hmac_sha256_tests COMMAND hmac_sha256_tests)
+    if(TIDESDB_WITH_S3)
+        add_test(NAME sha256_tests COMMAND sha256_tests)
+        add_test(NAME hmac_sha256_tests COMMAND hmac_sha256_tests)
+    endif()
     add_test(NAME tidesdb_tests COMMAND tidesdb_tests)
 
     # copy required DLLs to build directory for Windows (MSVC and MinGW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ if(TIDESDB_WITH_MIMALLOC)
 endif()
 
 project(tidesdb
-	VERSION 9.3.14
+	VERSION 9.4.0
 	LANGUAGES C)
 
 set(CMAKE_C_STANDARD 11)
@@ -158,6 +158,7 @@ include_directories(external) # for external libraries linking internally
 # users can override with -DBUILD_SHARED_LIBS=ON/OFF
 set(TIDESDB_SOURCES
     src/tidesdb.c src/block_manager.c src/skip_list.c src/compress.c src/bloom_filter.c
+    src/blocked_bloom_filter.c src/blocked_index.c
     src/manifest.c src/clock_cache.c src/queue.c src/btree.c src/alloc.c
     src/objstore_fs.c src/local_cache.c src/sha256.c src/hmac_sha256.c
     external/xxhash.c external/ini.c)
@@ -661,12 +662,6 @@ if(TIDESDB_BUILD_TESTS) # enable building tests and benchmarks
     if(NOT DEFINED BENCH_ENABLE_BLOCK_INDEXES)
         set(BENCH_ENABLE_BLOCK_INDEXES 1)
     endif()
-    if(NOT DEFINED BENCH_BLOCK_INDEX_SAMPLING_COUNT)
-        set(BENCH_BLOCK_INDEX_SAMPLING_COUNT 1)
-    endif()
-    if(NOT DEFINED BENCH_BLOCK_INDEX_PREFIX_LEN)
-        set(BENCH_BLOCK_INDEX_PREFIX_LEN 16)
-    endif()
     if(NOT DEFINED BENCH_SYNC_MODE)
         set(BENCH_SYNC_MODE TDB_SYNC_NONE)
     endif()
@@ -705,6 +700,8 @@ if(TIDESDB_BUILD_TESTS) # enable building tests and benchmarks
     add_executable(skip_list_tests test/skip_list__tests.c)
     add_executable(compress_tests test/compress__tests.c)
     add_executable(bloom_filter_tests test/bloom_filter__tests.c)
+    add_executable(blocked_bloom_filter_tests test/blocked_bloom_filter__tests.c)
+    add_executable(blocked_index_tests test/blocked_index__tests.c)
     add_executable(clock_cache_tests test/clock_cache__tests.c)
     add_executable(manifest_tests test/manifest__tests.c)
     add_executable(queue_tests test/queue__tests.c)
@@ -743,8 +740,6 @@ if(TIDESDB_BUILD_TESTS) # enable building tests and benchmarks
             BENCH_ENABLE_BLOOM_FILTER=${BENCH_ENABLE_BLOOM_FILTER}
             BENCH_BLOOM_FILTER_FP_RATE=${BENCH_BLOOM_FILTER_FP_RATE}
             BENCH_ENABLE_BLOCK_INDEXES=${BENCH_ENABLE_BLOCK_INDEXES}
-            BENCH_BLOCK_INDEX_SAMPLING_COUNT=${BENCH_BLOCK_INDEX_SAMPLING_COUNT}
-            BENCH_BLOCK_INDEX_PREFIX_LEN=${BENCH_BLOCK_INDEX_PREFIX_LEN}
             BENCH_SYNC_MODE=${BENCH_SYNC_MODE}
             BENCH_SYNC_INTERVAL_US=${BENCH_SYNC_INTERVAL_US}
             BENCH_COMPARATOR_NAME="${BENCH_COMPARATOR_NAME}"
@@ -785,7 +780,7 @@ if(TIDESDB_BUILD_TESTS) # enable building tests and benchmarks
     endif()
 
     # add include and link directories for test executables
-    foreach(test_target block_manager_tests skip_list_tests compress_tests bloom_filter_tests manifest_tests clock_cache_tests queue_tests btree_tests local_cache_tests objstore_tests sha256_tests hmac_sha256_tests tidesdb_tests tidesdb_bench)
+    foreach(test_target block_manager_tests skip_list_tests compress_tests bloom_filter_tests blocked_bloom_filter_tests blocked_index_tests manifest_tests clock_cache_tests queue_tests btree_tests local_cache_tests objstore_tests sha256_tests hmac_sha256_tests tidesdb_tests tidesdb_bench)
         target_link_libraries(${test_target} PRIVATE tidesdb)
         target_include_directories(${test_target} PRIVATE external)
     endforeach()
@@ -794,6 +789,8 @@ if(TIDESDB_BUILD_TESTS) # enable building tests and benchmarks
     add_test(NAME skip_list_tests COMMAND skip_list_tests)
     add_test(NAME compress_tests COMMAND compress_tests)
     add_test(NAME bloom_filter_tests COMMAND bloom_filter_tests)
+    add_test(NAME blocked_bloom_filter_tests COMMAND blocked_bloom_filter_tests)
+    add_test(NAME blocked_index_tests COMMAND blocked_index_tests)
     add_test(NAME manifest_tests COMMAND manifest_tests)
     add_test(NAME clock_cache_tests COMMAND clock_cache_tests)
     add_test(NAME queue_tests COMMAND queue_tests)
@@ -808,7 +805,7 @@ if(TIDESDB_BUILD_TESTS) # enable building tests and benchmarks
     if(WIN32)
         set(TIDESDB_TEST_TARGETS
                 block_manager_tests skip_list_tests compress_tests bloom_filter_tests
-                manifest_tests queue_tests tidesdb_tests tidesdb_bench)
+                blocked_bloom_filter_tests blocked_index_tests manifest_tests queue_tests tidesdb_tests tidesdb_bench)
 
         if(MINGW)
             # On MinGW (MSYS2), the test exes link against shared snappy/zstd/lz4

--- a/bench/tidesdb__bench.c
+++ b/bench/tidesdb__bench.c
@@ -847,7 +847,6 @@ int main()
     printf("  Bloom Filter: %s\n", BENCH_ENABLE_BLOOM_FILTER ? "enabled" : "disabled");
     printf("  Bloom Filter FP Rate: %.4f\n", BENCH_BLOOM_FILTER_FP_RATE);
     printf("  Block Indexes: %s\n", BENCH_ENABLE_BLOCK_INDEXES ? "enabled" : "disabled");
-    printf("  Block Index Prefix Length: %d\n", BENCH_BLOCK_INDEX_PREFIX_LEN);
     printf("  Comparator: %s\n", BENCH_COMPARATOR_NAME);
     printf("  Isolation Level: %s\n", get_isolation_level_name(BENCH_ISOLATION_LEVEL));
     printf("  K-Log Value Threshold: %zu bytes (%.2f KB)\n", (size_t)BENCH_KLOG_VALUE_THRESHOLD,
@@ -1001,13 +1000,11 @@ int main()
     cf_config.enable_bloom_filter = BENCH_ENABLE_BLOOM_FILTER;
     cf_config.bloom_fpr = BENCH_BLOOM_FILTER_FP_RATE;
     cf_config.enable_block_indexes = BENCH_ENABLE_BLOCK_INDEXES;
-    cf_config.index_sample_ratio = BENCH_BLOCK_INDEX_SAMPLING_COUNT;
     cf_config.sync_mode = BENCH_SYNC_MODE;
     cf_config.sync_interval_us = BENCH_SYNC_INTERVAL_US;
     strncpy(cf_config.comparator_name, BENCH_COMPARATOR_NAME, TDB_MAX_COMPARATOR_NAME - 1);
     cf_config.comparator_name[TDB_MAX_COMPARATOR_NAME - 1] = '\0';
     cf_config.default_isolation_level = BENCH_ISOLATION_LEVEL;
-    cf_config.block_index_prefix_len = BENCH_BLOCK_INDEX_PREFIX_LEN;
     cf_config.klog_value_threshold = BENCH_KLOG_VALUE_THRESHOLD;
     cf_config.min_disk_space = BENCH_MIN_DISK_SPACE;
     cf_config.l1_file_count_trigger = BENCH_L1_FILE_COUNT_TRIGGER;

--- a/src/blocked_bloom_filter.c
+++ b/src/blocked_bloom_filter.c
@@ -1,0 +1,456 @@
+/**
+ *
+ * Copyright (C) TidesDB
+ *
+ * Original Author: Alex Gaetano Padula
+ *
+ * Licensed under the Mozilla Public License, v. 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.mozilla.org/en-US/MPL/2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "blocked_bloom_filter.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+/* directory blob layout, all little-endian
+ *   magic (4) | version (4) | partition_count (4)
+ *   then partition_count records of
+ *     disk_offset (8) | blob_size (4) | entry_count (4) | first_key_len (4) | first_key bytes
+ * the partition records are in build (ascending key) order, so the reader binary-searches them
+ * directly. */
+#define BBF_DIR_MAGIC   0x46424254u /* "TBBF" little-endian */
+#define BBF_DIR_VERSION 1u
+/* magic + version + partition_count */
+#define BBF_DIR_HEADER_BYTES (3 * sizeof(uint32_t))
+/* per-record bytes before the variable first_key: disk_offset + blob_size + entry_count +
+ * first_key_len */
+#define BBF_DIR_ENTRY_FIXED (sizeof(uint64_t) + 3 * sizeof(uint32_t))
+
+/* little-endian byte codecs for the directory, endian-canonical so a filter built on one host
+ * reads back identically on another */
+static void bbf_put_u32le(uint8_t *p, uint32_t v)
+{
+    for (size_t i = 0; i < sizeof(uint32_t); i++) p[i] = (uint8_t)(v >> (8 * i));
+}
+
+static void bbf_put_u64le(uint8_t *p, uint64_t v)
+{
+    for (size_t i = 0; i < sizeof(uint64_t); i++) p[i] = (uint8_t)(v >> (8 * i));
+}
+
+static uint32_t bbf_get_u32le(const uint8_t *p)
+{
+    uint32_t v = 0;
+    for (size_t i = 0; i < sizeof(uint32_t); i++) v |= (uint32_t)p[i] << (8 * i);
+    return v;
+}
+
+static uint64_t bbf_get_u64le(const uint8_t *p)
+{
+    uint64_t v = 0;
+    for (size_t i = 0; i < sizeof(uint64_t); i++) v |= (uint64_t)p[i] << (8 * i);
+    return v;
+}
+
+/* one partition as tracked by the builder and reconstructed by the reader */
+typedef struct
+{
+    uint8_t *blob;      /* serialized partition, held until finish writes it (builder only) */
+    uint64_t offset;    /* where the partition blob was written, set at finish */
+    uint32_t size;      /* partition blob length */
+    uint32_t count;     /* keys in the partition */
+    uint8_t *first_key; /* owned copy of the partition's first key */
+    uint32_t first_key_len;
+} bbf_partition_t;
+
+struct blocked_bloom_builder
+{
+    double fpr;
+    uint32_t partition_entries;
+    blocked_bloom_write_fn write_fn;
+    void *write_ctx;
+
+    bloom_filter_t *current; /* partition being filled, NULL between partitions */
+    uint32_t current_count;
+    uint8_t *current_first_key;
+    uint32_t current_first_key_len;
+
+    bbf_partition_t *parts;
+    size_t num_parts;
+    size_t cap_parts;
+
+    uint64_t total_entries;
+    int failed; /* sticky -- a write or allocation failure poisons the build */
+};
+
+struct blocked_bloom_reader
+{
+    blocked_bloom_comparator_fn cmp;
+    void *cmp_ctx;
+    blocked_bloom_fetch_fn fetch_fn;
+    blocked_bloom_release_fn release_fn;
+    void *cb_ctx;
+
+    bbf_partition_t *parts; /* ascending key order; first_key owned */
+    uint32_t num_parts;
+    size_t resident_bytes;
+};
+
+/* free a partition array and the first-key copies it owns */
+static void bbf_partitions_free(bbf_partition_t *parts, size_t n)
+{
+    if (!parts) return;
+    for (size_t i = 0; i < n; i++)
+    {
+        free(parts[i].first_key);
+        free(parts[i].blob);
+    }
+    free(parts);
+}
+
+int blocked_bloom_builder_new(blocked_bloom_builder_t **out, double fpr, uint32_t partition_entries,
+                              blocked_bloom_write_fn write_fn, void *write_ctx)
+{
+    if (!out || !write_fn || !(fpr > 0.0 && fpr < 1.0)) return -1;
+    if (partition_entries == 0) partition_entries = TDB_BLOCKED_BLOOM_DEFAULT_PARTITION_ENTRIES;
+
+    blocked_bloom_builder_t *b = calloc(1, sizeof(*b));
+    if (!b) return -1;
+
+    b->fpr = fpr;
+    b->partition_entries = partition_entries;
+    b->write_fn = write_fn;
+    b->write_ctx = write_ctx;
+    *out = b;
+    return 0;
+}
+
+/* serialize the current partition and record it, holding its blob until finish writes it after the
+ * sstable's klog data. takes ownership of current_first_key on success. a no-op when no partition
+ * is open. */
+static int bbf_seal_current(blocked_bloom_builder_t *b)
+{
+    if (!b->current) return 0;
+
+    size_t blob_size = 0;
+    uint8_t *blob = bloom_filter_serialize(b->current, &blob_size);
+    if (!blob || blob_size == 0 || blob_size > UINT32_MAX)
+    {
+        free(blob);
+        return -1;
+    }
+
+    if (b->num_parts == b->cap_parts)
+    {
+        size_t ncap = b->cap_parts ? b->cap_parts * 2 : 16;
+        bbf_partition_t *np = realloc(b->parts, ncap * sizeof(*np));
+        if (!np)
+        {
+            free(blob);
+            return -1;
+        }
+        b->parts = np;
+        b->cap_parts = ncap;
+    }
+
+    bbf_partition_t *e = &b->parts[b->num_parts++];
+    e->blob = blob; /* written at finish */
+    e->offset = 0;  /* filled at finish */
+    e->size = (uint32_t)blob_size;
+    e->count = b->current_count;
+    e->first_key = b->current_first_key; /* ownership transferred */
+    e->first_key_len = b->current_first_key_len;
+
+    b->current_first_key = NULL;
+    b->current_first_key_len = 0;
+    bloom_filter_free(b->current);
+    b->current = NULL;
+    b->current_count = 0;
+    return 0;
+}
+
+int blocked_bloom_builder_add(blocked_bloom_builder_t *b, const uint8_t *key, size_t key_size)
+{
+    if (!b) return 0; /* a NULL builder means the filter is disabled -- adding is a no-op */
+    if (!key || key_size == 0) return -1;
+    if (b->failed) return -1;
+
+    if (!b->current)
+    {
+        if (bloom_filter_new(&b->current, b->fpr, (int)b->partition_entries) != 0)
+        {
+            b->failed = 1;
+            return -1;
+        }
+        b->current_first_key = malloc(key_size);
+        if (!b->current_first_key)
+        {
+            bloom_filter_free(b->current);
+            b->current = NULL;
+            b->failed = 1;
+            return -1;
+        }
+        memcpy(b->current_first_key, key, key_size);
+        b->current_first_key_len = (uint32_t)key_size;
+        b->current_count = 0;
+    }
+
+    bloom_filter_add(b->current, key, key_size);
+    b->current_count++;
+    b->total_entries++;
+
+    if (b->current_count >= b->partition_entries)
+    {
+        if (bbf_seal_current(b) != 0)
+        {
+            b->failed = 1;
+            return -1;
+        }
+    }
+    return 0;
+}
+
+/* serialized directory size for the recorded partitions */
+static size_t bbf_dir_size(const blocked_bloom_builder_t *b)
+{
+    size_t total = BBF_DIR_HEADER_BYTES;
+    for (size_t i = 0; i < b->num_parts; i++)
+        total += BBF_DIR_ENTRY_FIXED + b->parts[i].first_key_len;
+    return total;
+}
+
+int blocked_bloom_builder_finish(blocked_bloom_builder_t *b, uint64_t *out_dir_offset,
+                                 uint32_t *out_dir_size, uint64_t *out_total_entries)
+{
+    if (!b || !out_dir_offset || !out_dir_size) return -1;
+    if (b->failed) return -1;
+
+    if (bbf_seal_current(b) != 0)
+    {
+        b->failed = 1;
+        return -1;
+    }
+
+    /* write every buffered partition now -- the caller invokes finish from the sstable footer,
+     * after the klog data blocks, so these land contiguously past the data and their offsets are
+     * final */
+    for (size_t i = 0; i < b->num_parts; i++)
+    {
+        uint64_t offset = 0;
+        int rc = b->write_fn(b->write_ctx, b->parts[i].blob, b->parts[i].size, &offset);
+        if (rc != 0)
+        {
+            b->failed = 1;
+            return rc;
+        }
+        b->parts[i].offset = offset;
+        free(b->parts[i].blob);
+        b->parts[i].blob = NULL;
+    }
+
+    size_t dir_size = bbf_dir_size(b);
+    if (dir_size > UINT32_MAX) return -1;
+    uint8_t *dir = malloc(dir_size);
+    if (!dir) return -1;
+
+    uint8_t *p = dir;
+    bbf_put_u32le(p, BBF_DIR_MAGIC);
+    p += sizeof(uint32_t);
+    bbf_put_u32le(p, BBF_DIR_VERSION);
+    p += sizeof(uint32_t);
+    bbf_put_u32le(p, (uint32_t)b->num_parts);
+    p += sizeof(uint32_t);
+    for (size_t i = 0; i < b->num_parts; i++)
+    {
+        const bbf_partition_t *e = &b->parts[i];
+        bbf_put_u64le(p, e->offset);
+        p += sizeof(uint64_t);
+        bbf_put_u32le(p, e->size);
+        p += sizeof(uint32_t);
+        bbf_put_u32le(p, e->count);
+        p += sizeof(uint32_t);
+        bbf_put_u32le(p, e->first_key_len);
+        p += sizeof(uint32_t);
+        memcpy(p, e->first_key, e->first_key_len);
+        p += e->first_key_len;
+    }
+
+    uint64_t offset = 0;
+    int rc = b->write_fn(b->write_ctx, dir, dir_size, &offset);
+    free(dir);
+    if (rc != 0) return rc;
+
+    *out_dir_offset = offset;
+    *out_dir_size = (uint32_t)dir_size;
+    if (out_total_entries) *out_total_entries = b->total_entries;
+    return 0;
+}
+
+void blocked_bloom_builder_free(blocked_bloom_builder_t *b)
+{
+    if (!b) return;
+    if (b->current) bloom_filter_free(b->current);
+    free(b->current_first_key);
+    bbf_partitions_free(b->parts, b->num_parts);
+    free(b);
+}
+
+/* parse a directory blob into an ascending array of partitions. returns 0 on success. */
+static int bbf_parse_dir(const uint8_t *data, size_t len, bbf_partition_t **out_parts,
+                         uint32_t *out_n, size_t *out_resident)
+{
+    if (len < BBF_DIR_HEADER_BYTES) return -1;
+    if (bbf_get_u32le(data) != BBF_DIR_MAGIC) return -1;
+    if (bbf_get_u32le(data + sizeof(uint32_t)) != BBF_DIR_VERSION) return -1;
+    uint32_t n = bbf_get_u32le(data + 2 * sizeof(uint32_t));
+
+    if (n == 0)
+    {
+        *out_parts = NULL;
+        *out_n = 0;
+        *out_resident = 0;
+        return 0;
+    }
+
+    bbf_partition_t *parts = calloc(n, sizeof(*parts));
+    if (!parts) return -1;
+
+    size_t resident = n * sizeof(*parts);
+    const uint8_t *p = data + BBF_DIR_HEADER_BYTES;
+    const uint8_t *end = data + len;
+    for (uint32_t i = 0; i < n; i++)
+    {
+        if ((size_t)(end - p) < BBF_DIR_ENTRY_FIXED)
+        {
+            bbf_partitions_free(parts, i);
+            return -1;
+        }
+        parts[i].offset = bbf_get_u64le(p);
+        p += sizeof(uint64_t);
+        parts[i].size = bbf_get_u32le(p);
+        p += sizeof(uint32_t);
+        parts[i].count = bbf_get_u32le(p);
+        p += sizeof(uint32_t);
+        parts[i].first_key_len = bbf_get_u32le(p);
+        p += sizeof(uint32_t);
+        if (parts[i].first_key_len == 0 || (size_t)(end - p) < parts[i].first_key_len)
+        {
+            bbf_partitions_free(parts, i);
+            return -1;
+        }
+        parts[i].first_key = malloc(parts[i].first_key_len);
+        if (!parts[i].first_key)
+        {
+            bbf_partitions_free(parts, i);
+            return -1;
+        }
+        memcpy(parts[i].first_key, p, parts[i].first_key_len);
+        p += parts[i].first_key_len;
+        resident += parts[i].first_key_len;
+    }
+
+    *out_parts = parts;
+    *out_n = n;
+    *out_resident = resident;
+    return 0;
+}
+
+int blocked_bloom_reader_open(blocked_bloom_reader_t **out, uint64_t dir_offset, uint32_t dir_size,
+                              blocked_bloom_comparator_fn cmp, void *cmp_ctx,
+                              blocked_bloom_fetch_fn fetch_fn, blocked_bloom_release_fn release_fn,
+                              void *cb_ctx)
+{
+    if (!out || !cmp || !fetch_fn || dir_size == 0) return -1;
+
+    const uint8_t *dir_data = NULL;
+    void *pin = NULL;
+    if (fetch_fn(cb_ctx, dir_offset, dir_size, &dir_data, &pin) != 0 || !dir_data) return -1;
+
+    bbf_partition_t *parts = NULL;
+    uint32_t n = 0;
+    size_t resident = 0;
+    int rc = bbf_parse_dir(dir_data, dir_size, &parts, &n, &resident);
+    if (pin && release_fn) release_fn(cb_ctx, pin);
+    if (rc != 0) return -1;
+
+    blocked_bloom_reader_t *r = calloc(1, sizeof(*r));
+    if (!r)
+    {
+        bbf_partitions_free(parts, n);
+        return -1;
+    }
+    r->cmp = cmp;
+    r->cmp_ctx = cmp_ctx;
+    r->fetch_fn = fetch_fn;
+    r->release_fn = release_fn;
+    r->cb_ctx = cb_ctx;
+    r->parts = parts;
+    r->num_parts = n;
+    r->resident_bytes = sizeof(*r) + resident;
+    *out = r;
+    return 0;
+}
+
+/* index of the partition whose range covers key, or -1 if key sorts before the first partition.
+ * partitions are ascending, so this is the rightmost first_key <= key. */
+static int64_t bbf_route(const blocked_bloom_reader_t *r, const uint8_t *key, size_t key_size)
+{
+    int64_t lo = 0, hi = (int64_t)r->num_parts - 1, res = -1;
+    while (lo <= hi)
+    {
+        int64_t mid = lo + (hi - lo) / 2;
+        int c =
+            r->cmp(r->parts[mid].first_key, r->parts[mid].first_key_len, key, key_size, r->cmp_ctx);
+        if (c <= 0)
+        {
+            res = mid;
+            lo = mid + 1;
+        }
+        else
+        {
+            hi = mid - 1;
+        }
+    }
+    return res;
+}
+
+int blocked_bloom_reader_maybe_contains(blocked_bloom_reader_t *r, const uint8_t *key,
+                                        size_t key_size)
+{
+    if (!r || !key || key_size == 0) return -1;
+    if (r->num_parts == 0) return 1; /* no filter -- safe answer is may-present */
+
+    int64_t idx = bbf_route(r, key, key_size);
+    if (idx < 0) return 0; /* sorts before every partition -- definitely absent */
+
+    const bbf_partition_t *e = &r->parts[idx];
+    const uint8_t *blob = NULL;
+    void *pin = NULL;
+    if (r->fetch_fn(r->cb_ctx, e->offset, e->size, &blob, &pin) != 0 || !blob) return -1;
+
+    /* probe the pinned partition in place -- no filter is materialized per query */
+    const int c = bloom_filter_contains_serialized(blob, e->size, key, key_size);
+    if (pin && r->release_fn) r->release_fn(r->cb_ctx, pin);
+    return c;
+}
+
+size_t blocked_bloom_reader_resident_bytes(const blocked_bloom_reader_t *r)
+{
+    return r ? r->resident_bytes : 0;
+}
+
+void blocked_bloom_reader_free(blocked_bloom_reader_t *r)
+{
+    if (!r) return;
+    bbf_partitions_free(r->parts, r->num_parts);
+    free(r);
+}

--- a/src/blocked_bloom_filter.h
+++ b/src/blocked_bloom_filter.h
@@ -1,0 +1,196 @@
+/**
+ *
+ * Copyright (C) TidesDB
+ *
+ * Original Author: Alex Gaetano Padula
+ *
+ * Licensed under the Mozilla Public License, v. 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.mozilla.org/en-US/MPL/2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __BLOCKED_BLOOM_FILTER_H__
+#define __BLOCKED_BLOOM_FILTER_H__
+#include "bloom_filter.h"
+#include "compat.h"
+
+/**
+ * a per-sstable bloom filter, split into range partitions so its resident cost is bounded by the
+ * block cache rather than by the entry count.
+ *
+ * the key space is split, in sorted write order, into range partitions. each partition is an
+ * ordinary bloom_filter_t over its range, serialized to its own blob in the sstable's block-managed
+ * file. only a small directory of partition first-keys stays resident; the partition blobs are
+ * fetched on demand and are meant to live in the block cache. partitions are accumulated as they
+ * fill and written together when the build is finalized, so the aux region lands after the
+ * sstable's klog data and its data blocks stay contiguous.
+ *
+ * the directory holds each partition's full first-key, so routing a query to its partition is exact
+ * and the filter never reports a false negative.
+ *
+ * the writer is single-threaded and keys must arrive in non-decreasing comparator order. once
+ * built, a reader is read-only and may be queried concurrently by any number of threads.
+ */
+
+/* default number of keys per partition before rollover. at fpr 0.01 a partition holds roughly
+ * 1.2 bytes of filter per key, so the default keeps each partition blob around 80 KiB -- large
+ * enough to amortize the per-partition header, small enough to page and evict cheaply */
+#define TDB_BLOCKED_BLOOM_DEFAULT_PARTITION_ENTRIES 65536
+
+/**
+ * blocked_bloom_write_fn
+ * persist a finalized blob (a partition, or the directory) and report where it landed. the builder
+ * calls this for each accumulated partition and then the directory when it is finalized. the
+ * returned offset is opaque to the builder and is handed back to the reader's fetch to locate the
+ * same blob.
+ * @param ctx caller context
+ * @param data blob bytes
+ * @param size blob length
+ * @param out_offset receives the durable offset the blob was written at
+ * @return 0 on success, non-zero to abort the build
+ */
+typedef int (*blocked_bloom_write_fn)(void *ctx, const uint8_t *data, size_t size,
+                                      uint64_t *out_offset);
+
+/**
+ * blocked_bloom_fetch_fn
+ * fetch a previously written blob for reading. on success *out_data points at exactly `size`
+ * readable bytes that stay valid until release is called with *out_pin (which may be NULL when
+ * the buffer needs no pin, e.g. a test backing store). the intended production implementation
+ * is a block-cache lookup that faults the blob in on a miss and returns a pinned handle.
+ * @param ctx caller context
+ * @param offset blob offset reported earlier by the write sink
+ * @param size blob length to fetch
+ * @param out_data receives a readable buffer of `size` bytes valid until release
+ * @param out_pin receives a pin handle to pass to release, or NULL when none is needed
+ * @return 0 on success, non-zero on failure (a failure is treated as may-be-present)
+ */
+typedef int (*blocked_bloom_fetch_fn)(void *ctx, uint64_t offset, uint32_t size,
+                                      const uint8_t **out_data, void **out_pin);
+
+/**
+ * blocked_bloom_release_fn
+ * release a pin returned by fetch. never called for a NULL pin.
+ * @param ctx caller context
+ * @param pin the pin handle fetch produced
+ */
+typedef void (*blocked_bloom_release_fn)(void *ctx, void *pin);
+
+/**
+ * blocked_bloom_comparator_fn
+ * total order over keys, matching tidesdb_comparator_fn. used only to route a query key to its
+ * partition; the partition bloom itself hashes raw key bytes.
+ * @param key1 first key
+ * @param key1_size first key length
+ * @param key2 second key
+ * @param key2_size second key length
+ * @param ctx comparator context
+ * @return negative, zero, or positive as key1 orders before, equal to, or after key2
+ */
+typedef int (*blocked_bloom_comparator_fn)(const uint8_t *key1, size_t key1_size,
+                                           const uint8_t *key2, size_t key2_size, void *ctx);
+
+typedef struct blocked_bloom_builder blocked_bloom_builder_t;
+typedef struct blocked_bloom_reader blocked_bloom_reader_t;
+
+/**
+ * blocked_bloom_builder_new
+ * open a builder. keys are added in non-decreasing comparator order; each partition is serialized
+ * as it fills and all partitions are written via write_fn when the builder is finalized.
+ * @param out receives the builder
+ * @param fpr per-partition target false-positive rate, in (0, 1)
+ * @param partition_entries keys per partition before rollover; 0 selects the default
+ * @param write_fn sink for finalized partition and directory blobs
+ * @param write_ctx context passed to write_fn
+ * @return 0 on success, non-zero on invalid arguments or allocation failure
+ */
+int blocked_bloom_builder_new(blocked_bloom_builder_t **out, double fpr, uint32_t partition_entries,
+                              blocked_bloom_write_fn write_fn, void *write_ctx);
+
+/**
+ * blocked_bloom_builder_add
+ * add the next key. keys must be non-decreasing under the order the reader will use.
+ * @param b the builder, or NULL to make this a no-op (the filter is disabled)
+ * @param key the key to add
+ * @param key_size the key length
+ * @return 0 on success (or when b is NULL), non-zero on an allocation failure
+ */
+int blocked_bloom_builder_add(blocked_bloom_builder_t *b, const uint8_t *key, size_t key_size);
+
+/**
+ * blocked_bloom_builder_finish
+ * finalize the trailing partition, then serialize and write the directory. the directory's
+ * location and the total key count are returned for the sstable footer to record and hand to
+ * blocked_bloom_reader_open later. a build that added no keys writes an empty directory.
+ * @param out_dir_offset receives the directory blob offset
+ * @param out_dir_size receives the directory blob size
+ * @param out_total_entries receives the total number of keys added (may be NULL)
+ * @return 0 on success, non-zero on a write or allocation failure
+ */
+int blocked_bloom_builder_finish(blocked_bloom_builder_t *b, uint64_t *out_dir_offset,
+                                 uint32_t *out_dir_size, uint64_t *out_total_entries);
+
+/**
+ * blocked_bloom_builder_free
+ * release the builder. safe on NULL.
+ * @param b the builder
+ */
+void blocked_bloom_builder_free(blocked_bloom_builder_t *b);
+
+/**
+ * blocked_bloom_reader_open
+ * open a reader over a built filter, loading only the directory (one fetch at dir_offset). the
+ * comparator and fetch callbacks are retained and used per query. an empty directory
+ * (dir_size describing zero partitions) yields a reader whose queries all return may-present,
+ * which is the safe answer when no filter was built.
+ * @param out receives the reader
+ * @param dir_offset directory blob offset from builder_finish
+ * @param dir_size directory blob size from builder_finish
+ * @param cmp key order used to route a query to its partition
+ * @param cmp_ctx context passed to cmp
+ * @param fetch_fn source for the directory and partition blobs
+ * @param release_fn releases fetch pins
+ * @param cb_ctx context passed to fetch_fn and release_fn
+ * @return 0 on success, non-zero on a fetch or allocation failure
+ */
+int blocked_bloom_reader_open(blocked_bloom_reader_t **out, uint64_t dir_offset, uint32_t dir_size,
+                              blocked_bloom_comparator_fn cmp, void *cmp_ctx,
+                              blocked_bloom_fetch_fn fetch_fn, blocked_bloom_release_fn release_fn,
+                              void *cb_ctx);
+
+/**
+ * blocked_bloom_reader_maybe_contains
+ * route the key to its partition and probe that partition's bloom.
+ * @param r the reader
+ * @param key the key to test
+ * @param key_size the key length
+ * @return 1 if the key may be present, 0 if it is definitely absent, negative on a fetch or
+ *         decode error (callers must treat a negative result as may-be-present)
+ */
+int blocked_bloom_reader_maybe_contains(blocked_bloom_reader_t *r, const uint8_t *key,
+                                        size_t key_size);
+
+/**
+ * blocked_bloom_reader_resident_bytes
+ * bytes the reader keeps resident (the directory). the partition blobs are not counted -- they
+ * live in the fetch backing store (the block cache).
+ * @param r the reader
+ * @return resident byte count, or 0 when r is NULL
+ */
+size_t blocked_bloom_reader_resident_bytes(const blocked_bloom_reader_t *r);
+
+/**
+ * blocked_bloom_reader_free
+ * release the reader. safe on NULL.
+ * @param r the reader
+ */
+void blocked_bloom_reader_free(blocked_bloom_reader_t *r);
+
+#endif /* __BLOCKED_BLOOM_FILTER_H__ */

--- a/src/blocked_index.c
+++ b/src/blocked_index.c
@@ -1,0 +1,564 @@
+/**
+ *
+ * Copyright (C) TidesDB
+ *
+ * Original Author: Alex Gaetano Padula
+ *
+ * Licensed under the Mozilla Public License, v. 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.mozilla.org/en-US/MPL/2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "blocked_index.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+/* directory blob layout, all little-endian
+ *   magic (4) | version (4) | partition_count (4)
+ *   then partition_count records of
+ *     leaf_offset (8) | leaf_size (4) | block_count (4) | first_key_len (4) | first_key bytes
+ *
+ * leaf blob layout, all little-endian. an offset table lets the reader binary-search the
+ * variable-length records in place, with no per-lookup allocation.
+ *   block_count (4) | offsets[block_count] (4 each, byte offset of the record within the leaf)
+ *   then block_count records of
+ *     first_key_len (4) | first_key bytes | block_offset (8)
+ * records are in ascending first-key order. */
+#define BI_DIR_MAGIC   0x49424254u /* "TBBI" little-endian */
+#define BI_DIR_VERSION 1u
+/* magic + version + partition_count */
+#define BI_DIR_HEADER_BYTES (3 * sizeof(uint32_t))
+/* per-record bytes before the variable first_key: leaf_offset + leaf_size + block_count +
+ * first_key_len */
+#define BI_DIR_ENTRY_FIXED (sizeof(uint64_t) + 3 * sizeof(uint32_t))
+/* per-leaf-record bytes around the variable key: first_key_len + block_offset */
+#define BI_LEAF_REC_FIXED (sizeof(uint32_t) + sizeof(uint64_t))
+
+/* little-endian byte codecs for the directory and leaves, endian-canonical so an index built on one
+ * host reads back identically on another */
+static void bi_put_u32le(uint8_t *p, uint32_t v)
+{
+    for (size_t i = 0; i < sizeof(uint32_t); i++) p[i] = (uint8_t)(v >> (8 * i));
+}
+
+static void bi_put_u64le(uint8_t *p, uint64_t v)
+{
+    for (size_t i = 0; i < sizeof(uint64_t); i++) p[i] = (uint8_t)(v >> (8 * i));
+}
+
+static uint32_t bi_get_u32le(const uint8_t *p)
+{
+    uint32_t v = 0;
+    for (size_t i = 0; i < sizeof(uint32_t); i++) v |= (uint32_t)p[i] << (8 * i);
+    return v;
+}
+
+static uint64_t bi_get_u64le(const uint8_t *p)
+{
+    uint64_t v = 0;
+    for (size_t i = 0; i < sizeof(uint64_t); i++) v |= (uint64_t)p[i] << (8 * i);
+    return v;
+}
+
+/* one block as accumulated by the builder for the leaf it is filling */
+typedef struct
+{
+    uint8_t *first_key; /* owned copy */
+    uint32_t first_key_len;
+    uint64_t block_offset;
+} bi_block_t;
+
+/* one partition (leaf) as recorded in the directory */
+typedef struct
+{
+    uint8_t *leaf_blob; /* serialized leaf, held until finish writes it (builder only) */
+    uint64_t leaf_offset;
+    uint32_t leaf_size;
+    uint32_t block_count;
+    uint64_t base;      /* ordinal of this partition's first block, filled at reader open */
+    uint8_t *first_key; /* owned copy of the partition's first block first-key */
+    uint32_t first_key_len;
+} bi_part_t;
+
+struct blocked_index_builder
+{
+    uint32_t blocks_per_partition;
+    blocked_index_write_fn write_fn;
+    void *write_ctx;
+
+    bi_block_t *cur; /* blocks of the leaf being filled */
+    uint32_t cur_count;
+    uint32_t cur_cap;
+
+    bi_part_t *parts;
+    size_t num_parts;
+    size_t cap_parts;
+
+    uint64_t total_blocks;
+    int failed; /* sticky -- a write or allocation failure poisons the build */
+};
+
+struct blocked_index_reader
+{
+    blocked_index_comparator_fn cmp;
+    void *cmp_ctx;
+    blocked_index_fetch_fn fetch_fn;
+    blocked_index_release_fn release_fn;
+    void *cb_ctx;
+
+    bi_part_t *parts; /* ascending first-key order; first_key owned */
+    uint32_t num_parts;
+    size_t resident_bytes;
+};
+
+static void bi_parts_free(bi_part_t *parts, size_t n)
+{
+    if (!parts) return;
+    for (size_t i = 0; i < n; i++)
+    {
+        free(parts[i].first_key);
+        free(parts[i].leaf_blob);
+    }
+    free(parts);
+}
+
+static void bi_cur_free(blocked_index_builder_t *b)
+{
+    for (uint32_t i = 0; i < b->cur_count; i++) free(b->cur[i].first_key);
+    b->cur_count = 0;
+}
+
+int blocked_index_builder_new(blocked_index_builder_t **out, uint32_t blocks_per_partition,
+                              blocked_index_write_fn write_fn, void *write_ctx)
+{
+    if (!out || !write_fn) return -1;
+    if (blocks_per_partition == 0)
+        blocks_per_partition = TDB_BLOCKED_INDEX_DEFAULT_BLOCKS_PER_PARTITION;
+
+    blocked_index_builder_t *b = calloc(1, sizeof(*b));
+    if (!b) return -1;
+    b->blocks_per_partition = blocks_per_partition;
+    b->write_fn = write_fn;
+    b->write_ctx = write_ctx;
+    *out = b;
+    return 0;
+}
+
+/* serialize the current leaf and record the partition, holding its blob until finish writes it
+ * after the sstable's klog data. a no-op when the leaf is empty. takes ownership of the first
+ * block's first-key for the directory entry. */
+static int bi_seal_leaf(blocked_index_builder_t *b)
+{
+    if (b->cur_count == 0) return 0;
+
+    /* leaf header is a block_count then an offset-table slot per record, both u32 */
+    const size_t header = sizeof(uint32_t) + (size_t)sizeof(uint32_t) * b->cur_count;
+    size_t body = 0;
+    for (uint32_t i = 0; i < b->cur_count; i++) body += BI_LEAF_REC_FIXED + b->cur[i].first_key_len;
+    size_t leaf_size = header + body;
+    if (leaf_size > UINT32_MAX) return -1;
+
+    uint8_t *leaf = malloc(leaf_size);
+    if (!leaf) return -1;
+
+    bi_put_u32le(leaf, b->cur_count);
+    uint8_t *rec = leaf + header; /* records begin after the offset table */
+    for (uint32_t i = 0; i < b->cur_count; i++)
+    {
+        /* offset of record i in the offset table */
+        bi_put_u32le(leaf + sizeof(uint32_t) + (size_t)sizeof(uint32_t) * i,
+                     (uint32_t)(rec - leaf));
+        bi_put_u32le(rec, b->cur[i].first_key_len);
+        rec += sizeof(uint32_t);
+        memcpy(rec, b->cur[i].first_key, b->cur[i].first_key_len);
+        rec += b->cur[i].first_key_len;
+        bi_put_u64le(rec, b->cur[i].block_offset);
+        rec += sizeof(uint64_t);
+    }
+
+    if (b->num_parts == b->cap_parts)
+    {
+        size_t ncap = b->cap_parts ? b->cap_parts * 2 : 16;
+        bi_part_t *np = realloc(b->parts, ncap * sizeof(*np));
+        if (!np)
+        {
+            free(leaf);
+            return -1;
+        }
+        b->parts = np;
+        b->cap_parts = ncap;
+    }
+
+    bi_part_t *e = &b->parts[b->num_parts++];
+    e->leaf_blob = leaf; /* written at finish */
+    e->leaf_offset = 0;  /* filled at finish */
+    e->leaf_size = (uint32_t)leaf_size;
+    e->block_count = b->cur_count;
+    e->base = 0;
+    e->first_key = b->cur[0].first_key; /* ownership transferred */
+    e->first_key_len = b->cur[0].first_key_len;
+    b->cur[0].first_key = NULL;
+
+    bi_cur_free(b);
+    return 0;
+}
+
+int blocked_index_builder_add(blocked_index_builder_t *b, const uint8_t *first_key,
+                              size_t first_key_size, uint64_t block_offset)
+{
+    if (!b) return 0; /* a NULL builder means the index is disabled -- adding is a no-op */
+    if (!first_key || first_key_size == 0) return -1;
+    if (b->failed) return -1;
+
+    if (b->cur_count == b->cur_cap)
+    {
+        uint32_t ncap = b->cur_cap ? b->cur_cap * 2 : 64;
+        if (ncap > b->blocks_per_partition) ncap = b->blocks_per_partition;
+        bi_block_t *nc = realloc(b->cur, (size_t)ncap * sizeof(*nc));
+        if (!nc)
+        {
+            b->failed = 1;
+            return -1;
+        }
+        b->cur = nc;
+        b->cur_cap = ncap;
+    }
+
+    uint8_t *kc = malloc(first_key_size);
+    if (!kc)
+    {
+        b->failed = 1;
+        return -1;
+    }
+    memcpy(kc, first_key, first_key_size);
+    b->cur[b->cur_count].first_key = kc;
+    b->cur[b->cur_count].first_key_len = (uint32_t)first_key_size;
+    b->cur[b->cur_count].block_offset = block_offset;
+    b->cur_count++;
+    b->total_blocks++;
+
+    if (b->cur_count >= b->blocks_per_partition)
+    {
+        if (bi_seal_leaf(b) != 0)
+        {
+            b->failed = 1;
+            return -1;
+        }
+    }
+    return 0;
+}
+
+/* serialized directory size for the recorded partitions */
+static size_t bi_dir_size(const blocked_index_builder_t *b)
+{
+    size_t total = BI_DIR_HEADER_BYTES;
+    for (size_t i = 0; i < b->num_parts; i++)
+        total += BI_DIR_ENTRY_FIXED + b->parts[i].first_key_len;
+    return total;
+}
+
+int blocked_index_builder_finish(blocked_index_builder_t *b, uint64_t *out_dir_offset,
+                                 uint32_t *out_dir_size, uint64_t *out_total_blocks)
+{
+    if (!b || !out_dir_offset || !out_dir_size) return -1;
+    if (b->failed) return -1;
+
+    if (bi_seal_leaf(b) != 0)
+    {
+        b->failed = 1;
+        return -1;
+    }
+
+    /* write every buffered leaf now -- the caller invokes finish from the sstable footer, after the
+     * klog data blocks, so these land contiguously past the data and their offsets are final */
+    for (size_t i = 0; i < b->num_parts; i++)
+    {
+        uint64_t offset = 0;
+        int rc = b->write_fn(b->write_ctx, b->parts[i].leaf_blob, b->parts[i].leaf_size, &offset);
+        if (rc != 0)
+        {
+            b->failed = 1;
+            return rc;
+        }
+        b->parts[i].leaf_offset = offset;
+        free(b->parts[i].leaf_blob);
+        b->parts[i].leaf_blob = NULL;
+    }
+
+    size_t dir_size = bi_dir_size(b);
+    if (dir_size > UINT32_MAX) return -1;
+    uint8_t *dir = malloc(dir_size);
+    if (!dir) return -1;
+
+    uint8_t *p = dir;
+    bi_put_u32le(p, BI_DIR_MAGIC);
+    p += sizeof(uint32_t);
+    bi_put_u32le(p, BI_DIR_VERSION);
+    p += sizeof(uint32_t);
+    bi_put_u32le(p, (uint32_t)b->num_parts);
+    p += sizeof(uint32_t);
+    for (size_t i = 0; i < b->num_parts; i++)
+    {
+        const bi_part_t *e = &b->parts[i];
+        bi_put_u64le(p, e->leaf_offset);
+        p += sizeof(uint64_t);
+        bi_put_u32le(p, e->leaf_size);
+        p += sizeof(uint32_t);
+        bi_put_u32le(p, e->block_count);
+        p += sizeof(uint32_t);
+        bi_put_u32le(p, e->first_key_len);
+        p += sizeof(uint32_t);
+        memcpy(p, e->first_key, e->first_key_len);
+        p += e->first_key_len;
+    }
+
+    uint64_t offset = 0;
+    int rc = b->write_fn(b->write_ctx, dir, dir_size, &offset);
+    free(dir);
+    if (rc != 0) return rc;
+
+    *out_dir_offset = offset;
+    *out_dir_size = (uint32_t)dir_size;
+    if (out_total_blocks) *out_total_blocks = b->total_blocks;
+    return 0;
+}
+
+void blocked_index_builder_free(blocked_index_builder_t *b)
+{
+    if (!b) return;
+    bi_cur_free(b);
+    free(b->cur);
+    bi_parts_free(b->parts, b->num_parts);
+    free(b);
+}
+
+/* parse a directory blob into an ascending array of partitions and fill each partition's base
+ * ordinal from the running block total. returns 0 on success. */
+static int bi_parse_dir(const uint8_t *data, size_t len, bi_part_t **out_parts, uint32_t *out_n,
+                        size_t *out_resident)
+{
+    if (len < BI_DIR_HEADER_BYTES) return -1;
+    if (bi_get_u32le(data) != BI_DIR_MAGIC) return -1;
+    if (bi_get_u32le(data + sizeof(uint32_t)) != BI_DIR_VERSION) return -1;
+    uint32_t n = bi_get_u32le(data + 2 * sizeof(uint32_t));
+
+    if (n == 0)
+    {
+        *out_parts = NULL;
+        *out_n = 0;
+        *out_resident = 0;
+        return 0;
+    }
+
+    bi_part_t *parts = calloc(n, sizeof(*parts));
+    if (!parts) return -1;
+
+    size_t resident = n * sizeof(*parts);
+    uint64_t base = 0;
+    const uint8_t *p = data + BI_DIR_HEADER_BYTES;
+    const uint8_t *end = data + len;
+    for (uint32_t i = 0; i < n; i++)
+    {
+        if ((size_t)(end - p) < BI_DIR_ENTRY_FIXED)
+        {
+            bi_parts_free(parts, i);
+            return -1;
+        }
+        parts[i].leaf_offset = bi_get_u64le(p);
+        p += sizeof(uint64_t);
+        parts[i].leaf_size = bi_get_u32le(p);
+        p += sizeof(uint32_t);
+        parts[i].block_count = bi_get_u32le(p);
+        p += sizeof(uint32_t);
+        parts[i].first_key_len = bi_get_u32le(p);
+        p += sizeof(uint32_t);
+        if (parts[i].first_key_len == 0 || (size_t)(end - p) < parts[i].first_key_len)
+        {
+            bi_parts_free(parts, i);
+            return -1;
+        }
+        parts[i].first_key = malloc(parts[i].first_key_len);
+        if (!parts[i].first_key)
+        {
+            bi_parts_free(parts, i);
+            return -1;
+        }
+        memcpy(parts[i].first_key, p, parts[i].first_key_len);
+        p += parts[i].first_key_len;
+        parts[i].base = base;
+        base += parts[i].block_count;
+        resident += parts[i].first_key_len;
+    }
+
+    *out_parts = parts;
+    *out_n = n;
+    *out_resident = resident;
+    return 0;
+}
+
+int blocked_index_reader_open(blocked_index_reader_t **out, uint64_t dir_offset, uint32_t dir_size,
+                              blocked_index_comparator_fn cmp, void *cmp_ctx,
+                              blocked_index_fetch_fn fetch_fn, blocked_index_release_fn release_fn,
+                              void *cb_ctx)
+{
+    if (!out || !cmp || !fetch_fn || dir_size == 0) return -1;
+
+    const uint8_t *dir_data = NULL;
+    void *pin = NULL;
+    if (fetch_fn(cb_ctx, dir_offset, dir_size, &dir_data, &pin) != 0 || !dir_data) return -1;
+
+    bi_part_t *parts = NULL;
+    uint32_t n = 0;
+    size_t resident = 0;
+    int rc = bi_parse_dir(dir_data, dir_size, &parts, &n, &resident);
+    if (pin && release_fn) release_fn(cb_ctx, pin);
+    if (rc != 0) return -1;
+
+    blocked_index_reader_t *r = calloc(1, sizeof(*r));
+    if (!r)
+    {
+        bi_parts_free(parts, n);
+        return -1;
+    }
+    r->cmp = cmp;
+    r->cmp_ctx = cmp_ctx;
+    r->fetch_fn = fetch_fn;
+    r->release_fn = release_fn;
+    r->cb_ctx = cb_ctx;
+    r->parts = parts;
+    r->num_parts = n;
+    r->resident_bytes = sizeof(*r) + resident;
+    *out = r;
+    return 0;
+}
+
+/* index of the partition whose range covers key, or -1 if key sorts before the first partition */
+static int64_t bi_route(const blocked_index_reader_t *r, const uint8_t *key, size_t key_size)
+{
+    int64_t lo = 0, hi = (int64_t)r->num_parts - 1, res = -1;
+    while (lo <= hi)
+    {
+        int64_t mid = lo + (hi - lo) / 2;
+        int c =
+            r->cmp(r->parts[mid].first_key, r->parts[mid].first_key_len, key, key_size, r->cmp_ctx);
+        if (c <= 0)
+        {
+            res = mid;
+            lo = mid + 1;
+        }
+        else
+        {
+            hi = mid - 1;
+        }
+    }
+    return res;
+}
+
+/* locate record i in a leaf blob, validating every offset against the blob length. sets the key and
+ * block offset for a valid record. returns 0 on success, -1 on a malformed leaf. */
+static int bi_leaf_record(const uint8_t *leaf, uint32_t leaf_size, uint32_t block_count, uint32_t i,
+                          const uint8_t **out_key, uint32_t *out_key_len,
+                          uint64_t *out_block_offset)
+{
+    size_t table_end = sizeof(uint32_t) + (size_t)sizeof(uint32_t) * block_count;
+    if (table_end > leaf_size) return -1;
+    uint32_t rec_off = bi_get_u32le(leaf + sizeof(uint32_t) + (size_t)sizeof(uint32_t) * i);
+    if (rec_off < table_end || (size_t)rec_off + sizeof(uint32_t) > leaf_size) return -1;
+    uint32_t klen = bi_get_u32le(leaf + rec_off);
+    size_t need = (size_t)rec_off + BI_LEAF_REC_FIXED + klen;
+    if (klen == 0 || need > leaf_size) return -1;
+    *out_key = leaf + rec_off + sizeof(uint32_t);
+    *out_key_len = klen;
+    *out_block_offset = bi_get_u64le(leaf + rec_off + sizeof(uint32_t) + klen);
+    return 0;
+}
+
+int blocked_index_reader_find(blocked_index_reader_t *r, const uint8_t *key, size_t key_size,
+                              uint64_t *out_block_offset, uint64_t *out_block_ordinal)
+{
+    if (!r || !key || key_size == 0 || !out_block_offset) return -1;
+    if (r->num_parts == 0) return 0;
+
+    int64_t pi = bi_route(r, key, key_size);
+    if (pi < 0) return 0; /* sorts before every block */
+    const bi_part_t *part = &r->parts[pi];
+
+    const uint8_t *leaf = NULL;
+    void *pin = NULL;
+    if (r->fetch_fn(r->cb_ctx, part->leaf_offset, part->leaf_size, &leaf, &pin) != 0 || !leaf)
+        return -1;
+
+    int ret = -1;
+    if (part->leaf_size >= sizeof(uint32_t))
+    {
+        uint32_t block_count = bi_get_u32le(leaf);
+        if (block_count == part->block_count && block_count > 0)
+        {
+            /* rightmost record whose first-key is <= key */
+            int64_t lo = 0, hi = (int64_t)block_count - 1, res = -1;
+            int ok = 1;
+            while (lo <= hi)
+            {
+                int64_t mid = lo + (hi - lo) / 2;
+                const uint8_t *rk = NULL;
+                uint32_t rklen = 0;
+                uint64_t roff = 0;
+                if (bi_leaf_record(leaf, part->leaf_size, block_count, (uint32_t)mid, &rk, &rklen,
+                                   &roff) != 0)
+                {
+                    ok = 0;
+                    break;
+                }
+                if (r->cmp(rk, rklen, key, key_size, r->cmp_ctx) <= 0)
+                {
+                    res = mid;
+                    lo = mid + 1;
+                }
+                else
+                {
+                    hi = mid - 1;
+                }
+            }
+            if (ok && res >= 0)
+            {
+                const uint8_t *rk = NULL;
+                uint32_t rklen = 0;
+                uint64_t roff = 0;
+                if (bi_leaf_record(leaf, part->leaf_size, block_count, (uint32_t)res, &rk, &rklen,
+                                   &roff) == 0)
+                {
+                    *out_block_offset = roff;
+                    if (out_block_ordinal) *out_block_ordinal = part->base + (uint64_t)res;
+                    ret = 1;
+                }
+            }
+            else if (ok && res < 0)
+            {
+                ret = 0; /* routing guarantees this cannot normally happen */
+            }
+        }
+    }
+
+    if (pin && r->release_fn) r->release_fn(r->cb_ctx, pin);
+    return ret;
+}
+
+size_t blocked_index_reader_resident_bytes(const blocked_index_reader_t *r)
+{
+    return r ? r->resident_bytes : 0;
+}
+
+void blocked_index_reader_free(blocked_index_reader_t *r)
+{
+    if (!r) return;
+    bi_parts_free(r->parts, r->num_parts);
+    free(r);
+}

--- a/src/blocked_index.h
+++ b/src/blocked_index.h
@@ -1,0 +1,203 @@
+/**
+ *
+ * Copyright (C) TidesDB
+ *
+ * Original Author: Alex Gaetano Padula
+ *
+ * Licensed under the Mozilla Public License, v. 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.mozilla.org/en-US/MPL/2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __BLOCKED_INDEX_H__
+#define __BLOCKED_INDEX_H__
+#include "compat.h"
+
+/**
+ * a per-sstable index over klog blocks, split into range partitions so its resident cost is bounded
+ * by the block cache rather than by the amount of data.
+ *
+ * klog blocks are grouped, in sorted write order, into partitions. each partition is a leaf holding
+ * the full first-key and file offset of its blocks, serialized to its own blob in the block-managed
+ * file. only a small directory of partition first-keys stays resident; the leaves are fetched on
+ * demand and are meant to live in the block cache. leaves are accumulated as they fill and written
+ * together when the build is finalized, so the aux region lands after the sstable's klog data and
+ * its data blocks stay contiguous. a leaf holds only block first-keys, so this stays far smaller
+ * than the entry count even while buffered.
+ *
+ * each leaf holds full first-keys, so a lookup routes to exactly one candidate block. a point
+ * lookup reads that block and searches within it; an iterator seeks to it and scans from there, and
+ * can size a range from the block ordinals of its two ends. block first-keys must be strictly
+ * increasing, which holds when a klog block boundary always falls on a key boundary (a key's data
+ * never spans two blocks).
+ *
+ * the writer is single-threaded and blocks must be added in ascending first-key order. once built,
+ * a reader is read-only and may be queried concurrently by any number of threads.
+ */
+
+/* default number of klog blocks described by one leaf before rollover. a leaf is fetched whole per
+ * lookup, so this trades leaf size against directory size; the default keeps a leaf near tens of
+ * KiB for typical key sizes */
+#define TDB_BLOCKED_INDEX_DEFAULT_BLOCKS_PER_PARTITION 4096
+
+/**
+ * blocked_index_write_fn
+ * persist a finalized blob (a leaf, or the directory) and report where it landed. the builder calls
+ * this for each accumulated leaf and then the directory when it is finalized. the returned offset
+ * is opaque to the builder and is handed back to the reader's fetch to locate the same blob.
+ * @param ctx caller context
+ * @param data blob bytes
+ * @param size blob length
+ * @param out_offset receives the durable offset the blob was written at
+ * @return 0 on success, non-zero to abort the build
+ */
+typedef int (*blocked_index_write_fn)(void *ctx, const uint8_t *data, size_t size,
+                                      uint64_t *out_offset);
+
+/**
+ * blocked_index_fetch_fn
+ * fetch a previously written blob for reading. on success *out_data points at exactly `size`
+ * readable bytes valid until release is called with *out_pin (which may be NULL when the buffer
+ * needs no pin). the intended production implementation is a block-cache lookup that faults the
+ * blob in on a miss and returns a pinned handle.
+ * @param ctx caller context
+ * @param offset blob offset reported earlier by the write sink
+ * @param size blob length to fetch
+ * @param out_data receives a readable buffer of `size` bytes valid until release
+ * @param out_pin receives a pin handle to pass to release, or NULL when none is needed
+ * @return 0 on success, non-zero on failure
+ */
+typedef int (*blocked_index_fetch_fn)(void *ctx, uint64_t offset, uint32_t size,
+                                      const uint8_t **out_data, void **out_pin);
+
+/**
+ * blocked_index_release_fn
+ * release a pin returned by fetch. never called for a NULL pin.
+ * @param ctx caller context
+ * @param pin the pin handle fetch produced
+ */
+typedef void (*blocked_index_release_fn)(void *ctx, void *pin);
+
+/**
+ * blocked_index_comparator_fn
+ * total order over keys, matching tidesdb_comparator_fn. used to route a key to its partition and
+ * to its block within the leaf.
+ * @param key1 first key
+ * @param key1_size first key length
+ * @param key2 second key
+ * @param key2_size second key length
+ * @param ctx comparator context
+ * @return negative, zero, or positive as key1 orders before, equal to, or after key2
+ */
+typedef int (*blocked_index_comparator_fn)(const uint8_t *key1, size_t key1_size,
+                                           const uint8_t *key2, size_t key2_size, void *ctx);
+
+typedef struct blocked_index_builder blocked_index_builder_t;
+typedef struct blocked_index_reader blocked_index_reader_t;
+
+/**
+ * blocked_index_builder_new
+ * open a builder. blocks are added in ascending first-key order; each leaf is serialized as it
+ * fills and all leaves are written via write_fn when the builder is finalized.
+ * @param out receives the builder
+ * @param blocks_per_partition klog blocks per leaf before rollover; 0 selects the default
+ * @param write_fn sink for finalized leaf and directory blobs
+ * @param write_ctx context passed to write_fn
+ * @return 0 on success, non-zero on invalid arguments or allocation failure
+ */
+int blocked_index_builder_new(blocked_index_builder_t **out, uint32_t blocks_per_partition,
+                              blocked_index_write_fn write_fn, void *write_ctx);
+
+/**
+ * blocked_index_builder_add
+ * record the next klog block. first-keys must be strictly increasing.
+ * @param b the builder, or NULL to make this a no-op (the index is disabled)
+ * @param first_key the block's first key
+ * @param first_key_size the block's first key length
+ * @param block_offset the block's file offset
+ * @return 0 on success (or when b is NULL), non-zero on an allocation failure
+ */
+int blocked_index_builder_add(blocked_index_builder_t *b, const uint8_t *first_key,
+                              size_t first_key_size, uint64_t block_offset);
+
+/**
+ * blocked_index_builder_finish
+ * finalize the trailing leaf, then serialize and write the directory. the directory's location and
+ * the total block count are returned for the sstable footer to record and hand to
+ * blocked_index_reader_open later. a build that added no blocks writes an empty directory.
+ * @param b the builder
+ * @param out_dir_offset receives the directory blob offset
+ * @param out_dir_size receives the directory blob size
+ * @param out_total_blocks receives the total number of blocks added (may be NULL)
+ * @return 0 on success, non-zero on a write or allocation failure
+ */
+int blocked_index_builder_finish(blocked_index_builder_t *b, uint64_t *out_dir_offset,
+                                 uint32_t *out_dir_size, uint64_t *out_total_blocks);
+
+/**
+ * blocked_index_builder_free
+ * release the builder. safe on NULL.
+ * @param b the builder
+ */
+void blocked_index_builder_free(blocked_index_builder_t *b);
+
+/**
+ * blocked_index_reader_open
+ * open a reader over a built index, loading only the directory (one fetch at dir_offset). the
+ * comparator and fetch callbacks are retained and used per lookup. an empty directory yields a
+ * reader whose lookups all report not-found, which sends the caller to a full scan.
+ * @param out receives the reader
+ * @param dir_offset directory blob offset from builder_finish
+ * @param dir_size directory blob size from builder_finish
+ * @param cmp key order used to route a lookup
+ * @param cmp_ctx context passed to cmp
+ * @param fetch_fn source for the directory and leaf blobs
+ * @param release_fn releases fetch pins
+ * @param cb_ctx context passed to fetch_fn and release_fn
+ * @return 0 on success, non-zero on a fetch or allocation failure
+ */
+int blocked_index_reader_open(blocked_index_reader_t **out, uint64_t dir_offset, uint32_t dir_size,
+                              blocked_index_comparator_fn cmp, void *cmp_ctx,
+                              blocked_index_fetch_fn fetch_fn, blocked_index_release_fn release_fn,
+                              void *cb_ctx);
+
+/**
+ * blocked_index_reader_find
+ * locate the klog block whose range covers the key -- the block with the greatest first-key not
+ * greater than the key.
+ * @param r the reader
+ * @param key the lookup key
+ * @param key_size the key length
+ * @param out_block_offset receives the file offset of the covering block
+ * @param out_block_ordinal receives the covering block's 0-based ordinal across the sstable, so an
+ *        iterator can size a range as the ordinal span of its ends; may be NULL
+ * @return 1 if a covering block was found, 0 if the key sorts before every block (a definite miss),
+ *         negative on a fetch or decode error (the caller should fall back to a full scan)
+ */
+int blocked_index_reader_find(blocked_index_reader_t *r, const uint8_t *key, size_t key_size,
+                              uint64_t *out_block_offset, uint64_t *out_block_ordinal);
+
+/**
+ * blocked_index_reader_resident_bytes
+ * bytes the reader keeps resident (the directory). the leaves are not counted -- they live in the
+ * fetch backing store (the block cache).
+ * @param r the reader
+ * @return resident byte count, or 0 when r is NULL
+ */
+size_t blocked_index_reader_resident_bytes(const blocked_index_reader_t *r);
+
+/**
+ * blocked_index_reader_free
+ * release the reader. safe on NULL.
+ * @param r the reader
+ */
+void blocked_index_reader_free(blocked_index_reader_t *r);
+
+#endif /* __BLOCKED_INDEX_H__ */

--- a/src/bloom_filter.c
+++ b/src/bloom_filter.c
@@ -475,12 +475,14 @@ static int bf_get_varint64(const uint8_t **pp, const uint8_t *end, uint64_t *out
     return 0;
 }
 
-bloom_filter_t *bloom_filter_deserialize(const uint8_t *data, const size_t len)
+/* parse a serialized filter's header (optional version sentinel + format byte, then m and h) and
+ * point *out_body at the bitset body. shared by deserialize and contains_serialized so both read
+ * the framing identically. returns 0 on success, -1 on a truncated or invalid header. */
+static int bf_parse_header(const uint8_t *data, size_t len, unsigned int *out_encoding,
+                           unsigned int *out_hash_version, unsigned int *out_m, unsigned int *out_h,
+                           const uint8_t **out_body)
 {
-    if (data == NULL || len == 0)
-    {
-        return NULL;
-    }
+    if (data == NULL || len == 0) return -1;
 
     const uint8_t *ptr = data;
     const uint8_t *const end = data + len;
@@ -494,45 +496,44 @@ bloom_filter_t *bloom_filter_deserialize(const uint8_t *data, const size_t len)
     unsigned int encoding = BF_ENCODING_SPARSE;
     if (ptr[0] == BF_SERIALIZE_VERSION_SENTINEL)
     {
-        if (end - ptr < BF_SERIALIZE_VERSION_BYTES) return NULL; /* sentinel + format byte */
-        ptr++;                                                   /* skip sentinel */
+        if (end - ptr < BF_SERIALIZE_VERSION_BYTES) return -1; /* sentinel + format byte */
+        ptr++;                                                 /* skip sentinel */
         const uint8_t format = *ptr++;
         hash_version = BF_FORMAT_HASH_VERSION(format);
         encoding = BF_FORMAT_ENCODING(format);
         /* reject an unknown hash version (querying with an undefined scheme would
          * silently false-negative) or an unknown bitset encoding */
         if (hash_version < BF_HASH_VERSION_LEGACY || hash_version > BF_HASH_VERSION_CURRENT)
-        {
-            return NULL;
-        }
-        if (encoding != BF_ENCODING_SPARSE && encoding != BF_ENCODING_DENSE)
-        {
-            return NULL;
-        }
+            return -1;
+        if (encoding != BF_ENCODING_SPARSE && encoding != BF_ENCODING_DENSE) return -1;
     }
 
     /* we read header with bounded varint decoding */
     uint32_t m_u32, h_u32;
-    if (bf_get_varint32(&ptr, end, &m_u32) != 0) return NULL;
-    if (bf_get_varint32(&ptr, end, &h_u32) != 0) return NULL;
+    if (bf_get_varint32(&ptr, end, &m_u32) != 0) return -1;
+    if (bf_get_varint32(&ptr, end, &h_u32) != 0) return -1;
 
-    const unsigned int m = m_u32;
-    const unsigned int h = h_u32;
+    /* h is the per-query probe count, so an out-of-range h from a corrupt filter would turn every
+     * query into a multi-billion-iteration loop. reject it with the same cap the constructor
+     * enforces, which a valid filter can never exceed. */
+    if (m_u32 == 0 || h_u32 == 0 || h_u32 > BF_MAX_HASH_FUNCTIONS) return -1;
+    if (m_u32 > UINT32_MAX - BF_BITS_PER_WORD) return -1; /* size calculation overflow */
 
-    /* we validate deserialized values. h is the per-query probe count, so an out-of-range h from a
-     * corrupt filter would turn every contains() into a multi-billion-iteration loop. reject it
-     * with the same cap the constructor enforces, which a valid filter can never exceed. */
-    if (m == 0 || h == 0 || h > BF_MAX_HASH_FUNCTIONS)
-    {
-        return NULL;
-    }
+    *out_encoding = encoding;
+    *out_hash_version = hash_version;
+    *out_m = m_u32;
+    *out_h = h_u32;
+    *out_body = ptr;
+    return 0;
+}
 
-    /* we check for potential integer overflow in size calculation */
-    if (m > UINT32_MAX - BF_BITS_PER_WORD)
-    {
-        return NULL;
-    }
+bloom_filter_t *bloom_filter_deserialize(const uint8_t *data, const size_t len)
+{
+    unsigned int encoding, hash_version, m, h;
+    const uint8_t *ptr;
+    if (bf_parse_header(data, len, &encoding, &hash_version, &m, &h, &ptr) != 0) return NULL;
 
+    const uint8_t *const end = data + len;
     const unsigned int size_in_words = (m + BF_BITS_PER_WORD - 1) / BF_BITS_PER_WORD;
 
     /* we allocate and zero-initialize bitset */
@@ -610,6 +611,56 @@ bloom_filter_t *bloom_filter_deserialize(const uint8_t *data, const size_t len)
     bf->hash_version = hash_version;
 
     return bf;
+}
+
+int bloom_filter_contains_serialized(const uint8_t *data, const size_t len, const uint8_t *entry,
+                                     const size_t size)
+{
+    if (data == NULL || entry == NULL || size == 0) return -1;
+
+    unsigned int encoding, hash_version, m, h;
+    const uint8_t *body;
+    if (bf_parse_header(data, len, &encoding, &hash_version, &m, &h, &body) != 0) return -1;
+
+    /* the sparse encoding is rare for a well-filled filter; fall back to a full deserialize rather
+     * than re-scan its varint word list on every probe */
+    if (encoding != BF_ENCODING_DENSE)
+    {
+        bloom_filter_t *bf = bloom_filter_deserialize(data, len);
+        if (bf == NULL) return -1;
+        const int r = bloom_filter_contains(bf, entry, size);
+        bloom_filter_free(bf);
+        return r;
+    }
+
+    const uint8_t *const end = data + len;
+    const unsigned int size_in_words = (m + BF_BITS_PER_WORD - 1) / BF_BITS_PER_WORD;
+    if ((size_t)(end - body) < (size_t)size_in_words * BF_DENSE_WORD_BYTES) return -1;
+
+    /* a stack header carries only the fields the hash derivation reads; the raw bitset is probed in
+     * place, one little-endian word at a time, so no filter is materialized */
+    bloom_filter_t hdr;
+    hdr.m = m;
+    hdr.h = h;
+    hdr.size_in_words = size_in_words;
+    hdr.hash_version = hash_version;
+    hdr.bitset = NULL;
+
+    uint32_t h1, h2;
+    bf_derive_hashes(&hdr, entry, size, &h1, &h2);
+
+    for (unsigned int i = 0; i < h; i++)
+    {
+        const uint32_t index = bf_fast_range(h1 + i * h2, m);
+        const uint8_t *const w = body + (size_t)(index / BF_BITS_PER_WORD) * BF_DENSE_WORD_BYTES;
+        uint64_t word = 0;
+        for (int j = 0; j < BF_DENSE_WORD_BYTES; j++) word |= (uint64_t)w[j] << (8 * j);
+        if (BF_LIKELY(!((word >> (index % BF_BITS_PER_WORD)) & 1ULL)))
+        {
+            return 0; /* definitely not in set */
+        }
+    }
+    return 1; /* probably in set */
 }
 
 void bloom_filter_free(bloom_filter_t *bf)

--- a/src/bloom_filter.h
+++ b/src/bloom_filter.h
@@ -81,6 +81,22 @@ void bloom_filter_add(const bloom_filter_t *bf, const uint8_t *entry, size_t siz
 int bloom_filter_contains(const bloom_filter_t *bf, const uint8_t *entry, size_t size);
 
 /**
+ * bloom_filter_contains_serialized
+ * checks if an entry is in a serialized filter (as produced by bloom_filter_serialize) without
+ * materializing a bloom_filter_t. the common dense encoding is probed in place over the buffer, one
+ * word at a time, so no bitset is allocated or copied; the rare sparse encoding falls back to a
+ * full deserialize. accepts every framing bloom_filter_deserialize accepts.
+ * @param data serialized filter bytes
+ * @param len length of data
+ * @param entry the entry to check
+ * @param size the size of the entry
+ * @return 1 if probably present, 0 if definitely absent, -1 on a NULL/empty entry or a malformed
+ *         or truncated serialized filter
+ */
+int bloom_filter_contains_serialized(const uint8_t *data, size_t len, const uint8_t *entry,
+                                     size_t size);
+
+/**
  * bloom_filter_is_full
  * checks if every bit in the filter is set
  * @param bf the bloom filter to check

--- a/src/db.h
+++ b/src/db.h
@@ -230,8 +230,6 @@ typedef int (*tidesdb_commit_hook_fn)(const tidesdb_commit_op_t *ops, int num_op
  * @param enable_bloom_filter enable bloom filter
  * @param bloom_fpr bloom filter false positive rate
  * @param enable_block_indexes enable block indexes
- * @param index_sample_ratio index sample ratio
- * @param block_index_prefix_len block index prefix length
  * @param sync_mode sync mode
  * @param sync_interval_us sync interval in microseconds
  * @param comparator_name name of comparator
@@ -270,8 +268,6 @@ typedef struct tidesdb_column_family_config_t
     int enable_bloom_filter;
     double bloom_fpr;
     int enable_block_indexes;
-    int index_sample_ratio;
-    int block_index_prefix_len;
     int sync_mode;
     uint64_t sync_interval_us;
     char comparator_name[TDB_MAX_COMPARATOR_NAME];

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -161,26 +161,18 @@ typedef tidesdb_memtable_t tidesdb_immutable_memtable_t;
  * btree_root_offset(8) + btree_first_leaf(8) + btree_last_leaf(8) +
  * btree_node_count(8) + btree_height(4) */
 #define TDB_SSTABLE_METADATA_BTREE_SIZE 36
-/* chunked-aux descriptor appended after tombstone_count when SSTABLE_FLAG_CHUNKED_AUX
- * is set, bloom_blob_offset(8) + bloom_blob_size(8) + index_blob_offset(8) +
- * index_blob_size(8) */
+/* pre-blocked-format chunked-aux descriptor. no longer written; deserialize only skips it (this
+ * many bytes) when SSTABLE_FLAG_CHUNKED_AUX is set, so an older sstable's footer still parses */
 #define TDB_SSTABLE_METADATA_CHUNKED_AUX_SIZE 32
 /* distinct-key count appended after the chunked-aux descriptor when SSTABLE_FLAG_DISTINCT_KEYS
  * is set, distinct_key_count(8) */
 #define TDB_SSTABLE_METADATA_DISTINCT_KEYS_SIZE 8
+/* blocked-aux directory descriptor appended after the distinct-key count when
+ * SSTABLE_FLAG_BLOCKED_AUX is set, bloom_dir_offset(8) + bloom_dir_size(8) +
+ * index_dir_offset(8) + index_dir_size(8) */
+#define TDB_SSTABLE_METADATA_BLOCKED_AUX_SIZE 32
 #define TDB_SSTABLE_METADATA_FIXED_SIZE \
     (TDB_SSTABLE_METADATA_HEADER_SIZE + TDB_SSTABLE_METADATA_CHECKSUM_SIZE)
-/* the largest payload a single block can frame -- the block manager's on-disk
- * size field is a uint32, so block_manager_block_create rejects anything larger.
- * a bloom-filter or block-index footer blob at or below this is written as one
- * block, no chunking, SSTABLE_FLAG_CHUNKED_AUX stays clear, and the footer is
- * byte-identical to (and readable by) older binaries. every bloom that can exist
- * (m <= UINT32_MAX, ~900MB serialized) and every block index is well under this,
- * so chunking is dormant for all real data today -- it only splits a blob that
- * genuinely cannot fit one block, reachable only if bloom m is ever widened past
- * 32-bit. chunking at any smaller size would needlessly fragment real footers and
- * flip those sstables to the forward-incompatible chunked format for no benefit. */
-#define TDB_AUX_BLOCK_CHUNK_MAX ((uint64_t)UINT32_MAX)
 /* sentinel for tidesdb_sstable_t.tombstone_count when the footer was written before
  * SSTABLE_FLAG_TOMBSTONE_COUNT existed. trigger and stats code skip such sstables. */
 #define TDB_TOMBSTONE_COUNT_UNKNOWN UINT64_MAX
@@ -514,14 +506,6 @@ typedef tidesdb_memtable_t tidesdb_immutable_memtable_t;
 /* klog block configuration */
 #define TDB_KLOG_BLOCK_INITIAL_CAPACITY 512
 
-/* block index validation */
-#define TDB_BLOCK_INDEX_PREFIX_MIN 4
-#define TDB_BLOCK_INDEX_PREFIX_MAX 256
-#define TDB_BLOCK_INDEX_MAX_COUNT  INT_MAX
-
-/* empty block index placeholder ( 4 byte LE count (0) followed by 1 byte prefix_len ) */
-#define TDB_EMPTY_BLOCK_INDEX_SIZE 5
-
 /* merge and serialization configuration */
 #define TDB_MERGE_MIN_ESTIMATED_ENTRIES 100
 #define TDB_KLOG_DELTA_SEQ_MAX_DIFF     1000000
@@ -685,31 +669,6 @@ typedef struct
     uint8_t *data_ref;
     tidesdb_kv_arena_t kv_arena;
 } tidesdb_klog_block_t;
-
-/**
- * tidesdb_block_index_t
- * compact block index for fast key lookups
- * stores min/max key prefixes and file positions for each block
- * @param min_key_prefixes array of minimum key prefixes
- * @param max_key_prefixes array of maximum key prefixes
- * @param file_positions array of file positions for each block
- * @param count number of blocks indexed
- * @param capacity capacity of arrays
- * @param prefix_len length of key prefix stored
- * @param comparator comparator function for key ordering
- * @param comparator_ctx comparator context
- */
-struct tidesdb_block_index_t
-{
-    uint8_t *min_key_prefixes;
-    uint8_t *max_key_prefixes;
-    uint64_t *file_positions;
-    uint32_t count;
-    uint32_t capacity;
-    uint8_t prefix_len;
-    tidesdb_comparator_fn comparator;
-    void *comparator_ctx;
-};
 
 /**
  * tidesdb_vlog_block_t
@@ -1655,25 +1614,6 @@ static tidesdb_sstable_t *tidesdb_sstable_create(tidesdb_t *db, const char *base
                                                  const tidesdb_column_family_config_t *config);
 static void tidesdb_sstable_free(tidesdb_sstable_t *sst);
 
-static void compact_block_index_free(tidesdb_block_index_t *index);
-static int compact_block_index_find_predecessor(const tidesdb_block_index_t *index,
-                                                const uint8_t *key, size_t key_len,
-                                                uint64_t *file_position);
-static int compact_block_index_find_slot(const tidesdb_block_index_t *index, const uint8_t *key,
-                                         size_t key_len, int64_t *slot);
-static uint32_t compact_block_index_run_length(const tidesdb_block_index_t *index,
-                                               const uint8_t *key, size_t key_len,
-                                               int64_t start_slot);
-static int compact_block_index_add(tidesdb_block_index_t *index, const uint8_t *min_key,
-                                   size_t min_key_len, const uint8_t *max_key, size_t max_key_len,
-                                   uint64_t file_position);
-static tidesdb_block_index_t *compact_block_index_create(uint32_t initial_capacity,
-                                                         uint8_t prefix_len,
-                                                         tidesdb_comparator_fn comparator,
-                                                         void *comparator_ctx);
-static uint8_t *compact_block_index_serialize(const tidesdb_block_index_t *index, size_t *out_size);
-static tidesdb_block_index_t *compact_block_index_deserialize(const uint8_t *data,
-                                                              size_t data_size);
 static void tidesdb_sstable_ref(tidesdb_sstable_t *sst);
 static int tidesdb_sstable_try_ref(tidesdb_sstable_t *sst);
 static void tidesdb_sstable_unref(const tidesdb_t *db, tidesdb_sstable_t *sst);
@@ -1688,7 +1628,6 @@ static int tidesdb_sstable_get_seq(tidesdb_t *db, tidesdb_sstable_t *sst, const 
 static int tidesdb_sstable_load(tidesdb_t *db, tidesdb_sstable_t *sst);
 static tidesdb_level_t *tidesdb_level_create(int level_num, size_t capacity);
 static void tidesdb_level_free(const tidesdb_t *db, tidesdb_level_t *level);
-static int64_t tidesdb_sstable_aux_memory_bytes(const tidesdb_sstable_t *sst);
 static int tidesdb_level_add_sstable(tidesdb_level_t *level, tidesdb_sstable_t *sst);
 static int tidesdb_level_remove_sstable(const tidesdb_t *db, tidesdb_level_t *level,
                                         tidesdb_sstable_t *sst);
@@ -1739,20 +1678,18 @@ static int tidesdb_compact_steer_to_bottom(tidesdb_column_family_t *cf, uint8_t 
                                            size_t max_key_size);
 static int tdb_partitioned_merge_finalize_sst(tidesdb_column_family_t *cf, tidesdb_sstable_t *sst,
                                               block_manager_t *klog_bm, block_manager_t *vlog_bm,
-                                              bloom_filter_t *bloom,
-                                              tidesdb_block_index_t *block_indexes,
+                                              blocked_bloom_builder_t *bloom_builder,
+                                              blocked_index_builder_t *index_builder,
                                               uint64_t entry_count, uint64_t tombstone_count,
                                               uint64_t distinct_key_count, uint64_t klog_block_num,
                                               uint64_t vlog_block_num, uint64_t max_seq,
                                               int end_level, int partition);
-static int tidesdb_sstable_write_from_heap_btree(tidesdb_column_family_t *cf,
-                                                 tidesdb_sstable_t *sst, tidesdb_merge_heap_t *heap,
-                                                 block_manager_t *klog_bm, block_manager_t *vlog_bm,
-                                                 bloom_filter_t *bloom, queue_t *sstables_to_delete,
-                                                 int is_largest_level, const uint8_t *range_start,
-                                                 size_t range_start_size, const uint8_t *range_end,
-                                                 size_t range_end_size,
-                                                 uint64_t oldest_unflushed_seq);
+static int tidesdb_sstable_write_from_heap_btree(
+    tidesdb_column_family_t *cf, tidesdb_sstable_t *sst, tidesdb_merge_heap_t *heap,
+    block_manager_t *klog_bm, block_manager_t *vlog_bm, blocked_bloom_builder_t *bloom_builder,
+    queue_t *sstables_to_delete, int is_largest_level, const uint8_t *range_start,
+    size_t range_start_size, const uint8_t *range_end, size_t range_end_size,
+    uint64_t oldest_unflushed_seq);
 static int tidesdb_trigger_compaction(tidesdb_column_family_t *cf, int full_compaction);
 static int tidesdb_enqueue_compaction(tidesdb_column_family_t *cf, int full_compaction);
 static int tidesdb_enqueue_compaction_force(tidesdb_column_family_t *cf, int full_compaction);
@@ -2441,16 +2378,21 @@ static int tidesdb_validate_kv_size(tidesdb_t *db, const size_t key_size, const 
     0x02 /* footer carries an 8-byte tombstone_count after the \
           * btree section (or after max_key when use_btree=0)  \
           * and before the trailing checksum */
-#define SSTABLE_FLAG_CHUNKED_AUX                                          \
-    0x04 /* footer carries a 32-byte chunked-aux descriptor (bloom blob   \
-          * offset+size, index blob offset+size) after tombstone_count.   \
-          * present when a bloom/index blob spans multiple blocks; absent \
-          * sstables locate bloom/index by trailing-block navigation */
+#define SSTABLE_FLAG_CHUNKED_AUX                                             \
+    0x04 /* pre-blocked-format flag -- footer carried a 32-byte chunked-aux  \
+          * descriptor after tombstone_count. no longer written; deserialize \
+          * only skips those bytes so an older sstable's footer still parses */
 #define SSTABLE_FLAG_DISTINCT_KEYS                                            \
     0x08 /* footer carries an 8-byte distinct_key_count after the chunked-aux \
           * descriptor (or after tombstone_count when it is absent) and       \
           * before the trailing checksum. always set for sstables produced by \
           * this build; absent on older sstables, whose count reads UNKNOWN */
+#define SSTABLE_FLAG_BLOCKED_AUX                                             \
+    0x10 /* footer carries a 32-byte blocked-aux directory descriptor (bloom \
+          * dir offset+size, index dir offset+size) after the distinct-key   \
+          * count. present when the bloom filter and block index use the     \
+          * paged blocked-aux format; an older sstable without it has no     \
+          * resident aux and reads by full scan until compaction rewrites it */
 
 /**
  * sstable_metadata_serialize
@@ -2476,14 +2418,14 @@ static int sstable_metadata_serialize(tidesdb_sstable_t *sst, uint8_t **out_data
 
     const size_t tombstone_meta_size = TDB_SSTABLE_METADATA_TOMBSTONE_SIZE;
 
-    const size_t chunked_aux_size = sst->aux_chunked ? TDB_SSTABLE_METADATA_CHUNKED_AUX_SIZE : 0;
-
     /* this build always records the distinct-key count */
     const size_t distinct_keys_size = TDB_SSTABLE_METADATA_DISTINCT_KEYS_SIZE;
 
+    const size_t blocked_aux_size = sst->blocked_aux ? TDB_SSTABLE_METADATA_BLOCKED_AUX_SIZE : 0;
+
     const size_t total_size = header_size + sst->min_key_size + sst->max_key_size +
-                              btree_meta_size + tombstone_meta_size + chunked_aux_size +
-                              distinct_keys_size + checksum_size;
+                              btree_meta_size + tombstone_meta_size + distinct_keys_size +
+                              blocked_aux_size + checksum_size;
 
     uint8_t *data = malloc(total_size);
     if (!data) return -1;
@@ -2521,9 +2463,9 @@ static int sstable_metadata_serialize(tidesdb_sstable_t *sst, uint8_t **out_data
     {
         flags |= SSTABLE_FLAG_BTREE;
     }
-    if (sst->aux_chunked)
+    if (sst->blocked_aux)
     {
-        flags |= SSTABLE_FLAG_CHUNKED_AUX;
+        flags |= SSTABLE_FLAG_BLOCKED_AUX;
     }
     encode_uint32_le_compat(ptr, flags);
     ptr += 4;
@@ -2557,22 +2499,22 @@ static int sstable_metadata_serialize(tidesdb_sstable_t *sst, uint8_t **out_data
     encode_uint64_le_compat(ptr, sst->tombstone_count);
     ptr += 8;
 
-    /* chunked-aux descriptor (only when SSTABLE_FLAG_CHUNKED_AUX is set) */
-    if (sst->aux_chunked)
-    {
-        encode_uint64_le_compat(ptr, sst->bloom_blob_offset);
-        ptr += 8;
-        encode_uint64_le_compat(ptr, sst->bloom_blob_size);
-        ptr += 8;
-        encode_uint64_le_compat(ptr, sst->index_blob_offset);
-        ptr += 8;
-        encode_uint64_le_compat(ptr, sst->index_blob_size);
-        ptr += 8;
-    }
-
     /* distinct-key count (SSTABLE_FLAG_DISTINCT_KEYS always set by this build) */
     encode_uint64_le_compat(ptr, sst->distinct_key_count);
     ptr += 8;
+
+    /* blocked-aux directory descriptor (only when SSTABLE_FLAG_BLOCKED_AUX is set) */
+    if (sst->blocked_aux)
+    {
+        encode_uint64_le_compat(ptr, sst->bloom_dir_offset);
+        ptr += 8;
+        encode_uint64_le_compat(ptr, sst->bloom_dir_size);
+        ptr += 8;
+        encode_uint64_le_compat(ptr, sst->index_dir_offset);
+        ptr += 8;
+        encode_uint64_le_compat(ptr, sst->index_dir_size);
+        ptr += 8;
+    }
 
     /* we compute and append checksum over everything except the checksum field itself */
     const size_t checksum_data_size = total_size - checksum_size;
@@ -2640,6 +2582,7 @@ static int sstable_metadata_deserialize(const uint8_t *data, const size_t data_s
     const int has_tombstone_count = (flags & SSTABLE_FLAG_TOMBSTONE_COUNT) ? 1 : 0;
     const int has_chunked_aux = (flags & SSTABLE_FLAG_CHUNKED_AUX) ? 1 : 0;
     const int has_distinct_keys = (flags & SSTABLE_FLAG_DISTINCT_KEYS) ? 1 : 0;
+    const int has_blocked_aux = (flags & SSTABLE_FLAG_BLOCKED_AUX) ? 1 : 0;
 
     /* we calculate expected size based on which optional sections the flags promise */
     size_t btree_meta_size = 0;
@@ -2657,9 +2600,11 @@ static int sstable_metadata_deserialize(const uint8_t *data, const size_t data_s
     const size_t distinct_keys_size =
         has_distinct_keys ? TDB_SSTABLE_METADATA_DISTINCT_KEYS_SIZE : 0;
 
+    const size_t blocked_aux_size = has_blocked_aux ? TDB_SSTABLE_METADATA_BLOCKED_AUX_SIZE : 0;
+
     const size_t expected_size = TDB_SSTABLE_METADATA_FIXED_SIZE + min_key_size + max_key_size +
                                  btree_meta_size + tombstone_meta_size + chunked_aux_size +
-                                 distinct_keys_size;
+                                 distinct_keys_size + blocked_aux_size;
     if (data_size != expected_size)
     {
         TDB_DEBUG_LOG(TDB_LOG_FATAL, "SSTable metadata size mismatch (expected: %zu, got: %zu)",
@@ -2762,19 +2707,9 @@ static int sstable_metadata_deserialize(const uint8_t *data, const size_t data_s
 
     if (has_chunked_aux)
     {
-        sst->aux_chunked = 1;
-        sst->bloom_blob_offset = decode_uint64_le_compat(ptr);
-        ptr += 8;
-        sst->bloom_blob_size = decode_uint64_le_compat(ptr);
-        ptr += 8;
-        sst->index_blob_offset = decode_uint64_le_compat(ptr);
-        ptr += 8;
-        sst->index_blob_size = decode_uint64_le_compat(ptr);
-        ptr += 8;
-    }
-    else
-    {
-        sst->aux_chunked = 0;
+        /* skip a pre-blocked-format chunked-aux descriptor; such an sstable has no paged readers
+         * and reads by full scan until compaction rewrites it in the blocked format */
+        ptr += TDB_SSTABLE_METADATA_CHUNKED_AUX_SIZE;
     }
 
     if (has_distinct_keys)
@@ -2785,6 +2720,23 @@ static int sstable_metadata_deserialize(const uint8_t *data, const size_t data_s
     else
     {
         sst->distinct_key_count = TDB_DISTINCT_KEYS_UNKNOWN;
+    }
+
+    if (has_blocked_aux)
+    {
+        sst->blocked_aux = 1;
+        sst->bloom_dir_offset = decode_uint64_le_compat(ptr);
+        ptr += 8;
+        sst->bloom_dir_size = decode_uint64_le_compat(ptr);
+        ptr += 8;
+        sst->index_dir_offset = decode_uint64_le_compat(ptr);
+        ptr += 8;
+        sst->index_dir_size = decode_uint64_le_compat(ptr);
+        ptr += 8;
+    }
+    else
+    {
+        sst->blocked_aux = 0;
     }
 
     return 0;
@@ -2944,8 +2896,6 @@ tidesdb_column_family_config_t tidesdb_default_column_family_config(void)
         .enable_bloom_filter = 1,
         .bloom_fpr = TDB_DEFAULT_BLOOM_FPR,
         .enable_block_indexes = 1,
-        .index_sample_ratio = TDB_DEFAULT_INDEX_SAMPLE_RATIO,
-        .block_index_prefix_len = TDB_DEFAULT_BLOCK_INDEX_PREFIX_LEN,
         .sync_mode = TDB_SYNC_NONE,
         .sync_interval_us = TDB_DEFAULT_SYNC_INTERVAL_US,
         .comparator_fn_cached = NULL,
@@ -6894,8 +6844,8 @@ static void tidesdb_sstable_free(tidesdb_sstable_t *sst)
     free(sst->max_key);
     free(sst->config);
 
-    if (sst->bloom_filter) bloom_filter_free(sst->bloom_filter);
-    if (sst->block_indexes) compact_block_index_free(sst->block_indexes);
+    blocked_bloom_reader_free(sst->bloom_reader);
+    blocked_index_reader_free(sst->index_reader);
 
     free(sst);
 }
@@ -7723,21 +7673,17 @@ static int tidesdb_write_vlog_entry(const tidesdb_sstable_t *sst, block_manager_
  * @param sst sstable
  * @param klog_bm klog block manager
  * @param block klog block to flush
- * @param block_indexes optional block index to update
+ * @param index_builder optional blocked block index builder to record this block in
  * @param block_first_key first key in block
  * @param block_first_key_size size of first key
- * @param block_last_key last key in block
- * @param block_last_key_size size of last key
  * @param klog_block_num block counter (incremented on success)
  * @return TDB_SUCCESS on success, error code on failure
  */
 static int tidesdb_flush_klog_block(const tidesdb_sstable_t *sst, block_manager_t *klog_bm,
                                     tidesdb_klog_block_t *block,
-                                    tidesdb_block_index_t *block_indexes,
+                                    blocked_index_builder_t *index_builder,
                                     const uint8_t *block_first_key,
-                                    const size_t block_first_key_size,
-                                    const uint8_t *block_last_key, const size_t block_last_key_size,
-                                    uint64_t *klog_block_num)
+                                    const size_t block_first_key_size, uint64_t *klog_block_num)
 {
     if (block->num_entries == 0) return TDB_SUCCESS;
 
@@ -7783,14 +7729,11 @@ static int tidesdb_flush_klog_block(const tidesdb_sstable_t *sst, block_manager_
     block_manager_block_write(klog_bm, klog_block);
     block_manager_block_release(klog_block);
 
-    /* we add to index if enabled and sampling matches */
-    if (block_indexes && block_first_key && block_last_key)
+    /* record every block by its first key so a lookup routes to exactly one block */
+    if (block_first_key)
     {
-        if (*klog_block_num % sst->config->index_sample_ratio == 0)
-        {
-            compact_block_index_add(block_indexes, block_first_key, block_first_key_size,
-                                    block_last_key, block_last_key_size, block_file_position);
-        }
+        blocked_index_builder_add(index_builder, block_first_key, block_first_key_size,
+                                  block_file_position);
     }
 
     (*klog_block_num)++;
@@ -7799,227 +7742,230 @@ static int tidesdb_flush_klog_block(const tidesdb_sstable_t *sst, block_manager_
 }
 
 /**
- * tidesdb_sstable_write_aux_blob
- * writes a footer aux blob (serialized bloom filter or block index) as one or
- * more consecutive blocks, each at most TDB_AUX_BLOCK_CHUNK_MAX bytes, so no
- * single block exceeds the block manager's framing/read limits regardless of
- * total blob size. a blob at or below the chunk size is written as exactly one
- * block (identical on-disk layout to the pre-chunking single-block writes).
- * @param bm klog block manager
- * @param data blob bytes (size > 0)
- * @param size blob size in bytes
- * @param out_offset receives the offset of the first chunk
- * @return TDB_SUCCESS, or TDB_ERR_IO on a write failure
+ * tidesdb_blocked_aux_write
+ * write sink for the blocked bloom and block index builders. each finalized partition, leaf, or
+ * directory is appended to the klog as one block after the sstable's data blocks; the returned
+ * offset is recorded in the directory and, for a top-level directory, in the sstable footer.
+ * @param ctx the klog block manager
+ * @param data blob bytes
+ * @param size blob length
+ * @param out_offset receives the block's file offset
+ * @return 0 on success, -1 on a write failure
  */
-static int tidesdb_sstable_write_aux_blob(block_manager_t *bm, const uint8_t *data, uint64_t size,
-                                          uint64_t *out_offset)
+static int tidesdb_blocked_aux_write(void *ctx, const uint8_t *data, size_t size,
+                                     uint64_t *out_offset)
 {
-    if (!bm || !data || size == 0 || !out_offset) return TDB_ERR_INVALID_ARGS;
+    block_manager_t *bm = (block_manager_t *)ctx;
+    block_manager_block_t *blk = block_manager_block_create(size, data);
+    if (!blk) return -1;
+    const int64_t off = block_manager_block_write(bm, blk);
+    block_manager_block_release(blk);
+    if (off < 0) return -1;
+    *out_offset = (uint64_t)off;
+    return 0;
+}
 
-    int64_t start = -1;
-    uint64_t written = 0;
-    while (written < size)
+/* the fetch pin is a clock-cache entry (bit 0 clear, heap-aligned) or, when no cache holds the
+ * blob, the block-manager block read directly (low bit set so release frees the right kind) */
+#define TDB_AUX_PIN_BLOCK_TAG ((uintptr_t)1)
+
+/**
+ * tidesdb_blocked_aux_fetch
+ * read source for the blocked bloom and block index readers. serves a partition, leaf, or directory
+ * blob by its klog block offset, pinned through the block cache so a hot aux blob stays resident
+ * and is evicted under the cache budget. on a cache miss it reads the block from the sstable's
+ * klog, populates the cache, and re-pins from it; with no cache it hands back the block itself.
+ * @param ctx the sstable (tidesdb_sstable_t *)
+ * @param offset klog offset of the blob's block
+ * @param size expected blob length
+ * @param out_data receives the blob bytes, valid until release
+ * @param out_pin receives the pin to hand to release
+ * @return 0 on success, -1 on failure (treated by the reader as may-be-present / full scan)
+ */
+static int tidesdb_blocked_aux_fetch(void *ctx, uint64_t offset, uint32_t size,
+                                     const uint8_t **out_data, void **out_pin)
+{
+    tidesdb_sstable_t *sst = (tidesdb_sstable_t *)ctx;
+    tidesdb_t *db = sst->db;
+    const int cacheable =
+        db && db->clock_cache && sst->cf_name[0] != '\0' && sst->klog_filename != NULL;
+
+    if (cacheable)
     {
-        const uint64_t remaining = size - written;
-        const uint64_t chunk =
-            (remaining > TDB_AUX_BLOCK_CHUNK_MAX) ? TDB_AUX_BLOCK_CHUNK_MAX : remaining;
-        block_manager_block_t *blk = block_manager_block_create(chunk, data + written);
-        if (!blk) return TDB_ERR_IO;
-        const int64_t off = block_manager_block_write(bm, blk);
-        block_manager_block_release(blk);
-        if (off < 0) return TDB_ERR_IO;
-        if (start < 0) start = off;
-        written += chunk;
+        size_t sz = 0;
+        clock_cache_entry_t *entry = NULL;
+        const uint8_t *data = tidesdb_cache_raw_block_get_pinned(
+            db, sst->cf_name, sst->klog_filename, offset, &sz, &entry);
+        if (data && sz == size)
+        {
+            *out_data = data;
+            *out_pin = entry;
+            return 0;
+        }
+        if (data) clock_cache_release(entry);
     }
 
-    *out_offset = (uint64_t)start;
-    return TDB_SUCCESS;
+    block_manager_t *klog_bm = atomic_load_explicit(&sst->klog_bm, memory_order_acquire);
+    if (!klog_bm) return -1;
+
+    block_manager_cursor_t *cur = NULL;
+    if (block_manager_cursor_init(&cur, klog_bm) != 0) return -1;
+    if (block_manager_cursor_goto(cur, offset) != 0)
+    {
+        block_manager_cursor_free(cur);
+        return -1;
+    }
+    block_manager_block_t *blk = block_manager_cursor_read(cur);
+    block_manager_cursor_free(cur);
+    if (!blk) return -1;
+    if (blk->size != size)
+    {
+        block_manager_block_release(blk);
+        return -1;
+    }
+
+    if (cacheable)
+    {
+        /* populate the cache and re-pin from it so the pin is a uniform cache entry */
+        tidesdb_cache_raw_block_put(db, sst->cf_name, sst->klog_filename, offset, blk->data,
+                                    blk->size);
+        size_t sz = 0;
+        clock_cache_entry_t *entry = NULL;
+        const uint8_t *data = tidesdb_cache_raw_block_get_pinned(
+            db, sst->cf_name, sst->klog_filename, offset, &sz, &entry);
+        if (data && sz == size)
+        {
+            block_manager_block_release(blk);
+            *out_data = data;
+            *out_pin = entry;
+            return 0;
+        }
+        if (data) clock_cache_release(entry);
+    }
+
+    *out_data = blk->data;
+    *out_pin = (void *)((uintptr_t)blk | TDB_AUX_PIN_BLOCK_TAG);
+    return 0;
 }
 
 /**
- * tidesdb_sstable_read_aux_blob
- * reassembles a chunked footer aux blob into a single buffer by reading
- * consecutive blocks starting at offset until total bytes are gathered. refuses
- * (NULL + warning, not a crash) if total exceeds the database memory-safety
- * budget so a corrupt or pathological size cannot drive the process into OOM.
- * @param db database (for the memory budget)
- * @param bm klog block manager
- * @param offset offset of the first chunk
- * @param total total logical blob size in bytes
- * @return malloc'd buffer of `total` bytes (caller frees), or NULL
+ * tidesdb_blocked_aux_release
+ * release a pin returned by tidesdb_blocked_aux_fetch.
+ * @param ctx unused
+ * @param pin the pin
  */
-static uint8_t *tidesdb_sstable_read_aux_blob(tidesdb_t *db, block_manager_t *bm, uint64_t offset,
-                                              uint64_t total)
+static void tidesdb_blocked_aux_release(void *ctx, void *pin)
 {
-    if (!bm || total == 0) return NULL;
+    (void)ctx;
+    const uintptr_t p = (uintptr_t)pin;
+    if (p & TDB_AUX_PIN_BLOCK_TAG)
+        block_manager_block_release((block_manager_block_t *)(p & ~TDB_AUX_PIN_BLOCK_TAG));
+    else
+        clock_cache_release((clock_cache_entry_t *)pin);
+}
 
-    const size_t budget =
-        db ? atomic_load_explicit(&db->resolved_memory_limit, memory_order_relaxed) : 0;
-    if (budget > 0 && total > (uint64_t)budget / TDB_MEMORY_MAX_BLOCK_FRACTION_DENOM)
+/**
+ * tidesdb_sstable_open_blocked_readers
+ * open the paged blocked bloom filter and block index readers for a blocked-aux sstable from the
+ * directory locators in its footer. a no-op for a non-blocked sstable or one already opened. the
+ * readers page their partitions through the block cache via tidesdb_blocked_aux_fetch, so call this
+ * only once the sstable's klog_bm is published and its comparator resolved.
+ * @param sst the sstable
+ */
+static void tidesdb_sstable_open_blocked_readers(tidesdb_sstable_t *sst)
+{
+    if (!sst || !sst->blocked_aux || !sst->config) return;
+
+    void *cmp_ctx = sst->cached_comparator_ctx;
+
+    if (sst->config->enable_bloom_filter && sst->bloom_dir_size > 0 &&
+        sst->bloom_dir_size <= UINT32_MAX && !sst->bloom_reader)
     {
-        TDB_DEBUG_LOG(TDB_LOG_WARN,
-                      "aux blob of %" PRIu64
-                      " bytes exceeds memory-safety budget (%zu) -- skipping",
-                      total, budget);
-        return NULL;
-    }
-    if (total > SIZE_MAX) return NULL; /* 32-bit host guard */
-
-    uint8_t *buf = malloc((size_t)total);
-    if (!buf) return NULL;
-
-    block_manager_cursor_t *cur = NULL;
-    if (block_manager_cursor_init(&cur, bm) != 0 || block_manager_cursor_goto(cur, offset) != 0)
-    {
-        if (cur) block_manager_cursor_free(cur);
-        free(buf);
-        return NULL;
-    }
-
-    uint64_t got = 0;
-    while (got < total)
-    {
-        block_manager_block_t *blk = block_manager_cursor_read(cur);
-        if (!blk || got + blk->size > total)
-        {
-            if (blk) block_manager_block_release(blk);
-            block_manager_cursor_free(cur);
-            free(buf);
-            return NULL;
-        }
-        memcpy(buf + got, blk->data, blk->size);
-        got += blk->size;
-        block_manager_block_release(blk);
-        if (got < total && block_manager_cursor_next(cur) != 0)
-        {
-            block_manager_cursor_free(cur);
-            free(buf);
-            return NULL;
-        }
+        blocked_bloom_reader_open(&sst->bloom_reader, sst->bloom_dir_offset,
+                                  (uint32_t)sst->bloom_dir_size,
+                                  (blocked_bloom_comparator_fn)sst->cached_comparator_fn, cmp_ctx,
+                                  tidesdb_blocked_aux_fetch, tidesdb_blocked_aux_release, sst);
     }
 
-    block_manager_cursor_free(cur);
-    return buf;
+    if (!sst->config->use_btree && sst->index_dir_size > 0 && sst->index_dir_size <= UINT32_MAX &&
+        !sst->index_reader)
+    {
+        blocked_index_reader_open(&sst->index_reader, sst->index_dir_offset,
+                                  (uint32_t)sst->index_dir_size,
+                                  (blocked_index_comparator_fn)sst->cached_comparator_fn, cmp_ctx,
+                                  tidesdb_blocked_aux_fetch, tidesdb_blocked_aux_release, sst);
+    }
 }
 
 /**
  * tidesdb_sstable_write_footer_aux
- * writes the block index (optional) and bloom filter footer blobs for sst,
- * chunk-aware in that a blob larger than TDB_AUX_BLOCK_CHUNK_MAX is split across
- * consecutive blocks and the chunked-aux descriptor (offset+size) is recorded on
- * sst, so a bloom/index of any size (incl. >4GB) round-trips; a small blob is
- * written as a single block (byte-identical to the legacy footer). ownership of
- * block_indexes and bloom transfers to sst. callers write the metadata block
- * afterward -- metadata serialize reads sst->aux_chunked and the offsets. shared
- * by every flush and merge writer so they all get chunking uniformly.
+ * finalize the blocked bloom filter and block index builders for sst, writing their partitions,
+ * leaves, and top-level directories to the klog after the data blocks and recording the directory
+ * locators on sst. the builders keep only the directories out of the block cache; the partitions
+ * are paged back on demand at read time. callers write the metadata block afterward -- metadata
+ * serialize reads sst->blocked_aux and the directory locators. takes ownership of both builders and
+ * frees them before returning. shared by every flush and merge writer.
  * @param sst sstable being written
- * @param klog_bm klog block manager
- * @param block_indexes block index (NULL -> empty placeholder); used iff write_index
- * @param bloom bloom filter (NULL -> empty placeholder)
- * @param write_index 1 to emit an index block (block format), 0 for btree (bloom only)
+ * @param klog_bm klog block manager (unused directly -- the builders hold it as their write sink)
+ * @param index_builder block index builder (NULL when disabled); finalized iff write_index
+ * @param bloom_builder bloom filter builder (NULL when disabled)
+ * @param write_index 1 to emit the index directory (block format), 0 for btree (bloom only)
  */
 static void tidesdb_sstable_write_footer_aux(tidesdb_sstable_t *sst, block_manager_t *klog_bm,
-                                             tidesdb_block_index_t *block_indexes,
-                                             bloom_filter_t *bloom, int write_index)
+                                             blocked_index_builder_t *index_builder,
+                                             blocked_bloom_builder_t *bloom_builder,
+                                             int write_index)
 {
-    uint64_t index_off = 0;
-    uint64_t bloom_off = 0;
-    size_t index_size = 0;
-    size_t bloom_size = 0;
-    int index_chunked = 0;
+    (void)klog_bm;
 
-    /* index first, then bloom -- matches the legacy trailing-block order
-     * (index, bloom, metadata) used by the non-chunked read path */
-    if (write_index)
+    if (write_index && index_builder)
     {
-        uint8_t index_placeholder[TDB_EMPTY_BLOCK_INDEX_SIZE];
-        uint8_t *index_data = NULL;
-        uint8_t *index_owned = NULL;
-        if (block_indexes)
+        uint64_t dir_off = 0;
+        uint32_t dir_size = 0;
+        if (blocked_index_builder_finish(index_builder, &dir_off, &dir_size, NULL) == 0)
         {
-            sst->block_indexes = block_indexes;
-            index_data = compact_block_index_serialize(block_indexes, &index_size);
-            index_owned = index_data;
+            sst->index_dir_offset = dir_off;
+            sst->index_dir_size = dir_size;
+            sst->blocked_aux = 1;
         }
-        if (!index_data)
+    }
+
+    if (bloom_builder)
+    {
+        uint64_t dir_off = 0;
+        uint32_t dir_size = 0;
+        if (blocked_bloom_builder_finish(bloom_builder, &dir_off, &dir_size, NULL) == 0)
         {
-            encode_uint32_le_compat(index_placeholder, 0);
-            index_placeholder[sizeof(uint32_t)] = TDB_DEFAULT_BLOCK_INDEX_PREFIX_LEN;
-            index_data = index_placeholder;
-            index_size = TDB_EMPTY_BLOCK_INDEX_SIZE;
+            sst->bloom_dir_offset = dir_off;
+            sst->bloom_dir_size = dir_size;
+            sst->blocked_aux = 1;
         }
-        tidesdb_sstable_write_aux_blob(klog_bm, index_data, index_size, &index_off);
-        /* a size_t blob cannot exceed the 4 GB single-block limit on a 32-bit build, so only
-           compare where size_t is wide enough; otherwise index_chunked stays 0 */
-#if SIZE_MAX > UINT32_MAX
-        index_chunked = (index_size > TDB_AUX_BLOCK_CHUNK_MAX);
-#endif
-        free(index_owned);
     }
 
-    uint8_t bloom_placeholder[1] = {0};
-    uint8_t *bloom_data = NULL;
-    uint8_t *bloom_owned = NULL;
-    if (bloom)
-    {
-        bloom_data = bloom_filter_serialize(bloom, &bloom_size);
-        bloom_owned = bloom_data;
-        sst->bloom_filter = bloom;
-    }
-    if (!bloom_data)
-    {
-        bloom_data = bloom_placeholder;
-        bloom_size = 1;
-    }
-    tidesdb_sstable_write_aux_blob(klog_bm, bloom_data, bloom_size, &bloom_off);
-    free(bloom_owned);
-
-    int bloom_chunked = 0;
-#if SIZE_MAX > UINT32_MAX
-    bloom_chunked = (bloom_size > TDB_AUX_BLOCK_CHUNK_MAX);
-#endif
-    if (index_chunked || bloom_chunked)
-    {
-        sst->aux_chunked = 1;
-        sst->index_blob_offset = write_index ? index_off : 0;
-        sst->index_blob_size = write_index ? index_size : 0;
-        sst->bloom_blob_offset = bloom_off;
-        sst->bloom_blob_size = bloom_size;
-        TDB_DEBUG_LOG(TDB_LOG_INFO,
-                      "SSTable %" PRIu64 " footer aux chunked (index %zu B, bloom %zu B)", sst->id,
-                      write_index ? index_size : (size_t)0, bloom_size);
-    }
+    blocked_index_builder_free(index_builder);
+    blocked_bloom_builder_free(bloom_builder);
 }
 
 /**
  * tidesdb_sstable_write_footer
- * write index, bloom filter, and metadata blocks to klog
- * @param sst sstable (block_indexes and bloom_filter assigned here)
+ * write the blocked bloom filter, block index, and metadata blocks to klog
+ * @param sst sstable being written
  * @param klog_bm klog block manager
  * @param vlog_bm vlog block manager
- * @param block_indexes block indexes (ownership transferred to sst)
- * @param bloom bloom filter (ownership transferred to sst)
+ * @param index_builder block index builder (finalized here)
+ * @param bloom_builder bloom filter builder (finalized here)
  * @return TDB_SUCCESS on success
  */
 static int tidesdb_sstable_write_footer(tidesdb_sstable_t *sst, block_manager_t *klog_bm,
                                         block_manager_t *vlog_bm,
-                                        tidesdb_block_index_t *block_indexes, bloom_filter_t *bloom)
+                                        blocked_index_builder_t *index_builder,
+                                        blocked_bloom_builder_t *bloom_builder)
 {
     /* we capture klog file offset where data blocks end */
     block_manager_get_size(klog_bm, &sst->klog_data_end_offset);
 
-    /* we write index block */
-    if (block_indexes)
-    {
-        TDB_DEBUG_LOG(TDB_LOG_INFO,
-                      "SSTable " TDB_U64_FMT " block indexes built - %" PRIu32
-                      " samples, " TDB_U64_FMT " total blocks",
-                      TDB_U64_CAST(sst->id), block_indexes->count,
-                      TDB_U64_CAST(sst->num_klog_blocks));
-    }
-
-    /* write the index + bloom footer blobs (chunk-aware, shared with the merge writers) */
-    tidesdb_sstable_write_footer_aux(sst, klog_bm, block_indexes, bloom, 1);
+    /* finalize the blocked index + bloom directories after the data blocks (block format) */
+    tidesdb_sstable_write_footer_aux(sst, klog_bm, index_builder, bloom_builder, 1);
 
     /* we write metadata block */
     uint64_t klog_size_before_metadata;
@@ -8117,14 +8063,15 @@ static int tidesdb_sstable_write_from_memtable_btree_ex(tidesdb_t *db, tidesdb_c
         return TDB_ERR_MEMORY;
     }
 
-    /* we create bloom filter if enabled */
-    bloom_filter_t *bloom = NULL;
+    /* we create the bloom filter builder if enabled */
+    blocked_bloom_builder_t *bloom_builder = NULL;
     if (sst->config->enable_bloom_filter)
     {
-        if (bloom_filter_new(&bloom, sst->config->bloom_fpr, num_entries) != 0)
+        if (blocked_bloom_builder_new(&bloom_builder, sst->config->bloom_fpr, 0,
+                                      tidesdb_blocked_aux_write, klog_bm) != 0)
         {
-            TDB_DEBUG_LOG(TDB_LOG_ERROR, "SSTable %" PRIu64 " failed to create bloom filter",
-                          sst->id);
+            TDB_DEBUG_LOG(TDB_LOG_ERROR,
+                          "SSTable %" PRIu64 " failed to create bloom filter builder", sst->id);
             btree_builder_free(builder);
             return TDB_ERR_MEMORY;
         }
@@ -8134,7 +8081,7 @@ static int tidesdb_sstable_write_from_memtable_btree_ex(tidesdb_t *db, tidesdb_c
     skip_list_cursor_t *cursor = NULL;
     if (skip_list_cursor_init(&cursor, memtable) != 0)
     {
-        if (bloom) bloom_filter_free(bloom);
+        blocked_bloom_builder_free(bloom_builder);
         btree_builder_free(builder);
         return TDB_ERR_MEMORY;
     }
@@ -8252,17 +8199,14 @@ static int tidesdb_sstable_write_from_memtable_btree_ex(tidesdb_t *db, tidesdb_c
                  * wal is retained, rather than committing a btree with a dropped committed key */
                 TDB_DEBUG_LOG(TDB_LOG_ERROR, "SSTable %" PRIu64 " failed to add entry to btree",
                               sst->id);
-                if (bloom) bloom_filter_free(bloom);
+                blocked_bloom_builder_free(bloom_builder);
                 btree_builder_free(builder);
                 tidesdb_distinct_counter_free(&distinct);
                 return TDB_ERR_MEMORY;
             }
 
-            /* we add to bloom filter */
-            if (bloom)
-            {
-                bloom_filter_add(bloom, key, key_size);
-            }
+            /* we add to the bloom filter builder */
+            blocked_bloom_builder_add(bloom_builder, key, key_size);
 
             if (seq > max_seq) max_seq = seq;
             entry_count++;
@@ -8283,7 +8227,7 @@ static int tidesdb_sstable_write_from_memtable_btree_ex(tidesdb_t *db, tidesdb_c
     {
         TDB_DEBUG_LOG(TDB_LOG_INFO, "CF '%s' aborting btree flush write for SSTable %" PRIu64,
                       cf->name, sst->id);
-        if (bloom) bloom_filter_free(bloom);
+        blocked_bloom_builder_free(bloom_builder);
         btree_builder_free(builder);
         tidesdb_distinct_counter_free(&distinct);
         return TDB_SUCCESS;
@@ -8294,7 +8238,7 @@ static int tidesdb_sstable_write_from_memtable_btree_ex(tidesdb_t *db, tidesdb_c
     if (btree_builder_finish(builder, &tree) != 0)
     {
         TDB_DEBUG_LOG(TDB_LOG_ERROR, "SSTable %" PRIu64 " failed to finish btree", sst->id);
-        if (bloom) bloom_filter_free(bloom);
+        blocked_bloom_builder_free(bloom_builder);
         btree_builder_free(builder);
         tidesdb_distinct_counter_free(&distinct);
         return TDB_ERR_IO;
@@ -8336,8 +8280,8 @@ static int tidesdb_sstable_write_from_memtable_btree_ex(tidesdb_t *db, tidesdb_c
     btree_builder_free(builder);
     tidesdb_distinct_counter_free(&distinct);
 
-    /* write the bloom footer blob (chunk-aware, no index block in btree format) */
-    tidesdb_sstable_write_footer_aux(sst, klog_bm, NULL, bloom, 0);
+    /* finalize the bloom directory (btree format has no block index) */
+    tidesdb_sstable_write_footer_aux(sst, klog_bm, NULL, bloom_builder, 0);
 
     uint64_t klog_size_before_metadata;
     uint64_t vlog_size_before_metadata;
@@ -8413,14 +8357,14 @@ static uint64_t tidesdb_cf_oldest_unflushed_seq(tidesdb_column_family_t *cf)
  * @param heap merge heap containing entries
  * @param klog_bm klog block manager (already open)
  * @param vlog_bm vlog block manager (already open)
- * @param bloom bloom filter (optional, may be NULL)
+ * @param bloom_builder bloom filter builder (optional, may be NULL)
  * @param sstables_to_delete queue for corrupted sstables
  * @param is_largest_level whether this is the largest level
  * @return 0 on success, error code on failure
  */
 static int tidesdb_sstable_write_from_heap_btree(
     tidesdb_column_family_t *cf, tidesdb_sstable_t *sst, tidesdb_merge_heap_t *heap,
-    block_manager_t *klog_bm, block_manager_t *vlog_bm, bloom_filter_t *bloom,
+    block_manager_t *klog_bm, block_manager_t *vlog_bm, blocked_bloom_builder_t *bloom_builder,
     queue_t *sstables_to_delete, const int is_largest_level, const uint8_t *range_start,
     size_t range_start_size, const uint8_t *range_end, size_t range_end_size,
     uint64_t oldest_unflushed_seq)
@@ -8553,10 +8497,7 @@ static int tidesdb_sstable_write_from_heap_btree(
 
             if (!sd_pair_drop && !tombstone_drop && !ttl_drop)
             {
-                if (bloom)
-                {
-                    bloom_filter_add(bloom, pending->key, pending->entry.key_size);
-                }
+                blocked_bloom_builder_add(bloom_builder, pending->key, pending->entry.key_size);
 
                 uint64_t vlog_offset = 0;
                 if (pending->entry.value_size >= cf->config.klog_value_threshold && pending->value)
@@ -8675,8 +8616,8 @@ static int tidesdb_sstable_write_from_heap_btree(
     block_manager_get_size(klog_bm, &sst->klog_size);
     block_manager_get_size(vlog_bm, &sst->vlog_size);
 
-    /* write the bloom footer blob (chunk-aware, no index block in btree format) */
-    tidesdb_sstable_write_footer_aux(sst, klog_bm, NULL, bloom, 0);
+    /* finalize the bloom directory (btree format has no block index) */
+    tidesdb_sstable_write_footer_aux(sst, klog_bm, NULL, bloom_builder, 0);
 
     uint8_t *metadata = NULL;
     size_t metadata_size = 0;
@@ -8753,10 +8694,10 @@ static int tidesdb_sstable_write_from_memtable_ex(tidesdb_t *db, tidesdb_column_
         return TDB_ERR_IO;
     }
 
-    /* we create bloom filter and block indexes */
+    /* we create the blocked bloom filter and block index builders */
     int result = TDB_SUCCESS;
-    bloom_filter_t *bloom = NULL;
-    tidesdb_block_index_t *block_indexes = NULL;
+    blocked_bloom_builder_t *bloom_builder = NULL;
+    blocked_index_builder_t *index_builder = NULL;
     /* distinct key counter declared before the first goto cleanup so every cleanup path frees an
      * initialized counter */
     tidesdb_distinct_counter_t distinct;
@@ -8766,7 +8707,6 @@ static int tidesdb_sstable_write_from_memtable_ex(tidesdb_t *db, tidesdb_column_
     uint8_t *first_key = NULL;
     uint8_t *last_key = NULL;
     uint8_t *block_first_key = NULL;
-    uint8_t *block_last_key = NULL;
 
     /* we resolve comparator once for the entire flush operation */
     skip_list_comparator_fn comparator_fn = NULL;
@@ -8775,15 +8715,15 @@ static int tidesdb_sstable_write_from_memtable_ex(tidesdb_t *db, tidesdb_column_
 
     if (sst->config->enable_bloom_filter)
     {
-        if (bloom_filter_new(&bloom, sst->config->bloom_fpr, num_entries) != 0)
+        if (blocked_bloom_builder_new(&bloom_builder, sst->config->bloom_fpr, 0,
+                                      tidesdb_blocked_aux_write, bms.klog_bm) != 0)
         {
-            TDB_DEBUG_LOG(TDB_LOG_ERROR, "SSTable %" PRIu64 " failed to create bloom filter",
-                          sst->id);
+            TDB_DEBUG_LOG(TDB_LOG_ERROR,
+                          "SSTable %" PRIu64 " failed to create bloom filter builder", sst->id);
             return TDB_ERR_MEMORY;
         }
-        TDB_DEBUG_LOG(TDB_LOG_INFO,
-                      "SSTable %" PRIu64 " bloom filter created (fpr: %.4f, entries: %d)", sst->id,
-                      sst->config->bloom_fpr, num_entries);
+        TDB_DEBUG_LOG(TDB_LOG_INFO, "SSTable %" PRIu64 " bloom filter builder created (fpr: %.4f)",
+                      sst->id, sst->config->bloom_fpr);
     }
     else
     {
@@ -8792,18 +8732,15 @@ static int tidesdb_sstable_write_from_memtable_ex(tidesdb_t *db, tidesdb_column_
 
     if (sst->config->enable_block_indexes && !sst->config->use_btree)
     {
-        uint32_t initial_capacity = (num_entries / sst->config->index_sample_ratio) + 1;
-        block_indexes = compact_block_index_create(
-            initial_capacity, sst->config->block_index_prefix_len, comparator_fn, comparator_ctx);
-        if (!block_indexes)
+        if (blocked_index_builder_new(&index_builder, 0, tidesdb_blocked_aux_write, bms.klog_bm) !=
+            0)
         {
-            TDB_DEBUG_LOG(TDB_LOG_ERROR, "SSTable %" PRIu64 " failed to create block indexes",
+            TDB_DEBUG_LOG(TDB_LOG_ERROR, "SSTable %" PRIu64 " failed to create block index builder",
                           sst->id);
             result = TDB_ERR_MEMORY;
             goto cleanup;
         }
-        TDB_DEBUG_LOG(TDB_LOG_INFO, "SSTable %" PRIu64 " block indexes enabled (sample ratio: %d)",
-                      sst->id, sst->config->index_sample_ratio);
+        TDB_DEBUG_LOG(TDB_LOG_INFO, "SSTable %" PRIu64 " block index builder enabled", sst->id);
     }
     else
     {
@@ -8833,7 +8770,6 @@ static int tidesdb_sstable_write_from_memtable_ex(tidesdb_t *db, tidesdb_column_
     uint64_t tombstone_count = 0;
     uint64_t max_seq = 0;
     size_t block_first_key_size = 0;
-    size_t block_last_key_size = 0;
 
     /* seek into the cf's prefix run for a unified segment, else start at the first key */
     const int positioned = seg_prefix
@@ -8842,7 +8778,6 @@ static int tidesdb_sstable_write_from_memtable_ex(tidesdb_t *db, tidesdb_column_
     if (positioned)
     {
         size_t block_first_key_capacity = 0;
-        size_t block_last_key_capacity = 0;
         size_t first_key_capacity = 0;
         size_t last_key_capacity = 0;
         /* we use stack-allocated KV pair to avoid malloc/free per entry */
@@ -8954,25 +8889,12 @@ static int tidesdb_sstable_write_from_memtable_ex(tidesdb_t *db, tidesdb_column_
                     }
                 }
 
-                /* we reuse block_last_key buffer with capacity tracking */
-                if (key_size > block_last_key_capacity)
-                {
-                    free(block_last_key);
-                    block_last_key = malloc(key_size);
-                    block_last_key_capacity = block_last_key ? key_size : 0;
-                }
-                if (block_last_key)
-                {
-                    memcpy(block_last_key, key, key_size);
-                    block_last_key_size = key_size;
-                }
-
                 /* we flush full klog block */
                 if (tidesdb_klog_block_is_full(current_klog_block, TDB_KLOG_BLOCK_SIZE))
                 {
-                    result = tidesdb_flush_klog_block(
-                        sst, bms.klog_bm, current_klog_block, block_indexes, block_first_key,
-                        block_first_key_size, block_last_key, block_last_key_size, &klog_block_num);
+                    result = tidesdb_flush_klog_block(sst, bms.klog_bm, current_klog_block,
+                                                      index_builder, block_first_key,
+                                                      block_first_key_size, &klog_block_num);
                     if (result != TDB_SUCCESS)
                     {
                         TDB_DEBUG_LOG(TDB_LOG_ERROR, "SSTable %" PRIu64 " klog block flush failed",
@@ -8982,15 +8904,14 @@ static int tidesdb_sstable_write_from_memtable_ex(tidesdb_t *db, tidesdb_column_
 
                     tidesdb_klog_block_reset(current_klog_block);
 
-                    /* we reset sizes but keep buffers for reuse */
+                    /* we reset the size but keep the buffer for reuse */
                     block_first_key_size = 0;
-                    block_last_key_size = 0;
                 }
 
                 /* we track max sequence */
                 if (seq > max_seq) max_seq = seq;
 
-                if (bloom) bloom_filter_add(bloom, key, key_size);
+                blocked_bloom_builder_add(bloom_builder, key, key_size);
 
                 /* we reuse first_key buffer with capacity tracking */
                 if (first_key_size == 0)
@@ -9038,9 +8959,8 @@ static int tidesdb_sstable_write_from_memtable_ex(tidesdb_t *db, tidesdb_column_
     /* we flush remaining klog block */
     if (current_klog_block && current_klog_block->num_entries > 0)
     {
-        result = tidesdb_flush_klog_block(sst, bms.klog_bm, current_klog_block, block_indexes,
-                                          block_first_key, block_first_key_size, block_last_key,
-                                          block_last_key_size, &klog_block_num);
+        result = tidesdb_flush_klog_block(sst, bms.klog_bm, current_klog_block, index_builder,
+                                          block_first_key, block_first_key_size, &klog_block_num);
         if (result != TDB_SUCCESS)
         {
             TDB_DEBUG_LOG(TDB_LOG_ERROR, "SSTable %" PRIu64 " final klog block flush failed",
@@ -9050,9 +8970,7 @@ static int tidesdb_sstable_write_from_memtable_ex(tidesdb_t *db, tidesdb_column_
     }
 
     free(block_first_key);
-    free(block_last_key);
     block_first_key = NULL;
-    block_last_key = NULL;
 
     tidesdb_klog_block_free(current_klog_block);
     current_klog_block = NULL;
@@ -9074,11 +8992,12 @@ static int tidesdb_sstable_write_from_memtable_ex(tidesdb_t *db, tidesdb_column_
     last_key = NULL;
 
     /* we write footer (index, bloom, metadata) */
-    result = tidesdb_sstable_write_footer(sst, bms.klog_bm, bms.vlog_bm, block_indexes, bloom);
+    result =
+        tidesdb_sstable_write_footer(sst, bms.klog_bm, bms.vlog_bm, index_builder, bloom_builder);
 
-    /* ownership transferred to sst via footer */
-    block_indexes = NULL;
-    bloom = NULL;
+    /* the footer finalized and freed the builders */
+    index_builder = NULL;
+    bloom_builder = NULL;
 
     tidesdb_distinct_counter_free(&distinct);
     return result;
@@ -9087,12 +9006,11 @@ cleanup:
     tidesdb_distinct_counter_free(&distinct);
     if (cursor) skip_list_cursor_free(cursor);
     if (current_klog_block) tidesdb_klog_block_free(current_klog_block);
-    if (bloom) bloom_filter_free(bloom);
-    if (block_indexes) compact_block_index_free(block_indexes);
+    blocked_bloom_builder_free(bloom_builder);
+    blocked_index_builder_free(index_builder);
     free(first_key);
     free(last_key);
     free(block_first_key);
-    free(block_last_key);
     return result;
 }
 
@@ -9166,10 +9084,10 @@ static int tidesdb_sstable_get_btree(tidesdb_t *db, tidesdb_sstable_t *sst, cons
         if (min_cmp < 0 || max_cmp > 0) return TDB_ERR_NOT_FOUND;
     }
 
-    if (sst->bloom_filter)
+    if (sst->bloom_reader)
     {
         PROFILE_INC(db, bloom_checks);
-        if (!bloom_filter_contains(sst->bloom_filter, key, key_size))
+        if (blocked_bloom_reader_maybe_contains(sst->bloom_reader, key, key_size) == 0)
         {
             return TDB_ERR_NOT_FOUND;
         }
@@ -9347,10 +9265,10 @@ static int tidesdb_sstable_get(tidesdb_t *db, tidesdb_sstable_t *sst, const uint
     /* we check bloom filter for early exit (after range check since bloom is more expensive).
      * skip_bloom is set when boundary search at L1+ already identified this sstable,
      * making the bloom check redundant. */
-    if (sst->bloom_filter && !skip_bloom)
+    if (sst->bloom_reader && !skip_bloom)
     {
         PROFILE_INC(db, bloom_checks);
-        if (!bloom_filter_contains(sst->bloom_filter, key, key_size))
+        if (blocked_bloom_reader_maybe_contains(sst->bloom_reader, key, key_size) == 0)
         {
             return TDB_ERR_NOT_FOUND;
         }
@@ -9361,32 +9279,23 @@ static int tidesdb_sstable_get(tidesdb_t *db, tidesdb_sstable_t *sst, const uint
     const char *cf_name = sst->cf_name;
     const int has_cf_name = (cf_name[0] != '\0');
 
-    /* we utilize block indexes to find the target klog block.
-     * when block index covers all blocks (index_sample_ratio == 1), we do a
-     * single-block lookup -- no scan loop needed. this eliminates the O(N) scan
-     * that was the #1 source of slow reads (each scanned block triggers decompress
-     * + deserialize + cache_put). */
+    /* we utilize the block index to find the target klog block. the blocked index covers every
+     * block, so a lookup is a single-block position -- no scan loop needed. this eliminates the
+     * O(N) scan that was the #1 source of slow reads (each scanned block triggers decompress +
+     * deserialize + cache_put). */
     uint64_t start_file_position = 0;
     int block_index_definitive = 0;
     uint64_t block_index_run_len = 0;
-    if (sst->block_indexes && sst->block_indexes->count > 0)
+    if (sst->index_reader)
     {
-        int64_t start_slot = 0;
-        if (compact_block_index_find_slot(sst->block_indexes, key, key_size, &start_slot) == 0)
+        /* the blocked index stores full block first-keys, so a lookup routes to exactly one
+         * candidate block -- there is no lossy prefix run, and a hit is definitive */
+        uint64_t block_off = 0;
+        if (blocked_index_reader_find(sst->index_reader, key, key_size, &block_off, NULL) == 1)
         {
-            start_file_position = sst->block_indexes->file_positions[start_slot];
-            /* the prefix index is lossy -- keys sharing a prefix longer than
-             * prefix_len span multiple blocks with identical min/max prefixes.
-             * the run length is how many consecutive blocks the lookup must
-             * scan to be definitive, not just the first */
-            block_index_run_len =
-                compact_block_index_run_length(sst->block_indexes, key, key_size, start_slot);
-            /* block index covers all blocks when count matches num_klog_blocks
-             * (index_sample_ratio == 1). in this case the lookup is definitive:
-             * scanning the prefix-colliding run is enough -- if the key isn't in
-             * any block of the run, it's not in the sstable. */
-            block_index_definitive =
-                (sst->block_indexes->count >= sst->num_klog_blocks && start_file_position > 0);
+            start_file_position = block_off;
+            block_index_run_len = 1;
+            block_index_definitive = (start_file_position > 0);
         }
     }
 
@@ -9932,113 +9841,6 @@ static int tidesdb_sstable_load(tidesdb_t *db, tidesdb_sstable_t *sst)
     return TDB_ERR_CORRUPTION;
 
 load_bloom_and_index:; /* empty statement for C89/C90 compatibility */
-    /* load bloom filter and index from last blocks */
-    /* [klog blocks...] [index block] [bloom filter block] [metadata block] */
-
-    if (sst->aux_chunked)
-    {
-        /* chunked footer -- bloom and index are located by explicit offset+size
-         * and may span multiple blocks. reassemble each via read_aux_blob, which
-         * refuses (NULL) an oversized blob rather than risking OOM. an unreadable
-         * blob degrades gracefully (no bloom -> full block scan; no index ->
-         * sequential scan). */
-        if (sst->config && sst->config->enable_bloom_filter && sst->bloom_blob_size > 0)
-        {
-            uint8_t *bloom_buf = tidesdb_sstable_read_aux_blob(db, klog_bm, sst->bloom_blob_offset,
-                                                               sst->bloom_blob_size);
-            if (bloom_buf)
-            {
-                sst->bloom_filter = bloom_filter_deserialize(bloom_buf, sst->bloom_blob_size);
-                free(bloom_buf);
-            }
-            else
-            {
-                sst->bloom_filter = NULL;
-            }
-        }
-        else
-        {
-            sst->bloom_filter = NULL;
-        }
-
-        if (sst->config && !sst->config->use_btree && sst->index_blob_size > 0)
-        {
-            uint8_t *index_buf = tidesdb_sstable_read_aux_blob(db, klog_bm, sst->index_blob_offset,
-                                                               sst->index_blob_size);
-            if (index_buf)
-            {
-                sst->block_indexes =
-                    compact_block_index_deserialize(index_buf, sst->index_blob_size);
-                if (sst->block_indexes)
-                {
-                    sst->block_indexes->comparator = sst->config->comparator_fn_cached;
-                    sst->block_indexes->comparator_ctx = sst->config->comparator_ctx_cached;
-                }
-                free(index_buf);
-            }
-        }
-    }
-    else
-    {
-        block_manager_cursor_t *cursor;
-        if (block_manager_cursor_init(&cursor, klog_bm) != 0)
-        {
-            block_manager_close(klog_bm);
-            block_manager_close(vlog_bm);
-            return TDB_ERR_IO;
-        }
-
-        /* we go to last block (metadata) and skip it */
-        if (block_manager_cursor_goto_last(cursor) == 0)
-        {
-            /* we skip metadata block, go to bloom filter */
-            if (block_manager_cursor_prev(cursor) == 0)
-            {
-                block_manager_block_t *bloom_block = block_manager_cursor_read(cursor);
-                if (bloom_block)
-                {
-                    if (bloom_block->size > 0 && sst->config && sst->config->enable_bloom_filter)
-                    {
-                        sst->bloom_filter =
-                            bloom_filter_deserialize(bloom_block->data, bloom_block->size);
-                    }
-                    else
-                    {
-                        sst->bloom_filter = NULL;
-                    }
-                    block_manager_block_release(bloom_block);
-                }
-
-                /* go to index block -- skip for btree mode which uses its own
-                 * B+tree traversal and does not need block indexes */
-                if (block_manager_cursor_prev(cursor) == 0)
-                {
-                    block_manager_block_t *index_block = block_manager_cursor_read(cursor);
-                    if (index_block)
-                    {
-                        if (index_block->size > 0 && !sst->config->use_btree)
-                        {
-                            sst->block_indexes = compact_block_index_deserialize(index_block->data,
-                                                                                 index_block->size);
-
-                            /* we use cached comparator from config (already resolved during CF
-                             * creation) this avoids hash table lookup for every sst during
-                             * recovery */
-                            if (sst->block_indexes)
-                            {
-                                sst->block_indexes->comparator = sst->config->comparator_fn_cached;
-                                sst->block_indexes->comparator_ctx =
-                                    sst->config->comparator_ctx_cached;
-                            }
-                        }
-                        block_manager_block_release(index_block);
-                    }
-                }
-            }
-        }
-
-        block_manager_cursor_free(cursor);
-    }
 
     /* we keep block managers open and store them in the sstable
      * they will be managed by the cache and closed when the sstable is evicted or freed */
@@ -10063,6 +9865,10 @@ load_bloom_and_index:; /* empty statement for C89/C90 compatibility */
             sst->is_reverse = (min_max_cmp > 0);
         }
     }
+
+    /* open the paged blocked bloom and block index readers now that klog_bm and the comparator are
+     * set; a no-op for a non-blocked sstable */
+    tidesdb_sstable_open_blocked_readers(sst);
 
     /* we track that this file is now open */
     if (db)
@@ -10130,12 +9936,6 @@ static void tidesdb_level_free(const tidesdb_t *db, tidesdb_level_t *level)
     {
         if (ssts[i])
         {
-            /* freeing the level drops these sstables without going through
-             * tidesdb_level_remove_sstable, so decrement the aux memory total here */
-            if (db)
-                atomic_fetch_sub_explicit(&((tidesdb_t *)db)->sstable_aux_memory_bytes,
-                                          tidesdb_sstable_aux_memory_bytes(ssts[i]),
-                                          memory_order_relaxed);
             tidesdb_sstable_unref(db, ssts[i]);
         }
     }
@@ -10455,31 +10255,6 @@ static void tidesdb_defer_removed_sst_unref(tidesdb_t *db, tidesdb_level_t *leve
 }
 
 /**
- * tidesdb_sstable_aux_memory_bytes
- * resident bloom filter + block index memory of one sstable. bloom filters and
- * block indexes are immutable for the sstable's lifetime, so this is stable
- * between level add and level remove and the running total stays exact.
- * @param sst sstable
- * @return bloom filter + block index bytes
- */
-static int64_t tidesdb_sstable_aux_memory_bytes(const tidesdb_sstable_t *sst)
-{
-    int64_t bytes = 0;
-    if (sst->bloom_filter)
-    {
-        bytes +=
-            (int64_t)(sst->bloom_filter->size_in_words * sizeof(uint64_t) + sizeof(bloom_filter_t));
-    }
-    if (sst->block_indexes)
-    {
-        bytes += (int64_t)((size_t)sst->block_indexes->count *
-                               (sst->block_indexes->prefix_len * 2 + sizeof(uint64_t)) +
-                           sizeof(tidesdb_block_index_t));
-    }
-    return bytes;
-}
-
-/**
  * tidesdb_level_add_sstable
  * add an sstable to a level
  * @param level level to add sstable to
@@ -10565,10 +10340,6 @@ static int tidesdb_level_add_sstable(tidesdb_level_t *level, tidesdb_sstable_t *
 
                 atomic_fetch_add_explicit(&level->current_size, sst->klog_size + sst->vlog_size,
                                           memory_order_relaxed);
-                atomic_fetch_add_explicit(&sst->db->sstable_aux_memory_bytes,
-                                          tidesdb_sstable_aux_memory_bytes(sst),
-                                          memory_order_relaxed);
-
                 tidesdb_sstable_t **prev_retired = atomic_exchange_explicit(
                     &level->retired_sstables_arr, old_arr, memory_order_acq_rel);
                 tidesdb_retire_array(sst->db, prev_retired, level);
@@ -10601,10 +10372,6 @@ static int tidesdb_level_add_sstable(tidesdb_level_t *level, tidesdb_sstable_t *
 
                 atomic_fetch_add_explicit(&level->current_size, sst->klog_size + sst->vlog_size,
                                           memory_order_relaxed);
-                atomic_fetch_add_explicit(&sst->db->sstable_aux_memory_bytes,
-                                          tidesdb_sstable_aux_memory_bytes(sst),
-                                          memory_order_relaxed);
-
                 tidesdb_sstable_t **prev_retired = atomic_exchange_explicit(
                     &level->retired_sstables_arr, old_arr, memory_order_acq_rel);
                 tidesdb_retire_array(sst->db, prev_retired, level);
@@ -10709,8 +10476,6 @@ static int tidesdb_level_remove_sstable(const tidesdb_t *db, tidesdb_level_t *le
             /* success! we update size */
             atomic_fetch_sub_explicit(&level->current_size, sst->klog_size + sst->vlog_size,
                                       memory_order_relaxed);
-            atomic_fetch_sub_explicit(&((tidesdb_t *)db)->sstable_aux_memory_bytes,
-                                      tidesdb_sstable_aux_memory_bytes(sst), memory_order_relaxed);
 
             /* we unref old array's surviving sstables immediately (safe--new array holds refs)
              * but skip the removed sstable -- readers may still hold raw pointers from old array
@@ -10870,9 +10635,6 @@ static int tidesdb_level_remove_sstables_batch(const tidesdb_t *db, tidesdb_leve
                 out_removed[j] = 1;
                 atomic_fetch_sub_explicit(&level->current_size,
                                           to_remove[j]->klog_size + to_remove[j]->vlog_size,
-                                          memory_order_relaxed);
-                atomic_fetch_sub_explicit(&((tidesdb_t *)db)->sstable_aux_memory_bytes,
-                                          tidesdb_sstable_aux_memory_bytes(to_remove[j]),
                                           memory_order_relaxed);
                 tidesdb_defer_removed_sst_unref((tidesdb_t *)db, level, to_remove[j]);
             }
@@ -14379,52 +14141,36 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
             break;
         }
 
-        bloom_filter_t *bloom = NULL;
-        tidesdb_block_index_t *block_indexes = NULL;
+        blocked_bloom_builder_t *bloom_builder = NULL;
+        blocked_index_builder_t *index_builder = NULL;
 
         if (new_sst->config->enable_bloom_filter)
         {
-            if (bloom_filter_new(&bloom, new_sst->config->bloom_fpr, (int)estimated_entries) == 0)
+            if (blocked_bloom_builder_new(&bloom_builder, new_sst->config->bloom_fpr, 0,
+                                          tidesdb_blocked_aux_write, klog_bm) != 0)
             {
-                TDB_DEBUG_LOG(TDB_LOG_INFO, "Bloom filter created (estimated entries: %" PRIu64 ")",
-                              estimated_entries);
+                TDB_DEBUG_LOG(TDB_LOG_ERROR, "Bloom filter builder creation failed");
+                bloom_builder = NULL;
             }
-            else
-            {
-                TDB_DEBUG_LOG(TDB_LOG_ERROR, "Bloom filter creation failed");
-                bloom = NULL;
-            }
-        }
-        else
-        {
-            TDB_DEBUG_LOG(TDB_LOG_INFO, "Bloom filter disabled");
         }
 
         if (new_sst->config->enable_block_indexes && !cf->config.use_btree)
         {
-            block_indexes = compact_block_index_create(estimated_entries,
-                                                       new_sst->config->block_index_prefix_len,
-                                                       comparator_fn, comparator_ctx);
-            if (block_indexes)
+            if (blocked_index_builder_new(&index_builder, 0, tidesdb_blocked_aux_write, klog_bm) !=
+                0)
             {
-                TDB_DEBUG_LOG(TDB_LOG_INFO, "Block indexes created");
+                TDB_DEBUG_LOG(TDB_LOG_ERROR, "Block index builder creation failed");
+                index_builder = NULL;
             }
-            else
-            {
-                TDB_DEBUG_LOG(TDB_LOG_ERROR, "Block indexes builder creation failed");
-            }
-        }
-        else
-        {
-            TDB_DEBUG_LOG(TDB_LOG_INFO, "Block indexes disabled");
         }
 
         /* we branch to btree output if use_btree is enabled */
         if (cf->config.use_btree)
         {
             int btree_result = tidesdb_sstable_write_from_heap_btree(
-                cf, new_sst, heap, klog_bm, vlog_bm, bloom, sstables_to_delete, is_largest_level,
-                range_start, range_start_size, range_end, range_end_size, c->oldest_unflushed_seq);
+                cf, new_sst, heap, klog_bm, vlog_bm, bloom_builder, sstables_to_delete,
+                is_largest_level, range_start, range_start_size, range_end, range_end_size,
+                c->oldest_unflushed_seq);
             block_manager_close(klog_bm);
             block_manager_close(vlog_bm);
             tidesdb_merge_heap_free(heap);
@@ -14438,7 +14184,7 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
                 break;
             }
 
-            bloom = NULL;
+            bloom_builder = NULL;
             goto merge_complete;
         }
 
@@ -14448,11 +14194,9 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
         uint64_t vlog_block_num = 0;
         uint64_t max_seq = 0;
 
-        /* we track first and last key of current block for block index */
+        /* we track the first key of the current block for the block index */
         uint8_t *block_first_key = NULL;
         size_t block_first_key_size = 0;
-        uint8_t *block_last_key = NULL;
-        size_t block_last_key_size = 0;
 
         /* snapshot floor -- see tidesdb_sstable_write_from_heap_btree for rationale */
         const uint64_t min_snapshot_seq = tidesdb_min_active_snapshot_seq(cf->db);
@@ -14604,15 +14348,6 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
                         }
                     }
 
-                    /* we always update last key of block */
-                    free(block_last_key);
-                    block_last_key = malloc(pending->entry.key_size);
-                    if (block_last_key)
-                    {
-                        memcpy(block_last_key, pending->key, pending->entry.key_size);
-                        block_last_key_size = pending->entry.key_size;
-                    }
-
                     if (tidesdb_klog_block_is_full(current_klog_block, TDB_KLOG_BLOCK_SIZE))
                     {
                         uint8_t *klog_data;
@@ -14646,15 +14381,11 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
                                 block_manager_block_write(klog_bm, klog_block);
                                 block_manager_block_release(klog_block);
 
-                                if (block_indexes && block_first_key && block_last_key)
+                                if (block_first_key)
                                 {
-                                    if (klog_block_num % cf->config.index_sample_ratio == 0)
-                                    {
-                                        compact_block_index_add(block_indexes, block_first_key,
-                                                                block_first_key_size,
-                                                                block_last_key, block_last_key_size,
-                                                                block_file_position);
-                                    }
+                                    blocked_index_builder_add(index_builder, block_first_key,
+                                                              block_first_key_size,
+                                                              block_file_position);
                                 }
 
                                 klog_block_num++;
@@ -14665,9 +14396,7 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
                         tidesdb_klog_block_reset(current_klog_block);
 
                         free(block_first_key);
-                        free(block_last_key);
                         block_first_key = NULL;
-                        block_last_key = NULL;
                     }
 
                     if (pending->entry.seq > max_seq)
@@ -14675,10 +14404,7 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
                         max_seq = pending->entry.seq;
                     }
 
-                    if (bloom)
-                    {
-                        bloom_filter_add(bloom, pending->key, pending->entry.key_size);
-                    }
+                    blocked_bloom_builder_add(bloom_builder, pending->key, pending->entry.key_size);
 
                     if (!new_sst->min_key)
                     {
@@ -14721,9 +14447,8 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
             if (pending) tidesdb_kv_pair_free(pending);
             tidesdb_klog_block_free(current_klog_block);
             free(block_first_key);
-            free(block_last_key);
-            if (bloom) bloom_filter_free(bloom);
-            if (block_indexes) compact_block_index_free(block_indexes);
+            blocked_bloom_builder_free(bloom_builder);
+            blocked_index_builder_free(index_builder);
             tidesdb_merge_heap_free(heap);
             if (klog_bm) block_manager_close(klog_bm);
             if (vlog_bm) block_manager_close(vlog_bm);
@@ -14765,14 +14490,10 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
                     block_manager_block_write(klog_bm, klog_block);
                     block_manager_block_release(klog_block);
 
-                    if (block_indexes && block_first_key && block_last_key)
+                    if (block_first_key)
                     {
-                        if (klog_block_num % cf->config.index_sample_ratio == 0)
-                        {
-                            compact_block_index_add(block_indexes, block_first_key,
-                                                    block_first_key_size, block_last_key,
-                                                    block_last_key_size, block_file_position);
-                        }
+                        blocked_index_builder_add(index_builder, block_first_key,
+                                                  block_first_key_size, block_file_position);
                     }
 
                     klog_block_num++;
@@ -14782,7 +14503,6 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
         }
 
         free(block_first_key);
-        free(block_last_key);
 
         tidesdb_klog_block_free(current_klog_block);
 
@@ -14796,10 +14516,10 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
          * structure) */
         if (new_sst->num_entries > 0)
         {
-            /* write index + bloom footer blobs (chunk-aware, shared helper) */
-            tidesdb_sstable_write_footer_aux(new_sst, klog_bm, block_indexes, bloom, 1);
-            block_indexes = NULL;
-            bloom = NULL;
+            /* finalize the blocked index and bloom directories (shared helper) */
+            tidesdb_sstable_write_footer_aux(new_sst, klog_bm, index_builder, bloom_builder, 1);
+            index_builder = NULL;
+            bloom_builder = NULL;
         }
 
         /* we get file sizes before metadata write for serialization */
@@ -14874,8 +14594,8 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
          * post-join teardown unrefs inputs without touching the manifest */
         if (tidesdb_cf_abort_requested(cf))
         {
-            if (bloom) bloom_filter_free(bloom);
-            if (block_indexes) compact_block_index_free(block_indexes);
+            blocked_bloom_builder_free(bloom_builder);
+            blocked_index_builder_free(index_builder);
             remove(new_sst->klog_path);
             remove(new_sst->vlog_path);
             tidesdb_sstable_unref(cf->db, new_sst);
@@ -14946,8 +14666,8 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
         else
         {
             TDB_DEBUG_LOG(TDB_LOG_INFO, "Skipping empty SSTable %" PRIu64 " (0 entries)", sst_id);
-            if (bloom) bloom_filter_free(bloom);
-            if (block_indexes) compact_block_index_free(block_indexes);
+            blocked_bloom_builder_free(bloom_builder);
+            blocked_index_builder_free(index_builder);
             remove(new_sst->klog_path);
             remove(new_sst->vlog_path);
             tidesdb_sstable_unref(cf->db, new_sst);
@@ -15081,29 +14801,31 @@ static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t
     if (estimated_entries < TDB_MERGE_MIN_ESTIMATED_ENTRIES)
         estimated_entries = TDB_MERGE_MIN_ESTIMATED_ENTRIES;
 
-    bloom_filter_t *bloom = NULL;
-    tidesdb_block_index_t *block_indexes = NULL;
+    blocked_bloom_builder_t *bloom_builder = NULL;
+    blocked_index_builder_t *index_builder = NULL;
 
     if (new_sst->config->enable_bloom_filter)
     {
-        if (bloom_filter_new(&bloom, new_sst->config->bloom_fpr, (int)estimated_entries) != 0)
+        if (blocked_bloom_builder_new(&bloom_builder, new_sst->config->bloom_fpr, 0,
+                                      tidesdb_blocked_aux_write, klog_bm) != 0)
         {
-            bloom = NULL;
+            bloom_builder = NULL;
         }
     }
 
     if (new_sst->config->enable_block_indexes && !cf->config.use_btree)
     {
-        block_indexes =
-            compact_block_index_create(estimated_entries, new_sst->config->block_index_prefix_len,
-                                       comparator_fn, comparator_ctx);
+        if (blocked_index_builder_new(&index_builder, 0, tidesdb_blocked_aux_write, klog_bm) != 0)
+        {
+            index_builder = NULL;
+        }
     }
 
     if (cf->config.use_btree)
     {
         int btree_result = tidesdb_sstable_write_from_heap_btree(
-            cf, new_sst, heap, klog_bm, vlog_bm, bloom, sstables_to_delete, is_largest_level, NULL,
-            0, NULL, 0, oldest_unflushed_seq);
+            cf, new_sst, heap, klog_bm, vlog_bm, bloom_builder, sstables_to_delete,
+            is_largest_level, NULL, 0, NULL, 0, oldest_unflushed_seq);
         block_manager_close(klog_bm);
         block_manager_close(vlog_bm);
         tidesdb_merge_heap_free(heap);
@@ -15133,7 +14855,7 @@ static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t
             return btree_result;
         }
 
-        bloom = NULL;
+        bloom_builder = NULL;
         goto merge_complete;
     }
 
@@ -15145,8 +14867,6 @@ static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t
 
     uint8_t *block_first_key = NULL;
     size_t block_first_key_size = 0;
-    uint8_t *block_last_key = NULL;
-    size_t block_last_key_size = 0;
 
     tidesdb_kv_pair_t *pending = NULL;
     int pending_is_single_delete = 0;
@@ -15256,14 +14976,6 @@ static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t
                     }
                 }
 
-                free(block_last_key);
-                block_last_key = malloc(pending->entry.key_size);
-                if (block_last_key)
-                {
-                    memcpy(block_last_key, pending->key, pending->entry.key_size);
-                    block_last_key_size = pending->entry.key_size;
-                }
-
                 if (tidesdb_klog_block_is_full(current_klog_block, TDB_KLOG_BLOCK_SIZE))
                 {
                     uint8_t *klog_data;
@@ -15296,14 +15008,11 @@ static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t
                             block_manager_block_write(klog_bm, klog_block);
                             block_manager_block_release(klog_block);
 
-                            if (block_indexes && block_first_key && block_last_key)
+                            if (block_first_key)
                             {
-                                if (klog_block_num % cf->config.index_sample_ratio == 0)
-                                {
-                                    compact_block_index_add(
-                                        block_indexes, block_first_key, block_first_key_size,
-                                        block_last_key, block_last_key_size, block_file_position);
-                                }
+                                blocked_index_builder_add(index_builder, block_first_key,
+                                                          block_first_key_size,
+                                                          block_file_position);
                             }
 
                             klog_block_num++;
@@ -15314,14 +15023,12 @@ static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t
                     tidesdb_klog_block_reset(current_klog_block);
 
                     free(block_first_key);
-                    free(block_last_key);
                     block_first_key = NULL;
-                    block_last_key = NULL;
                 }
 
                 if (pending->entry.seq > max_seq) max_seq = pending->entry.seq;
 
-                if (bloom) bloom_filter_add(bloom, pending->key, pending->entry.key_size);
+                blocked_bloom_builder_add(bloom_builder, pending->key, pending->entry.key_size);
 
                 if (!new_sst->min_key)
                 {
@@ -15363,9 +15070,8 @@ static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t
         if (pending) tidesdb_kv_pair_free(pending);
         tidesdb_klog_block_free(current_klog_block);
         free(block_first_key);
-        free(block_last_key);
-        if (bloom) bloom_filter_free(bloom);
-        if (block_indexes) compact_block_index_free(block_indexes);
+        blocked_bloom_builder_free(bloom_builder);
+        blocked_index_builder_free(index_builder);
         tidesdb_merge_heap_free(heap);
         if (klog_bm) block_manager_close(klog_bm);
         if (vlog_bm) block_manager_close(vlog_bm);
@@ -15413,14 +15119,10 @@ static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t
                 block_manager_block_write(klog_bm, klog_block);
                 block_manager_block_release(klog_block);
 
-                if (block_indexes && block_first_key && block_last_key)
+                if (block_first_key)
                 {
-                    if (klog_block_num % cf->config.index_sample_ratio == 0)
-                    {
-                        compact_block_index_add(block_indexes, block_first_key,
-                                                block_first_key_size, block_last_key,
-                                                block_last_key_size, block_file_position);
-                    }
+                    blocked_index_builder_add(index_builder, block_first_key, block_first_key_size,
+                                              block_file_position);
                 }
 
                 klog_block_num++;
@@ -15430,7 +15132,6 @@ static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t
     }
 
     free(block_first_key);
-    free(block_last_key);
 
     tidesdb_klog_block_free(current_klog_block);
 
@@ -15442,10 +15143,10 @@ static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t
 
     if (new_sst->num_entries > 0)
     {
-        /* write index + bloom footer blobs (chunk-aware, shared helper) */
-        tidesdb_sstable_write_footer_aux(new_sst, klog_bm, block_indexes, bloom, 1);
-        block_indexes = NULL; /* ownership transferred; local must not double-free on abort */
-        bloom = NULL;         /* same as block_indexes */
+        /* finalize the blocked index and bloom directories (shared helper) */
+        tidesdb_sstable_write_footer_aux(new_sst, klog_bm, index_builder, bloom_builder, 1);
+        index_builder = NULL; /* finalized and freed by the footer; do not double-free on abort */
+        bloom_builder = NULL;
     }
 
     uint64_t klog_size_before_metadata;
@@ -15507,8 +15208,8 @@ merge_complete:;
 
     if (tidesdb_cf_abort_requested(cf))
     {
-        if (bloom) bloom_filter_free(bloom);
-        if (block_indexes) compact_block_index_free(block_indexes);
+        blocked_bloom_builder_free(bloom_builder);
+        blocked_index_builder_free(index_builder);
         remove(new_sst->klog_path);
         remove(new_sst->vlog_path);
         tidesdb_sstable_unref(cf->db, new_sst);
@@ -15564,8 +15265,8 @@ merge_complete:;
     }
     else
     {
-        if (bloom) bloom_filter_free(bloom);
-        if (block_indexes) compact_block_index_free(block_indexes);
+        blocked_bloom_builder_free(bloom_builder);
+        blocked_index_builder_free(index_builder);
         remove(new_sst->klog_path);
         remove(new_sst->vlog_path);
         tidesdb_sstable_unref(cf->db, new_sst);
@@ -16032,36 +15733,31 @@ static int tidesdb_dividing_merge_partition(void *vctx, int partition)
         uint8_t *last_key = NULL;
         size_t last_key_size = 0;
 
-        bloom_filter_t *bloom = NULL;
-        tidesdb_block_index_t *block_indexes = NULL;
+        blocked_bloom_builder_t *bloom_builder = NULL;
+        blocked_index_builder_t *index_builder = NULL;
 
-        /* we track first and last key of current block for block index */
+        /* we track the first key of the current block for the block index */
         uint8_t *block_first_key = NULL;
         size_t block_first_key_size = 0;
-        uint8_t *block_last_key = NULL;
-        size_t block_last_key_size = 0;
 
         if (cf->config.enable_bloom_filter)
         {
-            if (bloom_filter_new(&bloom, cf->config.bloom_fpr, (int)partition_entries) == 0)
-            {
-                TDB_DEBUG_LOG(TDB_LOG_INFO,
-                              "Partition %d bloom filter created (estimated entries: %" PRIu64 ")",
-                              partition, partition_entries);
-            }
-            else
+            if (blocked_bloom_builder_new(&bloom_builder, cf->config.bloom_fpr, 0,
+                                          tidesdb_blocked_aux_write, klog_bm) != 0)
             {
                 TDB_DEBUG_LOG(TDB_LOG_ERROR, "Partition %d bloom filter creation failed",
                               partition);
-                bloom = NULL;
+                bloom_builder = NULL;
             }
         }
 
         if (cf->config.enable_block_indexes && !cf->config.use_btree)
         {
-            block_indexes =
-                compact_block_index_create(partition_entries, cf->config.block_index_prefix_len,
-                                           comparator_fn, comparator_ctx);
+            if (blocked_index_builder_new(&index_builder, 0, tidesdb_blocked_aux_write, klog_bm) !=
+                0)
+            {
+                index_builder = NULL;
+            }
         }
 
         /* we branch to btree output if use_btree is enabled.
@@ -16075,13 +15771,14 @@ static int tidesdb_dividing_merge_partition(void *vctx, int partition)
             klog_block = NULL;
 
             int btree_result = tidesdb_sstable_write_from_heap_btree(
-                cf, new_sst, partition_heap, klog_bm, vlog_bm, bloom, NULL, is_largest_level,
-                range_start, range_start_size, range_end, range_end_size, c->oldest_unflushed_seq);
+                cf, new_sst, partition_heap, klog_bm, vlog_bm, bloom_builder, NULL,
+                is_largest_level, range_start, range_start_size, range_end, range_end_size,
+                c->oldest_unflushed_seq);
             block_manager_close(klog_bm);
             block_manager_close(vlog_bm);
             tidesdb_merge_heap_free(partition_heap);
 
-            bloom = NULL;
+            bloom_builder = NULL;
 
             if (btree_result != TDB_SUCCESS)
             {
@@ -16203,10 +15900,7 @@ static int tidesdb_dividing_merge_partition(void *vctx, int partition)
                         last_key_size = pending->entry.key_size;
                     }
 
-                    if (bloom)
-                    {
-                        bloom_filter_add(bloom, pending->key, pending->entry.key_size);
-                    }
+                    blocked_bloom_builder_add(bloom_builder, pending->key, pending->entry.key_size);
 
                     /* large values go to the output vlog -- without recording a
                      * fresh offset here the entry is neither inline nor in vlog
@@ -16271,15 +15965,6 @@ static int tidesdb_dividing_merge_partition(void *vctx, int partition)
                         }
                     }
 
-                    /* we always update last key of block */
-                    free(block_last_key);
-                    block_last_key = malloc(pending->entry.key_size);
-                    if (block_last_key)
-                    {
-                        memcpy(block_last_key, pending->key, pending->entry.key_size);
-                        block_last_key_size = pending->entry.key_size;
-                    }
-
                     if (tidesdb_klog_block_is_full(klog_block, TDB_KLOG_BLOCK_SIZE))
                     {
                         uint8_t *klog_data;
@@ -16312,15 +15997,11 @@ static int tidesdb_dividing_merge_partition(void *vctx, int partition)
                                 block_manager_block_write(klog_bm, klog_bm_block);
                                 block_manager_block_release(klog_bm_block);
 
-                                if (block_indexes && block_first_key && block_last_key)
+                                if (block_first_key)
                                 {
-                                    if (klog_block_num % cf->config.index_sample_ratio == 0)
-                                    {
-                                        compact_block_index_add(block_indexes, block_first_key,
-                                                                block_first_key_size,
-                                                                block_last_key, block_last_key_size,
-                                                                block_file_position);
-                                    }
+                                    blocked_index_builder_add(index_builder, block_first_key,
+                                                              block_first_key_size,
+                                                              block_file_position);
                                 }
 
                                 klog_block_num++;
@@ -16333,9 +16014,7 @@ static int tidesdb_dividing_merge_partition(void *vctx, int partition)
 
                         /* we reset block tracking for new block */
                         free(block_first_key);
-                        free(block_last_key);
                         block_first_key = NULL;
-                        block_last_key = NULL;
                     }
 
                     /* we track maximum sequence number */
@@ -16393,16 +16072,11 @@ static int tidesdb_dividing_merge_partition(void *vctx, int partition)
                     block_manager_block_write(klog_bm, block);
                     block_manager_block_release(block);
 
-                    /* we add final block to index after writing with correct file position */
-                    if (block_indexes && block_first_key && block_last_key)
+                    /* we add the final block to the index after writing, with its file position */
+                    if (block_first_key)
                     {
-                        /* we sample every Nth block (ratio validated to be >= 1) */
-                        if (klog_block_num % cf->config.index_sample_ratio == 0)
-                        {
-                            compact_block_index_add(block_indexes, block_first_key,
-                                                    block_first_key_size, block_last_key,
-                                                    block_last_key_size, block_file_position);
-                        }
+                        blocked_index_builder_add(index_builder, block_first_key,
+                                                  block_first_key_size, block_file_position);
                     }
 
                     klog_block_num++;
@@ -16412,7 +16086,6 @@ static int tidesdb_dividing_merge_partition(void *vctx, int partition)
         }
 
         free(block_first_key);
-        free(block_last_key);
 
         tidesdb_klog_block_free(klog_block);
 
@@ -16436,10 +16109,11 @@ static int tidesdb_dividing_merge_partition(void *vctx, int partition)
          * structure) */
         if (entry_count > 0)
         {
-            /* write index + bloom footer blobs (chunk-aware, shared helper) */
-            tidesdb_sstable_write_footer_aux(new_sst, klog_bm, block_indexes, bloom, 1);
-            block_indexes = NULL; /* ownership transferred; local must not double-free on abort */
-            bloom = NULL;         /* ownership transferred; local must not double-free on abort */
+            /* finalize the blocked index and bloom directories (shared helper) */
+            tidesdb_sstable_write_footer_aux(new_sst, klog_bm, index_builder, bloom_builder, 1);
+            index_builder =
+                NULL; /* finalized and freed by the footer; do not double-free on abort */
+            bloom_builder = NULL;
         }
 
         /* we get file sizes before metadata write for serialization */
@@ -16495,8 +16169,8 @@ static int tidesdb_dividing_merge_partition(void *vctx, int partition)
         if (entry_count > 0 && tidesdb_cf_abort_requested(cf))
         {
             /* drop fired during this partition's merge; do not publish the partition output */
-            if (bloom) bloom_filter_free(bloom);
-            if (block_indexes) compact_block_index_free(block_indexes);
+            blocked_bloom_builder_free(bloom_builder);
+            blocked_index_builder_free(index_builder);
             remove(new_sst->klog_path);
             remove(new_sst->vlog_path);
             tidesdb_sstable_unref(cf->db, new_sst);
@@ -16567,8 +16241,8 @@ static int tidesdb_dividing_merge_partition(void *vctx, int partition)
                           "Partition %d skipping empty SSTable %" PRIu64 " (0 entries)", partition,
                           new_sst->id);
 
-            if (bloom) bloom_filter_free(bloom);
-            if (block_indexes) compact_block_index_free(block_indexes);
+            blocked_bloom_builder_free(bloom_builder);
+            blocked_index_builder_free(index_builder);
 
             remove(new_sst->klog_path);
             remove(new_sst->vlog_path);
@@ -16593,8 +16267,8 @@ static int tidesdb_dividing_merge_partition(void *vctx, int partition)
  * @param sst sstable to finalize (takes ownership, caller must not use after)
  * @param klog_bm klog block manager (closed on return)
  * @param vlog_bm vlog block manager (closed on return)
- * @param bloom bloom filter (ownership transferred to sst)
- * @param block_indexes block index (ownership transferred to sst)
+ * @param bloom_builder bloom filter builder (finalized here)
+ * @param index_builder block index builder (finalized here)
  * @param entry_count number of entries written
  * @param tombstone_count number of tombstones
  * @param klog_block_num number of klog blocks written
@@ -16606,8 +16280,9 @@ static int tidesdb_dividing_merge_partition(void *vctx, int partition)
  */
 static int tdb_partitioned_merge_finalize_sst(
     tidesdb_column_family_t *cf, tidesdb_sstable_t *sst, block_manager_t *klog_bm,
-    block_manager_t *vlog_bm, bloom_filter_t *bloom, tidesdb_block_index_t *block_indexes,
-    const uint64_t entry_count, const uint64_t tombstone_count, const uint64_t distinct_key_count,
+    block_manager_t *vlog_bm, blocked_bloom_builder_t *bloom_builder,
+    blocked_index_builder_t *index_builder, const uint64_t entry_count,
+    const uint64_t tombstone_count, const uint64_t distinct_key_count,
     const uint64_t klog_block_num, const uint64_t vlog_block_num, const uint64_t max_seq,
     const int end_level, const int partition)
 {
@@ -16622,9 +16297,8 @@ static int tdb_partitioned_merge_finalize_sst(
 
     if (entry_count > 0)
     {
-        /* write index + bloom footer blobs (chunk-aware, shared helper). ownership
-         * of block_indexes/bloom transfers to sst inside the helper. */
-        tidesdb_sstable_write_footer_aux(sst, klog_bm, block_indexes, bloom, 1);
+        /* finalize the blocked index and bloom directories (shared helper) */
+        tidesdb_sstable_write_footer_aux(sst, klog_bm, index_builder, bloom_builder, 1);
     }
 
     uint64_t klog_size_before_metadata;
@@ -16725,8 +16399,8 @@ static int tdb_partitioned_merge_finalize_sst(
     }
     else
     {
-        if (bloom) bloom_filter_free(bloom);
-        if (block_indexes) compact_block_index_free(block_indexes);
+        blocked_bloom_builder_free(bloom_builder);
+        blocked_index_builder_free(index_builder);
         remove(sst->klog_path);
         remove(sst->vlog_path);
         tidesdb_sstable_unref(cf->db, sst);
@@ -17298,34 +16972,28 @@ static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
                 break;
             }
 
-            bloom_filter_t *bloom = NULL;
-            tidesdb_block_index_t *block_indexes = NULL;
+            blocked_bloom_builder_t *bloom_builder = NULL;
+            blocked_index_builder_t *index_builder = NULL;
 
             if (cf->config.enable_bloom_filter)
             {
-                if (bloom_filter_new(&bloom, cf->config.bloom_fpr, (int)estimated_entries) == 0)
-                {
-                    TDB_DEBUG_LOG(
-                        TDB_LOG_INFO,
-                        "Partitioned merge partition %d bloom filter created (estimated entries: "
-                        "%" PRIu64 ")",
-                        partition, estimated_entries);
-                }
-                else
+                if (blocked_bloom_builder_new(&bloom_builder, cf->config.bloom_fpr, 0,
+                                              tidesdb_blocked_aux_write, klog_bm) != 0)
                 {
                     TDB_DEBUG_LOG(TDB_LOG_ERROR,
                                   "Partitioned merge partition %d bloom filter creation failed",
                                   partition);
-                    bloom = NULL;
+                    bloom_builder = NULL;
                 }
             }
 
             if (cf->config.enable_block_indexes && !cf->config.use_btree)
             {
-                /* we reuse comparator_fn and comparator_ctx from outer scope */
-                block_indexes =
-                    compact_block_index_create(estimated_entries, cf->config.block_index_prefix_len,
-                                               comparator_fn, comparator_ctx);
+                if (blocked_index_builder_new(&index_builder, 0, tidesdb_blocked_aux_write,
+                                              klog_bm) != 0)
+                {
+                    index_builder = NULL;
+                }
             }
 
             /* btree output. is_largest_level mirrors the non-btree branch
@@ -17333,13 +17001,14 @@ static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
             if (cf->config.use_btree)
             {
                 int btree_result = tidesdb_sstable_write_from_heap_btree(
-                    cf, new_sst, heap, klog_bm, vlog_bm, bloom, NULL, reap_tombstones, range_start,
-                    range_start_size, range_end, range_end_size, c->oldest_unflushed_seq);
+                    cf, new_sst, heap, klog_bm, vlog_bm, bloom_builder, NULL, reap_tombstones,
+                    range_start, range_start_size, range_end, range_end_size,
+                    c->oldest_unflushed_seq);
                 block_manager_close(klog_bm);
                 block_manager_close(vlog_bm);
                 tidesdb_merge_heap_free(heap);
 
-                bloom = NULL;
+                bloom_builder = NULL;
 
                 if (btree_result != TDB_SUCCESS)
                 {
@@ -17385,11 +17054,9 @@ static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
             uint8_t *last_key = NULL;
             size_t last_key_size = 0;
 
-            /* we track first and last key of current block for block index */
+            /* we track the first key of the current block for the block index */
             uint8_t *block_first_key = NULL;
             size_t block_first_key_size = 0;
-            uint8_t *block_last_key = NULL;
-            size_t block_last_key_size = 0;
 
             /* we track last key for duplicate detection */
             uint8_t *last_seen_key = NULL;
@@ -17526,10 +17193,7 @@ static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
                     free(compressed);
                 }
 
-                if (bloom)
-                {
-                    bloom_filter_add(bloom, kv->key, kv->entry.key_size);
-                }
+                blocked_bloom_builder_add(bloom_builder, kv->key, kv->entry.key_size);
 
                 /* we check if this is first entry in a new block (before adding) */
                 int is_first_entry_in_block = (klog_block->num_entries == 0);
@@ -17553,15 +17217,6 @@ static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
                         memcpy(block_first_key, kv->key, kv->entry.key_size);
                         block_first_key_size = kv->entry.key_size;
                     }
-                }
-
-                /* we always update last key of block */
-                free(block_last_key);
-                block_last_key = malloc(kv->entry.key_size);
-                if (block_last_key)
-                {
-                    memcpy(block_last_key, kv->key, kv->entry.key_size);
-                    block_last_key_size = kv->entry.key_size;
                 }
 
                 /** we track maximum sequence number */
@@ -17606,16 +17261,12 @@ static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
                             block_manager_block_write(klog_bm, block);
                             block_manager_block_release(block);
 
-                            /* we add completed block to index after writing with file position */
-                            if (block_indexes && block_first_key && block_last_key)
+                            /* we record the block by its first key after writing */
+                            if (block_first_key)
                             {
-                                /* we sample every Nth block (ratio validated to be >= 1) */
-                                if (klog_block_num % cf->config.index_sample_ratio == 0)
-                                {
-                                    compact_block_index_add(
-                                        block_indexes, block_first_key, block_first_key_size,
-                                        block_last_key, block_last_key_size, block_file_position);
-                                }
+                                blocked_index_builder_add(index_builder, block_first_key,
+                                                          block_first_key_size,
+                                                          block_file_position);
                             }
 
                             klog_block_num++;
@@ -17627,9 +17278,7 @@ static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
 
                     /* we reset block tracking for new block */
                     free(block_first_key);
-                    free(block_last_key);
                     block_first_key = NULL;
-                    block_last_key = NULL;
 
                     /*** spooky file_max splits if output exceeds C_X, finalize this
                      **  sstable and start a new one within the same partition.
@@ -17654,9 +17303,9 @@ static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
                                           file_max);
 
                             tdb_partitioned_merge_finalize_sst(
-                                cf, new_sst, klog_bm, vlog_bm, bloom, block_indexes, entry_count,
-                                tombstone_count, distinct.distinct, klog_block_num, vlog_block_num,
-                                max_seq, end_level, partition);
+                                cf, new_sst, klog_bm, vlog_bm, bloom_builder, index_builder,
+                                entry_count, tombstone_count, distinct.distinct, klog_block_num,
+                                vlog_block_num, max_seq, end_level, partition);
 
                             /* we create replacement sst for remaining entries in this partition */
                             uint64_t split_id = atomic_fetch_add(&cf->next_sstable_id, 1);
@@ -17685,13 +17334,13 @@ static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
                                         break;
                                 }
                                 /* the prior split was already finalized (it consumed klog_bm,
-                                 * vlog_bm, bloom, block_indexes), so NULL them before the post-loop
-                                 * finalize guard runs -- otherwise it would double-free/close them.
-                                 * abort so the sources are preserved (no data loss; retried). */
+                                 * vlog_bm, and freed the builders), so NULL them before the
+                                 * post-loop finalize guard runs -- otherwise it would
+                                 * double-free/close them. abort so the sources are preserved. */
                                 klog_bm = NULL;
                                 vlog_bm = NULL;
-                                bloom = NULL;
-                                block_indexes = NULL;
+                                bloom_builder = NULL;
+                                index_builder = NULL;
                                 aborted = 1;
                                 break;
                             }
@@ -17719,37 +17368,37 @@ static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
                                 new_sst = NULL;
                                 klog_bm = NULL;
                                 vlog_bm = NULL;
-                                bloom =
-                                    NULL; /* consumed by the prior finalize -- don't reuse/free */
-                                block_indexes = NULL;
+                                bloom_builder = NULL; /* consumed by the prior finalize */
+                                index_builder = NULL;
                                 aborted = 1;
                                 break;
                             }
 
-                            bloom = NULL;
-                            block_indexes = NULL;
+                            bloom_builder = NULL;
+                            index_builder = NULL;
                             if (cf->config.enable_bloom_filter)
                             {
-                                /* bloom_filter_new nulls bloom on failure
-                                 * (see contract in src/bloom_filter.c), so a
-                                 * miss here leaves bloom NULL and the merge
-                                 * loop skips bloom_filter_add */
-                                if (bloom_filter_new(&bloom, cf->config.bloom_fpr,
-                                                     (int)estimated_entries) != 0)
+                                /* a miss here leaves bloom_builder NULL and the merge loop's add
+                                 * becomes a no-op, so the split sstable is written without a bloom
+                                 */
+                                if (blocked_bloom_builder_new(&bloom_builder, cf->config.bloom_fpr,
+                                                              0, tidesdb_blocked_aux_write,
+                                                              klog_bm) != 0)
                                 {
                                     TDB_DEBUG_LOG(
                                         TDB_LOG_WARN,
-                                        "Partitioned merge partition %d bloom_filter_new "
-                                        "failed on file_max split (estimated_entries=%" PRIu64
-                                        "), continuing without bloom for this split sstable",
-                                        partition, estimated_entries);
+                                        "Partitioned merge partition %d bloom builder creation "
+                                        "failed on file_max split, continuing without a bloom",
+                                        partition);
                                 }
                             }
                             if (cf->config.enable_block_indexes && !cf->config.use_btree)
                             {
-                                block_indexes = compact_block_index_create(
-                                    estimated_entries, cf->config.block_index_prefix_len,
-                                    comparator_fn, comparator_ctx);
+                                if (blocked_index_builder_new(
+                                        &index_builder, 0, tidesdb_blocked_aux_write, klog_bm) != 0)
+                                {
+                                    index_builder = NULL;
+                                }
                             }
 
                             /* we reset per-sst counters */
@@ -17806,14 +17455,10 @@ static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
                         block_manager_block_write(klog_bm, block);
                         block_manager_block_release(block);
 
-                        if (block_indexes && block_first_key && block_last_key)
+                        if (block_first_key)
                         {
-                            if (klog_block_num % cf->config.index_sample_ratio == 0)
-                            {
-                                compact_block_index_add(block_indexes, block_first_key,
-                                                        block_first_key_size, block_last_key,
-                                                        block_last_key_size, block_file_position);
-                            }
+                            blocked_index_builder_add(index_builder, block_first_key,
+                                                      block_first_key_size, block_file_position);
                         }
 
                         klog_block_num++;
@@ -17824,7 +17469,6 @@ static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
 
             tidesdb_klog_block_free(klog_block);
             free(block_first_key);
-            free(block_last_key);
 
             /* we assign min/max keys and finalize via helper -- unless an output open aborted the
              * merge, in which case we must not finalize through a NULL block manager. release this
@@ -17837,8 +17481,8 @@ static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
                 new_sst->max_key = last_key;
                 new_sst->max_key_size = last_key_size;
 
-                tdb_partitioned_merge_finalize_sst(cf, new_sst, klog_bm, vlog_bm, bloom,
-                                                   block_indexes, entry_count, tombstone_count,
+                tdb_partitioned_merge_finalize_sst(cf, new_sst, klog_bm, vlog_bm, bloom_builder,
+                                                   index_builder, entry_count, tombstone_count,
                                                    distinct.distinct, klog_block_num,
                                                    vlog_block_num, max_seq, end_level, partition);
             }
@@ -17846,8 +17490,8 @@ static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
             {
                 free(first_key);
                 free(last_key);
-                if (bloom) bloom_filter_free(bloom);
-                if (block_indexes) compact_block_index_free(block_indexes);
+                blocked_bloom_builder_free(bloom_builder);
+                blocked_index_builder_free(index_builder);
                 if (klog_bm) block_manager_close(klog_bm);
                 if (vlog_bm) block_manager_close(vlog_bm);
                 if (new_sst) tidesdb_sstable_unref(cf->db, new_sst);
@@ -20075,9 +19719,7 @@ static void *tidesdb_reaper_thread(void *arg)
                         atomic_load_explicit(&cf->immutable_bytes, memory_order_relaxed);
                 }
 
-                /* count sstables per cf for the compaction victim heuristic. bloom
-                 * filter and block index memory is not summed here -- it is tracked
-                 * by the sstable_aux_memory_bytes running total and added once below */
+                /* count sstables per cf for the compaction victim heuristic */
                 int total_cf_ssts = 0;
                 int num_levels = atomic_load_explicit(&cf->num_active_levels, memory_order_acquire);
                 for (int lv = 0; lv < num_levels && lv < TDB_MAX_LEVELS; lv++)
@@ -20135,10 +19777,8 @@ static void *tidesdb_reaper_thread(void *arg)
                 }
             }
 
-            /* bloom filter + block index memory across every sstable, maintained
-             * as a running total at level add and remove */
-            total_mem_bytes +=
-                atomic_load_explicit(&db->sstable_aux_memory_bytes, memory_order_relaxed);
+            /* bloom filter and block index memory is not summed separately -- the blocked aux lives
+             * in the block cache and is counted by the cache stats below */
 
             /* we add cache memory */
             if (db->clock_cache)
@@ -22960,19 +22600,6 @@ int tidesdb_create_column_family(tidesdb_t *db, const char *name,
         tidesdb_unimap_resolve(db, name, &cf->unified_cf_index, &unimap_is_new);
         TDB_DEBUG_LOG(TDB_LOG_INFO, "CF '%s' assigned unified_cf_index=%u", name,
                       cf->unified_cf_index);
-    }
-
-    /* we validate and fix index_sample_ratio (must be at least 1 to avoid division by zero) */
-    if (cf->config.index_sample_ratio < 1)
-    {
-        cf->config.index_sample_ratio = TDB_DEFAULT_INDEX_SAMPLE_RATIO;
-    }
-
-    /* we validate and fix block_index_prefix_len */
-    if (cf->config.block_index_prefix_len < TDB_BLOCK_INDEX_PREFIX_MIN ||
-        cf->config.block_index_prefix_len > TDB_BLOCK_INDEX_PREFIX_MAX)
-    {
-        cf->config.block_index_prefix_len = TDB_DEFAULT_BLOCK_INDEX_PREFIX_LEN;
     }
 
     /**** we validate write_buffer_size against resolved_memory_limit to prevent
@@ -31042,9 +30669,11 @@ static void tidesdb_iter_seek_sstable_source_forward(const tidesdb_iter_t *iter,
 
     /* we use block index to find starting position */
     uint64_t block_position = 0;
-    if (sst->block_indexes && sst->block_indexes->count > 0)
+    if (sst->index_reader)
     {
-        compact_block_index_find_predecessor(sst->block_indexes, key, key_size, &block_position);
+        uint64_t block_off = 0;
+        if (blocked_index_reader_find(sst->index_reader, key, key_size, &block_off, NULL) == 1)
+            block_position = block_off;
     }
 
     if (block_position > 0)
@@ -31442,9 +31071,11 @@ static void tidesdb_iter_seek_sstable_source_backward(const tidesdb_iter_t *iter
 
     /* we use block index to find starting position */
     uint64_t block_position = 0;
-    if (sst->block_indexes && sst->block_indexes->count > 0)
+    if (sst->index_reader)
     {
-        compact_block_index_find_predecessor(sst->block_indexes, key, key_size, &block_position);
+        uint64_t block_off = 0;
+        if (blocked_index_reader_find(sst->index_reader, key, key_size, &block_off, NULL) == 1)
+            block_position = block_off;
     }
 
     if (block_position > 0)
@@ -34680,33 +34311,25 @@ int tidesdb_range_cost(tidesdb_column_family_t *cf, const uint8_t *key_a, const 
                     ? TDB_RANGE_COST_COMPRESSION_WEIGHT
                     : 1.0;
 
-            if (sst->block_indexes && sst->block_indexes->count > 0)
+            if (sst->index_reader)
             {
-                /* we use block index slots to estimate block span */
-                int64_t slot_a = 0, slot_b = 0;
+                /* the blocked index covers every block, so the ordinal span of the two ends is the
+                 * exact block span -- no sample-ratio scaling */
+                uint64_t off_a = 0, ord_a = 0, off_b = 0, ord_b = 0;
                 const int found_a =
-                    compact_block_index_find_slot(sst->block_indexes, lo, lo_size, &slot_a);
+                    blocked_index_reader_find(sst->index_reader, lo, lo_size, &off_a, &ord_a);
                 const int found_b =
-                    compact_block_index_find_slot(sst->block_indexes, hi, hi_size, &slot_b);
-
-                if (found_a == 0 && found_b == 0)
+                    blocked_index_reader_find(sst->index_reader, hi, hi_size, &off_b, &ord_b);
+                if (found_a == 1 && found_b == 1)
                 {
-                    int64_t sampled_blocks = (slot_b - slot_a) + 1;
-                    if (sampled_blocks < 1) sampled_blocks = 1;
-
-                    /* we scale by index_sample_ratio to get actual block count */
-                    const int sample_ratio = (sst->config && sst->config->index_sample_ratio > 0)
-                                                 ? sst->config->index_sample_ratio
-                                                 : 1;
-                    est_blocks = (double)sampled_blocks * (double)sample_ratio;
-
-                    /* we clamp to actual block count */
+                    int64_t blocks = (int64_t)ord_b - (int64_t)ord_a + 1;
+                    if (blocks < 1) blocks = 1;
+                    est_blocks = (double)blocks;
                     if (est_blocks > (double)sst->num_klog_blocks)
                         est_blocks = (double)sst->num_klog_blocks;
                 }
                 else
                 {
-                    /* we fallback to full sstable if slot search failed */
                     est_blocks = (double)sst->num_klog_blocks;
                 }
             }
@@ -35792,8 +35415,6 @@ int tidesdb_clone_column_family(tidesdb_t *db, const char *src_name, const char 
 #define TDB_INI_KEY_ENABLE_BLOOM_FILTER           "enable_bloom_filter"
 #define TDB_INI_KEY_BLOOM_FPR                     "bloom_fpr"
 #define TDB_INI_KEY_ENABLE_BLOCK_INDEXES          "enable_block_indexes"
-#define TDB_INI_KEY_INDEX_SAMPLE_RATIO            "index_sample_ratio"
-#define TDB_INI_KEY_BLOCK_INDEX_PREFIX_LEN        "block_index_prefix_len"
 #define TDB_INI_KEY_SYNC_MODE                     "sync_mode"
 #define TDB_INI_KEY_SYNC_INTERVAL_US              "sync_interval_us"
 #define TDB_INI_KEY_SKIP_LIST_MAX_LEVEL           "skip_list_max_level"
@@ -35892,14 +35513,6 @@ static int ini_config_handler(void *user, const char *section, const char *name,
     else if (strcmp(name, TDB_INI_KEY_ENABLE_BLOCK_INDEXES) == 0)
     {
         ctx->config->enable_block_indexes = (int)strtol(value, NULL, 10);
-    }
-    else if (strcmp(name, TDB_INI_KEY_INDEX_SAMPLE_RATIO) == 0)
-    {
-        ctx->config->index_sample_ratio = (int)strtol(value, NULL, 10);
-    }
-    else if (strcmp(name, TDB_INI_KEY_BLOCK_INDEX_PREFIX_LEN) == 0)
-    {
-        ctx->config->block_index_prefix_len = (int)strtol(value, NULL, 10);
     }
     else if (strcmp(name, TDB_INI_KEY_SYNC_MODE) == 0)
     {
@@ -36033,8 +35646,6 @@ int tidesdb_cf_config_save_to_ini(const char *ini_file, const char *section_name
     fprintf(fp, TDB_INI_KEY_ENABLE_BLOOM_FILTER " = %d\n", config->enable_bloom_filter);
     fprintf(fp, TDB_INI_KEY_BLOOM_FPR " = %f\n", config->bloom_fpr);
     fprintf(fp, TDB_INI_KEY_ENABLE_BLOCK_INDEXES " = %d\n", config->enable_block_indexes);
-    fprintf(fp, TDB_INI_KEY_INDEX_SAMPLE_RATIO " = %d\n", config->index_sample_ratio);
-    fprintf(fp, TDB_INI_KEY_BLOCK_INDEX_PREFIX_LEN " = %d\n", config->block_index_prefix_len);
     fprintf(fp, TDB_INI_KEY_SYNC_MODE " = %d\n", config->sync_mode);
     fprintf(fp, TDB_INI_KEY_SYNC_INTERVAL_US " = %" PRIu64 "\n", config->sync_interval_us);
     fprintf(fp, TDB_INI_KEY_SKIP_LIST_MAX_LEVEL " = %d\n", config->skip_list_max_level);
@@ -36090,8 +35701,6 @@ int tidesdb_cf_update_runtime_config(tidesdb_column_family_t *cf,
     cf->config.enable_bloom_filter = new_config->enable_bloom_filter;
     cf->config.bloom_fpr = new_config->bloom_fpr;
     cf->config.enable_block_indexes = new_config->enable_block_indexes;
-    cf->config.index_sample_ratio = new_config->index_sample_ratio;
-    cf->config.block_index_prefix_len = new_config->block_index_prefix_len;
     cf->config.compression_algorithm = new_config->compression_algorithm;
     cf->config.write_buffer_size = new_config->write_buffer_size;
     cf->config.level_size_ratio = new_config->level_size_ratio;
@@ -36143,436 +35752,6 @@ int tidesdb_cf_set_commit_hook(tidesdb_column_family_t *cf, tidesdb_commit_hook_
     cf->config.commit_hook_ctx = ctx;
 
     return TDB_SUCCESS;
-}
-
-/**
- * compact_block_index_create
- * creates a new block index for fast key-to-block lookups in sstables
- * @param initial_capacity initial number of index entries
- * @param prefix_len length of key prefixes to store
- * @param comparator comparator function for key ordering
- * @param comparator_ctx context for comparator
- * @return new block index, or NULL on failure
- */
-static tidesdb_block_index_t *compact_block_index_create(uint32_t initial_capacity,
-                                                         uint8_t prefix_len,
-                                                         const tidesdb_comparator_fn comparator,
-                                                         void *comparator_ctx)
-{
-    if (initial_capacity == 0) initial_capacity = TDB_INITIAL_BLOCK_INDEX_CAPACITY;
-    if (prefix_len < TDB_BLOCK_INDEX_PREFIX_MIN) prefix_len = TDB_DEFAULT_BLOCK_INDEX_PREFIX_LEN;
-
-    tidesdb_block_index_t *index = calloc(1, sizeof(tidesdb_block_index_t));
-    if (!index) return NULL;
-
-    index->min_key_prefixes = malloc(initial_capacity * prefix_len);
-    index->max_key_prefixes = malloc(initial_capacity * prefix_len);
-    index->file_positions = malloc(initial_capacity * sizeof(uint64_t));
-
-    if (!index->min_key_prefixes || !index->max_key_prefixes || !index->file_positions)
-    {
-        compact_block_index_free(index);
-        return NULL;
-    }
-
-    index->capacity = initial_capacity;
-    index->count = 0;
-    index->prefix_len = prefix_len;
-    index->comparator = comparator;
-    index->comparator_ctx = comparator_ctx;
-
-    return index;
-}
-
-/**
- * compact_block_index_serialize
- * serializes a block index to a byte buffer for writing to disk
- * @param index block index to serialize
- * @param out_size output parameter for serialized size
- * @return serialized data (caller must free), or NULL on failure
- */
-static uint8_t *compact_block_index_serialize(const tidesdb_block_index_t *index, size_t *out_size)
-{
-    if (!index || !out_size) return NULL;
-
-    /** header
-     *  count (4) + prefix_len (1) + file_positions (varint) + min/max prefixes */
-    const size_t max_size = sizeof(uint32_t) + sizeof(uint8_t) +
-                            index->count * 10 +                   /* file_positions (varint) */
-                            index->count * index->prefix_len * 2; /* min + max prefixes */
-
-    uint8_t *data = malloc(max_size);
-    if (!data) return NULL;
-
-    uint8_t *ptr = data;
-
-    /** header
-     *  count + prefix_len */
-    encode_uint32_le_compat(ptr, index->count);
-    ptr += sizeof(uint32_t);
-    *ptr++ = index->prefix_len;
-
-    /* delta encode + varint compress file_positions */
-    if (index->count > 0)
-    {
-        /* first file position stored as-is */
-        ptr += encode_varint(ptr, index->file_positions[0]);
-
-        /* remaining file positions stored as deltas */
-        for (uint32_t i = 1; i < index->count; i++)
-        {
-            const uint64_t delta = index->file_positions[i] - index->file_positions[i - 1];
-            ptr += encode_varint(ptr, delta);
-        }
-    }
-
-    const size_t prefix_bytes = index->count * index->prefix_len;
-    memcpy(ptr, index->min_key_prefixes, prefix_bytes);
-    ptr += prefix_bytes;
-    memcpy(ptr, index->max_key_prefixes, prefix_bytes);
-    ptr += prefix_bytes;
-
-    /* we calc actual size and shrink buffer */
-    const size_t actual_size = ptr - data;
-    uint8_t *final_data = realloc(data, actual_size);
-    if (!final_data)
-    {
-        /* realloc failed, but the original data is still valid */
-        *out_size = actual_size;
-        return data;
-    }
-
-    *out_size = actual_size;
-    return final_data;
-}
-
-/**
- * compact_block_index_deserialize
- * deserializes a block index from a byte buffer read from disk
- * @param data serialized data
- * @param data_size size of serialized data
- * @return deserialized block index, or NULL on failure
- */
-static tidesdb_block_index_t *compact_block_index_deserialize(const uint8_t *data,
-                                                              const size_t data_size)
-{
-    if (!data || data_size < sizeof(uint32_t) + sizeof(uint8_t)) return NULL;
-
-    const uint8_t *ptr = data;
-    const uint8_t *end = data + data_size;
-
-    /* we read header
-     * count + prefix_len */
-    const uint32_t count = decode_uint32_le_compat(ptr);
-    ptr += sizeof(uint32_t);
-    const uint8_t prefix_len = *ptr++;
-
-    if (prefix_len < TDB_BLOCK_INDEX_PREFIX_MIN)
-    {
-        TDB_DEBUG_LOG(
-            TDB_LOG_WARN,
-            "Block index deserialization failed with invalid prefix_len=%u (must be %d-%d)",
-            prefix_len, TDB_BLOCK_INDEX_PREFIX_MIN, TDB_BLOCK_INDEX_PREFIX_MAX);
-        return NULL; /* invalid format */
-    }
-
-    if (count > TDB_BLOCK_INDEX_MAX_COUNT)
-    {
-        TDB_DEBUG_LOG(TDB_LOG_WARN, "Block index deserialization failed with unreasonable count=%u",
-                      count);
-        return NULL;
-    }
-
-    tidesdb_block_index_t *index = calloc(1, sizeof(tidesdb_block_index_t));
-    if (!index) return NULL;
-
-    if (count == 0)
-    {
-        index->count = 0;
-        index->capacity = 0;
-        index->prefix_len = prefix_len;
-        index->min_key_prefixes = NULL;
-        index->max_key_prefixes = NULL;
-        index->file_positions = NULL;
-        return index;
-    }
-
-    index->min_key_prefixes = malloc(count * prefix_len);
-    index->max_key_prefixes = malloc(count * prefix_len);
-    index->file_positions = malloc(count * sizeof(uint64_t));
-
-    if (!index->min_key_prefixes || !index->max_key_prefixes || !index->file_positions)
-    {
-        compact_block_index_free(index);
-        return NULL;
-    }
-
-    /* we decode file_positions (delta-encoded varints) */
-    if (count > 0)
-    {
-        uint64_t value;
-
-        int bytes_read = decode_varint(ptr, &value, (int)(end - ptr));
-        if (bytes_read < 0) goto error;
-        index->file_positions[0] = value;
-        ptr += bytes_read;
-
-        /* remaining file positions (deltas) */
-        for (uint32_t i = 1; i < count; i++)
-        {
-            uint64_t delta;
-            bytes_read = decode_varint(ptr, &delta, (int)(end - ptr));
-            if (bytes_read < 0) goto error;
-            ptr += bytes_read;
-            index->file_positions[i] = index->file_positions[i - 1] + delta;
-        }
-    }
-
-    const size_t prefix_bytes = count * prefix_len;
-    if (ptr + prefix_bytes > end) goto error;
-    memcpy(index->min_key_prefixes, ptr, prefix_bytes);
-    ptr += prefix_bytes;
-
-    if (ptr + prefix_bytes > end) goto error;
-    memcpy(index->max_key_prefixes, ptr, prefix_bytes);
-    ptr += prefix_bytes;
-
-    index->count = count;
-    index->capacity = count;
-    index->prefix_len = prefix_len;
-    index->comparator = NULL;
-    index->comparator_ctx = NULL;
-
-    return index;
-
-error:
-    compact_block_index_free(index);
-    return NULL;
-}
-
-/**
- * compact_block_index_add
- * add a new entry to the block index
- * @param index block index
- * @param min_key minimum key in block
- * @param min_key_len length of minimum key
- * @param max_key maximum key in block
- * @param max_key_len length of maximum key
- * @param file_position position of block in file
- * @return 0 on success, -1 on error
- */
-static int compact_block_index_add(tidesdb_block_index_t *index, const uint8_t *min_key,
-                                   const size_t min_key_len, const uint8_t *max_key,
-                                   const size_t max_key_len, const uint64_t file_position)
-{
-    if (!index || !min_key || !max_key) return -1;
-
-    if (index->count >= index->capacity)
-    {
-        const uint32_t new_capacity = index->capacity * 2;
-
-        /** we must handle realloc failures carefully to avoid memory leaks
-         *  if any realloc fails, we keep the original pointers intact */
-        uint8_t *new_min = realloc(index->min_key_prefixes, new_capacity * index->prefix_len);
-        if (!new_min) return -1;
-        index->min_key_prefixes = new_min;
-
-        uint8_t *new_max = realloc(index->max_key_prefixes, new_capacity * index->prefix_len);
-        if (!new_max) return -1;
-        index->max_key_prefixes = new_max;
-
-        uint64_t *new_positions = realloc(index->file_positions, new_capacity * sizeof(uint64_t));
-        if (!new_positions) return -1;
-        index->file_positions = new_positions;
-
-        index->capacity = new_capacity;
-    }
-
-    const size_t min_copy_len = (min_key_len < index->prefix_len) ? min_key_len : index->prefix_len;
-    const size_t max_copy_len = (max_key_len < index->prefix_len) ? max_key_len : index->prefix_len;
-
-    uint8_t *min_dest = index->min_key_prefixes + (index->count * index->prefix_len);
-    uint8_t *max_dest = index->max_key_prefixes + (index->count * index->prefix_len);
-
-    memcpy(min_dest, min_key, min_copy_len);
-    if (min_copy_len < index->prefix_len)
-    {
-        memset(min_dest + min_copy_len, 0, index->prefix_len - min_copy_len);
-    }
-
-    memcpy(max_dest, max_key, max_copy_len);
-    if (max_copy_len < index->prefix_len)
-    {
-        memset(max_dest + max_copy_len, 0, index->prefix_len - max_copy_len);
-    }
-
-    index->file_positions[index->count] = file_position;
-    index->count++;
-
-    return 0;
-}
-
-/**
- * compact_block_index_find_slot
- * finds the leftmost block that could contain the given key using binary search
- *
- * the block index is lossy, it stores only the first prefix_len bytes of each
- * block's min/max key. when several keys share a prefix longer than prefix_len
- * they can span multiple klog blocks that all have identical min/max prefixes.
- * returning the rightmost prefix match would overshoot the block that actually
- * holds the key, so this finds the leftmost block whose max prefix is >= the
- * search prefix -- the first block that could hold the key or a key after it.
- * callers needing a definitive answer scan the prefix-colliding run forward
- * from here via compact_block_index_run_length.
- *
- * @param index the block index to search
- * @param key the search key
- * @param key_len length of the search key
- * @param slot output parameter for the found slot number
- * @return 0 on success, -1 if no suitable slot found
- */
-static int compact_block_index_find_slot(const tidesdb_block_index_t *index, const uint8_t *key,
-                                         const size_t key_len, int64_t *slot)
-{
-    if (!index || !key || index->count == 0 || !slot) return -1;
-
-    uint8_t search_prefix[TDB_BLOCK_INDEX_PREFIX_MAX];
-    const size_t copy_len = (key_len < index->prefix_len) ? key_len : index->prefix_len;
-    memcpy(search_prefix, key, copy_len);
-    if (copy_len < index->prefix_len)
-    {
-        memset(search_prefix + copy_len, 0, index->prefix_len - copy_len);
-    }
-
-    int64_t left = 0;
-    int64_t right = (int64_t)index->count - 1;
-    int64_t candidate = -1;
-
-    while (left <= right)
-    {
-        const int64_t mid = left + (right - left) / 2;
-        const uint8_t *mid_max_prefix = index->max_key_prefixes + (mid * index->prefix_len);
-
-        int cmp_max;
-        if (index->comparator)
-        {
-            cmp_max = index->comparator(search_prefix, index->prefix_len, mid_max_prefix,
-                                        index->prefix_len, index->comparator_ctx);
-        }
-        else
-        {
-            cmp_max = memcmp(search_prefix, mid_max_prefix, index->prefix_len);
-        }
-
-        if (cmp_max <= 0)
-        {
-            /* search_prefix <= max_prefix[mid] -- mid could hold the key; keep it
-             * and look left for an earlier block that also could */
-            candidate = mid;
-            right = mid - 1;
-        }
-        else
-        {
-            /* search_prefix > max_prefix[mid] -- the key sorts past this block */
-            left = mid + 1;
-        }
-    }
-
-    /* if no block has max_prefix >= search_prefix the key sorts past every
-     * indexed block; fall back to the last block so iterators position at the
-     * end and point lookups scan it and find nothing */
-    *slot = (candidate >= 0) ? candidate : (int64_t)index->count - 1;
-    return 0;
-}
-
-/**
- * compact_block_index_find_predecessor
- * thin wrapper over compact_block_index_find_slot that returns the file
- * position of the leftmost block that could contain the key
- *
- * @param index the block index to search
- * @param key the search key
- * @param key_len length of the search key
- * @param file_position output parameter for the found block file position
- * @return 0 on success, -1 if no suitable block found
- */
-static int compact_block_index_find_predecessor(const tidesdb_block_index_t *index,
-                                                const uint8_t *key, const size_t key_len,
-                                                uint64_t *file_position)
-{
-    int64_t slot = 0;
-    if (compact_block_index_find_slot(index, key, key_len, &slot) != 0) return -1;
-    *file_position = index->file_positions[slot];
-    return 0;
-}
-
-/**
- * compact_block_index_run_length
- * counts the prefix-colliding run starting at start_slot -- the number of
- * consecutive blocks whose min prefix is <= the search prefix. because the
- * prefix index is lossy a definitive point lookup must scan every block in
- * this run, not just the first, since the index cannot tell which one holds
- * the key. returns at least 1 so the caller always scans the starting block.
- *
- * @param index the block index to search
- * @param key the search key
- * @param key_len length of the search key
- * @param start_slot leftmost candidate slot from compact_block_index_find_slot
- * @return number of consecutive candidate blocks, 0 if start_slot is invalid
- */
-static uint32_t compact_block_index_run_length(const tidesdb_block_index_t *index,
-                                               const uint8_t *key, const size_t key_len,
-                                               const int64_t start_slot)
-{
-    if (!index || !key || start_slot < 0 || (uint32_t)start_slot >= index->count) return 0;
-
-    uint8_t search_prefix[TDB_BLOCK_INDEX_PREFIX_MAX];
-    const size_t copy_len = (key_len < index->prefix_len) ? key_len : index->prefix_len;
-    memcpy(search_prefix, key, copy_len);
-    if (copy_len < index->prefix_len)
-    {
-        memset(search_prefix + copy_len, 0, index->prefix_len - copy_len);
-    }
-
-    uint32_t run = 0;
-    for (uint32_t s = (uint32_t)start_slot; s < index->count; s++)
-    {
-        const uint8_t *min_prefix = index->min_key_prefixes + (s * index->prefix_len);
-        int cmp_min;
-        if (index->comparator)
-        {
-            cmp_min = index->comparator(min_prefix, index->prefix_len, search_prefix,
-                                        index->prefix_len, index->comparator_ctx);
-        }
-        else
-        {
-            cmp_min = memcmp(min_prefix, search_prefix, index->prefix_len);
-        }
-
-        /* min_prefix > search_prefix -- the key sorts before this block, so it
-         * cannot be in this block or any later one; the run ends here */
-        if (cmp_min > 0) break;
-        run++;
-    }
-
-    /* a gap (start_slot's min prefix already past the search prefix) still scans
-     * one block so the in-block search can report not found consistently */
-    if (run == 0) run = 1;
-    return run;
-}
-
-/**
- * compact_block_index_free
- * free a block index
- * @param index block index to free
- */
-static void compact_block_index_free(tidesdb_block_index_t *index)
-{
-    if (!index) return;
-    free(index->min_key_prefixes);
-    free(index->max_key_prefixes);
-    free(index->file_positions);
-    free(index);
 }
 
 #ifdef TDB_ENABLE_READ_PROFILING

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -21,6 +21,8 @@
 
 #include "alloc.h"
 #include "block_manager.h"
+#include "blocked_bloom_filter.h"
+#include "blocked_index.h"
 #include "bloom_filter.h"
 #include "btree.h"
 #include "clock_cache.h"
@@ -224,8 +226,6 @@ typedef enum
 #define TDB_DEFAULT_MAX_CONCURRENT_FLUSHES TDB_DEFAULT_FLUSH_THREAD_POOL_SIZE
 #define TDB_DEFAULT_BLOOM_FPR              0.01
 #define TDB_DEFAULT_KLOG_VALUE_THRESHOLD   512
-#define TDB_DEFAULT_INDEX_SAMPLE_RATIO     1
-#define TDB_DEFAULT_BLOCK_INDEX_PREFIX_LEN 16
 #define TDB_DEFAULT_MIN_DISK_SPACE         (100 * 1024 * 1024)
 #if defined(__OpenBSD__)
 #define TDB_DEFAULT_MAX_OPEN_SSTABLES 64 /* x2 OpenBSD has lower default fd limits */
@@ -300,7 +300,6 @@ typedef struct tidesdb_kv_pair_t tidesdb_kv_pair_t;
 typedef struct tidesdb_commit_status_t tidesdb_commit_status_t;
 typedef struct tidesdb_level_t tidesdb_level_t;
 typedef struct tidesdb_sstable_t tidesdb_sstable_t;
-typedef struct tidesdb_block_index_t tidesdb_block_index_t;
 typedef struct tidesdb_memtable_t tidesdb_memtable_t;
 typedef struct tidesdb_deferred_free_node_t tidesdb_deferred_free_node_t;
 typedef struct tidesdb_t tidesdb_t;
@@ -370,8 +369,6 @@ typedef struct tidesdb_stats_t tidesdb_stats_t;
  * @param enable_bloom_filter enable bloom filter
  * @param bloom_fpr bloom filter false positive rate
  * @param enable_block_indexes enable block indexes
- * @param index_sample_ratio index sample ratio
- * @param block_index_prefix_len block index prefix length
  * @param sync_mode sync mode
  * @param sync_interval_us sync interval in microseconds
  * @param comparator_name name of comparator
@@ -412,8 +409,6 @@ typedef struct tidesdb_column_family_config_t
     int enable_bloom_filter;
     double bloom_fpr;
     int enable_block_indexes;
-    int index_sample_ratio;
-    int block_index_prefix_len;
     int sync_mode;
     uint64_t sync_interval_us;
     char comparator_name[TDB_MAX_COMPARATOR_NAME];
@@ -709,8 +704,12 @@ struct tidesdb_sstable_t
     uint64_t klog_size;
     uint64_t vlog_size;
     uint64_t max_seq;
-    bloom_filter_t *bloom_filter;
-    tidesdb_block_index_t *block_indexes;
+    /* paged aux -- the blocked bloom filter and block index keep only a small directory resident
+     * and page their partitions through the block cache. present when the sstable was written in
+     * the blocked-aux format (SSTABLE_FLAG_BLOCKED_AUX); NULL for older sstables, whose reads fall
+     * back to a full scan until compaction rewrites them. */
+    blocked_bloom_reader_t *bloom_reader;
+    blocked_index_reader_t *index_reader;
     _Atomic(int) refcount;
     /* opened lazily by tidesdb_sstable_ensure_open and published by CAS, so the
      * pointers are _Atomic -- readers acquire-load them and so observe the fully
@@ -731,17 +730,14 @@ struct tidesdb_sstable_t
     void *cached_comparator_ctx;
     int is_reverse;
     uint64_t cache_key_prefix;
-    /* chunked footer aux blobs -- when a bloom filter or block index footer blob
-     * exceeds the single-block chunk size it is written as multiple consecutive
-     * blocks and located by explicit offset+size instead of trailing-block
-     * navigation. aux_chunked is set (and the offsets persisted in metadata) only
-     * for such sstables; legacy/small sstables leave it 0 and use the original
-     * trailing-block read path. */
-    int aux_chunked;
-    uint64_t bloom_blob_offset;
-    uint64_t bloom_blob_size;
-    uint64_t index_blob_offset;
-    uint64_t index_blob_size;
+    /* blocked-aux directory locators -- persisted in metadata under SSTABLE_FLAG_BLOCKED_AUX and
+     * handed to blocked_bloom_reader_open / blocked_index_reader_open at load. blocked_aux is set
+     * for sstables written in this format. */
+    int blocked_aux;
+    uint64_t bloom_dir_offset;
+    uint64_t bloom_dir_size;
+    uint64_t index_dir_offset;
+    uint64_t index_dir_size;
 };
 
 /**
@@ -821,10 +817,6 @@ struct tidesdb_level_t
  * @param total_memory total system memory in bytes
  * @param resolved_memory_limit resolved global memory limit in bytes
  * @param cached_memtable_bytes cached total memtable + cache memory (updated by reaper)
- * @param sstable_aux_memory_bytes running total of bloom filter + block index
- *                                 memory across every sstable currently in a
- *                                 level, maintained at level add and remove so
- *                                 the reaper does not rescan every sstable
  * @param memory_pressure_level cached pressure level 0=normal 1=elevated 2=high 3=critical
  * @param txn_memory_bytes bytes held by in-flight transactions
  * @param flush_pending_count number of pending flush operations (queued + in-flight)
@@ -912,7 +904,6 @@ struct tidesdb_t
     uint64_t total_memory;
     _Atomic(size_t) resolved_memory_limit;
     _Atomic(int64_t) cached_memtable_bytes;
-    _Atomic(int64_t) sstable_aux_memory_bytes;
     _Atomic(int64_t) txn_memory_bytes;
     _Atomic(int) memory_pressure_level;
     _Atomic(int) flush_pending_count;

--- a/test/blocked_bloom_filter__tests.c
+++ b/test/blocked_bloom_filter__tests.c
@@ -1,0 +1,457 @@
+/**
+ *
+ * Copyright (C) TidesDB
+ *
+ * Original Author: Alex Gaetano Padula
+ *
+ * Licensed under the Mozilla Public License, v. 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.mozilla.org/en-US/MPL/2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../src/block_manager.h"
+#include "../src/blocked_bloom_filter.h"
+#include "test_utils.h"
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+/* an append-only in-memory backing store standing in for the sstable's block-managed file. write
+ * appends and hands back the offset; fetch returns a pointer into the buffer (no pin needed). the
+ * write counter lets a test observe that partitions are flushed as they roll over, not buffered. */
+typedef struct
+{
+    uint8_t *buf;
+    size_t len;
+    size_t cap;
+    int writes;
+} bbf_store_t;
+
+static int store_write(void *ctx, const uint8_t *data, size_t size, uint64_t *out_offset)
+{
+    bbf_store_t *s = ctx;
+    if (s->len + size > s->cap)
+    {
+        size_t ncap = s->cap ? s->cap * 2 : 4096;
+        while (ncap < s->len + size) ncap *= 2;
+        uint8_t *nb = realloc(s->buf, ncap);
+        if (!nb) return -1;
+        s->buf = nb;
+        s->cap = ncap;
+    }
+    *out_offset = s->len;
+    memcpy(s->buf + s->len, data, size);
+    s->len += size;
+    s->writes++;
+    return 0;
+}
+
+static int store_fetch(void *ctx, uint64_t offset, uint32_t size, const uint8_t **out_data,
+                       void **out_pin)
+{
+    bbf_store_t *s = ctx;
+    if (offset > s->len || (uint64_t)size > s->len - offset) return -1;
+    *out_data = s->buf + offset;
+    *out_pin = NULL;
+    return 0;
+}
+
+static void store_free(bbf_store_t *s)
+{
+    free(s->buf);
+}
+
+/* callbacks that drive a real block manager, the same way the sstable klog stores aux blobs. write
+ * appends one block and returns its offset; fetch reads the block at that offset and hands the
+ * block back as the pin so release can free it once the probe is done. */
+static int bm_write(void *ctx, const uint8_t *data, size_t size, uint64_t *out_offset)
+{
+    block_manager_block_t *blk = block_manager_block_create(size, data);
+    if (!blk) return -1;
+    int64_t off = block_manager_block_write((block_manager_t *)ctx, blk);
+    block_manager_block_release(blk);
+    if (off < 0) return -1;
+    *out_offset = (uint64_t)off;
+    return 0;
+}
+
+static int bm_fetch(void *ctx, uint64_t offset, uint32_t size, const uint8_t **out_data,
+                    void **out_pin)
+{
+    block_manager_cursor_t *cur = NULL;
+    if (block_manager_cursor_init(&cur, (block_manager_t *)ctx) != 0) return -1;
+    if (block_manager_cursor_goto(cur, offset) != 0)
+    {
+        block_manager_cursor_free(cur);
+        return -1;
+    }
+    block_manager_block_t *blk = block_manager_cursor_read(cur);
+    block_manager_cursor_free(cur);
+    if (!blk) return -1;
+    if (blk->size != size)
+    {
+        block_manager_block_release(blk);
+        return -1;
+    }
+    *out_data = blk->data;
+    *out_pin = blk;
+    return 0;
+}
+
+static void bm_release(void *ctx, void *pin)
+{
+    (void)ctx;
+    block_manager_block_release((block_manager_block_t *)pin);
+}
+
+/* lexicographic order over raw bytes, matching tidesdb_comparator_fn */
+static int cmp_lex(const uint8_t *a, size_t alen, const uint8_t *b, size_t blen, void *ctx)
+{
+    (void)ctx;
+    size_t n = alen < blen ? alen : blen;
+    int c = memcmp(a, b, n);
+    if (c != 0) return c;
+    return (alen > blen) - (alen < blen);
+}
+
+/* fixed-width zero-padded key so lexicographic order equals numeric order */
+static size_t make_key(int v, uint8_t *out)
+{
+    return (size_t)snprintf((char *)out, 16, "k%08d", v);
+}
+
+void test_bbf_builder_new_invalid_args()
+{
+    blocked_bloom_builder_t *b = NULL;
+    ASSERT_NE(blocked_bloom_builder_new(NULL, 0.01, 0, store_write, NULL), 0);
+    ASSERT_NE(blocked_bloom_builder_new(&b, 0.0, 0, store_write, NULL), 0);
+    ASSERT_NE(blocked_bloom_builder_new(&b, 1.0, 0, store_write, NULL), 0);
+    ASSERT_NE(blocked_bloom_builder_new(&b, 0.01, 0, NULL, NULL), 0);
+}
+
+/* every added key must report may-present -- a bloom may never report a false negative */
+void test_bbf_no_false_negatives()
+{
+    bbf_store_t store = {0};
+    blocked_bloom_builder_t *b = NULL;
+    ASSERT_EQ(blocked_bloom_builder_new(&b, 0.01, 512, store_write, &store), 0);
+
+    const int n = 20000;
+    for (int i = 0; i < n; i++)
+    {
+        uint8_t key[16];
+        size_t klen = make_key(i, key);
+        ASSERT_EQ(blocked_bloom_builder_add(b, key, klen), 0);
+    }
+    uint64_t dir_off = 0, total = 0;
+    uint32_t dir_size = 0;
+    ASSERT_EQ(blocked_bloom_builder_finish(b, &dir_off, &dir_size, &total), 0);
+    ASSERT_EQ(total, (uint64_t)n);
+    blocked_bloom_builder_free(b);
+
+    /* rollover at 512 keys over 20000 keys means many partitions plus the directory were written */
+    ASSERT_TRUE(store.writes > n / 512);
+
+    blocked_bloom_reader_t *r = NULL;
+    ASSERT_EQ(
+        blocked_bloom_reader_open(&r, dir_off, dir_size, cmp_lex, NULL, store_fetch, NULL, &store),
+        0);
+    for (int i = 0; i < n; i++)
+    {
+        uint8_t key[16];
+        size_t klen = make_key(i, key);
+        ASSERT_EQ(blocked_bloom_reader_maybe_contains(r, key, klen), 1);
+    }
+    blocked_bloom_reader_free(r);
+    store_free(&store);
+}
+
+/* a key sorting before the first partition is a definite miss, answered without a fetch */
+void test_bbf_below_range_is_absent()
+{
+    bbf_store_t store = {0};
+    blocked_bloom_builder_t *b = NULL;
+    ASSERT_EQ(blocked_bloom_builder_new(&b, 0.01, 256, store_write, &store), 0);
+    for (int i = 100; i < 5000; i++)
+    {
+        uint8_t key[16];
+        size_t klen = make_key(i, key);
+        ASSERT_EQ(blocked_bloom_builder_add(b, key, klen), 0);
+    }
+    uint64_t dir_off = 0;
+    uint32_t dir_size = 0;
+    ASSERT_EQ(blocked_bloom_builder_finish(b, &dir_off, &dir_size, NULL), 0);
+    blocked_bloom_builder_free(b);
+
+    blocked_bloom_reader_t *r = NULL;
+    ASSERT_EQ(
+        blocked_bloom_reader_open(&r, dir_off, dir_size, cmp_lex, NULL, store_fetch, NULL, &store),
+        0);
+    uint8_t key[16];
+    size_t klen = make_key(0, key); /* below the smallest inserted key (100) */
+    ASSERT_EQ(blocked_bloom_reader_maybe_contains(r, key, klen), 0);
+    blocked_bloom_reader_free(r);
+    store_free(&store);
+}
+
+/* absent keys spread across partitions should trip the filter at roughly the configured rate */
+void test_bbf_false_positive_rate()
+{
+    bbf_store_t store = {0};
+    blocked_bloom_builder_t *b = NULL;
+    ASSERT_EQ(blocked_bloom_builder_new(&b, 0.01, 4096, store_write, &store), 0);
+
+    const int n = 50000;
+    for (int i = 0; i < n; i++) /* even keys inserted, ascending */
+    {
+        uint8_t key[16];
+        size_t klen = make_key(i * 2, key);
+        ASSERT_EQ(blocked_bloom_builder_add(b, key, klen), 0);
+    }
+    uint64_t dir_off = 0;
+    uint32_t dir_size = 0;
+    ASSERT_EQ(blocked_bloom_builder_finish(b, &dir_off, &dir_size, NULL), 0);
+    blocked_bloom_builder_free(b);
+
+    blocked_bloom_reader_t *r = NULL;
+    ASSERT_EQ(
+        blocked_bloom_reader_open(&r, dir_off, dir_size, cmp_lex, NULL, store_fetch, NULL, &store),
+        0);
+    int fp = 0;
+    for (int i = 0; i < n; i++) /* odd keys never inserted, interleaved across partitions */
+    {
+        uint8_t key[16];
+        size_t klen = make_key(i * 2 + 1, key);
+        if (blocked_bloom_reader_maybe_contains(r, key, klen) == 1) fp++;
+    }
+    /* generous ceiling at 3x the target so the fixed seed cannot flake */
+    ASSERT_TRUE(fp < n * 3 / 100);
+    blocked_bloom_reader_free(r);
+    store_free(&store);
+}
+
+/* a build with no keys yields an empty directory, and its reader answers may-present, which is the
+ * safe fallback when no filter exists */
+void test_bbf_empty_build()
+{
+    bbf_store_t store = {0};
+    blocked_bloom_builder_t *b = NULL;
+    ASSERT_EQ(blocked_bloom_builder_new(&b, 0.01, 256, store_write, &store), 0);
+    uint64_t dir_off = 0, total = 1;
+    uint32_t dir_size = 0;
+    ASSERT_EQ(blocked_bloom_builder_finish(b, &dir_off, &dir_size, &total), 0);
+    ASSERT_EQ(total, 0u);
+    blocked_bloom_builder_free(b);
+
+    blocked_bloom_reader_t *r = NULL;
+    ASSERT_EQ(
+        blocked_bloom_reader_open(&r, dir_off, dir_size, cmp_lex, NULL, store_fetch, NULL, &store),
+        0);
+    uint8_t key[16];
+    size_t klen = make_key(42, key);
+    ASSERT_EQ(blocked_bloom_reader_maybe_contains(r, key, klen), 1);
+    ASSERT_TRUE(blocked_bloom_reader_resident_bytes(r) > 0);
+    blocked_bloom_reader_free(r);
+    store_free(&store);
+}
+
+/* one key, one partition */
+void test_bbf_single_key()
+{
+    bbf_store_t store = {0};
+    blocked_bloom_builder_t *b = NULL;
+    ASSERT_EQ(blocked_bloom_builder_new(&b, 0.01, 0, store_write, &store), 0);
+    uint8_t key[16];
+    size_t klen = make_key(7, key);
+    ASSERT_EQ(blocked_bloom_builder_add(b, key, klen), 0);
+    uint64_t dir_off = 0;
+    uint32_t dir_size = 0;
+    ASSERT_EQ(blocked_bloom_builder_finish(b, &dir_off, &dir_size, NULL), 0);
+    blocked_bloom_builder_free(b);
+
+    blocked_bloom_reader_t *r = NULL;
+    ASSERT_EQ(
+        blocked_bloom_reader_open(&r, dir_off, dir_size, cmp_lex, NULL, store_fetch, NULL, &store),
+        0);
+    ASSERT_EQ(blocked_bloom_reader_maybe_contains(r, key, klen), 1);
+    uint8_t other[16];
+    size_t olen = make_key(999999, other); /* absent, above range -> routes to the sole partition */
+    ASSERT_EQ(blocked_bloom_reader_maybe_contains(r, other, olen), 0);
+    blocked_bloom_reader_free(r);
+    store_free(&store);
+}
+
+void test_bbf_free_null_safe()
+{
+    blocked_bloom_builder_free(NULL);
+    blocked_bloom_reader_free(NULL);
+    ASSERT_EQ(blocked_bloom_reader_resident_bytes(NULL), 0u);
+}
+
+/* end to end over a real block manager file, exercising the exact write and read path the sstable
+ * klog will use, and reopening the reader from a fresh block manager to prove the on-disk directory
+ * and partitions round-trip through storage */
+void test_bbf_block_manager_backed()
+{
+    const char *path = "./test_bbf_klog.bm";
+    remove(path);
+
+    block_manager_t *bm = NULL;
+    ASSERT_EQ(block_manager_open(&bm, path, BLOCK_MANAGER_SYNC_NONE), 0);
+
+    blocked_bloom_builder_t *b = NULL;
+    ASSERT_EQ(blocked_bloom_builder_new(&b, 0.01, 1024, bm_write, bm), 0);
+    const int n = 30000;
+    for (int i = 0; i < n; i++)
+    {
+        uint8_t key[16];
+        size_t klen = make_key(i, key);
+        ASSERT_EQ(blocked_bloom_builder_add(b, key, klen), 0);
+    }
+    uint64_t dir_off = 0, total = 0;
+    uint32_t dir_size = 0;
+    ASSERT_EQ(blocked_bloom_builder_finish(b, &dir_off, &dir_size, &total), 0);
+    ASSERT_EQ(total, (uint64_t)n);
+    blocked_bloom_builder_free(b);
+    ASSERT_EQ(block_manager_close(bm), 0);
+
+    /* reopen from disk so the reader loads its directory through the block manager, not from any
+     * builder state left in memory */
+    block_manager_t *bm2 = NULL;
+    ASSERT_EQ(block_manager_open(&bm2, path, BLOCK_MANAGER_SYNC_NONE), 0);
+    blocked_bloom_reader_t *r = NULL;
+    ASSERT_EQ(
+        blocked_bloom_reader_open(&r, dir_off, dir_size, cmp_lex, NULL, bm_fetch, bm_release, bm2),
+        0);
+    for (int i = 0; i < n; i++)
+    {
+        uint8_t key[16];
+        size_t klen = make_key(i, key);
+        ASSERT_EQ(blocked_bloom_reader_maybe_contains(r, key, klen), 1);
+    }
+    uint8_t absent[16];
+    size_t alen = make_key(-1, absent); /* "k-0000001" sorts before every inserted key */
+    ASSERT_EQ(blocked_bloom_reader_maybe_contains(r, absent, alen), 0);
+
+    blocked_bloom_reader_free(r);
+    ASSERT_EQ(block_manager_close(bm2), 0);
+    remove(path);
+}
+
+/* a variable-length key owned by the stress test */
+typedef struct
+{
+    uint8_t *k;
+    uint32_t len;
+} bbf_skey_t;
+
+/* deterministic xorshift so the stress run is reproducible and never flakes */
+static uint32_t bbf_rand(uint32_t *s)
+{
+    uint32_t x = *s;
+    x ^= x << 13;
+    x ^= x >> 17;
+    x ^= x << 5;
+    *s = x;
+    return x;
+}
+
+static int bbf_skey_cmp(const void *a, const void *b)
+{
+    const bbf_skey_t *x = a, *y = b;
+    return cmp_lex(x->k, x->len, y->k, y->len, NULL);
+}
+
+/* large scale over random variable-length binary keys. sorted-unique keys are built in order, then
+ * every inserted key must report may-present (the invariant a bloom must never break) and a
+ * disjoint set of random keys must keep the false-positive rate near the target across all
+ * partitions */
+void test_bbf_stress_correctness()
+{
+    uint32_t seed = 0x9e3779b9u;
+    const int n = 200000;
+
+    bbf_skey_t *keys = malloc((size_t)n * sizeof(*keys));
+    ASSERT_TRUE(keys != NULL);
+    for (int i = 0; i < n; i++)
+    {
+        uint32_t len = 4 + (bbf_rand(&seed) % 21); /* 4..24 bytes */
+        uint8_t *k = malloc(len);
+        for (uint32_t j = 0; j < len; j++) k[j] = (uint8_t)bbf_rand(&seed);
+        keys[i].k = k;
+        keys[i].len = len;
+    }
+    qsort(keys, (size_t)n, sizeof(*keys), bbf_skey_cmp);
+
+    /* drop adjacent duplicates so the disjoint-query check below is exact */
+    int m = n ? 1 : 0;
+    for (int i = 1; i < n; i++)
+    {
+        if (bbf_skey_cmp(&keys[m - 1], &keys[i]) == 0)
+            free(keys[i].k);
+        else
+            keys[m++] = keys[i];
+    }
+
+    bbf_store_t store = {0};
+    blocked_bloom_builder_t *b = NULL;
+    ASSERT_EQ(blocked_bloom_builder_new(&b, 0.01, 2048, store_write, &store), 0);
+    for (int i = 0; i < m; i++) ASSERT_EQ(blocked_bloom_builder_add(b, keys[i].k, keys[i].len), 0);
+    uint64_t dir_off = 0, total = 0;
+    uint32_t dir_size = 0;
+    ASSERT_EQ(blocked_bloom_builder_finish(b, &dir_off, &dir_size, &total), 0);
+    ASSERT_EQ(total, (uint64_t)m);
+    blocked_bloom_builder_free(b);
+
+    blocked_bloom_reader_t *r = NULL;
+    ASSERT_EQ(
+        blocked_bloom_reader_open(&r, dir_off, dir_size, cmp_lex, NULL, store_fetch, NULL, &store),
+        0);
+
+    for (int i = 0; i < m; i++)
+        ASSERT_EQ(blocked_bloom_reader_maybe_contains(r, keys[i].k, keys[i].len), 1);
+
+    int tested = 0, fp = 0;
+    for (int t = 0; t < n; t++)
+    {
+        uint8_t q[24];
+        uint32_t len = 4 + (bbf_rand(&seed) % 21);
+        for (uint32_t j = 0; j < len; j++) q[j] = (uint8_t)bbf_rand(&seed);
+        bbf_skey_t probe = {q, len};
+        if (bsearch(&probe, keys, (size_t)m, sizeof(*keys), bbf_skey_cmp))
+            continue; /* skip present */
+        tested++;
+        if (blocked_bloom_reader_maybe_contains(r, q, len) == 1) fp++;
+    }
+    ASSERT_TRUE(tested > 0);
+    ASSERT_TRUE(fp < tested * 3 / 100); /* 3x the 0.01 target -- a wide margin against flaking */
+
+    blocked_bloom_reader_free(r);
+    for (int i = 0; i < m; i++) free(keys[i].k);
+    free(keys);
+    store_free(&store);
+}
+
+int main(int argc, char **argv)
+{
+    INIT_TEST_FILTER(argc, argv);
+    RUN_TEST(test_bbf_builder_new_invalid_args, tests_passed);
+    RUN_TEST(test_bbf_no_false_negatives, tests_passed);
+    RUN_TEST(test_bbf_below_range_is_absent, tests_passed);
+    RUN_TEST(test_bbf_false_positive_rate, tests_passed);
+    RUN_TEST(test_bbf_empty_build, tests_passed);
+    RUN_TEST(test_bbf_single_key, tests_passed);
+    RUN_TEST(test_bbf_free_null_safe, tests_passed);
+    RUN_TEST(test_bbf_block_manager_backed, tests_passed);
+    RUN_TEST(test_bbf_stress_correctness, tests_passed);
+    PRINT_TEST_RESULTS(tests_passed, tests_failed);
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/test/blocked_index__tests.c
+++ b/test/blocked_index__tests.c
@@ -1,0 +1,412 @@
+/**
+ *
+ * Copyright (C) TidesDB
+ *
+ * Original Author: Alex Gaetano Padula
+ *
+ * Licensed under the Mozilla Public License, v. 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.mozilla.org/en-US/MPL/2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../src/block_manager.h"
+#include "../src/blocked_index.h"
+#include "test_utils.h"
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+/* an append-only in-memory backing store standing in for the sstable's block-managed file */
+typedef struct
+{
+    uint8_t *buf;
+    size_t len;
+    size_t cap;
+} bi_store_t;
+
+static int store_write(void *ctx, const uint8_t *data, size_t size, uint64_t *out_offset)
+{
+    bi_store_t *s = ctx;
+    if (s->len + size > s->cap)
+    {
+        size_t ncap = s->cap ? s->cap * 2 : 4096;
+        while (ncap < s->len + size) ncap *= 2;
+        uint8_t *nb = realloc(s->buf, ncap);
+        if (!nb) return -1;
+        s->buf = nb;
+        s->cap = ncap;
+    }
+    *out_offset = s->len;
+    memcpy(s->buf + s->len, data, size);
+    s->len += size;
+    return 0;
+}
+
+static int store_fetch(void *ctx, uint64_t offset, uint32_t size, const uint8_t **out_data,
+                       void **out_pin)
+{
+    bi_store_t *s = ctx;
+    if (offset > s->len || (uint64_t)size > s->len - offset) return -1;
+    *out_data = s->buf + offset;
+    *out_pin = NULL;
+    return 0;
+}
+
+static void store_free(bi_store_t *s)
+{
+    free(s->buf);
+}
+
+/* callbacks that drive a real block manager, the same way the sstable klog stores aux blobs */
+static int bm_write(void *ctx, const uint8_t *data, size_t size, uint64_t *out_offset)
+{
+    block_manager_block_t *blk = block_manager_block_create(size, data);
+    if (!blk) return -1;
+    int64_t off = block_manager_block_write((block_manager_t *)ctx, blk);
+    block_manager_block_release(blk);
+    if (off < 0) return -1;
+    *out_offset = (uint64_t)off;
+    return 0;
+}
+
+static int bm_fetch(void *ctx, uint64_t offset, uint32_t size, const uint8_t **out_data,
+                    void **out_pin)
+{
+    block_manager_cursor_t *cur = NULL;
+    if (block_manager_cursor_init(&cur, (block_manager_t *)ctx) != 0) return -1;
+    if (block_manager_cursor_goto(cur, offset) != 0)
+    {
+        block_manager_cursor_free(cur);
+        return -1;
+    }
+    block_manager_block_t *blk = block_manager_cursor_read(cur);
+    block_manager_cursor_free(cur);
+    if (!blk) return -1;
+    if (blk->size != size)
+    {
+        block_manager_block_release(blk);
+        return -1;
+    }
+    *out_data = blk->data;
+    *out_pin = blk;
+    return 0;
+}
+
+static void bm_release(void *ctx, void *pin)
+{
+    (void)ctx;
+    block_manager_block_release((block_manager_block_t *)pin);
+}
+
+/* lexicographic order over raw bytes, matching tidesdb_comparator_fn */
+static int cmp_lex(const uint8_t *a, size_t alen, const uint8_t *b, size_t blen, void *ctx)
+{
+    (void)ctx;
+    size_t n = alen < blen ? alen : blen;
+    int c = memcmp(a, b, n);
+    if (c != 0) return c;
+    return (alen > blen) - (alen < blen);
+}
+
+/* fixed-width zero-padded key so lexicographic order equals numeric order */
+static size_t make_bkey(uint64_t v, uint8_t *out)
+{
+    return (size_t)snprintf((char *)out, 24, "b%010llu", (unsigned long long)v);
+}
+
+void test_bi_builder_new_invalid_args()
+{
+    blocked_index_builder_t *b = NULL;
+    ASSERT_NE(blocked_index_builder_new(NULL, 0, store_write, NULL), 0);
+    ASSERT_NE(blocked_index_builder_new(&b, 0, NULL, NULL), 0);
+}
+
+/* find returns the covering block and its ordinal for keys inside, at, and between block starts */
+void test_bi_find_covering_block()
+{
+    bi_store_t store = {0};
+    blocked_index_builder_t *b = NULL;
+    ASSERT_EQ(blocked_index_builder_new(&b, 4, store_write, &store),
+              0); /* small leaf to roll over */
+
+    const int nblocks = 1000;
+    for (int i = 0; i < nblocks; i++)
+    {
+        uint8_t key[24];
+        size_t klen = make_bkey((uint64_t)i * 10, key); /* block i covers [i*10, i*10+9] */
+        ASSERT_EQ(blocked_index_builder_add(b, key, klen, (uint64_t)i * 4096), 0);
+    }
+    uint64_t dir_off = 0, total = 0;
+    uint32_t dir_size = 0;
+    ASSERT_EQ(blocked_index_builder_finish(b, &dir_off, &dir_size, &total), 0);
+    ASSERT_EQ(total, (uint64_t)nblocks);
+    blocked_index_builder_free(b);
+
+    blocked_index_reader_t *r = NULL;
+    ASSERT_EQ(
+        blocked_index_reader_open(&r, dir_off, dir_size, cmp_lex, NULL, store_fetch, NULL, &store),
+        0);
+
+    for (int i = 0; i < nblocks; i++)
+    {
+        uint8_t key[24];
+        uint64_t off = 0, ord = 0;
+        /* a key inside block i (first-key + 5) routes to block i */
+        size_t klen = make_bkey((uint64_t)i * 10 + 5, key);
+        ASSERT_EQ(blocked_index_reader_find(r, key, klen, &off, &ord), 1);
+        ASSERT_EQ(off, (uint64_t)i * 4096);
+        ASSERT_EQ(ord, (uint64_t)i);
+        /* the exact first-key routes to the same block */
+        klen = make_bkey((uint64_t)i * 10, key);
+        ASSERT_EQ(blocked_index_reader_find(r, key, klen, &off, &ord), 1);
+        ASSERT_EQ(off, (uint64_t)i * 4096);
+    }
+    blocked_index_reader_free(r);
+    store_free(&store);
+}
+
+/* a key below the first block is a definite miss */
+void test_bi_below_range_not_found()
+{
+    bi_store_t store = {0};
+    blocked_index_builder_t *b = NULL;
+    ASSERT_EQ(blocked_index_builder_new(&b, 0, store_write, &store), 0);
+    for (int i = 10; i < 500; i++)
+    {
+        uint8_t key[24];
+        size_t klen = make_bkey((uint64_t)i, key);
+        ASSERT_EQ(blocked_index_builder_add(b, key, klen, (uint64_t)i * 100), 0);
+    }
+    uint64_t dir_off = 0;
+    uint32_t dir_size = 0;
+    ASSERT_EQ(blocked_index_builder_finish(b, &dir_off, &dir_size, NULL), 0);
+    blocked_index_builder_free(b);
+
+    blocked_index_reader_t *r = NULL;
+    ASSERT_EQ(
+        blocked_index_reader_open(&r, dir_off, dir_size, cmp_lex, NULL, store_fetch, NULL, &store),
+        0);
+    uint8_t key[24];
+    uint64_t off = 12345, ord = 999;
+    size_t klen = make_bkey(0, key); /* below the smallest block first-key (10) */
+    ASSERT_EQ(blocked_index_reader_find(r, key, klen, &off, &ord), 0);
+    blocked_index_reader_free(r);
+    store_free(&store);
+}
+
+void test_bi_empty_and_single()
+{
+    /* empty build -- find reports not-found so the caller full-scans */
+    bi_store_t store = {0};
+    blocked_index_builder_t *b = NULL;
+    ASSERT_EQ(blocked_index_builder_new(&b, 0, store_write, &store), 0);
+    uint64_t dir_off = 0, total = 1;
+    uint32_t dir_size = 0;
+    ASSERT_EQ(blocked_index_builder_finish(b, &dir_off, &dir_size, &total), 0);
+    ASSERT_EQ(total, 0u);
+    blocked_index_builder_free(b);
+
+    blocked_index_reader_t *r = NULL;
+    ASSERT_EQ(
+        blocked_index_reader_open(&r, dir_off, dir_size, cmp_lex, NULL, store_fetch, NULL, &store),
+        0);
+    uint8_t key[24];
+    uint64_t off = 0, ord = 0;
+    size_t klen = make_bkey(5, key);
+    ASSERT_EQ(blocked_index_reader_find(r, key, klen, &off, &ord), 0);
+    ASSERT_TRUE(blocked_index_reader_resident_bytes(r) > 0);
+    blocked_index_reader_free(r);
+    store_free(&store);
+
+    /* single block */
+    bi_store_t s2 = {0};
+    ASSERT_EQ(blocked_index_builder_new(&b, 0, store_write, &s2), 0);
+    ASSERT_EQ(blocked_index_builder_add(b, key, klen, 777), 0);
+    ASSERT_EQ(blocked_index_builder_finish(b, &dir_off, &dir_size, NULL), 0);
+    blocked_index_builder_free(b);
+    ASSERT_EQ(
+        blocked_index_reader_open(&r, dir_off, dir_size, cmp_lex, NULL, store_fetch, NULL, &s2), 0);
+    ASSERT_EQ(blocked_index_reader_find(r, key, klen, &off, &ord), 1);
+    ASSERT_EQ(off, 777u);
+    ASSERT_EQ(ord, 0u);
+    blocked_index_reader_free(r);
+    store_free(&s2);
+}
+
+void test_bi_free_null_safe()
+{
+    blocked_index_builder_free(NULL);
+    blocked_index_reader_free(NULL);
+    ASSERT_EQ(blocked_index_reader_resident_bytes(NULL), 0u);
+}
+
+/* end to end over a real block manager file, reopened from disk so the directory round-trips */
+void test_bi_block_manager_backed()
+{
+    const char *path = "./test_bi_klog.bm";
+    remove(path);
+
+    block_manager_t *bm = NULL;
+    ASSERT_EQ(block_manager_open(&bm, path, BLOCK_MANAGER_SYNC_NONE), 0);
+
+    blocked_index_builder_t *b = NULL;
+    ASSERT_EQ(blocked_index_builder_new(&b, 64, bm_write, bm), 0);
+    const int nblocks = 5000;
+    for (int i = 0; i < nblocks; i++)
+    {
+        uint8_t key[24];
+        size_t klen = make_bkey((uint64_t)i * 3, key);
+        ASSERT_EQ(blocked_index_builder_add(b, key, klen, (uint64_t)i * 8192), 0);
+    }
+    uint64_t dir_off = 0, total = 0;
+    uint32_t dir_size = 0;
+    ASSERT_EQ(blocked_index_builder_finish(b, &dir_off, &dir_size, &total), 0);
+    ASSERT_EQ(total, (uint64_t)nblocks);
+    blocked_index_builder_free(b);
+    ASSERT_EQ(block_manager_close(bm), 0);
+
+    block_manager_t *bm2 = NULL;
+    ASSERT_EQ(block_manager_open(&bm2, path, BLOCK_MANAGER_SYNC_NONE), 0);
+    blocked_index_reader_t *r = NULL;
+    ASSERT_EQ(
+        blocked_index_reader_open(&r, dir_off, dir_size, cmp_lex, NULL, bm_fetch, bm_release, bm2),
+        0);
+    for (int i = 0; i < nblocks; i++)
+    {
+        uint8_t key[24];
+        uint64_t off = 0, ord = 0;
+        size_t klen = make_bkey((uint64_t)i * 3 + 1, key); /* inside block i */
+        ASSERT_EQ(blocked_index_reader_find(r, key, klen, &off, &ord), 1);
+        ASSERT_EQ(off, (uint64_t)i * 8192);
+        ASSERT_EQ(ord, (uint64_t)i);
+    }
+    blocked_index_reader_free(r);
+    ASSERT_EQ(block_manager_close(bm2), 0);
+    remove(path);
+}
+
+/* deterministic xorshift so the stress run is reproducible */
+static uint32_t bi_rand(uint32_t *s)
+{
+    uint32_t x = *s;
+    x ^= x << 13;
+    x ^= x >> 17;
+    x ^= x << 5;
+    *s = x;
+    return x;
+}
+
+/* rightmost i with vals[i] <= q, or -1 -- the brute-force oracle the reader must match */
+static int64_t oracle(const uint64_t *vals, int n, uint64_t q)
+{
+    int64_t lo = 0, hi = n - 1, res = -1;
+    while (lo <= hi)
+    {
+        int64_t mid = lo + (hi - lo) / 2;
+        if (vals[mid] <= q)
+        {
+            res = mid;
+            lo = mid + 1;
+        }
+        else
+        {
+            hi = mid - 1;
+        }
+    }
+    return res;
+}
+
+/* large scale over strictly-increasing blocks. every lookup -- exact first-keys and a fuzz of
+ * random query values -- must return the same covering block a linear scan would, with the matching
+ * ordinal */
+void test_bi_stress_correctness()
+{
+    uint32_t seed = 0x243f6a88u;
+    const int n = 100000;
+    uint64_t *vals = malloc((size_t)n * sizeof(*vals));
+    ASSERT_TRUE(vals != NULL);
+
+    uint64_t v = 0;
+    for (int i = 0; i < n; i++)
+    {
+        v += 1 + (bi_rand(&seed) % 50); /* strictly increasing gaps */
+        vals[i] = v;
+    }
+
+    bi_store_t store = {0};
+    blocked_index_builder_t *b = NULL;
+    ASSERT_EQ(blocked_index_builder_new(&b, 128, store_write, &store), 0);
+    for (int i = 0; i < n; i++)
+    {
+        uint8_t key[24];
+        size_t klen = make_bkey(vals[i], key);
+        ASSERT_EQ(blocked_index_builder_add(b, key, klen, (uint64_t)i * 4096 + 17), 0);
+    }
+    uint64_t dir_off = 0;
+    uint32_t dir_size = 0;
+    ASSERT_EQ(blocked_index_builder_finish(b, &dir_off, &dir_size, NULL), 0);
+    blocked_index_builder_free(b);
+
+    blocked_index_reader_t *r = NULL;
+    ASSERT_EQ(
+        blocked_index_reader_open(&r, dir_off, dir_size, cmp_lex, NULL, store_fetch, NULL, &store),
+        0);
+
+    /* exact first-keys route to their own block */
+    for (int i = 0; i < n; i++)
+    {
+        uint8_t key[24];
+        uint64_t off = 0, ord = 0;
+        size_t klen = make_bkey(vals[i], key);
+        ASSERT_EQ(blocked_index_reader_find(r, key, klen, &off, &ord), 1);
+        ASSERT_EQ(off, (uint64_t)i * 4096 + 17);
+        ASSERT_EQ(ord, (uint64_t)i);
+    }
+
+    /* random query values agree with the linear-scan oracle */
+    for (int t = 0; t < n; t++)
+    {
+        uint64_t q = ((uint64_t)bi_rand(&seed) << 4) % (vals[n - 1] + 100);
+        int64_t expect = oracle(vals, n, q);
+        uint8_t key[24];
+        uint64_t off = 0, ord = 0;
+        size_t klen = make_bkey(q, key);
+        int rc = blocked_index_reader_find(r, key, klen, &off, &ord);
+        if (expect < 0)
+        {
+            ASSERT_EQ(rc, 0);
+        }
+        else
+        {
+            ASSERT_EQ(rc, 1);
+            ASSERT_EQ(off, (uint64_t)expect * 4096 + 17);
+            ASSERT_EQ(ord, (uint64_t)expect);
+        }
+    }
+
+    blocked_index_reader_free(r);
+    free(vals);
+    store_free(&store);
+}
+
+int main(int argc, char **argv)
+{
+    INIT_TEST_FILTER(argc, argv);
+    RUN_TEST(test_bi_builder_new_invalid_args, tests_passed);
+    RUN_TEST(test_bi_find_covering_block, tests_passed);
+    RUN_TEST(test_bi_below_range_not_found, tests_passed);
+    RUN_TEST(test_bi_empty_and_single, tests_passed);
+    RUN_TEST(test_bi_free_null_safe, tests_passed);
+    RUN_TEST(test_bi_block_manager_backed, tests_passed);
+    RUN_TEST(test_bi_stress_correctness, tests_passed);
+    PRINT_TEST_RESULTS(tests_passed, tests_failed);
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/test/bloom_filter__tests.c
+++ b/test/bloom_filter__tests.c
@@ -951,6 +951,104 @@ void test_bloom_filter_sparse_encoding_unchanged(void)
     bloom_filter_free(rt);
 }
 
+/* bloom_filter_contains_serialized must answer identically to deserialize + contains
+ * across both encodings and both hash versions, without materializing a filter. the
+ * dense path is probed in place over the buffer, the sparse path falls back to a full
+ * deserialize -- either way the answer has to match the in-memory filter exactly, and
+ * a malformed buffer or empty entry returns -1 */
+void test_bloom_filter_contains_serialized(void)
+{
+    /* dense v2 -- over-fill so the serialized form is dense, then every probe the
+     * in-place path gives must match the materialized filter */
+    bloom_filter_t *dense;
+    ASSERT_EQ(bloom_filter_new(&dense, 0.01, 2000), 0);
+    for (int i = 0; i < 4000; i++)
+    {
+        char key[24];
+        int n = snprintf(key, sizeof(key), "dense_%d", i);
+        bloom_filter_add(dense, (const uint8_t *)key, (size_t)n);
+    }
+    size_t dsize;
+    uint8_t *dblob = bloom_filter_serialize(dense, &dsize);
+    ASSERT_TRUE(dblob != NULL);
+    ASSERT_EQ(dblob[1] >> 4, 1); /* confirm dense so we exercise the in-place path */
+
+    for (int i = 0; i < 4000; i++)
+    {
+        char key[24];
+        int n = snprintf(key, sizeof(key), "dense_%d", i);
+        ASSERT_EQ(bloom_filter_contains_serialized(dblob, dsize, (const uint8_t *)key, (size_t)n),
+                  1);
+    }
+    int dmismatch = 0;
+    for (int i = 0; i < 8000; i++)
+    {
+        char probe[24];
+        int n = snprintf(probe, sizeof(probe), "absent_%d", i);
+        if (bloom_filter_contains_serialized(dblob, dsize, (const uint8_t *)probe, (size_t)n) !=
+            bloom_filter_contains(dense, (const uint8_t *)probe, (size_t)n))
+            dmismatch++;
+    }
+    ASSERT_EQ(dmismatch, 0);
+
+    /* sparse v2 -- a big filter with three keys serializes sparse, exercising the
+     * deserialize fallback */
+    bloom_filter_t *sparse;
+    ASSERT_EQ(bloom_filter_new(&sparse, 0.01, 100000), 0);
+    const char *skeys[] = {"alpha", "beta", "gamma"};
+    for (int i = 0; i < 3; i++)
+        bloom_filter_add(sparse, (const uint8_t *)skeys[i], strlen(skeys[i]));
+    size_t ssize;
+    uint8_t *sblob = bloom_filter_serialize(sparse, &ssize);
+    ASSERT_TRUE(sblob != NULL);
+    ASSERT_EQ(sblob[1], 0x02); /* confirm sparse so we exercise the fallback path */
+    for (int i = 0; i < 3; i++)
+        ASSERT_EQ(bloom_filter_contains_serialized(sblob, ssize, (const uint8_t *)skeys[i],
+                                                   strlen(skeys[i])),
+                  1);
+    ASSERT_EQ(
+        bloom_filter_contains_serialized(sblob, ssize, (const uint8_t *)"not_present_key_xyz", 19),
+        bloom_filter_contains(sparse, (const uint8_t *)"not_present_key_xyz", 19));
+
+    /* legacy v1 hash -- a dense filter built with the old hash must still probe
+     * consistently in place (a regression that assumed v2 would false-negative) */
+    bloom_filter_t *v1;
+    ASSERT_EQ(bloom_filter_new(&v1, 0.01, 2000), 0);
+    v1->hash_version = 1;
+    for (int i = 0; i < 4000; i++)
+    {
+        char key[24];
+        int n = snprintf(key, sizeof(key), "v1_%d", i);
+        bloom_filter_add(v1, (const uint8_t *)key, (size_t)n);
+    }
+    size_t v1size;
+    uint8_t *v1blob = bloom_filter_serialize(v1, &v1size);
+    ASSERT_TRUE(v1blob != NULL);
+    int v1mismatch = 0;
+    for (int i = 0; i < 8000; i++)
+    {
+        char probe[24];
+        int n = snprintf(probe, sizeof(probe), "v1_%d", i);
+        if (bloom_filter_contains_serialized(v1blob, v1size, (const uint8_t *)probe, (size_t)n) !=
+            bloom_filter_contains(v1, (const uint8_t *)probe, (size_t)n))
+            v1mismatch++;
+    }
+    ASSERT_EQ(v1mismatch, 0);
+
+    /* malformed and empty inputs return -1 */
+    ASSERT_EQ(bloom_filter_contains_serialized(NULL, 0, (const uint8_t *)"x", 1), -1);
+    ASSERT_EQ(bloom_filter_contains_serialized(dblob, dsize, NULL, 1), -1);
+    ASSERT_EQ(bloom_filter_contains_serialized(dblob, dsize, (const uint8_t *)"x", 0), -1);
+    ASSERT_EQ(bloom_filter_contains_serialized(dblob, 1, (const uint8_t *)"x", 1), -1);
+
+    free(dblob);
+    free(sblob);
+    free(v1blob);
+    bloom_filter_free(dense);
+    bloom_filter_free(sparse);
+    bloom_filter_free(v1);
+}
+
 /* deserialize must reject malformed buffers without over-reading, a buffer ending
  * mid-varint, a lone sentinel, an unknown hash version, an unknown encoding, and
  * a header that promises more bitset words than the buffer holds */
@@ -1118,6 +1216,7 @@ int main(int argc, char **argv)
     RUN_TEST(test_bloom_filter_deserialize_overflow_m, tests_passed);
     RUN_TEST(test_bloom_filter_dense_encoding, tests_passed);
     RUN_TEST(test_bloom_filter_sparse_encoding_unchanged, tests_passed);
+    RUN_TEST(test_bloom_filter_contains_serialized, tests_passed);
     RUN_TEST(test_bloom_filter_deserialize_malformed, tests_passed);
     RUN_TEST(test_bloom_filter_is_full_multiword, tests_passed);
     RUN_TEST(benchmark_bloom_filter, tests_passed);

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -6036,7 +6036,6 @@ static void test_block_indexes(void)
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
     cf_config.enable_block_indexes = 1;
-    cf_config.index_sample_ratio = 10;
 
     ASSERT_EQ(tidesdb_create_column_family(db, "bidx_cf", &cf_config), 0);
     tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "bidx_cf");
@@ -6094,7 +6093,6 @@ static void test_block_indexes_sparse_sample_ratio(void)
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
     cf_config.enable_block_indexes = 1;
-    cf_config.index_sample_ratio = 32;
 
     ASSERT_EQ(tidesdb_create_column_family(db, "bidx_sparse_cf", &cf_config), 0);
     tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "bidx_sparse_cf");
@@ -13875,7 +13873,6 @@ void test_tidesdb_block_index_seek()
 
     tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
     cf_config.enable_block_indexes = 1;
-    cf_config.index_sample_ratio = 1;
     cf_config.write_buffer_size = 512 * 1024;
 
     ASSERT_EQ(tidesdb_create_column_family(db, "test_cf", &cf_config), TDB_SUCCESS);
@@ -21338,7 +21335,6 @@ static void test_full_merge_block_index_sampling(void)
     cf_config.write_buffer_size = 2048;
     cf_config.level_size_ratio = 10;
     cf_config.enable_block_indexes = 1;
-    cf_config.index_sample_ratio = 2;
 
     ASSERT_EQ(tidesdb_create_column_family(db, "sample_cf", &cf_config), 0);
     tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "sample_cf");
@@ -28707,11 +28703,9 @@ static void test_perf_cached_iter_seek(void)
 
 static void test_block_index_shared_prefix(void)
 {
-    /* keys that share a prefix longer than block_index_prefix_len span multiple
-     * klog blocks whose min/max prefixes are all identical. the block index
-     * search must land on the leftmost such block and the lookup must scan the
-     * whole prefix-colliding run -- otherwise point lookups and seeks for keys
-     * in any but the overshot block return a false NOT_FOUND. */
+    /* many keys sharing a long common prefix span multiple klog blocks. the blocked index stores
+     * each block's full first-key, so a lookup routes to exactly the covering block -- this pins
+     * that point lookups and seeks for such keys never return a false NOT_FOUND. */
     cleanup_test_dir();
 
     tidesdb_config_t config = tidesdb_default_config();
@@ -28720,9 +28714,8 @@ static void test_block_index_shared_prefix(void)
     tidesdb_t *db = NULL;
     ASSERT_EQ(tidesdb_open(&config, &db), 0);
 
-    /* default cf config -- block_index_prefix_len 16, index_sample_ratio 1,
-     * block indexes enabled. small write buffer + padded values force the
-     * shared-prefix keys across many blocks. */
+    /* block indexes enabled. small write buffer + padded values force the shared-prefix keys across
+     * many blocks. */
     tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
     cf_config.write_buffer_size = 16 * 1024;
     cf_config.compression_algorithm = TDB_COMPRESS_NONE;
@@ -28732,7 +28725,7 @@ static void test_block_index_shared_prefix(void)
     tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "bidx_prefix_cf");
     ASSERT_TRUE(cf != NULL);
 
-    /* 24 byte prefix -- longer than the 16 byte block_index_prefix_len */
+    /* a long shared prefix that spreads the keys across many blocks */
     static const char SHARED[] = "shared_prefix_blockidx__";
     const int SHARED_KEYS = 3000;
     const int UNIQUE_KEYS = 500;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tidesdb",
-  "version-string": "9.3.14",
+  "version-string": "9.4.0",
   "description": "TidesDB is a high-performance durable, transactional embeddable storage engine designed for flash and RAM optimization with optional object storage support for unlimited data scaling.",
   "dependencies": ["zstd", "snappy", "lz4", "pthreads", "curl"],
   "features": {


### PR DESCRIPTION
replace the per-sstable in-memory bloom filter and block-index arrays and the chunked-aux scheme with two streaming range-partitioned modules, blocked_bloom_filter and blocked_index, that live in the block-managed klog file and page partitions through the block cache. aux memory is now bounded and evictable and the reaper no longer probes it, so pushing terabytes no longer grows resident aux without limit.

the top-level directory holds the full first key of each partition so a lookup routes to exactly one block with no false negatives. builders buffer partitions and emit them at finish since the single-file klog forces aux blocks after the data blocks. old sstables load with null readers, degrade to a full scan, and migrate to blocked aux on compaction, and metadata deserialize skips the old chunked-aux descriptor.

add bloom_filter_contains_serialized to probe a serialized dense filter in place over the pinned cache buffer with no per-query allocation, falling back to deserialize for the sparse encoding. remove the now-moot index_sample_ratio and block_index_prefix_len configs and the sstable_aux_memory_bytes accounting.

bump to 9.4.0