### PR TITLE
TidesDB 10 MAJOR (v10.0.0)

### DIFF
--- a/.github/workflows/object_store_test.yml
+++ b/.github/workflows/object_store_test.yml
@@ -39,27 +39,70 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake build-essential liblz4-dev libzstd-dev libsnappy-dev \
-            libcurl4-openssl-dev
+            libcurl4-openssl-dev gdb
 
       - name: Build TidesDB with S3 connector
         run: |
           mkdir -p build && cd build
-          cmake .. -DCMAKE_BUILD_TYPE=Release -DTIDESDB_WITH_S3=ON -DTIDESDB_WITH_SANITIZER=OFF
+          # -g keeps the Release optimisation level (a rare fault here has only ever reproduced
+          # under full optimisation) while giving crash backtraces symbols and line numbers
+          cmake .. -DCMAKE_BUILD_TYPE=Release -DTIDESDB_WITH_S3=ON -DTIDESDB_WITH_SANITIZER=OFF \
+            -DCMAKE_C_FLAGS="-g"
           cmake --build . -j$(nproc)
+
+      # run every test binary through gdb so a fault leaves a stack behind instead of just exit 139.
+      # gdb -batch exits 0 even when the child dies on a signal, so the signal is detected in the
+      # captured output and turned back into a step failure.
+      - name: Install crash-capturing test runner
+        run: |
+          cat > "$RUNNER_TEMP/run_with_bt.sh" <<'EOS'
+          #!/usr/bin/env bash
+          # usage: run_with_bt.sh <log-name> <binary> [args...]
+          set -uo pipefail
+          log_name="$1"; shift
+          log="$RUNNER_TEMP/crashlogs/${log_name}.log"
+          mkdir -p "$RUNNER_TEMP/crashlogs"
+          ulimit -c unlimited || true
+          # quit with the child's own exit code so an ordinary non-zero exit still fails the step --
+          # gdb -batch otherwise reports success no matter how the program ended. on a signal
+          # $_exitcode is unset, that quit errors, and the signal grep below catches it anyway.
+          gdb -batch \
+            -ex "handle SIGPIPE nostop noprint pass" \
+            -ex run \
+            -ex "echo \n===== CRASH BACKTRACE =====\n" \
+            -ex "thread apply all bt full" \
+            -ex "info registers" \
+            -ex "quit \$_exitcode" \
+            --args "$@" 2>&1 | tee "$log"
+          gdb_rc=${PIPESTATUS[0]}
+          if grep -qE "SIGSEGV|SIGBUS|SIGILL|SIGFPE|SIGABRT" "$log"; then
+            echo "::error::$* crashed on a signal -- backtrace above and in the crashlogs artifact"
+            exit 1
+          fi
+          if grep -q "FAILED:" "$log" && ! grep -q "FAILED: 0" "$log"; then
+            echo "::error::$* reported test failures"
+            exit 1
+          fi
+          if [ "$gdb_rc" -ne 0 ]; then
+            echo "::error::$* exited with status $gdb_rc"
+            exit "$gdb_rc"
+          fi
+          EOS
+          chmod +x "$RUNNER_TEMP/run_with_bt.sh"
 
       - name: Run standard test suite
         run: |
           cd build
-          ./tidesdb_tests
+          "$RUNNER_TEMP/run_with_bt.sh" standard-suite ./tidesdb_tests
 
       - name: Run object store tests (filesystem connector)
         run: |
           cd build
-          ./objstore_tests test_objstore_fs
-          ./tidesdb_tests test_objstore_fs_roundtrip
-          ./tidesdb_tests test_objstore_cold_start
-          ./tidesdb_tests test_objstore_compaction_and_iterators
-          ./tidesdb_tests test_unified_iterator_consistency
+          "$RUNNER_TEMP/run_with_bt.sh" objstore-fs ./objstore_tests test_objstore_fs
+          "$RUNNER_TEMP/run_with_bt.sh" fs-roundtrip ./tidesdb_tests test_objstore_fs_roundtrip
+          "$RUNNER_TEMP/run_with_bt.sh" cold-start ./tidesdb_tests test_objstore_cold_start
+          "$RUNNER_TEMP/run_with_bt.sh" compaction-iterators ./tidesdb_tests test_objstore_compaction_and_iterators
+          "$RUNNER_TEMP/run_with_bt.sh" unified-iterator ./tidesdb_tests test_unified_iterator_consistency
 
       - name: Run object store tests (MinIO S3 connector)
         env:
@@ -69,8 +112,22 @@ jobs:
           TIDESDB_S3_SECRET_KEY: minioadmin
         run: |
           cd build
-          ./objstore_tests test_objstore_s3_minio
-          ./tidesdb_tests test_objstore_s3_minio
+          "$RUNNER_TEMP/run_with_bt.sh" objstore-s3 ./objstore_tests test_objstore_s3_minio
+          "$RUNNER_TEMP/run_with_bt.sh" s3-minio ./tidesdb_tests test_objstore_s3_minio
+
+      # keep the gdb output and the symbolised binaries so a fault can be dug into offline
+      - name: Upload crash artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: objstore-crash-artifacts
+          path: |
+            ${{ runner.temp }}/crashlogs/
+            build/tidesdb_tests
+            build/objstore_tests
+            build/libtidesdb.so*
+          if-no-files-found: ignore
+          retention-days: 14
 
       - name: Stop MinIO
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 *.a
 *.lib
 *.exe
+*.txt
 *.out
 *.app
 build-*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ if(TIDESDB_WITH_MIMALLOC)
 endif()
 
 project(tidesdb
-	VERSION 9.3.14
+	VERSION 9.4.0
 	LANGUAGES C)
 
 set(CMAKE_C_STANDARD 11)
@@ -158,6 +158,7 @@ include_directories(external) # for external libraries linking internally
 # users can override with -DBUILD_SHARED_LIBS=ON/OFF
 set(TIDESDB_SOURCES
     src/tidesdb.c src/block_manager.c src/skip_list.c src/compress.c src/bloom_filter.c
+    src/blocked_bloom_filter.c src/blocked_index.c
     src/manifest.c src/clock_cache.c src/queue.c src/btree.c src/alloc.c
     src/objstore_fs.c src/local_cache.c
     external/xxhash.c external/ini.c)
@@ -663,12 +664,6 @@ if(TIDESDB_BUILD_TESTS) # enable building tests and benchmarks
     if(NOT DEFINED BENCH_ENABLE_BLOCK_INDEXES)
         set(BENCH_ENABLE_BLOCK_INDEXES 1)
     endif()
-    if(NOT DEFINED BENCH_BLOCK_INDEX_SAMPLING_COUNT)
-        set(BENCH_BLOCK_INDEX_SAMPLING_COUNT 1)
-    endif()
-    if(NOT DEFINED BENCH_BLOCK_INDEX_PREFIX_LEN)
-        set(BENCH_BLOCK_INDEX_PREFIX_LEN 16)
-    endif()
     if(NOT DEFINED BENCH_SYNC_MODE)
         set(BENCH_SYNC_MODE TDB_SYNC_NONE)
     endif()
@@ -707,6 +702,8 @@ if(TIDESDB_BUILD_TESTS) # enable building tests and benchmarks
     add_executable(skip_list_tests test/skip_list__tests.c)
     add_executable(compress_tests test/compress__tests.c)
     add_executable(bloom_filter_tests test/bloom_filter__tests.c)
+    add_executable(blocked_bloom_filter_tests test/blocked_bloom_filter__tests.c)
+    add_executable(blocked_index_tests test/blocked_index__tests.c)
     add_executable(clock_cache_tests test/clock_cache__tests.c)
     add_executable(manifest_tests test/manifest__tests.c)
     add_executable(queue_tests test/queue__tests.c)
@@ -746,8 +743,6 @@ if(TIDESDB_BUILD_TESTS) # enable building tests and benchmarks
             BENCH_ENABLE_BLOOM_FILTER=${BENCH_ENABLE_BLOOM_FILTER}
             BENCH_BLOOM_FILTER_FP_RATE=${BENCH_BLOOM_FILTER_FP_RATE}
             BENCH_ENABLE_BLOCK_INDEXES=${BENCH_ENABLE_BLOCK_INDEXES}
-            BENCH_BLOCK_INDEX_SAMPLING_COUNT=${BENCH_BLOCK_INDEX_SAMPLING_COUNT}
-            BENCH_BLOCK_INDEX_PREFIX_LEN=${BENCH_BLOCK_INDEX_PREFIX_LEN}
             BENCH_SYNC_MODE=${BENCH_SYNC_MODE}
             BENCH_SYNC_INTERVAL_US=${BENCH_SYNC_INTERVAL_US}
             BENCH_COMPARATOR_NAME="${BENCH_COMPARATOR_NAME}"
@@ -790,6 +785,7 @@ if(TIDESDB_BUILD_TESTS) # enable building tests and benchmarks
     # add include and link directories for test executables
     set(TIDESDB_TEST_LINK_TARGETS
             block_manager_tests skip_list_tests compress_tests bloom_filter_tests
+            blocked_bloom_filter_tests blocked_index_tests
             manifest_tests clock_cache_tests queue_tests btree_tests local_cache_tests
             objstore_tests tidesdb_tests tidesdb_bench)
     if(TIDESDB_WITH_S3)
@@ -804,6 +800,8 @@ if(TIDESDB_BUILD_TESTS) # enable building tests and benchmarks
     add_test(NAME skip_list_tests COMMAND skip_list_tests)
     add_test(NAME compress_tests COMMAND compress_tests)
     add_test(NAME bloom_filter_tests COMMAND bloom_filter_tests)
+    add_test(NAME blocked_bloom_filter_tests COMMAND blocked_bloom_filter_tests)
+    add_test(NAME blocked_index_tests COMMAND blocked_index_tests)
     add_test(NAME manifest_tests COMMAND manifest_tests)
     add_test(NAME clock_cache_tests COMMAND clock_cache_tests)
     add_test(NAME queue_tests COMMAND queue_tests)
@@ -820,7 +818,7 @@ if(TIDESDB_BUILD_TESTS) # enable building tests and benchmarks
     if(WIN32)
         set(TIDESDB_TEST_TARGETS
                 block_manager_tests skip_list_tests compress_tests bloom_filter_tests
-                manifest_tests queue_tests tidesdb_tests tidesdb_bench)
+                blocked_bloom_filter_tests blocked_index_tests manifest_tests queue_tests tidesdb_tests tidesdb_bench)
 
         if(MINGW)
             # On MinGW (MSYS2), the test exes link against shared snappy/zstd/lz4

--- a/bench/tidesdb__bench.c
+++ b/bench/tidesdb__bench.c
@@ -847,7 +847,6 @@ int main()
     printf("  Bloom Filter: %s\n", BENCH_ENABLE_BLOOM_FILTER ? "enabled" : "disabled");
     printf("  Bloom Filter FP Rate: %.4f\n", BENCH_BLOOM_FILTER_FP_RATE);
     printf("  Block Indexes: %s\n", BENCH_ENABLE_BLOCK_INDEXES ? "enabled" : "disabled");
-    printf("  Block Index Prefix Length: %d\n", BENCH_BLOCK_INDEX_PREFIX_LEN);
     printf("  Comparator: %s\n", BENCH_COMPARATOR_NAME);
     printf("  Isolation Level: %s\n", get_isolation_level_name(BENCH_ISOLATION_LEVEL));
     printf("  K-Log Value Threshold: %zu bytes (%.2f KB)\n", (size_t)BENCH_KLOG_VALUE_THRESHOLD,
@@ -1001,13 +1000,11 @@ int main()
     cf_config.enable_bloom_filter = BENCH_ENABLE_BLOOM_FILTER;
     cf_config.bloom_fpr = BENCH_BLOOM_FILTER_FP_RATE;
     cf_config.enable_block_indexes = BENCH_ENABLE_BLOCK_INDEXES;
-    cf_config.index_sample_ratio = BENCH_BLOCK_INDEX_SAMPLING_COUNT;
     cf_config.sync_mode = BENCH_SYNC_MODE;
     cf_config.sync_interval_us = BENCH_SYNC_INTERVAL_US;
     strncpy(cf_config.comparator_name, BENCH_COMPARATOR_NAME, TDB_MAX_COMPARATOR_NAME - 1);
     cf_config.comparator_name[TDB_MAX_COMPARATOR_NAME - 1] = '\0';
     cf_config.default_isolation_level = BENCH_ISOLATION_LEVEL;
-    cf_config.block_index_prefix_len = BENCH_BLOCK_INDEX_PREFIX_LEN;
     cf_config.klog_value_threshold = BENCH_KLOG_VALUE_THRESHOLD;
     cf_config.min_disk_space = BENCH_MIN_DISK_SPACE;
     cf_config.l1_file_count_trigger = BENCH_L1_FILE_COUNT_TRIGGER;

--- a/src/block_manager.c
+++ b/src/block_manager.c
@@ -611,6 +611,12 @@ static int block_manager_open_internal(block_manager_t **bm, const char *file_pa
     return 0;
 }
 
+/* buffered-append staging-buffer pool, defined below with the other buffered helpers */
+static int bm_buf_pool_acquire(uint64_t ring_size, uint8_t **ring,
+                               _Atomic unsigned char **done_ring);
+static void bm_buf_pool_release(uint8_t *ring, _Atomic unsigned char *done_ring,
+                                uint64_t ring_size);
+
 int block_manager_close(block_manager_t *bm)
 {
     if (!bm) return -1;
@@ -625,8 +631,16 @@ int block_manager_close(block_manager_t *bm)
         pthread_cond_signal(&bm->buf_work_cv);
         pthread_mutex_unlock(&bm->buf_mtx);
         pthread_join(bm->flush_tid, NULL);
-        free(bm->ring);
-        free((void *)bm->done_ring);
+        /* a clean drain left every done-ring flag cleared, so return the warm buffer pair to the
+         * pool for the next WAL. a flush error may have left flags set, so free that pair instead.
+         */
+        if (atomic_load_explicit(&bm->flush_error, memory_order_acquire))
+        {
+            free(bm->ring);
+            free((void *)bm->done_ring);
+        }
+        else
+            bm_buf_pool_release(bm->ring, bm->done_ring, bm->ring_size);
         bm->ring = NULL;
         bm->done_ring = NULL;
         pthread_mutex_destroy(&bm->buf_mtx);
@@ -717,13 +731,72 @@ block_manager_block_t *block_manager_block_create_from_buffer(const uint64_t siz
 
 /* buffered-append tunables */
 #define BM_BUF_DEFAULT_RING (8ull * 1024 * 1024) /* default staging ring size */
-#define BM_BUF_MIN_RING     (1ull * 1024 * 1024) /* ring floor; larger records use the oversized path \
-                                                  */
-#define BM_BUF_SPIN          2048                /* spin iterations before parking on a cond var */
+#define BM_BUF_MIN_RING                                                                \
+    (1ull * 1024 * 1024)          /* ring floor; larger records use the oversized path \
+                                   */
+#define BM_BUF_SPIN          2048 /* spin iterations before parking on a cond var */
 #define BM_BUF_FLUSH_PARK_US 500  /* flush-thread park timeout, a missed-signal safety net */
 #define BM_BUF_WAIT_PARK_US  2000 /* appender durability-wait park timeout */
 #define BM_NS_PER_US         1000L
 #define BM_NS_PER_SEC        1000000000L
+
+/* a rotating WAL opens a fresh buffered handle every generation; without pooling that mallocs and
+ * first-touches (page-faults) a new ring plus done-ring each time, on the rotation critical path. a
+ * small free-list hands a retired, already-resident buffer pair to the next open instead. a
+ * released done-ring is all-zero (the flush thread cleared every flag as it drained before close),
+ * so it is reusable as-is. bounded -- overflow is freed. */
+#define BM_BUF_POOL_MAX 8
+
+typedef struct
+{
+    uint8_t *ring;
+    _Atomic unsigned char *done_ring;
+    uint64_t ring_size;
+} bm_buf_pooled_t;
+
+static bm_buf_pooled_t bm_buf_pool[BM_BUF_POOL_MAX];
+static int bm_buf_pool_count = 0;
+static pthread_mutex_t bm_buf_pool_mtx = PTHREAD_MUTEX_INITIALIZER;
+
+/* pop a pooled buffer pair of exactly ring_size bytes into *ring/*done_ring, returning 1, or 0 if
+ * the pool holds none of that size. */
+static int bm_buf_pool_acquire(uint64_t ring_size, uint8_t **ring,
+                               _Atomic unsigned char **done_ring)
+{
+    int got = 0;
+    pthread_mutex_lock(&bm_buf_pool_mtx);
+    for (int i = bm_buf_pool_count - 1; i >= 0; i--)
+    {
+        if (bm_buf_pool[i].ring_size == ring_size)
+        {
+            *ring = bm_buf_pool[i].ring;
+            *done_ring = bm_buf_pool[i].done_ring;
+            bm_buf_pool[i] = bm_buf_pool[--bm_buf_pool_count];
+            got = 1;
+            break;
+        }
+    }
+    pthread_mutex_unlock(&bm_buf_pool_mtx);
+    return got;
+}
+
+/* return a clean (all-zero done_ring) buffer pair to the pool, or free it if the pool is full. */
+static void bm_buf_pool_release(uint8_t *ring, _Atomic unsigned char *done_ring, uint64_t ring_size)
+{
+    pthread_mutex_lock(&bm_buf_pool_mtx);
+    if (bm_buf_pool_count < BM_BUF_POOL_MAX)
+    {
+        bm_buf_pool[bm_buf_pool_count].ring = ring;
+        bm_buf_pool[bm_buf_pool_count].done_ring = done_ring;
+        bm_buf_pool[bm_buf_pool_count].ring_size = ring_size;
+        bm_buf_pool_count++;
+        pthread_mutex_unlock(&bm_buf_pool_mtx);
+        return;
+    }
+    pthread_mutex_unlock(&bm_buf_pool_mtx);
+    free(ring);
+    free((void *)done_ring);
+}
 
 /**
  * bm_cpu_relax
@@ -2399,8 +2472,12 @@ int block_manager_open_buffered(block_manager_t **bm, const char *file_path, con
 
     uint64_t R = ring_size ? ring_size : BM_BUF_DEFAULT_RING;
     if (R < BM_BUF_MIN_RING) R = BM_BUF_MIN_RING;
-    b->ring = malloc(R);
-    b->done_ring = calloc(R, 1); /* per-ring-position completion flags, zeroed */
+    /* reuse a retired, warm buffer pair when one of this size is pooled; else allocate fresh */
+    if (!bm_buf_pool_acquire(R, &b->ring, &b->done_ring))
+    {
+        b->ring = malloc(R);
+        b->done_ring = calloc(R, 1); /* per-ring-position completion flags, zeroed */
+    }
     if (!b->ring || !b->done_ring)
     {
         free(b->ring);

--- a/src/block_manager.c
+++ b/src/block_manager.c
@@ -458,6 +458,15 @@ static int truncate_to_header(block_manager_t *bm)
     /** preallocation is invalidated by ftruncate; we reset to current size so the next
      *  write triggers a fresh extend */
     atomic_store(&bm->preallocated_size, BLOCK_MANAGER_HEADER_SIZE);
+    /* keep the buffered flush and group-durability watermarks in lockstep with the reset size;
+     * the caller must have quiesced the flush thread (no in-flight appends) before truncating a
+     * buffered handle. a stale-high group_durable_size would make the group sync skip an fdatasync
+     * a post-truncate commit actually needs. */
+    if (bm->buffered)
+    {
+        atomic_store(&bm->buf_flushed, BLOCK_MANAGER_HEADER_SIZE);
+        atomic_store(&bm->group_durable_size, BLOCK_MANAGER_HEADER_SIZE);
+    }
     return 0;
 }
 
@@ -491,6 +500,18 @@ static int block_manager_open_internal(block_manager_t **bm, const char *file_pa
     atomic_init(&new_bm->prealloc_chunk, prealloc_chunk);
     atomic_init(&new_bm->group_durable_size, 0);
     atomic_init(&new_bm->group_sync_active, 0);
+
+    /* buffered-append fields default to the direct path; block_manager_open_buffered turns them on.
+     * zero-init is mandatory -- a garbage `buffered` flag would misroute every append. */
+    new_bm->buffered = 0;
+    new_bm->ring = NULL;
+    new_bm->done_ring = NULL;
+    new_bm->ring_size = 0;
+    atomic_init(&new_bm->buf_flushed, 0);
+    atomic_init(&new_bm->flush_stop, 0);
+    atomic_init(&new_bm->flush_error, 0);
+    atomic_init(&new_bm->flush_sleeping, 0);
+    atomic_init(&new_bm->durable_waiters, 0);
 
     new_bm->sync_mode = sync_mode;
     atomic_init(&new_bm->sync_full_cached, sync_mode == BLOCK_MANAGER_SYNC_FULL);
@@ -594,6 +615,26 @@ int block_manager_close(block_manager_t *bm)
 {
     if (!bm) return -1;
 
+    /* in buffered mode stop and join the flush thread, draining the ring, before touching the fd.
+     * callers quiesce appenders first (no reservation left outstanding), so every reserved record
+     * is completed and the flush thread drains to flushed == current_file_size then exits. */
+    if (bm->buffered)
+    {
+        atomic_store_explicit(&bm->flush_stop, 1, memory_order_release);
+        pthread_mutex_lock(&bm->buf_mtx);
+        pthread_cond_signal(&bm->buf_work_cv);
+        pthread_mutex_unlock(&bm->buf_mtx);
+        pthread_join(bm->flush_tid, NULL);
+        free(bm->ring);
+        free((void *)bm->done_ring);
+        bm->ring = NULL;
+        bm->done_ring = NULL;
+        pthread_mutex_destroy(&bm->buf_mtx);
+        pthread_cond_destroy(&bm->buf_work_cv);
+        pthread_cond_destroy(&bm->buf_durable_cv);
+        bm->buffered = 0;
+    }
+
     /* preallocation advances logical EOF past actual data; trim back so next-open
      * validation sees the real tail block instead of trailing zeros. crash recovery
      * still has to tolerate trailing zeros (size_field == 0 marks the boundary). */
@@ -674,6 +715,344 @@ block_manager_block_t *block_manager_block_create_from_buffer(const uint64_t siz
     return block;
 }
 
+/* buffered-append tunables */
+#define BM_BUF_DEFAULT_RING (8ull * 1024 * 1024) /* default staging ring size */
+#define BM_BUF_MIN_RING     (1ull * 1024 * 1024) /* ring floor; larger records use the oversized path \
+                                                  */
+#define BM_BUF_SPIN          2048                /* spin iterations before parking on a cond var */
+#define BM_BUF_FLUSH_PARK_US 500  /* flush-thread park timeout, a missed-signal safety net */
+#define BM_BUF_WAIT_PARK_US  2000 /* appender durability-wait park timeout */
+#define BM_NS_PER_US         1000L
+#define BM_NS_PER_SEC        1000000000L
+
+/**
+ * bm_cpu_relax
+ * emit a CPU pause/yield hint inside a spin loop so a hyperthread sibling makes progress and the
+ * spin draws less power. a no-op on architectures without such a hint.
+ */
+static inline void bm_cpu_relax(void)
+{
+#if defined(__x86_64__) || defined(__i386__)
+    __builtin_ia32_pause();
+#elif defined(__aarch64__) || defined(__arm__)
+    __asm__ __volatile__("yield");
+#endif
+}
+
+/**
+ * bm_ring_copy
+ * copy n bytes of src into the staging ring at file offset off, wrapping at the ring boundary.
+ * @param ring the staging ring buffer
+ * @param R the ring capacity in bytes
+ * @param off the file offset whose ring slot (off % R) receives the copy
+ * @param src the bytes to copy in
+ * @param n the number of bytes to copy
+ */
+static inline void bm_ring_copy(uint8_t *ring, uint64_t R, uint64_t off, const void *src, size_t n)
+{
+    uint64_t pos = off % R;
+    if (pos + n <= R)
+    {
+        memcpy(ring + pos, src, n);
+    }
+    else
+    {
+        size_t part1 = (size_t)(R - pos);
+        memcpy(ring + pos, src, part1);
+        memcpy(ring, (const uint8_t *)src + part1, n - part1);
+    }
+}
+
+/**
+ * bm_deadline
+ * fill ts with an absolute CLOCK_REALTIME deadline us microseconds from now, for cond_timedwait.
+ * @param ts output timespec set to the deadline
+ * @param us microseconds from now until the deadline
+ */
+static inline void bm_deadline(struct timespec *ts, long us)
+{
+    clock_gettime(CLOCK_REALTIME, ts);
+    ts->tv_nsec += us * BM_NS_PER_US;
+    if (ts->tv_nsec >= BM_NS_PER_SEC)
+    {
+        ts->tv_sec += ts->tv_nsec / BM_NS_PER_SEC;
+        ts->tv_nsec %= BM_NS_PER_SEC;
+    }
+}
+
+/**
+ * bm_ring_read_u32
+ * read a record's little-endian uint32 size field from the ring at file offset off, wrapping at the
+ * ring boundary. a plain (non-atomic) read -- the caller only reaches here after acquire-loading
+ * done_ring[off], which synchronizes-with the appender's release-store after it copied the record.
+ * @param ring the staging ring buffer
+ * @param R the ring capacity in bytes
+ * @param off the file offset of the size field to read
+ * @return the decoded size field
+ */
+static inline uint32_t bm_ring_read_u32(const uint8_t *ring, uint64_t R, uint64_t off)
+{
+    uint64_t pos = off % R;
+    uint8_t b[BLOCK_MANAGER_SIZE_FIELD_SIZE];
+    if (pos + BLOCK_MANAGER_SIZE_FIELD_SIZE <= R)
+    {
+        memcpy(b, ring + pos, BLOCK_MANAGER_SIZE_FIELD_SIZE);
+    }
+    else
+    {
+        size_t p1 = (size_t)(R - pos);
+        memcpy(b, ring + pos, p1);
+        memcpy(b + p1, ring, (size_t)(BLOCK_MANAGER_SIZE_FIELD_SIZE - p1));
+    }
+    return decode_uint32_le_compat(b);
+}
+
+/**
+ * bm_done
+ * report whether the record starting at file offset off has been fully copied into the ring, by
+ * acquire-loading its completion flag in done_ring.
+ * @param bm the block manager
+ * @param off the record's start file offset
+ * @return non-zero if the record is fully copied, 0 otherwise
+ */
+static inline int bm_done(block_manager_t *bm, uint64_t off)
+{
+    return atomic_load_explicit(&bm->done_ring[off % bm->ring_size], memory_order_acquire) != 0;
+}
+
+/**
+ * bm_flush_thread
+ * the single writer for a buffered block manager. advances over the contiguous run of completed
+ * records starting at buf_flushed (each record's completion flag lives in done_ring, its size in
+ * its own header), pwrites the whole run in one call (wrapping as needed), clears the consumed
+ * flags, and advances buf_flushed. appenders never wait on each other -- they just set their flag,
+ * so there is no in-order release convoy under thread oversubscription. only this thread touches
+ * the fd.
+ * @param arg the block manager, passed as void* per the pthread start-routine signature
+ * @return always NULL; exits when flush_stop is set and the ring is drained, or on a flush error
+ */
+static void *bm_flush_thread(void *arg)
+{
+    block_manager_t *bm = (block_manager_t *)arg;
+    const uint64_t R = bm->ring_size;
+    for (;;)
+    {
+        /* exit on any flagged error -- our own (below) or one the oversized-record path set after a
+         * failed direct write. otherwise a gap left at the frontier would stall the join at close.
+         */
+        if (atomic_load_explicit(&bm->flush_error, memory_order_acquire)) break;
+
+        const uint64_t fl = atomic_load_explicit(&bm->buf_flushed, memory_order_relaxed);
+        const uint64_t reserved =
+            atomic_load_explicit(&bm->current_file_size, memory_order_acquire);
+
+        /* find the end of the contiguous completed run [fl, p) */
+        uint64_t p = fl;
+        while (p < reserved && bm_done(bm, p))
+            p += BLOCK_MANAGER_BLOCK_HEADER_SIZE + (uint64_t)bm_ring_read_u32(bm->ring, R, p) +
+                 BLOCK_MANAGER_FOOTER_SIZE;
+
+        if (p > fl)
+        {
+            const uint64_t sz = p - fl;
+            const uint64_t pos = fl % R;
+            int rc;
+            if (pos + sz <= R)
+                rc = pwrite_all(bm->fd, (const void *)(bm->ring + pos), (size_t)sz, (off_t)fl);
+            else
+            {
+                const uint64_t part1 = R - pos;
+                rc = pwrite_all(bm->fd, (const void *)(bm->ring + pos), (size_t)part1, (off_t)fl);
+                if (rc == 0)
+                    rc = pwrite_all(bm->fd, (const void *)bm->ring, (size_t)(sz - part1),
+                                    (off_t)(fl + part1));
+            }
+            if (rc != 0)
+            {
+                atomic_store_explicit(&bm->flush_error, errno ? errno : EIO, memory_order_release);
+                break;
+            }
+            if (is_sync_full(bm) && !odsync_available() && fdatasync(bm->fd) != 0)
+            {
+                atomic_store_explicit(&bm->flush_error, errno ? errno : EIO, memory_order_release);
+                break;
+            }
+            /* clear the consumed done flags so those ring slots can be reused after wrap */
+            for (uint64_t q = fl; q < p;)
+            {
+                const uint32_t rs = bm_ring_read_u32(bm->ring, R, q);
+                atomic_store_explicit(&bm->done_ring[q % R], 0, memory_order_relaxed);
+                q += BLOCK_MANAGER_BLOCK_HEADER_SIZE + (uint64_t)rs + BLOCK_MANAGER_FOOTER_SIZE;
+            }
+            atomic_store_explicit(&bm->buf_flushed, p, memory_order_release);
+            atomic_store_explicit(&bm->group_durable_size, p, memory_order_release);
+            /* always broadcast (per drain-batch) -- a lock-free waiter-count gate races the
+             * waiter's increment and drops wakeups, stalling backpressured appenders for a full
+             * cond timeout */
+            pthread_mutex_lock(&bm->buf_mtx);
+            pthread_cond_broadcast(&bm->buf_durable_cv);
+            pthread_mutex_unlock(&bm->buf_mtx);
+            continue;
+        }
+
+        /* nothing completed at the frontier, so exit if stopped and fully drained */
+        if (atomic_load_explicit(&bm->flush_stop, memory_order_acquire) && fl == reserved) break;
+
+        /* spin for the frontier record to complete, then park briefly (timeout = missed-signal net)
+         */
+        int got = 0;
+        for (int s = 0; s < BM_BUF_SPIN; s++)
+        {
+            if (fl < atomic_load_explicit(&bm->current_file_size, memory_order_acquire) &&
+                bm_done(bm, fl))
+            {
+                got = 1;
+                break;
+            }
+            bm_cpu_relax();
+        }
+        if (got) continue;
+        pthread_mutex_lock(&bm->buf_mtx);
+        atomic_store_explicit(&bm->flush_sleeping, 1, memory_order_seq_cst);
+        const uint64_t res2 = atomic_load_explicit(&bm->current_file_size, memory_order_acquire);
+        if (!(fl < res2 && bm_done(bm, fl)) &&
+            !(atomic_load_explicit(&bm->flush_stop, memory_order_acquire) && fl == res2))
+        {
+            struct timespec ts;
+            bm_deadline(&ts, BM_BUF_FLUSH_PARK_US);
+            pthread_cond_timedwait(&bm->buf_work_cv, &bm->buf_mtx, &ts);
+        }
+        atomic_store_explicit(&bm->flush_sleeping, 0, memory_order_seq_cst);
+        pthread_mutex_unlock(&bm->buf_mtx);
+    }
+    pthread_mutex_lock(&bm->buf_mtx);
+    pthread_cond_broadcast(&bm->buf_durable_cv);
+    pthread_mutex_unlock(&bm->buf_mtx);
+    return NULL;
+}
+
+/**
+ * bm_wait_flushed
+ * block until the flush thread has advanced buf_flushed to at least need. serves both durability (a
+ * committer waiting for its record to reach the fd) and ring backpressure (an appender waiting for
+ * a slot to free). spins briefly, then parks on buf_durable_cv with a timeout as a missed-signal
+ * net.
+ * @param bm the block manager
+ * @param need the flushed offset to wait for
+ * @return 0 once buf_flushed >= need, -1 if the flush thread reported an I/O error
+ */
+static int bm_wait_flushed(block_manager_t *bm, uint64_t need)
+{
+    if (atomic_load_explicit(&bm->buf_flushed, memory_order_acquire) >= need) return 0;
+    for (int s = 0; s < BM_BUF_SPIN; s++)
+    {
+        if (atomic_load_explicit(&bm->buf_flushed, memory_order_acquire) >= need) return 0;
+        if (atomic_load_explicit(&bm->flush_error, memory_order_acquire)) return -1;
+        bm_cpu_relax();
+    }
+    pthread_mutex_lock(&bm->buf_mtx);
+    atomic_fetch_add_explicit(&bm->durable_waiters, 1, memory_order_acq_rel);
+    while (atomic_load_explicit(&bm->buf_flushed, memory_order_acquire) < need &&
+           !atomic_load_explicit(&bm->flush_error, memory_order_acquire))
+    {
+        struct timespec ts;
+        bm_deadline(&ts, BM_BUF_WAIT_PARK_US);
+        pthread_cond_timedwait(&bm->buf_durable_cv, &bm->buf_mtx, &ts);
+    }
+    atomic_fetch_sub_explicit(&bm->durable_waiters, 1, memory_order_acq_rel);
+    pthread_mutex_unlock(&bm->buf_mtx);
+    return atomic_load_explicit(&bm->flush_error, memory_order_acquire) ? -1 : 0;
+}
+
+/**
+ * bm_wake_flush
+ * signal the flush thread if it is parked, so it promptly picks up newly released work. the
+ * seq_cst load of flush_sleeping is StoreLoad-ordered against the appender's done_ring release so a
+ * wake is never lost against the flush thread's park decision.
+ * @param bm the block manager
+ */
+static inline void bm_wake_flush(block_manager_t *bm)
+{
+    if (atomic_load_explicit(&bm->flush_sleeping, memory_order_seq_cst))
+    {
+        pthread_mutex_lock(&bm->buf_mtx);
+        pthread_cond_signal(&bm->buf_work_cv);
+        pthread_mutex_unlock(&bm->buf_mtx);
+    }
+}
+
+/**
+ * bm_buffered_append
+ * append path for a buffered block manager. reserves a file offset lock-free (current_file_size
+ * fetch-add), waits for ring space if the slot is still unflushed (backpressure), copies the framed
+ * block into the ring in parallel with other appenders, and sets its done_ring flag -- it does NOT
+ * pwrite, the flush thread does. a record larger than the whole ring takes the oversized path,
+ * becoming the flush frontier and writing itself straight to the file.
+ * @param bm the block manager
+ * @param data the payload to frame and append
+ * @param size the payload size in bytes
+ * @return the reserved file offset the record was written at, or -1 on a flush I/O error
+ */
+static int64_t bm_buffered_append(block_manager_t *bm, const void *data, const uint32_t size)
+{
+    const size_t total = BLOCK_MANAGER_BLOCK_HEADER_SIZE + (size_t)size + BLOCK_MANAGER_FOOTER_SIZE;
+    const uint64_t R = bm->ring_size;
+    const uint32_t checksum = compute_checksum(data, size);
+
+    const uint64_t off = atomic_fetch_add(&bm->current_file_size, total);
+    const uint64_t end = off + total;
+
+    unsigned char header[BLOCK_MANAGER_BLOCK_HEADER_SIZE];
+    encode_uint32_le_compat(header, size);
+    encode_uint32_le_compat(header + BLOCK_MANAGER_SIZE_FIELD_SIZE, checksum);
+    unsigned char footer[BLOCK_MANAGER_FOOTER_SIZE];
+    encode_uint32_le_compat(footer, size);
+    encode_uint32_le_compat(footer + BLOCK_MANAGER_CHECKSUM_LENGTH, BLOCK_MANAGER_FOOTER_MAGIC);
+
+    /* a record larger than the whole ring cannot be staged -- it would wrap onto itself. wait to
+     * become the flush frontier (buf_flushed == off means every prior record is written and the
+     * flush thread is parked at off), pwrite the framed record straight to the file, then publish
+     * the advanced flushed watermark ourselves. backpressure holds every later appender until we
+     * publish, so none reuses a ring slot our span aliases. rare -- only oversized commit batches.
+     */
+    if (total > R)
+    {
+        if (bm_wait_flushed(bm, off) != 0) return -1;
+        int rc = pwrite_all(bm->fd, header, BLOCK_MANAGER_BLOCK_HEADER_SIZE, (off_t)off);
+        if (rc == 0)
+            rc = pwrite_all(bm->fd, data, size, (off_t)(off + BLOCK_MANAGER_BLOCK_HEADER_SIZE));
+        if (rc == 0)
+            rc = pwrite_all(bm->fd, footer, BLOCK_MANAGER_FOOTER_SIZE,
+                            (off_t)(off + BLOCK_MANAGER_BLOCK_HEADER_SIZE + size));
+        if (rc == 0 && is_sync_full(bm) && !odsync_available() && fdatasync(bm->fd) != 0) rc = -1;
+        if (rc != 0)
+            atomic_store_explicit(&bm->flush_error, errno ? errno : EIO, memory_order_release);
+        else
+            atomic_store_explicit(&bm->buf_flushed, end, memory_order_release);
+        bm_wake_flush(bm);
+        pthread_mutex_lock(&bm->buf_mtx);
+        pthread_cond_broadcast(&bm->buf_durable_cv);
+        pthread_mutex_unlock(&bm->buf_mtx);
+        return rc != 0 ? -1 : (int64_t)off;
+    }
+
+    /* backpressure keeps us from clobbering unflushed data -- our ring slot last held bytes
+     * [off-R, end-R), so wait until they are flushed. a no-op on the first pass (end <= R). */
+    if (end > R && bm_wait_flushed(bm, end - R) != 0) return -1;
+
+    bm_ring_copy(bm->ring, R, off, header, BLOCK_MANAGER_BLOCK_HEADER_SIZE);
+    bm_ring_copy(bm->ring, R, off + BLOCK_MANAGER_BLOCK_HEADER_SIZE, data, size);
+    bm_ring_copy(bm->ring, R, off + BLOCK_MANAGER_BLOCK_HEADER_SIZE + size, footer,
+                 BLOCK_MANAGER_FOOTER_SIZE);
+
+    /* publish completion -- release-ordered so the flush thread, on seeing the flag, sees the whole
+     * framed record. no waiting on other appenders; the flush thread advances over the contiguous
+     * run of set flags itself. seq_cst pairs with the flush thread's sleeping-flag StoreLoad. */
+    atomic_store_explicit(&bm->done_ring[off % R], (unsigned char)1, memory_order_seq_cst);
+    bm_wake_flush(bm);
+    return (int64_t)off;
+}
+
 /**
  * bm_append_block
  * append one framed block [size][checksum][data][size][magic] at the atomically
@@ -687,6 +1066,8 @@ block_manager_block_t *block_manager_block_create_from_buffer(const uint64_t siz
  */
 static int64_t bm_append_block(block_manager_t *bm, const void *data, const uint32_t size)
 {
+    if (bm->buffered) return bm_buffered_append(bm, data, size);
+
     const size_t total_size =
         BLOCK_MANAGER_BLOCK_HEADER_SIZE + (size_t)size + BLOCK_MANAGER_FOOTER_SIZE;
     const uint32_t checksum = compute_checksum(data, size);
@@ -1617,7 +1998,11 @@ int block_manager_cursor_at_last(block_manager_cursor_t *cursor)
 int block_manager_get_size(block_manager_t *bm, uint64_t *size)
 {
     if (!bm || !size) return -1;
-    *size = atomic_load(&bm->current_file_size);
+    /* on a buffered handle current_file_size is the reservation watermark -- records reserved but
+     * still in the staging ring are not yet in the file. report the flushed extent so a consumer
+     * reading the file (e.g. a sync-on-commit WAL upload) only sees bytes that are actually on
+     * disk. buffered handles are WAL-only, so sstable callers are unaffected. */
+    *size = atomic_load(bm->buffered ? &bm->buf_flushed : &bm->current_file_size);
     return 0;
 }
 
@@ -2001,4 +2386,64 @@ int block_manager_open_pre(block_manager_t **bm, const char *file_path, const in
 {
     if (!bm || !file_path) return -1;
     return block_manager_open_internal(bm, file_path, convert_sync_mode(sync_mode), prealloc_chunk);
+}
+
+int block_manager_open_buffered(block_manager_t **bm, const char *file_path, const int sync_mode,
+                                const uint64_t ring_size)
+{
+    if (!bm || !file_path) return -1;
+    int rc = block_manager_open_internal(bm, file_path, convert_sync_mode(sync_mode),
+                                         BLOCK_MANAGER_PREALLOC_CHUNK);
+    if (rc != 0) return rc;
+    block_manager_t *b = *bm;
+
+    uint64_t R = ring_size ? ring_size : BM_BUF_DEFAULT_RING;
+    if (R < BM_BUF_MIN_RING) R = BM_BUF_MIN_RING;
+    b->ring = malloc(R);
+    b->done_ring = calloc(R, 1); /* per-ring-position completion flags, zeroed */
+    if (!b->ring || !b->done_ring)
+    {
+        free(b->ring);
+        free((void *)b->done_ring);
+        b->ring = NULL;
+        b->done_ring = NULL;
+        block_manager_close(b);
+        *bm = NULL;
+        return -1;
+    }
+    b->ring_size = R;
+
+    /* watermarks start at the current (post-header / post-recovery) file size -- reservations
+     * continue from there and the flush thread only ever writes newly-appended bytes. */
+    const uint64_t fsz = atomic_load(&b->current_file_size);
+    atomic_store(&b->buf_flushed, fsz);
+    atomic_store(&b->group_durable_size, fsz);
+
+    pthread_mutex_init(&b->buf_mtx, NULL);
+    pthread_cond_init(&b->buf_work_cv, NULL);
+    pthread_cond_init(&b->buf_durable_cv, NULL);
+    b->buffered = 1;
+
+    if (pthread_create(&b->flush_tid, NULL, bm_flush_thread, b) != 0)
+    {
+        b->buffered = 0;
+        pthread_mutex_destroy(&b->buf_mtx);
+        pthread_cond_destroy(&b->buf_work_cv);
+        pthread_cond_destroy(&b->buf_durable_cv);
+        free(b->ring);
+        free((void *)b->done_ring);
+        b->ring = NULL;
+        b->done_ring = NULL;
+        block_manager_close(b);
+        *bm = NULL;
+        return -1;
+    }
+    return 0;
+}
+
+int block_manager_wait_durable(block_manager_t *bm, const uint64_t offset)
+{
+    if (!bm) return -1;
+    if (!bm->buffered) return 0; /* direct path is already durable per its sync mode */
+    return bm_wait_flushed(bm, offset);
 }

--- a/src/block_manager.c
+++ b/src/block_manager.c
@@ -734,7 +734,7 @@ block_manager_block_t *block_manager_block_create_from_buffer(const uint64_t siz
 #define BM_BUF_MIN_RING                                                                \
     (1ull * 1024 * 1024)          /* ring floor; larger records use the oversized path \
                                    */
-#define BM_BUF_SPIN          2048 /* spin iterations before parking on a cond var */
+#define BM_BUF_SPIN          128  /* spin iterations before parking on a cond var */
 #define BM_BUF_FLUSH_PARK_US 500  /* flush-thread park timeout, a missed-signal safety net */
 #define BM_BUF_WAIT_PARK_US  2000 /* appender durability-wait park timeout */
 #define BM_NS_PER_US         1000L

--- a/src/block_manager.h
+++ b/src/block_manager.h
@@ -101,6 +101,20 @@ typedef enum
  * @param group_durable_size bytes of the file confirmed fdatasync'd, used by group-commit
  *                           callers to tell whether their write is already durable
  * @param group_sync_active set while a group-commit leader is mid-fdatasync on this file
+ * @param buffered 1 when buffered append mode is enabled, 0 on the direct path
+ * @param ring staging ring buffer of ring_size bytes that appenders copy their framed record into
+ * @param done_ring per-ring-position completion flags; an appender sets done_ring[off % ring_size]
+ *                  after copying its record and the flush thread advances over the contiguous run
+ * @param ring_size ring capacity in bytes
+ * @param buf_flushed contiguous file offset the flush thread has pwritten, the durability watermark
+ * @param flush_tid the single flush thread that owns every pwrite in buffered mode
+ * @param flush_stop set at close so the flush thread drains the ring and exits
+ * @param flush_error errno set if a flush-thread pwrite or fdatasync failed
+ * @param flush_sleeping 1 while the flush thread is parked waiting for work
+ * @param durable_waiters count of appenders parked waiting for buf_flushed to advance
+ * @param buf_mtx guards the buffered condition variables
+ * @param buf_work_cv the flush thread parks here when the ring has no released work
+ * @param buf_durable_cv appenders park here waiting for buf_flushed to advance
  */
 typedef struct
 {
@@ -123,6 +137,28 @@ typedef struct
     ATOMIC_ALIGN(8) _Atomic uint64_t group_durable_size;
     /* atomic so concurrent group-commit leaders don't race on this flag */
     _Atomic int group_sync_active;
+
+    /**** buffered append mode (Aether decoupled fill + single flush thread)
+     * when active, concurrent appenders reserve a file offset (current_file_size fetch-add), copy
+     * their framed block into the staging ring in parallel, and release in offset order; ONE flush
+     * thread pwrites contiguous released runs to the fd and advances buf_flushed. only the flush
+     * thread touches the fd, so concurrent appenders never serialize on the inode write lock. the
+     * on-disk bytes are byte-identical to the direct path, so recovery and readers are unchanged.
+     * enabled per-bm via block_manager_open_buffered; zero/NULL on the direct path.
+     * current_file_size doubles as the reservation watermark (the next file offset handed out). */
+    int buffered;
+    uint8_t *ring;
+    _Atomic unsigned char *done_ring;
+    uint64_t ring_size;
+    ATOMIC_ALIGN(8) _Atomic uint64_t buf_flushed;
+    pthread_t flush_tid;
+    _Atomic int flush_stop;
+    _Atomic int flush_error;
+    _Atomic int flush_sleeping;
+    _Atomic int durable_waiters;
+    pthread_mutex_t buf_mtx;
+    pthread_cond_t buf_work_cv;
+    pthread_cond_t buf_durable_cv;
 } block_manager_t;
 
 /**
@@ -183,6 +219,33 @@ int block_manager_open(block_manager_t **bm, const char *file_path, int sync_mod
  */
 int block_manager_open_pre(block_manager_t **bm, const char *file_path, int sync_mode,
                            uint64_t prealloc_chunk);
+
+/**
+ * block_manager_open_buffered
+ * like block_manager_open but enables buffered append mode -- concurrent appenders stage into an
+ * in-memory ring and a single flush thread does all the pwrites, so many writers no longer
+ * serialize on the file inode write lock. use for the WAL, where many transactions append
+ * concurrently. reads, recovery, and the on-disk format are identical to the direct path.
+ * @param bm output block manager
+ * @param file_path path of the file
+ * @param sync_mode TDB_SYNC_NONE or TDB_SYNC_FULL
+ * @param ring_size staging ring capacity in bytes (0 = a sensible default); rounded up internally
+ * @return 0 on success, -1 on failure
+ */
+int block_manager_open_buffered(block_manager_t **bm, const char *file_path, int sync_mode,
+                                uint64_t ring_size);
+
+/**
+ * block_manager_wait_durable
+ * block until the buffered flush thread has written (and, in SYNC_FULL, fdatasync'd) every byte up
+ * to file offset `offset`. used by a committer that needs its WAL record durable before returning.
+ * on a non-buffered block manager this returns 0 immediately (the direct path is already durable
+ * per its sync mode).
+ * @param bm the block manager
+ * @param offset the file offset that must be durable
+ * @return 0 on success, -1 if the flush thread reported an I/O error
+ */
+int block_manager_wait_durable(block_manager_t *bm, uint64_t offset);
 
 /**
  * block_manager_close

--- a/src/blocked_bloom_filter.c
+++ b/src/blocked_bloom_filter.c
@@ -1,0 +1,456 @@
+/**
+ *
+ * Copyright (C) TidesDB
+ *
+ * Original Author: Alex Gaetano Padula
+ *
+ * Licensed under the Mozilla Public License, v. 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.mozilla.org/en-US/MPL/2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "blocked_bloom_filter.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+/* directory blob layout, all little-endian
+ *   magic (4) | version (4) | partition_count (4)
+ *   then partition_count records of
+ *     disk_offset (8) | blob_size (4) | entry_count (4) | first_key_len (4) | first_key bytes
+ * the partition records are in build (ascending key) order, so the reader binary-searches them
+ * directly. */
+#define BBF_DIR_MAGIC   0x46424254u /* "TBBF" little-endian */
+#define BBF_DIR_VERSION 1u
+/* magic + version + partition_count */
+#define BBF_DIR_HEADER_BYTES (3 * sizeof(uint32_t))
+/* per-record bytes before the variable first_key: disk_offset + blob_size + entry_count +
+ * first_key_len */
+#define BBF_DIR_ENTRY_FIXED (sizeof(uint64_t) + 3 * sizeof(uint32_t))
+
+/* little-endian byte codecs for the directory, endian-canonical so a filter built on one host
+ * reads back identically on another */
+static void bbf_put_u32le(uint8_t *p, uint32_t v)
+{
+    for (size_t i = 0; i < sizeof(uint32_t); i++) p[i] = (uint8_t)(v >> (8 * i));
+}
+
+static void bbf_put_u64le(uint8_t *p, uint64_t v)
+{
+    for (size_t i = 0; i < sizeof(uint64_t); i++) p[i] = (uint8_t)(v >> (8 * i));
+}
+
+static uint32_t bbf_get_u32le(const uint8_t *p)
+{
+    uint32_t v = 0;
+    for (size_t i = 0; i < sizeof(uint32_t); i++) v |= (uint32_t)p[i] << (8 * i);
+    return v;
+}
+
+static uint64_t bbf_get_u64le(const uint8_t *p)
+{
+    uint64_t v = 0;
+    for (size_t i = 0; i < sizeof(uint64_t); i++) v |= (uint64_t)p[i] << (8 * i);
+    return v;
+}
+
+/* one partition as tracked by the builder and reconstructed by the reader */
+typedef struct
+{
+    uint8_t *blob;      /* serialized partition, held until finish writes it (builder only) */
+    uint64_t offset;    /* where the partition blob was written, set at finish */
+    uint32_t size;      /* partition blob length */
+    uint32_t count;     /* keys in the partition */
+    uint8_t *first_key; /* owned copy of the partition's first key */
+    uint32_t first_key_len;
+} bbf_partition_t;
+
+struct blocked_bloom_builder
+{
+    double fpr;
+    uint32_t partition_entries;
+    blocked_bloom_write_fn write_fn;
+    void *write_ctx;
+
+    bloom_filter_t *current; /* partition being filled, NULL between partitions */
+    uint32_t current_count;
+    uint8_t *current_first_key;
+    uint32_t current_first_key_len;
+
+    bbf_partition_t *parts;
+    size_t num_parts;
+    size_t cap_parts;
+
+    uint64_t total_entries;
+    int failed; /* sticky -- a write or allocation failure poisons the build */
+};
+
+struct blocked_bloom_reader
+{
+    blocked_bloom_comparator_fn cmp;
+    void *cmp_ctx;
+    blocked_bloom_fetch_fn fetch_fn;
+    blocked_bloom_release_fn release_fn;
+    void *cb_ctx;
+
+    bbf_partition_t *parts; /* ascending key order; first_key owned */
+    uint32_t num_parts;
+    size_t resident_bytes;
+};
+
+/* free a partition array and the first-key copies it owns */
+static void bbf_partitions_free(bbf_partition_t *parts, size_t n)
+{
+    if (!parts) return;
+    for (size_t i = 0; i < n; i++)
+    {
+        free(parts[i].first_key);
+        free(parts[i].blob);
+    }
+    free(parts);
+}
+
+int blocked_bloom_builder_new(blocked_bloom_builder_t **out, double fpr, uint32_t partition_entries,
+                              blocked_bloom_write_fn write_fn, void *write_ctx)
+{
+    if (!out || !write_fn || !(fpr > 0.0 && fpr < 1.0)) return -1;
+    if (partition_entries == 0) partition_entries = TDB_BLOCKED_BLOOM_DEFAULT_PARTITION_ENTRIES;
+
+    blocked_bloom_builder_t *b = calloc(1, sizeof(*b));
+    if (!b) return -1;
+
+    b->fpr = fpr;
+    b->partition_entries = partition_entries;
+    b->write_fn = write_fn;
+    b->write_ctx = write_ctx;
+    *out = b;
+    return 0;
+}
+
+/* serialize the current partition and record it, holding its blob until finish writes it after the
+ * sstable's klog data. takes ownership of current_first_key on success. a no-op when no partition
+ * is open. */
+static int bbf_seal_current(blocked_bloom_builder_t *b)
+{
+    if (!b->current) return 0;
+
+    size_t blob_size = 0;
+    uint8_t *blob = bloom_filter_serialize(b->current, &blob_size);
+    if (!blob || blob_size == 0 || blob_size > UINT32_MAX)
+    {
+        free(blob);
+        return -1;
+    }
+
+    if (b->num_parts == b->cap_parts)
+    {
+        size_t ncap = b->cap_parts ? b->cap_parts * 2 : 16;
+        bbf_partition_t *np = realloc(b->parts, ncap * sizeof(*np));
+        if (!np)
+        {
+            free(blob);
+            return -1;
+        }
+        b->parts = np;
+        b->cap_parts = ncap;
+    }
+
+    bbf_partition_t *e = &b->parts[b->num_parts++];
+    e->blob = blob; /* written at finish */
+    e->offset = 0;  /* filled at finish */
+    e->size = (uint32_t)blob_size;
+    e->count = b->current_count;
+    e->first_key = b->current_first_key; /* ownership transferred */
+    e->first_key_len = b->current_first_key_len;
+
+    b->current_first_key = NULL;
+    b->current_first_key_len = 0;
+    bloom_filter_free(b->current);
+    b->current = NULL;
+    b->current_count = 0;
+    return 0;
+}
+
+int blocked_bloom_builder_add(blocked_bloom_builder_t *b, const uint8_t *key, size_t key_size)
+{
+    if (!b) return 0; /* a NULL builder means the filter is disabled -- adding is a no-op */
+    if (!key || key_size == 0) return -1;
+    if (b->failed) return -1;
+
+    if (!b->current)
+    {
+        if (bloom_filter_new(&b->current, b->fpr, (int)b->partition_entries) != 0)
+        {
+            b->failed = 1;
+            return -1;
+        }
+        b->current_first_key = malloc(key_size);
+        if (!b->current_first_key)
+        {
+            bloom_filter_free(b->current);
+            b->current = NULL;
+            b->failed = 1;
+            return -1;
+        }
+        memcpy(b->current_first_key, key, key_size);
+        b->current_first_key_len = (uint32_t)key_size;
+        b->current_count = 0;
+    }
+
+    bloom_filter_add(b->current, key, key_size);
+    b->current_count++;
+    b->total_entries++;
+
+    if (b->current_count >= b->partition_entries)
+    {
+        if (bbf_seal_current(b) != 0)
+        {
+            b->failed = 1;
+            return -1;
+        }
+    }
+    return 0;
+}
+
+/* serialized directory size for the recorded partitions */
+static size_t bbf_dir_size(const blocked_bloom_builder_t *b)
+{
+    size_t total = BBF_DIR_HEADER_BYTES;
+    for (size_t i = 0; i < b->num_parts; i++)
+        total += BBF_DIR_ENTRY_FIXED + b->parts[i].first_key_len;
+    return total;
+}
+
+int blocked_bloom_builder_finish(blocked_bloom_builder_t *b, uint64_t *out_dir_offset,
+                                 uint32_t *out_dir_size, uint64_t *out_total_entries)
+{
+    if (!b || !out_dir_offset || !out_dir_size) return -1;
+    if (b->failed) return -1;
+
+    if (bbf_seal_current(b) != 0)
+    {
+        b->failed = 1;
+        return -1;
+    }
+
+    /* write every buffered partition now -- the caller invokes finish from the sstable footer,
+     * after the klog data blocks, so these land contiguously past the data and their offsets are
+     * final */
+    for (size_t i = 0; i < b->num_parts; i++)
+    {
+        uint64_t offset = 0;
+        int rc = b->write_fn(b->write_ctx, b->parts[i].blob, b->parts[i].size, &offset);
+        if (rc != 0)
+        {
+            b->failed = 1;
+            return rc;
+        }
+        b->parts[i].offset = offset;
+        free(b->parts[i].blob);
+        b->parts[i].blob = NULL;
+    }
+
+    size_t dir_size = bbf_dir_size(b);
+    if (dir_size > UINT32_MAX) return -1;
+    uint8_t *dir = malloc(dir_size);
+    if (!dir) return -1;
+
+    uint8_t *p = dir;
+    bbf_put_u32le(p, BBF_DIR_MAGIC);
+    p += sizeof(uint32_t);
+    bbf_put_u32le(p, BBF_DIR_VERSION);
+    p += sizeof(uint32_t);
+    bbf_put_u32le(p, (uint32_t)b->num_parts);
+    p += sizeof(uint32_t);
+    for (size_t i = 0; i < b->num_parts; i++)
+    {
+        const bbf_partition_t *e = &b->parts[i];
+        bbf_put_u64le(p, e->offset);
+        p += sizeof(uint64_t);
+        bbf_put_u32le(p, e->size);
+        p += sizeof(uint32_t);
+        bbf_put_u32le(p, e->count);
+        p += sizeof(uint32_t);
+        bbf_put_u32le(p, e->first_key_len);
+        p += sizeof(uint32_t);
+        memcpy(p, e->first_key, e->first_key_len);
+        p += e->first_key_len;
+    }
+
+    uint64_t offset = 0;
+    int rc = b->write_fn(b->write_ctx, dir, dir_size, &offset);
+    free(dir);
+    if (rc != 0) return rc;
+
+    *out_dir_offset = offset;
+    *out_dir_size = (uint32_t)dir_size;
+    if (out_total_entries) *out_total_entries = b->total_entries;
+    return 0;
+}
+
+void blocked_bloom_builder_free(blocked_bloom_builder_t *b)
+{
+    if (!b) return;
+    if (b->current) bloom_filter_free(b->current);
+    free(b->current_first_key);
+    bbf_partitions_free(b->parts, b->num_parts);
+    free(b);
+}
+
+/* parse a directory blob into an ascending array of partitions. returns 0 on success. */
+static int bbf_parse_dir(const uint8_t *data, size_t len, bbf_partition_t **out_parts,
+                         uint32_t *out_n, size_t *out_resident)
+{
+    if (len < BBF_DIR_HEADER_BYTES) return -1;
+    if (bbf_get_u32le(data) != BBF_DIR_MAGIC) return -1;
+    if (bbf_get_u32le(data + sizeof(uint32_t)) != BBF_DIR_VERSION) return -1;
+    uint32_t n = bbf_get_u32le(data + 2 * sizeof(uint32_t));
+
+    if (n == 0)
+    {
+        *out_parts = NULL;
+        *out_n = 0;
+        *out_resident = 0;
+        return 0;
+    }
+
+    bbf_partition_t *parts = calloc(n, sizeof(*parts));
+    if (!parts) return -1;
+
+    size_t resident = n * sizeof(*parts);
+    const uint8_t *p = data + BBF_DIR_HEADER_BYTES;
+    const uint8_t *end = data + len;
+    for (uint32_t i = 0; i < n; i++)
+    {
+        if ((size_t)(end - p) < BBF_DIR_ENTRY_FIXED)
+        {
+            bbf_partitions_free(parts, i);
+            return -1;
+        }
+        parts[i].offset = bbf_get_u64le(p);
+        p += sizeof(uint64_t);
+        parts[i].size = bbf_get_u32le(p);
+        p += sizeof(uint32_t);
+        parts[i].count = bbf_get_u32le(p);
+        p += sizeof(uint32_t);
+        parts[i].first_key_len = bbf_get_u32le(p);
+        p += sizeof(uint32_t);
+        if (parts[i].first_key_len == 0 || (size_t)(end - p) < parts[i].first_key_len)
+        {
+            bbf_partitions_free(parts, i);
+            return -1;
+        }
+        parts[i].first_key = malloc(parts[i].first_key_len);
+        if (!parts[i].first_key)
+        {
+            bbf_partitions_free(parts, i);
+            return -1;
+        }
+        memcpy(parts[i].first_key, p, parts[i].first_key_len);
+        p += parts[i].first_key_len;
+        resident += parts[i].first_key_len;
+    }
+
+    *out_parts = parts;
+    *out_n = n;
+    *out_resident = resident;
+    return 0;
+}
+
+int blocked_bloom_reader_open(blocked_bloom_reader_t **out, uint64_t dir_offset, uint32_t dir_size,
+                              blocked_bloom_comparator_fn cmp, void *cmp_ctx,
+                              blocked_bloom_fetch_fn fetch_fn, blocked_bloom_release_fn release_fn,
+                              void *cb_ctx)
+{
+    if (!out || !cmp || !fetch_fn || dir_size == 0) return -1;
+
+    const uint8_t *dir_data = NULL;
+    void *pin = NULL;
+    if (fetch_fn(cb_ctx, dir_offset, dir_size, &dir_data, &pin) != 0 || !dir_data) return -1;
+
+    bbf_partition_t *parts = NULL;
+    uint32_t n = 0;
+    size_t resident = 0;
+    int rc = bbf_parse_dir(dir_data, dir_size, &parts, &n, &resident);
+    if (pin && release_fn) release_fn(cb_ctx, pin);
+    if (rc != 0) return -1;
+
+    blocked_bloom_reader_t *r = calloc(1, sizeof(*r));
+    if (!r)
+    {
+        bbf_partitions_free(parts, n);
+        return -1;
+    }
+    r->cmp = cmp;
+    r->cmp_ctx = cmp_ctx;
+    r->fetch_fn = fetch_fn;
+    r->release_fn = release_fn;
+    r->cb_ctx = cb_ctx;
+    r->parts = parts;
+    r->num_parts = n;
+    r->resident_bytes = sizeof(*r) + resident;
+    *out = r;
+    return 0;
+}
+
+/* index of the partition whose range covers key, or -1 if key sorts before the first partition.
+ * partitions are ascending, so this is the rightmost first_key <= key. */
+static int64_t bbf_route(const blocked_bloom_reader_t *r, const uint8_t *key, size_t key_size)
+{
+    int64_t lo = 0, hi = (int64_t)r->num_parts - 1, res = -1;
+    while (lo <= hi)
+    {
+        int64_t mid = lo + (hi - lo) / 2;
+        int c =
+            r->cmp(r->parts[mid].first_key, r->parts[mid].first_key_len, key, key_size, r->cmp_ctx);
+        if (c <= 0)
+        {
+            res = mid;
+            lo = mid + 1;
+        }
+        else
+        {
+            hi = mid - 1;
+        }
+    }
+    return res;
+}
+
+int blocked_bloom_reader_maybe_contains(blocked_bloom_reader_t *r, const uint8_t *key,
+                                        size_t key_size)
+{
+    if (!r || !key || key_size == 0) return -1;
+    if (r->num_parts == 0) return 1; /* no filter -- safe answer is may-present */
+
+    int64_t idx = bbf_route(r, key, key_size);
+    if (idx < 0) return 0; /* sorts before every partition -- definitely absent */
+
+    const bbf_partition_t *e = &r->parts[idx];
+    const uint8_t *blob = NULL;
+    void *pin = NULL;
+    if (r->fetch_fn(r->cb_ctx, e->offset, e->size, &blob, &pin) != 0 || !blob) return -1;
+
+    /* probe the pinned partition in place -- no filter is materialized per query */
+    const int c = bloom_filter_contains_serialized(blob, e->size, key, key_size);
+    if (pin && r->release_fn) r->release_fn(r->cb_ctx, pin);
+    return c;
+}
+
+size_t blocked_bloom_reader_resident_bytes(const blocked_bloom_reader_t *r)
+{
+    return r ? r->resident_bytes : 0;
+}
+
+void blocked_bloom_reader_free(blocked_bloom_reader_t *r)
+{
+    if (!r) return;
+    bbf_partitions_free(r->parts, r->num_parts);
+    free(r);
+}

--- a/src/blocked_bloom_filter.c
+++ b/src/blocked_bloom_filter.c
@@ -31,7 +31,7 @@
 #define BBF_DIR_VERSION 1u
 /* magic + version + partition_count */
 #define BBF_DIR_HEADER_BYTES (3 * sizeof(uint32_t))
-/* per-record bytes before the variable first_key: disk_offset + blob_size + entry_count +
+/* per-record bytes before the variable first_key -- disk_offset + blob_size + entry_count +
  * first_key_len */
 #define BBF_DIR_ENTRY_FIXED (sizeof(uint64_t) + 3 * sizeof(uint32_t))
 

--- a/src/blocked_bloom_filter.h
+++ b/src/blocked_bloom_filter.h
@@ -1,0 +1,196 @@
+/**
+ *
+ * Copyright (C) TidesDB
+ *
+ * Original Author: Alex Gaetano Padula
+ *
+ * Licensed under the Mozilla Public License, v. 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.mozilla.org/en-US/MPL/2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __BLOCKED_BLOOM_FILTER_H__
+#define __BLOCKED_BLOOM_FILTER_H__
+#include "bloom_filter.h"
+#include "compat.h"
+
+/**
+ * a per-sstable bloom filter, split into range partitions so its resident cost is bounded by the
+ * block cache rather than by the entry count.
+ *
+ * the key space is split, in sorted write order, into range partitions. each partition is an
+ * ordinary bloom_filter_t over its range, serialized to its own blob in the sstable's block-managed
+ * file. only a small directory of partition first-keys stays resident; the partition blobs are
+ * fetched on demand and are meant to live in the block cache. partitions are accumulated as they
+ * fill and written together when the build is finalized, so the aux region lands after the
+ * sstable's klog data and its data blocks stay contiguous.
+ *
+ * the directory holds each partition's full first-key, so routing a query to its partition is exact
+ * and the filter never reports a false negative.
+ *
+ * the writer is single-threaded and keys must arrive in non-decreasing comparator order. once
+ * built, a reader is read-only and may be queried concurrently by any number of threads.
+ */
+
+/* default number of keys per partition before rollover. at fpr 0.01 a partition holds roughly
+ * 1.2 bytes of filter per key, so the default keeps each partition blob around 80 KiB -- large
+ * enough to amortize the per-partition header, small enough to page and evict cheaply */
+#define TDB_BLOCKED_BLOOM_DEFAULT_PARTITION_ENTRIES 65536
+
+/**
+ * blocked_bloom_write_fn
+ * persist a finalized blob (a partition, or the directory) and report where it landed. the builder
+ * calls this for each accumulated partition and then the directory when it is finalized. the
+ * returned offset is opaque to the builder and is handed back to the reader's fetch to locate the
+ * same blob.
+ * @param ctx caller context
+ * @param data blob bytes
+ * @param size blob length
+ * @param out_offset receives the durable offset the blob was written at
+ * @return 0 on success, non-zero to abort the build
+ */
+typedef int (*blocked_bloom_write_fn)(void *ctx, const uint8_t *data, size_t size,
+                                      uint64_t *out_offset);
+
+/**
+ * blocked_bloom_fetch_fn
+ * fetch a previously written blob for reading. on success *out_data points at exactly `size`
+ * readable bytes that stay valid until release is called with *out_pin (which may be NULL when
+ * the buffer needs no pin, e.g. a test backing store). the intended production implementation
+ * is a block-cache lookup that faults the blob in on a miss and returns a pinned handle.
+ * @param ctx caller context
+ * @param offset blob offset reported earlier by the write sink
+ * @param size blob length to fetch
+ * @param out_data receives a readable buffer of `size` bytes valid until release
+ * @param out_pin receives a pin handle to pass to release, or NULL when none is needed
+ * @return 0 on success, non-zero on failure (a failure is treated as may-be-present)
+ */
+typedef int (*blocked_bloom_fetch_fn)(void *ctx, uint64_t offset, uint32_t size,
+                                      const uint8_t **out_data, void **out_pin);
+
+/**
+ * blocked_bloom_release_fn
+ * release a pin returned by fetch. never called for a NULL pin.
+ * @param ctx caller context
+ * @param pin the pin handle fetch produced
+ */
+typedef void (*blocked_bloom_release_fn)(void *ctx, void *pin);
+
+/**
+ * blocked_bloom_comparator_fn
+ * total order over keys, matching tidesdb_comparator_fn. used only to route a query key to its
+ * partition; the partition bloom itself hashes raw key bytes.
+ * @param key1 first key
+ * @param key1_size first key length
+ * @param key2 second key
+ * @param key2_size second key length
+ * @param ctx comparator context
+ * @return negative, zero, or positive as key1 orders before, equal to, or after key2
+ */
+typedef int (*blocked_bloom_comparator_fn)(const uint8_t *key1, size_t key1_size,
+                                           const uint8_t *key2, size_t key2_size, void *ctx);
+
+typedef struct blocked_bloom_builder blocked_bloom_builder_t;
+typedef struct blocked_bloom_reader blocked_bloom_reader_t;
+
+/**
+ * blocked_bloom_builder_new
+ * open a builder. keys are added in non-decreasing comparator order; each partition is serialized
+ * as it fills and all partitions are written via write_fn when the builder is finalized.
+ * @param out receives the builder
+ * @param fpr per-partition target false-positive rate, in (0, 1)
+ * @param partition_entries keys per partition before rollover; 0 selects the default
+ * @param write_fn sink for finalized partition and directory blobs
+ * @param write_ctx context passed to write_fn
+ * @return 0 on success, non-zero on invalid arguments or allocation failure
+ */
+int blocked_bloom_builder_new(blocked_bloom_builder_t **out, double fpr, uint32_t partition_entries,
+                              blocked_bloom_write_fn write_fn, void *write_ctx);
+
+/**
+ * blocked_bloom_builder_add
+ * add the next key. keys must be non-decreasing under the order the reader will use.
+ * @param b the builder, or NULL to make this a no-op (the filter is disabled)
+ * @param key the key to add
+ * @param key_size the key length
+ * @return 0 on success (or when b is NULL), non-zero on an allocation failure
+ */
+int blocked_bloom_builder_add(blocked_bloom_builder_t *b, const uint8_t *key, size_t key_size);
+
+/**
+ * blocked_bloom_builder_finish
+ * finalize the trailing partition, then serialize and write the directory. the directory's
+ * location and the total key count are returned for the sstable footer to record and hand to
+ * blocked_bloom_reader_open later. a build that added no keys writes an empty directory.
+ * @param out_dir_offset receives the directory blob offset
+ * @param out_dir_size receives the directory blob size
+ * @param out_total_entries receives the total number of keys added (may be NULL)
+ * @return 0 on success, non-zero on a write or allocation failure
+ */
+int blocked_bloom_builder_finish(blocked_bloom_builder_t *b, uint64_t *out_dir_offset,
+                                 uint32_t *out_dir_size, uint64_t *out_total_entries);
+
+/**
+ * blocked_bloom_builder_free
+ * release the builder. safe on NULL.
+ * @param b the builder
+ */
+void blocked_bloom_builder_free(blocked_bloom_builder_t *b);
+
+/**
+ * blocked_bloom_reader_open
+ * open a reader over a built filter, loading only the directory (one fetch at dir_offset). the
+ * comparator and fetch callbacks are retained and used per query. an empty directory
+ * (dir_size describing zero partitions) yields a reader whose queries all return may-present,
+ * which is the safe answer when no filter was built.
+ * @param out receives the reader
+ * @param dir_offset directory blob offset from builder_finish
+ * @param dir_size directory blob size from builder_finish
+ * @param cmp key order used to route a query to its partition
+ * @param cmp_ctx context passed to cmp
+ * @param fetch_fn source for the directory and partition blobs
+ * @param release_fn releases fetch pins
+ * @param cb_ctx context passed to fetch_fn and release_fn
+ * @return 0 on success, non-zero on a fetch or allocation failure
+ */
+int blocked_bloom_reader_open(blocked_bloom_reader_t **out, uint64_t dir_offset, uint32_t dir_size,
+                              blocked_bloom_comparator_fn cmp, void *cmp_ctx,
+                              blocked_bloom_fetch_fn fetch_fn, blocked_bloom_release_fn release_fn,
+                              void *cb_ctx);
+
+/**
+ * blocked_bloom_reader_maybe_contains
+ * route the key to its partition and probe that partition's bloom.
+ * @param r the reader
+ * @param key the key to test
+ * @param key_size the key length
+ * @return 1 if the key may be present, 0 if it is definitely absent, negative on a fetch or
+ *         decode error (callers must treat a negative result as may-be-present)
+ */
+int blocked_bloom_reader_maybe_contains(blocked_bloom_reader_t *r, const uint8_t *key,
+                                        size_t key_size);
+
+/**
+ * blocked_bloom_reader_resident_bytes
+ * bytes the reader keeps resident (the directory). the partition blobs are not counted -- they
+ * live in the fetch backing store (the block cache).
+ * @param r the reader
+ * @return resident byte count, or 0 when r is NULL
+ */
+size_t blocked_bloom_reader_resident_bytes(const blocked_bloom_reader_t *r);
+
+/**
+ * blocked_bloom_reader_free
+ * release the reader. safe on NULL.
+ * @param r the reader
+ */
+void blocked_bloom_reader_free(blocked_bloom_reader_t *r);
+
+#endif /* __BLOCKED_BLOOM_FILTER_H__ */

--- a/src/blocked_index.c
+++ b/src/blocked_index.c
@@ -1,0 +1,564 @@
+/**
+ *
+ * Copyright (C) TidesDB
+ *
+ * Original Author: Alex Gaetano Padula
+ *
+ * Licensed under the Mozilla Public License, v. 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.mozilla.org/en-US/MPL/2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "blocked_index.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+/* directory blob layout, all little-endian
+ *   magic (4) | version (4) | partition_count (4)
+ *   then partition_count records of
+ *     leaf_offset (8) | leaf_size (4) | block_count (4) | first_key_len (4) | first_key bytes
+ *
+ * leaf blob layout, all little-endian. an offset table lets the reader binary-search the
+ * variable-length records in place, with no per-lookup allocation.
+ *   block_count (4) | offsets[block_count] (4 each, byte offset of the record within the leaf)
+ *   then block_count records of
+ *     first_key_len (4) | first_key bytes | block_offset (8)
+ * records are in ascending first-key order. */
+#define BI_DIR_MAGIC   0x49424254u /* "TBBI" little-endian */
+#define BI_DIR_VERSION 1u
+/* magic + version + partition_count */
+#define BI_DIR_HEADER_BYTES (3 * sizeof(uint32_t))
+/* per-record bytes before the variable first_key: leaf_offset + leaf_size + block_count +
+ * first_key_len */
+#define BI_DIR_ENTRY_FIXED (sizeof(uint64_t) + 3 * sizeof(uint32_t))
+/* per-leaf-record bytes around the variable key: first_key_len + block_offset */
+#define BI_LEAF_REC_FIXED (sizeof(uint32_t) + sizeof(uint64_t))
+
+/* little-endian byte codecs for the directory and leaves, endian-canonical so an index built on one
+ * host reads back identically on another */
+static void bi_put_u32le(uint8_t *p, uint32_t v)
+{
+    for (size_t i = 0; i < sizeof(uint32_t); i++) p[i] = (uint8_t)(v >> (8 * i));
+}
+
+static void bi_put_u64le(uint8_t *p, uint64_t v)
+{
+    for (size_t i = 0; i < sizeof(uint64_t); i++) p[i] = (uint8_t)(v >> (8 * i));
+}
+
+static uint32_t bi_get_u32le(const uint8_t *p)
+{
+    uint32_t v = 0;
+    for (size_t i = 0; i < sizeof(uint32_t); i++) v |= (uint32_t)p[i] << (8 * i);
+    return v;
+}
+
+static uint64_t bi_get_u64le(const uint8_t *p)
+{
+    uint64_t v = 0;
+    for (size_t i = 0; i < sizeof(uint64_t); i++) v |= (uint64_t)p[i] << (8 * i);
+    return v;
+}
+
+/* one block as accumulated by the builder for the leaf it is filling */
+typedef struct
+{
+    uint8_t *first_key; /* owned copy */
+    uint32_t first_key_len;
+    uint64_t block_offset;
+} bi_block_t;
+
+/* one partition (leaf) as recorded in the directory */
+typedef struct
+{
+    uint8_t *leaf_blob; /* serialized leaf, held until finish writes it (builder only) */
+    uint64_t leaf_offset;
+    uint32_t leaf_size;
+    uint32_t block_count;
+    uint64_t base;      /* ordinal of this partition's first block, filled at reader open */
+    uint8_t *first_key; /* owned copy of the partition's first block first-key */
+    uint32_t first_key_len;
+} bi_part_t;
+
+struct blocked_index_builder
+{
+    uint32_t blocks_per_partition;
+    blocked_index_write_fn write_fn;
+    void *write_ctx;
+
+    bi_block_t *cur; /* blocks of the leaf being filled */
+    uint32_t cur_count;
+    uint32_t cur_cap;
+
+    bi_part_t *parts;
+    size_t num_parts;
+    size_t cap_parts;
+
+    uint64_t total_blocks;
+    int failed; /* sticky -- a write or allocation failure poisons the build */
+};
+
+struct blocked_index_reader
+{
+    blocked_index_comparator_fn cmp;
+    void *cmp_ctx;
+    blocked_index_fetch_fn fetch_fn;
+    blocked_index_release_fn release_fn;
+    void *cb_ctx;
+
+    bi_part_t *parts; /* ascending first-key order; first_key owned */
+    uint32_t num_parts;
+    size_t resident_bytes;
+};
+
+static void bi_parts_free(bi_part_t *parts, size_t n)
+{
+    if (!parts) return;
+    for (size_t i = 0; i < n; i++)
+    {
+        free(parts[i].first_key);
+        free(parts[i].leaf_blob);
+    }
+    free(parts);
+}
+
+static void bi_cur_free(blocked_index_builder_t *b)
+{
+    for (uint32_t i = 0; i < b->cur_count; i++) free(b->cur[i].first_key);
+    b->cur_count = 0;
+}
+
+int blocked_index_builder_new(blocked_index_builder_t **out, uint32_t blocks_per_partition,
+                              blocked_index_write_fn write_fn, void *write_ctx)
+{
+    if (!out || !write_fn) return -1;
+    if (blocks_per_partition == 0)
+        blocks_per_partition = TDB_BLOCKED_INDEX_DEFAULT_BLOCKS_PER_PARTITION;
+
+    blocked_index_builder_t *b = calloc(1, sizeof(*b));
+    if (!b) return -1;
+    b->blocks_per_partition = blocks_per_partition;
+    b->write_fn = write_fn;
+    b->write_ctx = write_ctx;
+    *out = b;
+    return 0;
+}
+
+/* serialize the current leaf and record the partition, holding its blob until finish writes it
+ * after the sstable's klog data. a no-op when the leaf is empty. takes ownership of the first
+ * block's first-key for the directory entry. */
+static int bi_seal_leaf(blocked_index_builder_t *b)
+{
+    if (b->cur_count == 0) return 0;
+
+    /* leaf header is a block_count then an offset-table slot per record, both u32 */
+    const size_t header = sizeof(uint32_t) + (size_t)sizeof(uint32_t) * b->cur_count;
+    size_t body = 0;
+    for (uint32_t i = 0; i < b->cur_count; i++) body += BI_LEAF_REC_FIXED + b->cur[i].first_key_len;
+    size_t leaf_size = header + body;
+    if (leaf_size > UINT32_MAX) return -1;
+
+    uint8_t *leaf = malloc(leaf_size);
+    if (!leaf) return -1;
+
+    bi_put_u32le(leaf, b->cur_count);
+    uint8_t *rec = leaf + header; /* records begin after the offset table */
+    for (uint32_t i = 0; i < b->cur_count; i++)
+    {
+        /* offset of record i in the offset table */
+        bi_put_u32le(leaf + sizeof(uint32_t) + (size_t)sizeof(uint32_t) * i,
+                     (uint32_t)(rec - leaf));
+        bi_put_u32le(rec, b->cur[i].first_key_len);
+        rec += sizeof(uint32_t);
+        memcpy(rec, b->cur[i].first_key, b->cur[i].first_key_len);
+        rec += b->cur[i].first_key_len;
+        bi_put_u64le(rec, b->cur[i].block_offset);
+        rec += sizeof(uint64_t);
+    }
+
+    if (b->num_parts == b->cap_parts)
+    {
+        size_t ncap = b->cap_parts ? b->cap_parts * 2 : 16;
+        bi_part_t *np = realloc(b->parts, ncap * sizeof(*np));
+        if (!np)
+        {
+            free(leaf);
+            return -1;
+        }
+        b->parts = np;
+        b->cap_parts = ncap;
+    }
+
+    bi_part_t *e = &b->parts[b->num_parts++];
+    e->leaf_blob = leaf; /* written at finish */
+    e->leaf_offset = 0;  /* filled at finish */
+    e->leaf_size = (uint32_t)leaf_size;
+    e->block_count = b->cur_count;
+    e->base = 0;
+    e->first_key = b->cur[0].first_key; /* ownership transferred */
+    e->first_key_len = b->cur[0].first_key_len;
+    b->cur[0].first_key = NULL;
+
+    bi_cur_free(b);
+    return 0;
+}
+
+int blocked_index_builder_add(blocked_index_builder_t *b, const uint8_t *first_key,
+                              size_t first_key_size, uint64_t block_offset)
+{
+    if (!b) return 0; /* a NULL builder means the index is disabled -- adding is a no-op */
+    if (!first_key || first_key_size == 0) return -1;
+    if (b->failed) return -1;
+
+    if (b->cur_count == b->cur_cap)
+    {
+        uint32_t ncap = b->cur_cap ? b->cur_cap * 2 : 64;
+        if (ncap > b->blocks_per_partition) ncap = b->blocks_per_partition;
+        bi_block_t *nc = realloc(b->cur, (size_t)ncap * sizeof(*nc));
+        if (!nc)
+        {
+            b->failed = 1;
+            return -1;
+        }
+        b->cur = nc;
+        b->cur_cap = ncap;
+    }
+
+    uint8_t *kc = malloc(first_key_size);
+    if (!kc)
+    {
+        b->failed = 1;
+        return -1;
+    }
+    memcpy(kc, first_key, first_key_size);
+    b->cur[b->cur_count].first_key = kc;
+    b->cur[b->cur_count].first_key_len = (uint32_t)first_key_size;
+    b->cur[b->cur_count].block_offset = block_offset;
+    b->cur_count++;
+    b->total_blocks++;
+
+    if (b->cur_count >= b->blocks_per_partition)
+    {
+        if (bi_seal_leaf(b) != 0)
+        {
+            b->failed = 1;
+            return -1;
+        }
+    }
+    return 0;
+}
+
+/* serialized directory size for the recorded partitions */
+static size_t bi_dir_size(const blocked_index_builder_t *b)
+{
+    size_t total = BI_DIR_HEADER_BYTES;
+    for (size_t i = 0; i < b->num_parts; i++)
+        total += BI_DIR_ENTRY_FIXED + b->parts[i].first_key_len;
+    return total;
+}
+
+int blocked_index_builder_finish(blocked_index_builder_t *b, uint64_t *out_dir_offset,
+                                 uint32_t *out_dir_size, uint64_t *out_total_blocks)
+{
+    if (!b || !out_dir_offset || !out_dir_size) return -1;
+    if (b->failed) return -1;
+
+    if (bi_seal_leaf(b) != 0)
+    {
+        b->failed = 1;
+        return -1;
+    }
+
+    /* write every buffered leaf now -- the caller invokes finish from the sstable footer, after the
+     * klog data blocks, so these land contiguously past the data and their offsets are final */
+    for (size_t i = 0; i < b->num_parts; i++)
+    {
+        uint64_t offset = 0;
+        int rc = b->write_fn(b->write_ctx, b->parts[i].leaf_blob, b->parts[i].leaf_size, &offset);
+        if (rc != 0)
+        {
+            b->failed = 1;
+            return rc;
+        }
+        b->parts[i].leaf_offset = offset;
+        free(b->parts[i].leaf_blob);
+        b->parts[i].leaf_blob = NULL;
+    }
+
+    size_t dir_size = bi_dir_size(b);
+    if (dir_size > UINT32_MAX) return -1;
+    uint8_t *dir = malloc(dir_size);
+    if (!dir) return -1;
+
+    uint8_t *p = dir;
+    bi_put_u32le(p, BI_DIR_MAGIC);
+    p += sizeof(uint32_t);
+    bi_put_u32le(p, BI_DIR_VERSION);
+    p += sizeof(uint32_t);
+    bi_put_u32le(p, (uint32_t)b->num_parts);
+    p += sizeof(uint32_t);
+    for (size_t i = 0; i < b->num_parts; i++)
+    {
+        const bi_part_t *e = &b->parts[i];
+        bi_put_u64le(p, e->leaf_offset);
+        p += sizeof(uint64_t);
+        bi_put_u32le(p, e->leaf_size);
+        p += sizeof(uint32_t);
+        bi_put_u32le(p, e->block_count);
+        p += sizeof(uint32_t);
+        bi_put_u32le(p, e->first_key_len);
+        p += sizeof(uint32_t);
+        memcpy(p, e->first_key, e->first_key_len);
+        p += e->first_key_len;
+    }
+
+    uint64_t offset = 0;
+    int rc = b->write_fn(b->write_ctx, dir, dir_size, &offset);
+    free(dir);
+    if (rc != 0) return rc;
+
+    *out_dir_offset = offset;
+    *out_dir_size = (uint32_t)dir_size;
+    if (out_total_blocks) *out_total_blocks = b->total_blocks;
+    return 0;
+}
+
+void blocked_index_builder_free(blocked_index_builder_t *b)
+{
+    if (!b) return;
+    bi_cur_free(b);
+    free(b->cur);
+    bi_parts_free(b->parts, b->num_parts);
+    free(b);
+}
+
+/* parse a directory blob into an ascending array of partitions and fill each partition's base
+ * ordinal from the running block total. returns 0 on success. */
+static int bi_parse_dir(const uint8_t *data, size_t len, bi_part_t **out_parts, uint32_t *out_n,
+                        size_t *out_resident)
+{
+    if (len < BI_DIR_HEADER_BYTES) return -1;
+    if (bi_get_u32le(data) != BI_DIR_MAGIC) return -1;
+    if (bi_get_u32le(data + sizeof(uint32_t)) != BI_DIR_VERSION) return -1;
+    uint32_t n = bi_get_u32le(data + 2 * sizeof(uint32_t));
+
+    if (n == 0)
+    {
+        *out_parts = NULL;
+        *out_n = 0;
+        *out_resident = 0;
+        return 0;
+    }
+
+    bi_part_t *parts = calloc(n, sizeof(*parts));
+    if (!parts) return -1;
+
+    size_t resident = n * sizeof(*parts);
+    uint64_t base = 0;
+    const uint8_t *p = data + BI_DIR_HEADER_BYTES;
+    const uint8_t *end = data + len;
+    for (uint32_t i = 0; i < n; i++)
+    {
+        if ((size_t)(end - p) < BI_DIR_ENTRY_FIXED)
+        {
+            bi_parts_free(parts, i);
+            return -1;
+        }
+        parts[i].leaf_offset = bi_get_u64le(p);
+        p += sizeof(uint64_t);
+        parts[i].leaf_size = bi_get_u32le(p);
+        p += sizeof(uint32_t);
+        parts[i].block_count = bi_get_u32le(p);
+        p += sizeof(uint32_t);
+        parts[i].first_key_len = bi_get_u32le(p);
+        p += sizeof(uint32_t);
+        if (parts[i].first_key_len == 0 || (size_t)(end - p) < parts[i].first_key_len)
+        {
+            bi_parts_free(parts, i);
+            return -1;
+        }
+        parts[i].first_key = malloc(parts[i].first_key_len);
+        if (!parts[i].first_key)
+        {
+            bi_parts_free(parts, i);
+            return -1;
+        }
+        memcpy(parts[i].first_key, p, parts[i].first_key_len);
+        p += parts[i].first_key_len;
+        parts[i].base = base;
+        base += parts[i].block_count;
+        resident += parts[i].first_key_len;
+    }
+
+    *out_parts = parts;
+    *out_n = n;
+    *out_resident = resident;
+    return 0;
+}
+
+int blocked_index_reader_open(blocked_index_reader_t **out, uint64_t dir_offset, uint32_t dir_size,
+                              blocked_index_comparator_fn cmp, void *cmp_ctx,
+                              blocked_index_fetch_fn fetch_fn, blocked_index_release_fn release_fn,
+                              void *cb_ctx)
+{
+    if (!out || !cmp || !fetch_fn || dir_size == 0) return -1;
+
+    const uint8_t *dir_data = NULL;
+    void *pin = NULL;
+    if (fetch_fn(cb_ctx, dir_offset, dir_size, &dir_data, &pin) != 0 || !dir_data) return -1;
+
+    bi_part_t *parts = NULL;
+    uint32_t n = 0;
+    size_t resident = 0;
+    int rc = bi_parse_dir(dir_data, dir_size, &parts, &n, &resident);
+    if (pin && release_fn) release_fn(cb_ctx, pin);
+    if (rc != 0) return -1;
+
+    blocked_index_reader_t *r = calloc(1, sizeof(*r));
+    if (!r)
+    {
+        bi_parts_free(parts, n);
+        return -1;
+    }
+    r->cmp = cmp;
+    r->cmp_ctx = cmp_ctx;
+    r->fetch_fn = fetch_fn;
+    r->release_fn = release_fn;
+    r->cb_ctx = cb_ctx;
+    r->parts = parts;
+    r->num_parts = n;
+    r->resident_bytes = sizeof(*r) + resident;
+    *out = r;
+    return 0;
+}
+
+/* index of the partition whose range covers key, or -1 if key sorts before the first partition */
+static int64_t bi_route(const blocked_index_reader_t *r, const uint8_t *key, size_t key_size)
+{
+    int64_t lo = 0, hi = (int64_t)r->num_parts - 1, res = -1;
+    while (lo <= hi)
+    {
+        int64_t mid = lo + (hi - lo) / 2;
+        int c =
+            r->cmp(r->parts[mid].first_key, r->parts[mid].first_key_len, key, key_size, r->cmp_ctx);
+        if (c <= 0)
+        {
+            res = mid;
+            lo = mid + 1;
+        }
+        else
+        {
+            hi = mid - 1;
+        }
+    }
+    return res;
+}
+
+/* locate record i in a leaf blob, validating every offset against the blob length. sets the key and
+ * block offset for a valid record. returns 0 on success, -1 on a malformed leaf. */
+static int bi_leaf_record(const uint8_t *leaf, uint32_t leaf_size, uint32_t block_count, uint32_t i,
+                          const uint8_t **out_key, uint32_t *out_key_len,
+                          uint64_t *out_block_offset)
+{
+    size_t table_end = sizeof(uint32_t) + (size_t)sizeof(uint32_t) * block_count;
+    if (table_end > leaf_size) return -1;
+    uint32_t rec_off = bi_get_u32le(leaf + sizeof(uint32_t) + (size_t)sizeof(uint32_t) * i);
+    if (rec_off < table_end || (size_t)rec_off + sizeof(uint32_t) > leaf_size) return -1;
+    uint32_t klen = bi_get_u32le(leaf + rec_off);
+    size_t need = (size_t)rec_off + BI_LEAF_REC_FIXED + klen;
+    if (klen == 0 || need > leaf_size) return -1;
+    *out_key = leaf + rec_off + sizeof(uint32_t);
+    *out_key_len = klen;
+    *out_block_offset = bi_get_u64le(leaf + rec_off + sizeof(uint32_t) + klen);
+    return 0;
+}
+
+int blocked_index_reader_find(blocked_index_reader_t *r, const uint8_t *key, size_t key_size,
+                              uint64_t *out_block_offset, uint64_t *out_block_ordinal)
+{
+    if (!r || !key || key_size == 0 || !out_block_offset) return -1;
+    if (r->num_parts == 0) return 0;
+
+    int64_t pi = bi_route(r, key, key_size);
+    if (pi < 0) return 0; /* sorts before every block */
+    const bi_part_t *part = &r->parts[pi];
+
+    const uint8_t *leaf = NULL;
+    void *pin = NULL;
+    if (r->fetch_fn(r->cb_ctx, part->leaf_offset, part->leaf_size, &leaf, &pin) != 0 || !leaf)
+        return -1;
+
+    int ret = -1;
+    if (part->leaf_size >= sizeof(uint32_t))
+    {
+        uint32_t block_count = bi_get_u32le(leaf);
+        if (block_count == part->block_count && block_count > 0)
+        {
+            /* rightmost record whose first-key is <= key */
+            int64_t lo = 0, hi = (int64_t)block_count - 1, res = -1;
+            int ok = 1;
+            while (lo <= hi)
+            {
+                int64_t mid = lo + (hi - lo) / 2;
+                const uint8_t *rk = NULL;
+                uint32_t rklen = 0;
+                uint64_t roff = 0;
+                if (bi_leaf_record(leaf, part->leaf_size, block_count, (uint32_t)mid, &rk, &rklen,
+                                   &roff) != 0)
+                {
+                    ok = 0;
+                    break;
+                }
+                if (r->cmp(rk, rklen, key, key_size, r->cmp_ctx) <= 0)
+                {
+                    res = mid;
+                    lo = mid + 1;
+                }
+                else
+                {
+                    hi = mid - 1;
+                }
+            }
+            if (ok && res >= 0)
+            {
+                const uint8_t *rk = NULL;
+                uint32_t rklen = 0;
+                uint64_t roff = 0;
+                if (bi_leaf_record(leaf, part->leaf_size, block_count, (uint32_t)res, &rk, &rklen,
+                                   &roff) == 0)
+                {
+                    *out_block_offset = roff;
+                    if (out_block_ordinal) *out_block_ordinal = part->base + (uint64_t)res;
+                    ret = 1;
+                }
+            }
+            else if (ok && res < 0)
+            {
+                ret = 0; /* routing guarantees this cannot normally happen */
+            }
+        }
+    }
+
+    if (pin && r->release_fn) r->release_fn(r->cb_ctx, pin);
+    return ret;
+}
+
+size_t blocked_index_reader_resident_bytes(const blocked_index_reader_t *r)
+{
+    return r ? r->resident_bytes : 0;
+}
+
+void blocked_index_reader_free(blocked_index_reader_t *r)
+{
+    if (!r) return;
+    bi_parts_free(r->parts, r->num_parts);
+    free(r);
+}

--- a/src/blocked_index.c
+++ b/src/blocked_index.c
@@ -36,10 +36,10 @@
 #define BI_DIR_VERSION 1u
 /* magic + version + partition_count */
 #define BI_DIR_HEADER_BYTES (3 * sizeof(uint32_t))
-/* per-record bytes before the variable first_key: leaf_offset + leaf_size + block_count +
+/* per-record bytes before the variable first_key -- leaf_offset + leaf_size + block_count +
  * first_key_len */
 #define BI_DIR_ENTRY_FIXED (sizeof(uint64_t) + 3 * sizeof(uint32_t))
-/* per-leaf-record bytes around the variable key: first_key_len + block_offset */
+/* per-leaf-record bytes around the variable key -- first_key_len + block_offset */
 #define BI_LEAF_REC_FIXED (sizeof(uint32_t) + sizeof(uint64_t))
 
 /* little-endian byte codecs for the directory and leaves, endian-canonical so an index built on one

--- a/src/blocked_index.h
+++ b/src/blocked_index.h
@@ -1,0 +1,203 @@
+/**
+ *
+ * Copyright (C) TidesDB
+ *
+ * Original Author: Alex Gaetano Padula
+ *
+ * Licensed under the Mozilla Public License, v. 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.mozilla.org/en-US/MPL/2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __BLOCKED_INDEX_H__
+#define __BLOCKED_INDEX_H__
+#include "compat.h"
+
+/**
+ * a per-sstable index over klog blocks, split into range partitions so its resident cost is bounded
+ * by the block cache rather than by the amount of data.
+ *
+ * klog blocks are grouped, in sorted write order, into partitions. each partition is a leaf holding
+ * the full first-key and file offset of its blocks, serialized to its own blob in the block-managed
+ * file. only a small directory of partition first-keys stays resident; the leaves are fetched on
+ * demand and are meant to live in the block cache. leaves are accumulated as they fill and written
+ * together when the build is finalized, so the aux region lands after the sstable's klog data and
+ * its data blocks stay contiguous. a leaf holds only block first-keys, so this stays far smaller
+ * than the entry count even while buffered.
+ *
+ * each leaf holds full first-keys, so a lookup routes to exactly one candidate block. a point
+ * lookup reads that block and searches within it; an iterator seeks to it and scans from there, and
+ * can size a range from the block ordinals of its two ends. block first-keys must be strictly
+ * increasing, which holds when a klog block boundary always falls on a key boundary (a key's data
+ * never spans two blocks).
+ *
+ * the writer is single-threaded and blocks must be added in ascending first-key order. once built,
+ * a reader is read-only and may be queried concurrently by any number of threads.
+ */
+
+/* default number of klog blocks described by one leaf before rollover. a leaf is fetched whole per
+ * lookup, so this trades leaf size against directory size; the default keeps a leaf near tens of
+ * KiB for typical key sizes */
+#define TDB_BLOCKED_INDEX_DEFAULT_BLOCKS_PER_PARTITION 4096
+
+/**
+ * blocked_index_write_fn
+ * persist a finalized blob (a leaf, or the directory) and report where it landed. the builder calls
+ * this for each accumulated leaf and then the directory when it is finalized. the returned offset
+ * is opaque to the builder and is handed back to the reader's fetch to locate the same blob.
+ * @param ctx caller context
+ * @param data blob bytes
+ * @param size blob length
+ * @param out_offset receives the durable offset the blob was written at
+ * @return 0 on success, non-zero to abort the build
+ */
+typedef int (*blocked_index_write_fn)(void *ctx, const uint8_t *data, size_t size,
+                                      uint64_t *out_offset);
+
+/**
+ * blocked_index_fetch_fn
+ * fetch a previously written blob for reading. on success *out_data points at exactly `size`
+ * readable bytes valid until release is called with *out_pin (which may be NULL when the buffer
+ * needs no pin). the intended production implementation is a block-cache lookup that faults the
+ * blob in on a miss and returns a pinned handle.
+ * @param ctx caller context
+ * @param offset blob offset reported earlier by the write sink
+ * @param size blob length to fetch
+ * @param out_data receives a readable buffer of `size` bytes valid until release
+ * @param out_pin receives a pin handle to pass to release, or NULL when none is needed
+ * @return 0 on success, non-zero on failure
+ */
+typedef int (*blocked_index_fetch_fn)(void *ctx, uint64_t offset, uint32_t size,
+                                      const uint8_t **out_data, void **out_pin);
+
+/**
+ * blocked_index_release_fn
+ * release a pin returned by fetch. never called for a NULL pin.
+ * @param ctx caller context
+ * @param pin the pin handle fetch produced
+ */
+typedef void (*blocked_index_release_fn)(void *ctx, void *pin);
+
+/**
+ * blocked_index_comparator_fn
+ * total order over keys, matching tidesdb_comparator_fn. used to route a key to its partition and
+ * to its block within the leaf.
+ * @param key1 first key
+ * @param key1_size first key length
+ * @param key2 second key
+ * @param key2_size second key length
+ * @param ctx comparator context
+ * @return negative, zero, or positive as key1 orders before, equal to, or after key2
+ */
+typedef int (*blocked_index_comparator_fn)(const uint8_t *key1, size_t key1_size,
+                                           const uint8_t *key2, size_t key2_size, void *ctx);
+
+typedef struct blocked_index_builder blocked_index_builder_t;
+typedef struct blocked_index_reader blocked_index_reader_t;
+
+/**
+ * blocked_index_builder_new
+ * open a builder. blocks are added in ascending first-key order; each leaf is serialized as it
+ * fills and all leaves are written via write_fn when the builder is finalized.
+ * @param out receives the builder
+ * @param blocks_per_partition klog blocks per leaf before rollover; 0 selects the default
+ * @param write_fn sink for finalized leaf and directory blobs
+ * @param write_ctx context passed to write_fn
+ * @return 0 on success, non-zero on invalid arguments or allocation failure
+ */
+int blocked_index_builder_new(blocked_index_builder_t **out, uint32_t blocks_per_partition,
+                              blocked_index_write_fn write_fn, void *write_ctx);
+
+/**
+ * blocked_index_builder_add
+ * record the next klog block. first-keys must be strictly increasing.
+ * @param b the builder, or NULL to make this a no-op (the index is disabled)
+ * @param first_key the block's first key
+ * @param first_key_size the block's first key length
+ * @param block_offset the block's file offset
+ * @return 0 on success (or when b is NULL), non-zero on an allocation failure
+ */
+int blocked_index_builder_add(blocked_index_builder_t *b, const uint8_t *first_key,
+                              size_t first_key_size, uint64_t block_offset);
+
+/**
+ * blocked_index_builder_finish
+ * finalize the trailing leaf, then serialize and write the directory. the directory's location and
+ * the total block count are returned for the sstable footer to record and hand to
+ * blocked_index_reader_open later. a build that added no blocks writes an empty directory.
+ * @param b the builder
+ * @param out_dir_offset receives the directory blob offset
+ * @param out_dir_size receives the directory blob size
+ * @param out_total_blocks receives the total number of blocks added (may be NULL)
+ * @return 0 on success, non-zero on a write or allocation failure
+ */
+int blocked_index_builder_finish(blocked_index_builder_t *b, uint64_t *out_dir_offset,
+                                 uint32_t *out_dir_size, uint64_t *out_total_blocks);
+
+/**
+ * blocked_index_builder_free
+ * release the builder. safe on NULL.
+ * @param b the builder
+ */
+void blocked_index_builder_free(blocked_index_builder_t *b);
+
+/**
+ * blocked_index_reader_open
+ * open a reader over a built index, loading only the directory (one fetch at dir_offset). the
+ * comparator and fetch callbacks are retained and used per lookup. an empty directory yields a
+ * reader whose lookups all report not-found, which sends the caller to a full scan.
+ * @param out receives the reader
+ * @param dir_offset directory blob offset from builder_finish
+ * @param dir_size directory blob size from builder_finish
+ * @param cmp key order used to route a lookup
+ * @param cmp_ctx context passed to cmp
+ * @param fetch_fn source for the directory and leaf blobs
+ * @param release_fn releases fetch pins
+ * @param cb_ctx context passed to fetch_fn and release_fn
+ * @return 0 on success, non-zero on a fetch or allocation failure
+ */
+int blocked_index_reader_open(blocked_index_reader_t **out, uint64_t dir_offset, uint32_t dir_size,
+                              blocked_index_comparator_fn cmp, void *cmp_ctx,
+                              blocked_index_fetch_fn fetch_fn, blocked_index_release_fn release_fn,
+                              void *cb_ctx);
+
+/**
+ * blocked_index_reader_find
+ * locate the klog block whose range covers the key -- the block with the greatest first-key not
+ * greater than the key.
+ * @param r the reader
+ * @param key the lookup key
+ * @param key_size the key length
+ * @param out_block_offset receives the file offset of the covering block
+ * @param out_block_ordinal receives the covering block's 0-based ordinal across the sstable, so an
+ *        iterator can size a range as the ordinal span of its ends; may be NULL
+ * @return 1 if a covering block was found, 0 if the key sorts before every block (a definite miss),
+ *         negative on a fetch or decode error (the caller should fall back to a full scan)
+ */
+int blocked_index_reader_find(blocked_index_reader_t *r, const uint8_t *key, size_t key_size,
+                              uint64_t *out_block_offset, uint64_t *out_block_ordinal);
+
+/**
+ * blocked_index_reader_resident_bytes
+ * bytes the reader keeps resident (the directory). the leaves are not counted -- they live in the
+ * fetch backing store (the block cache).
+ * @param r the reader
+ * @return resident byte count, or 0 when r is NULL
+ */
+size_t blocked_index_reader_resident_bytes(const blocked_index_reader_t *r);
+
+/**
+ * blocked_index_reader_free
+ * release the reader. safe on NULL.
+ * @param r the reader
+ */
+void blocked_index_reader_free(blocked_index_reader_t *r);
+
+#endif /* __BLOCKED_INDEX_H__ */

--- a/src/bloom_filter.c
+++ b/src/bloom_filter.c
@@ -475,12 +475,14 @@ static int bf_get_varint64(const uint8_t **pp, const uint8_t *end, uint64_t *out
     return 0;
 }
 
-bloom_filter_t *bloom_filter_deserialize(const uint8_t *data, const size_t len)
+/* parse a serialized filter's header (optional version sentinel + format byte, then m and h) and
+ * point *out_body at the bitset body. shared by deserialize and contains_serialized so both read
+ * the framing identically. returns 0 on success, -1 on a truncated or invalid header. */
+static int bf_parse_header(const uint8_t *data, size_t len, unsigned int *out_encoding,
+                           unsigned int *out_hash_version, unsigned int *out_m, unsigned int *out_h,
+                           const uint8_t **out_body)
 {
-    if (data == NULL || len == 0)
-    {
-        return NULL;
-    }
+    if (data == NULL || len == 0) return -1;
 
     const uint8_t *ptr = data;
     const uint8_t *const end = data + len;
@@ -494,45 +496,44 @@ bloom_filter_t *bloom_filter_deserialize(const uint8_t *data, const size_t len)
     unsigned int encoding = BF_ENCODING_SPARSE;
     if (ptr[0] == BF_SERIALIZE_VERSION_SENTINEL)
     {
-        if (end - ptr < BF_SERIALIZE_VERSION_BYTES) return NULL; /* sentinel + format byte */
-        ptr++;                                                   /* skip sentinel */
+        if (end - ptr < BF_SERIALIZE_VERSION_BYTES) return -1; /* sentinel + format byte */
+        ptr++;                                                 /* skip sentinel */
         const uint8_t format = *ptr++;
         hash_version = BF_FORMAT_HASH_VERSION(format);
         encoding = BF_FORMAT_ENCODING(format);
         /* reject an unknown hash version (querying with an undefined scheme would
          * silently false-negative) or an unknown bitset encoding */
         if (hash_version < BF_HASH_VERSION_LEGACY || hash_version > BF_HASH_VERSION_CURRENT)
-        {
-            return NULL;
-        }
-        if (encoding != BF_ENCODING_SPARSE && encoding != BF_ENCODING_DENSE)
-        {
-            return NULL;
-        }
+            return -1;
+        if (encoding != BF_ENCODING_SPARSE && encoding != BF_ENCODING_DENSE) return -1;
     }
 
     /* we read header with bounded varint decoding */
     uint32_t m_u32, h_u32;
-    if (bf_get_varint32(&ptr, end, &m_u32) != 0) return NULL;
-    if (bf_get_varint32(&ptr, end, &h_u32) != 0) return NULL;
+    if (bf_get_varint32(&ptr, end, &m_u32) != 0) return -1;
+    if (bf_get_varint32(&ptr, end, &h_u32) != 0) return -1;
 
-    const unsigned int m = m_u32;
-    const unsigned int h = h_u32;
+    /* h is the per-query probe count, so an out-of-range h from a corrupt filter would turn every
+     * query into a multi-billion-iteration loop. reject it with the same cap the constructor
+     * enforces, which a valid filter can never exceed. */
+    if (m_u32 == 0 || h_u32 == 0 || h_u32 > BF_MAX_HASH_FUNCTIONS) return -1;
+    if (m_u32 > UINT32_MAX - BF_BITS_PER_WORD) return -1; /* size calculation overflow */
 
-    /* we validate deserialized values. h is the per-query probe count, so an out-of-range h from a
-     * corrupt filter would turn every contains() into a multi-billion-iteration loop. reject it
-     * with the same cap the constructor enforces, which a valid filter can never exceed. */
-    if (m == 0 || h == 0 || h > BF_MAX_HASH_FUNCTIONS)
-    {
-        return NULL;
-    }
+    *out_encoding = encoding;
+    *out_hash_version = hash_version;
+    *out_m = m_u32;
+    *out_h = h_u32;
+    *out_body = ptr;
+    return 0;
+}
 
-    /* we check for potential integer overflow in size calculation */
-    if (m > UINT32_MAX - BF_BITS_PER_WORD)
-    {
-        return NULL;
-    }
+bloom_filter_t *bloom_filter_deserialize(const uint8_t *data, const size_t len)
+{
+    unsigned int encoding, hash_version, m, h;
+    const uint8_t *ptr;
+    if (bf_parse_header(data, len, &encoding, &hash_version, &m, &h, &ptr) != 0) return NULL;
 
+    const uint8_t *const end = data + len;
     const unsigned int size_in_words = (m + BF_BITS_PER_WORD - 1) / BF_BITS_PER_WORD;
 
     /* we allocate and zero-initialize bitset */
@@ -610,6 +611,56 @@ bloom_filter_t *bloom_filter_deserialize(const uint8_t *data, const size_t len)
     bf->hash_version = hash_version;
 
     return bf;
+}
+
+int bloom_filter_contains_serialized(const uint8_t *data, const size_t len, const uint8_t *entry,
+                                     const size_t size)
+{
+    if (data == NULL || entry == NULL || size == 0) return -1;
+
+    unsigned int encoding, hash_version, m, h;
+    const uint8_t *body;
+    if (bf_parse_header(data, len, &encoding, &hash_version, &m, &h, &body) != 0) return -1;
+
+    /* the sparse encoding is rare for a well-filled filter; fall back to a full deserialize rather
+     * than re-scan its varint word list on every probe */
+    if (encoding != BF_ENCODING_DENSE)
+    {
+        bloom_filter_t *bf = bloom_filter_deserialize(data, len);
+        if (bf == NULL) return -1;
+        const int r = bloom_filter_contains(bf, entry, size);
+        bloom_filter_free(bf);
+        return r;
+    }
+
+    const uint8_t *const end = data + len;
+    const unsigned int size_in_words = (m + BF_BITS_PER_WORD - 1) / BF_BITS_PER_WORD;
+    if ((size_t)(end - body) < (size_t)size_in_words * BF_DENSE_WORD_BYTES) return -1;
+
+    /* a stack header carries only the fields the hash derivation reads; the raw bitset is probed in
+     * place, one little-endian word at a time, so no filter is materialized */
+    bloom_filter_t hdr;
+    hdr.m = m;
+    hdr.h = h;
+    hdr.size_in_words = size_in_words;
+    hdr.hash_version = hash_version;
+    hdr.bitset = NULL;
+
+    uint32_t h1, h2;
+    bf_derive_hashes(&hdr, entry, size, &h1, &h2);
+
+    for (unsigned int i = 0; i < h; i++)
+    {
+        const uint32_t index = bf_fast_range(h1 + i * h2, m);
+        const uint8_t *const w = body + (size_t)(index / BF_BITS_PER_WORD) * BF_DENSE_WORD_BYTES;
+        uint64_t word = 0;
+        for (int j = 0; j < BF_DENSE_WORD_BYTES; j++) word |= (uint64_t)w[j] << (8 * j);
+        if (BF_LIKELY(!((word >> (index % BF_BITS_PER_WORD)) & 1ULL)))
+        {
+            return 0; /* definitely not in set */
+        }
+    }
+    return 1; /* probably in set */
 }
 
 void bloom_filter_free(bloom_filter_t *bf)

--- a/src/bloom_filter.h
+++ b/src/bloom_filter.h
@@ -81,6 +81,22 @@ void bloom_filter_add(const bloom_filter_t *bf, const uint8_t *entry, size_t siz
 int bloom_filter_contains(const bloom_filter_t *bf, const uint8_t *entry, size_t size);
 
 /**
+ * bloom_filter_contains_serialized
+ * checks if an entry is in a serialized filter (as produced by bloom_filter_serialize) without
+ * materializing a bloom_filter_t. the common dense encoding is probed in place over the buffer, one
+ * word at a time, so no bitset is allocated or copied; the rare sparse encoding falls back to a
+ * full deserialize. accepts every framing bloom_filter_deserialize accepts.
+ * @param data serialized filter bytes
+ * @param len length of data
+ * @param entry the entry to check
+ * @param size the size of the entry
+ * @return 1 if probably present, 0 if definitely absent, -1 on a NULL/empty entry or a malformed
+ *         or truncated serialized filter
+ */
+int bloom_filter_contains_serialized(const uint8_t *data, size_t len, const uint8_t *entry,
+                                     size_t size);
+
+/**
  * bloom_filter_is_full
  * checks if every bit in the filter is set
  * @param bf the bloom filter to check

--- a/src/db.h
+++ b/src/db.h
@@ -230,8 +230,6 @@ typedef int (*tidesdb_commit_hook_fn)(const tidesdb_commit_op_t *ops, int num_op
  * @param enable_bloom_filter enable bloom filter
  * @param bloom_fpr bloom filter false positive rate
  * @param enable_block_indexes enable block indexes
- * @param index_sample_ratio index sample ratio
- * @param block_index_prefix_len block index prefix length
  * @param sync_mode sync mode
  * @param sync_interval_us sync interval in microseconds
  * @param comparator_name name of comparator
@@ -270,8 +268,6 @@ typedef struct tidesdb_column_family_config_t
     int enable_bloom_filter;
     double bloom_fpr;
     int enable_block_indexes;
-    int index_sample_ratio;
-    int block_index_prefix_len;
     int sync_mode;
     uint64_t sync_interval_us;
     char comparator_name[TDB_MAX_COMPARATOR_NAME];

--- a/src/db.h
+++ b/src/db.h
@@ -67,12 +67,12 @@ typedef struct tidesdb_objstore_t tidesdb_objstore_t;
  * configuration for object store mode behavior
  * @param local_cache_path local directory for cached sstable files (NULL = use db_path)
  * @param local_cache_max_bytes max local cache size in bytes (0 = unlimited)
- * @param cache_on_read cache downloaded files locally (default 1)
- * @param cache_on_write keep local copy after upload (default 1)
+ * @param cache_on_read add a downloaded object to the bounded local cache so it can be evicted and
+ *                      re-fetched on a miss (default 1); when 0 the local copy stays pinned on disk
+ * @param cache_on_write add a flushed/uploaded sstable to the bounded local cache so it can be
+ *                       evicted and re-fetched on a miss (default 1); when 0 the copy stays pinned
  * @param max_concurrent_uploads parallel upload threads (default 4)
  * @param max_concurrent_downloads parallel download threads (default 8)
- * @param multipart_threshold use multipart upload above this size (default 64MB)
- * @param multipart_part_size multipart chunk size (default 8MB)
  * @param sync_manifest_to_object upload MANIFEST after each compaction (default 1)
  * @param replicate_wal upload closed WAL segments for node-failure recovery (default 1)
  * @param wal_upload_sync 0 = background WAL upload (default), 1 = block flush until uploaded
@@ -91,8 +91,6 @@ typedef struct
     int cache_on_write;
     int max_concurrent_uploads;
     int max_concurrent_downloads;
-    size_t multipart_threshold;
-    size_t multipart_part_size;
     int sync_manifest_to_object;
     int replicate_wal;
     int wal_upload_sync;
@@ -252,7 +250,6 @@ typedef int (*tidesdb_commit_hook_fn)(const tidesdb_commit_op_t *ops, int num_op
  * @param use_btree whether btree is used
  * @param commit_hook_fn optional commit hook callback (NULL = disabled, runtime-only)
  * @param commit_hook_ctx optional user context passed to commit hook (runtime-only)
- * @param object_target_file_size reserved for API compatibility, not used
  * @param object_lazy_compaction 1 = compact less aggressively in object store mode (default 0)
  * @param object_prefetch_compaction 1 = download all inputs before merge (default 1)
  */
@@ -285,7 +282,6 @@ typedef struct tidesdb_column_family_config_t
     int use_btree;
     tidesdb_commit_hook_fn commit_hook_fn;
     void *commit_hook_ctx;
-    size_t object_target_file_size; /* reserved, not used */
     int object_lazy_compaction;
     int object_prefetch_compaction;
 } tidesdb_column_family_config_t;
@@ -310,6 +306,10 @@ typedef struct tidesdb_column_family_config_t
  * @param unified_memtable_skip_list_probability skip list probability (0 = default 0.25)
  * @param unified_memtable_sync_mode sync mode for unified WAL (default TDB_SYNC_NONE)
  * @param unified_memtable_sync_interval_us sync interval for unified WAL (0 = default)
+ * @param unified_memtable_l0_queue_stall_threshold immutable-queue depth at which writer
+ *                               backpressure hard-stalls in unified mode. the shared unified
+ *                               immutable queue is db-wide, so it is bounded by this one db-level
+ *                               value rather than a per-column-family threshold. 0 = default
  * @param object_store pluggable object store connector (NULL = local only, default)
  * @param object_store_config object store behavior configuration (NULL = use defaults)
  * @param max_concurrent_flushes global semaphore on the number of in-flight memtable flushes
@@ -339,6 +339,7 @@ typedef struct tidesdb_config_t
     float unified_memtable_skip_list_probability;
     int unified_memtable_sync_mode;
     uint64_t unified_memtable_sync_interval_us;
+    int unified_memtable_l0_queue_stall_threshold;
     tidesdb_objstore_t *object_store;
     tidesdb_objstore_config_t *object_store_config;
     int max_concurrent_flushes;
@@ -645,6 +646,7 @@ int tidesdb_list_column_families(tidesdb_t *db, char ***names, int *count);
 int tidesdb_txn_begin(tidesdb_t *db, tidesdb_txn_t **txn);
 int tidesdb_txn_begin_with_isolation(tidesdb_t *db, tidesdb_isolation_level_t isolation,
                                      tidesdb_txn_t **txn);
+int tidesdb_txn_begin_cf(tidesdb_t *db, tidesdb_column_family_t *cf, tidesdb_txn_t **txn);
 int tidesdb_txn_put(tidesdb_txn_t *txn, tidesdb_column_family_t *cf, const uint8_t *key,
                     size_t key_size, const uint8_t *value, size_t value_size, time_t ttl);
 int tidesdb_txn_get(tidesdb_txn_t *txn, tidesdb_column_family_t *cf, const uint8_t *key,

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -63,7 +63,7 @@ static inline uint64_t manifest_get_u64(const uint8_t *p)
 /* forward declarations; documented at their definitions */
 static int tidesdb_manifest_add_sstable_unlocked(tidesdb_manifest_t *manifest, int level,
                                                  uint64_t id, uint64_t num_entries,
-                                                 uint64_t size_bytes);
+                                                 uint64_t size_bytes, int partition);
 static int manifest_rollover_locked(tidesdb_manifest_t *manifest, int durable_sync);
 
 /**
@@ -72,7 +72,7 @@ static int manifest_rollover_locked(tidesdb_manifest_t *manifest, int durable_sy
  */
 static int tidesdb_manifest_add_sstable_unlocked(tidesdb_manifest_t *manifest, const int level,
                                                  const uint64_t id, const uint64_t num_entries,
-                                                 const uint64_t size_bytes)
+                                                 const uint64_t size_bytes, const int partition)
 {
     for (int i = 0; i < manifest->num_entries; i++)
     {
@@ -80,6 +80,7 @@ static int tidesdb_manifest_add_sstable_unlocked(tidesdb_manifest_t *manifest, c
         {
             manifest->entries[i].num_entries = num_entries;
             manifest->entries[i].size_bytes = size_bytes;
+            manifest->entries[i].partition = partition;
             return 0;
         }
     }
@@ -98,6 +99,7 @@ static int tidesdb_manifest_add_sstable_unlocked(tidesdb_manifest_t *manifest, c
     manifest->entries[manifest->num_entries].id = id;
     manifest->entries[manifest->num_entries].num_entries = num_entries;
     manifest->entries[manifest->num_entries].size_bytes = size_bytes;
+    manifest->entries[manifest->num_entries].partition = partition;
     manifest->num_entries++;
     return 0;
 }
@@ -146,13 +148,14 @@ static int manifest_pending_reset(tidesdb_manifest_t *manifest)
  */
 static int manifest_pending_add_record(tidesdb_manifest_t *manifest, const uint8_t op,
                                        const int level, const uint64_t id,
-                                       const uint64_t num_entries, const uint64_t size_bytes)
+                                       const uint64_t num_entries, const uint64_t size_bytes,
+                                       const int partition)
 {
     size_t need;
     switch (op)
     {
-        case MANIFEST_OP_ADD:
-            need = MANIFEST_REC_ADD_SIZE;
+        case MANIFEST_OP_ADD_P:
+            need = MANIFEST_REC_ADD_P_SIZE;
             break;
         case MANIFEST_OP_REMOVE:
             need = MANIFEST_REC_REMOVE_SIZE;
@@ -188,11 +191,13 @@ static int manifest_pending_add_record(tidesdb_manifest_t *manifest, const uint8
         p += 4;
         manifest_put_u64(p, id);
         p += 8;
-        if (op == MANIFEST_OP_ADD)
+        if (op == MANIFEST_OP_ADD_P)
         {
             manifest_put_u64(p, num_entries);
             p += 8;
             manifest_put_u64(p, size_bytes);
+            p += 8;
+            manifest_put_u32(p, (uint32_t)partition);
         }
     }
     manifest->pending_len += need;
@@ -220,13 +225,28 @@ static int manifest_apply_batch(tidesdb_manifest_t *manifest, const uint8_t *dat
         {
             case MANIFEST_OP_ADD:
             {
+                /* legacy record with no partition -- a pre-partition-aware writer produced it, so
+                 * it is a non-partitioned sstable */
                 if (off + MANIFEST_REC_ADD_SIZE > size) return -1;
                 const int level = (int)manifest_get_u32(data + off + 1);
                 const uint64_t id = manifest_get_u64(data + off + 5);
                 const uint64_t ne = manifest_get_u64(data + off + 13);
                 const uint64_t sz = manifest_get_u64(data + off + 21);
-                tidesdb_manifest_add_sstable_unlocked(manifest, level, id, ne, sz);
+                tidesdb_manifest_add_sstable_unlocked(manifest, level, id, ne, sz,
+                                                      MANIFEST_NO_PARTITION);
                 off += MANIFEST_REC_ADD_SIZE;
+                break;
+            }
+            case MANIFEST_OP_ADD_P:
+            {
+                if (off + MANIFEST_REC_ADD_P_SIZE > size) return -1;
+                const int level = (int)manifest_get_u32(data + off + 1);
+                const uint64_t id = manifest_get_u64(data + off + 5);
+                const uint64_t ne = manifest_get_u64(data + off + 13);
+                const uint64_t sz = manifest_get_u64(data + off + 21);
+                const int partition = (int)manifest_get_u32(data + off + 29);
+                tidesdb_manifest_add_sstable_unlocked(manifest, level, id, ne, sz, partition);
+                off += MANIFEST_REC_ADD_P_SIZE;
                 break;
             }
             case MANIFEST_OP_REMOVE:
@@ -314,7 +334,7 @@ static int manifest_replay_locked(tidesdb_manifest_t *manifest)
 static int manifest_rollover_locked(tidesdb_manifest_t *manifest, const int durable_sync)
 {
     const size_t need = MANIFEST_BATCH_HDR_SIZE +
-                        (size_t)manifest->num_entries * MANIFEST_REC_ADD_SIZE +
+                        (size_t)manifest->num_entries * MANIFEST_REC_ADD_P_SIZE +
                         MANIFEST_REC_SEQ_SIZE;
     uint8_t *buf = malloc(need);
     if (!buf) return -1;
@@ -323,12 +343,13 @@ static int manifest_rollover_locked(tidesdb_manifest_t *manifest, const int dura
     buf[off++] = (uint8_t)MANIFEST_BATCH_FORMAT;
     for (int i = 0; i < manifest->num_entries; i++)
     {
-        buf[off] = MANIFEST_OP_ADD;
+        buf[off] = MANIFEST_OP_ADD_P;
         manifest_put_u32(buf + off + 1, (uint32_t)manifest->entries[i].level);
         manifest_put_u64(buf + off + 5, manifest->entries[i].id);
         manifest_put_u64(buf + off + 13, manifest->entries[i].num_entries);
         manifest_put_u64(buf + off + 21, manifest->entries[i].size_bytes);
-        off += MANIFEST_REC_ADD_SIZE;
+        manifest_put_u32(buf + off + 29, (uint32_t)manifest->entries[i].partition);
+        off += MANIFEST_REC_ADD_P_SIZE;
     }
     buf[off] = MANIFEST_OP_SEQ;
     manifest_put_u64(buf + off + 1, atomic_load(&manifest->sequence));
@@ -527,7 +548,9 @@ static int manifest_parse_legacy_text(tidesdb_manifest_t *manifest, FILE *fp)
             continue;
         }
 
-        tidesdb_manifest_add_sstable_unlocked(manifest, level, id, num_entries, size_bytes);
+        /* legacy text manifest predates partition tracking -- non-partitioned */
+        tidesdb_manifest_add_sstable_unlocked(manifest, level, id, num_entries, size_bytes,
+                                              MANIFEST_NO_PARTITION);
     }
 
     if (is_v8)
@@ -742,18 +765,19 @@ tidesdb_manifest_t *tidesdb_manifest_open(const char *path)
 }
 
 int tidesdb_manifest_add_sstable(tidesdb_manifest_t *manifest, const int level, const uint64_t id,
-                                 const uint64_t num_entries, const uint64_t size_bytes)
+                                 const uint64_t num_entries, const uint64_t size_bytes,
+                                 const int partition)
 {
     if (!manifest) return -1;
 
     atomic_fetch_add(&manifest->active_ops, 1);
     pthread_rwlock_wrlock(&manifest->lock);
-    int result =
-        tidesdb_manifest_add_sstable_unlocked(manifest, level, id, num_entries, size_bytes);
+    int result = tidesdb_manifest_add_sstable_unlocked(manifest, level, id, num_entries, size_bytes,
+                                                       partition);
     if (result == 0)
     {
-        result = manifest_pending_add_record(manifest, MANIFEST_OP_ADD, level, id, num_entries,
-                                             size_bytes);
+        result = manifest_pending_add_record(manifest, MANIFEST_OP_ADD_P, level, id, num_entries,
+                                             size_bytes, partition);
         if (result == 0) manifest->records_since_snapshot++;
     }
     pthread_rwlock_unlock(&manifest->lock);
@@ -771,7 +795,8 @@ int tidesdb_manifest_remove_sstable(tidesdb_manifest_t *manifest, const int leve
     int result = -1;
     if (manifest_remove_entry_unlocked(manifest, level, id))
     {
-        result = manifest_pending_add_record(manifest, MANIFEST_OP_REMOVE, level, id, 0, 0);
+        result = manifest_pending_add_record(manifest, MANIFEST_OP_REMOVE, level, id, 0, 0,
+                                             MANIFEST_NO_PARTITION);
         if (result == 0) manifest->records_since_snapshot++;
     }
     pthread_rwlock_unlock(&manifest->lock);
@@ -848,7 +873,7 @@ int tidesdb_manifest_commit(tidesdb_manifest_t *manifest, const char *path, cons
 
     /* close the batch with a SEQ record carrying the current sequence so replay's last SEQ wins */
     if (manifest_pending_add_record(manifest, MANIFEST_OP_SEQ, 0, atomic_load(&manifest->sequence),
-                                    0, 0) != 0)
+                                    0, 0, MANIFEST_NO_PARTITION) != 0)
         result = -1;
 
     if (result == 0)

--- a/src/manifest.h
+++ b/src/manifest.h
@@ -44,12 +44,17 @@
 #define MANIFEST_OP_ADD       0x01
 #define MANIFEST_OP_REMOVE    0x02
 #define MANIFEST_OP_SEQ       0x03
+#define MANIFEST_OP_ADD_P     0x04 /* like ADD but records the sstable's partition shard */
 #define MANIFEST_BATCH_FORMAT 1
+/* partition value for a non-partitioned sstable (a flush output); a partitioned merge output
+ * records its shard index instead. a legacy ADD record carries no partition and reads as this. */
+#define MANIFEST_NO_PARTITION (-1)
 /* on-disk record sizes (opcode byte + fields); a batch is a single format byte then self-delimiting
  * records (each record's opcode fixes its length, so no count is needed). all integers big-endian
  */
 #define MANIFEST_BATCH_HDR_SIZE  1  /* u8 format */
 #define MANIFEST_REC_ADD_SIZE    29 /* u8 op + i32 level + u64 id + u64 num_entries + u64 size */
+#define MANIFEST_REC_ADD_P_SIZE  33 /* ADD_SIZE + i32 partition */
 #define MANIFEST_REC_REMOVE_SIZE 13 /* u8 op + i32 level + u64 id */
 #define MANIFEST_REC_SEQ_SIZE    9  /* u8 op + u64 sequence */
 /* roll the log over into a fresh single snapshot block when records since the last snapshot exceed
@@ -68,6 +73,10 @@
  * @param id sstable ID
  * @param num_entries number of entries in sstable
  * @param size_bytes total size in bytes
+ * @param partition partition shard index for a partitioned merge output, or MANIFEST_NO_PARTITION
+ *                  for a non-partitioned flush output. reconstructing the sstable filename from the
+ *                  manifest (replica sync, object-store cold start) needs it so the local name
+ *                  mirrors what was written and uploaded
  */
 typedef struct
 {
@@ -75,6 +84,7 @@ typedef struct
     uint64_t id;
     uint64_t num_entries;
     uint64_t size_bytes;
+    int partition;
 } tidesdb_manifest_entry_t;
 
 /**
@@ -132,10 +142,11 @@ tidesdb_manifest_t *tidesdb_manifest_open(const char *path);
  * @param id sstable ID
  * @param num_entries number of entries
  * @param size_bytes size in bytes
+ * @param partition partition shard for a partitioned merge output, MANIFEST_NO_PARTITION otherwise
  * @return 0 on success, -1 on error
  */
 int tidesdb_manifest_add_sstable(tidesdb_manifest_t *manifest, int level, uint64_t id,
-                                 uint64_t num_entries, uint64_t size_bytes);
+                                 uint64_t num_entries, uint64_t size_bytes, int partition);
 
 /**
  * tidesdb_manifest_remove_sstable

--- a/src/objstore_fs.c
+++ b/src/objstore_fs.c
@@ -49,8 +49,6 @@
 #define TDB_OBJSTORE_DEFAULT_CACHE_ON_WRITE        1
 #define TDB_OBJSTORE_DEFAULT_MAX_UPLOADS           4
 #define TDB_OBJSTORE_DEFAULT_MAX_DOWNLOADS         8
-#define TDB_OBJSTORE_DEFAULT_MULTIPART_THRESHOLD   (64 * 1024 * 1024)
-#define TDB_OBJSTORE_DEFAULT_MULTIPART_PART_SIZE   (8 * 1024 * 1024)
 #define TDB_OBJSTORE_DEFAULT_SYNC_MANIFEST         1
 #define TDB_OBJSTORE_DEFAULT_REPLICATE_WAL         1
 #define TDB_OBJSTORE_DEFAULT_WAL_UPLOAD_SYNC       0
@@ -712,8 +710,6 @@ tidesdb_objstore_config_t tidesdb_objstore_default_config(void)
         .cache_on_write = TDB_OBJSTORE_DEFAULT_CACHE_ON_WRITE,
         .max_concurrent_uploads = TDB_OBJSTORE_DEFAULT_MAX_UPLOADS,
         .max_concurrent_downloads = TDB_OBJSTORE_DEFAULT_MAX_DOWNLOADS,
-        .multipart_threshold = TDB_OBJSTORE_DEFAULT_MULTIPART_THRESHOLD,
-        .multipart_part_size = TDB_OBJSTORE_DEFAULT_MULTIPART_PART_SIZE,
         .sync_manifest_to_object = TDB_OBJSTORE_DEFAULT_SYNC_MANIFEST,
         .replicate_wal = TDB_OBJSTORE_DEFAULT_REPLICATE_WAL,
         .wal_upload_sync = TDB_OBJSTORE_DEFAULT_WAL_UPLOAD_SYNC,

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -359,6 +359,16 @@ typedef tidesdb_memtable_t tidesdb_immutable_memtable_t;
 /* db-level L0 stall threshold for the shared unified immutable queue (unified mode) */
 #define TDB_DEFAULT_UNIFIED_L0_QUEUE_STALL_THRESHOLD 10
 
+/* flush-output partitioning -- a uniform-random memtable flush produces one keyspace-wide L1
+ * sstable that overlaps every largest-level partition, so the L1->largest merge re-reads it once
+ * per partition (the dominant read-amplification source). splitting a flush into narrow sstables
+ * aligned to the largest level's boundaries makes each L1 file overlap only a handful of
+ * partitions. the count is bounded so a flush emits a few reasonably sized files rather than one
+ * tiny file per boundary -- aim for roughly TDB_FLUSH_PARTITION_TARGET_BYTES per slice, capped at
+ * TDB_MAX_FLUSH_PARTITIONS. */
+#define TDB_FLUSH_PARTITION_TARGET_BYTES ((size_t)1 << 20)
+#define TDB_MAX_FLUSH_PARTITIONS         16
+
 /* default tombstone density trigger configuration -- 0.0 disables the check, an sstable
  * must hold at least TDB_DEFAULT_TOMBSTONE_DENSITY_MIN_ENTRIES entries before its density
  * counts toward the trigger so tiny sstables can't cause spurious compactions */
@@ -1857,7 +1867,7 @@ static inline size_t tdb_cf_effective_stall(const tidesdb_column_family_t *cf)
 /**
  * tdb_cf_flush_backlog
  * the flush backlog backpressure throttles on -- memtables that have been frozen and enqueued for
- * flush but whose flush has not yet completed. this is deliberately NOT the immutable queue length:
+ * flush but whose flush has not yet completed. this is deliberately not the immutable queue length:
  * that queue also holds memtables already flushed (their data durable in an sstable) that a
  * concurrent reader's snapshot is pinning against reaper reclamation, and throttling writes on
  * those would stall for a reader-blocked GC backlog rather than real flush pressure. the
@@ -8787,18 +8797,29 @@ static int tidesdb_sstable_write_from_heap_btree(
  * single cf's run inside the unified skip list is written straight to its sstable with no
  * intermediate per-cf skip list. seg_entry_count sizes the bloom/index for the segment, since
  * skip_list_count_entries would count the whole unified skip list.
+ * range_start/range_end bound the walk to the half-open user-key interval [range_start, range_end)
+ * so a single flush can be split into narrow boundary-aligned partitions instead of one keyspace-
+ * wide sstable (which forces the L1 merge to re-read it once per partition). a NULL range_start is
+ * -infinity, a NULL range_end is +infinity; the bound is compared against the real user key after
+ * any seg_prefix strip. an empty slice writes a zero-entry sstable, which the caller must discard.
  * @param db database instance
  * @param sst sstable to write to
  * @param memtable memtable to write from
  * @param seg_prefix cf_index prefix to restrict to, or NULL for the whole memtable
  * @param seg_prefix_len length of seg_prefix in bytes (0 when seg_prefix is NULL)
  * @param seg_entry_count entry-count hint for sizing, used only when seg_prefix is non-NULL
+ * @param range_start inclusive lower key bound, or NULL for -infinity
+ * @param range_start_size length of range_start (0 when NULL)
+ * @param range_end exclusive upper key bound, or NULL for +infinity
+ * @param range_end_size length of range_end (0 when NULL)
  * @return 0 on success, -1 on error
  */
 static int tidesdb_sstable_write_from_memtable_ex(tidesdb_t *db, tidesdb_column_family_t *cf,
                                                   tidesdb_sstable_t *sst, skip_list_t *memtable,
                                                   const uint8_t *seg_prefix, size_t seg_prefix_len,
-                                                  int seg_entry_count)
+                                                  int seg_entry_count, const uint8_t *range_start,
+                                                  size_t range_start_size, const uint8_t *range_end,
+                                                  size_t range_end_size)
 {
     if (!db || !cf || !sst || !memtable) return TDB_ERR_INVALID_ARGS;
 
@@ -8898,10 +8919,12 @@ static int tidesdb_sstable_write_from_memtable_ex(tidesdb_t *db, tidesdb_column_
     uint64_t max_seq = 0;
     size_t block_first_key_size = 0;
 
-    /* seek into the cf's prefix run for a unified segment, else start at the first key */
-    const int positioned = seg_prefix
-                               ? (skip_list_cursor_seek_ge(cursor, seg_prefix, seg_prefix_len) == 0)
-                               : (skip_list_cursor_goto_first(cursor) == 0);
+    /* seek into the cf's prefix run for a unified segment; else seek to the partition's lower key
+     * bound when this is a range slice, or the first key for a whole-memtable flush */
+    const int positioned =
+        seg_prefix    ? (skip_list_cursor_seek_ge(cursor, seg_prefix, seg_prefix_len) == 0)
+        : range_start ? (skip_list_cursor_seek_ge(cursor, range_start, range_start_size) == 0)
+                      : (skip_list_cursor_goto_first(cursor) == 0);
     if (positioned)
     {
         size_t block_first_key_capacity = 0;
@@ -8963,6 +8986,16 @@ static int tidesdb_sstable_write_from_memtable_ex(tidesdb_t *db, tidesdb_column_
                     }
                     key += seg_prefix_len;
                     key_size -= seg_prefix_len;
+                }
+
+                /* range slice -- keys ascend and we seeked to range_start, so the first key at or
+                 * past the exclusive upper bound ends this partition's run (reuse segment_done to
+                 * break both the version-chain loop and the node walk) */
+                if (range_end &&
+                    comparator_fn(key, key_size, range_end, range_end_size, comparator_ctx) >= 0)
+                {
+                    segment_done = 1;
+                    break;
                 }
 
                 /* we populate stack-allocated KV pair (no malloc needed) */
@@ -9152,7 +9185,8 @@ cleanup:
 static int tidesdb_sstable_write_from_memtable(tidesdb_t *db, tidesdb_column_family_t *cf,
                                                tidesdb_sstable_t *sst, skip_list_t *memtable)
 {
-    return tidesdb_sstable_write_from_memtable_ex(db, cf, sst, memtable, NULL, 0, 0);
+    return tidesdb_sstable_write_from_memtable_ex(db, cf, sst, memtable, NULL, 0, 0, NULL, 0, NULL,
+                                                  0);
 }
 
 /**
@@ -10882,6 +10916,115 @@ static int tidesdb_level_sort_by_min_key(tidesdb_t *db, tidesdb_level_t *level,
 static void tidesdb_bump_sstable_layout_version(tidesdb_column_family_t *cf)
 {
     atomic_fetch_add_explicit(&cf->sstable_layout_version, 1, memory_order_release);
+}
+
+/* one endpoint of an L1 sstable's [min_key,max_key] interval for the overlap-depth sweep */
+typedef struct
+{
+    const uint8_t *key;
+    size_t size;
+    int delta; /* +1 at a min_key (interval opens), -1 at a max_key (interval closes) */
+} tidesdb_overlap_event_t;
+
+/**
+ * tidesdb_compute_l1_overlap_depth
+ * the maximum number of L1 sstables whose [min_key,max_key] covers a single key -- i.e. the number
+ * of files a point read must consult in the worst case, which is the real read-amplification. a
+ * sweep over the interval endpoints under array_readers; ties resolve opens before closes so
+ * intervals sharing a boundary count as overlapping (the ranges are closed). only ever called on a
+ * layout change via the cached accessor below.
+ * @return worst-case per-key L1 overlap (0 when L1 is empty)
+ */
+static int tidesdb_compute_l1_overlap_depth(tidesdb_column_family_t *cf)
+{
+    tidesdb_level_t *lvl = cf->levels ? cf->levels[0] : NULL;
+    if (!lvl) return 0;
+
+    skip_list_comparator_fn cmp = NULL;
+    void *ctx = NULL;
+    tidesdb_resolve_comparator(cf->db, &cf->config, &cmp, &ctx);
+    if (!cmp) return 0;
+
+    /* array_readers pins the sstable array and its entries against a concurrent retire while we
+     * read their boundary keys (same guard the flush out-of-order scan uses) */
+    atomic_fetch_add_explicit(&lvl->array_readers, 1, memory_order_acq_rel);
+    const int n = atomic_load_explicit(&lvl->num_sstables, memory_order_acquire);
+    tidesdb_sstable_t **ssts = atomic_load_explicit(&lvl->sstables, memory_order_acquire);
+
+    tidesdb_overlap_event_t *ev = (n > 0) ? malloc((size_t)(2 * n) * sizeof(*ev)) : NULL;
+    int m = 0;
+    if (ev)
+    {
+        for (int i = 0; i < n; i++)
+        {
+            tidesdb_sstable_t *s = ssts ? ssts[i] : NULL;
+            if (!s || !s->min_key || !s->max_key) continue;
+            ev[m].key = s->min_key;
+            ev[m].size = s->min_key_size;
+            ev[m].delta = 1;
+            m++;
+            ev[m].key = s->max_key;
+            ev[m].size = s->max_key_size;
+            ev[m].delta = -1;
+            m++;
+        }
+    }
+    atomic_fetch_sub_explicit(&lvl->array_readers, 1, memory_order_release);
+
+    if (!ev || m == 0)
+    {
+        free(ev);
+        return (n > 0) ? 1 : 0; /* alloc failure -- fall back to a conservative depth of 1 */
+    }
+
+    /* insertion sort ascending by key; ties -> opens (delta 1) before closes (delta -1). m is 2x
+     * the L1 file count, small, and this runs only when the layout version moves. */
+    for (int i = 1; i < m; i++)
+    {
+        tidesdb_overlap_event_t e = ev[i];
+        int j = i - 1;
+        while (j >= 0)
+        {
+            const int c = cmp(ev[j].key, ev[j].size, e.key, e.size, ctx);
+            if (c > 0 || (c == 0 && ev[j].delta < e.delta))
+            {
+                ev[j + 1] = ev[j];
+                j--;
+            }
+            else
+                break;
+        }
+        ev[j + 1] = e;
+    }
+
+    int depth = 0, max_depth = 0;
+    for (int i = 0; i < m; i++)
+    {
+        depth += ev[i].delta;
+        if (depth > max_depth) max_depth = depth;
+    }
+    free(ev);
+    return max_depth;
+}
+
+/**
+ * tidesdb_l1_overlap_depth_cached
+ * the L1 overlap depth, recomputed only when the sstable layout version has moved since the last
+ * call and otherwise served from the cache -- so the per-commit backpressure path pays a full sweep
+ * only on a flush or compaction, not on every write.
+ * @return worst-case per-key L1 overlap
+ */
+static int tidesdb_l1_overlap_depth_cached(tidesdb_column_family_t *cf)
+{
+    const uint64_t ver = atomic_load_explicit(&cf->sstable_layout_version, memory_order_acquire);
+    if (atomic_load_explicit(&cf->l1_overlap_ver, memory_order_acquire) != ver)
+    {
+        const int d = tidesdb_compute_l1_overlap_depth(cf);
+        atomic_store_explicit(&cf->l1_overlap_depth, d, memory_order_release);
+        atomic_store_explicit(&cf->l1_overlap_ver, ver, memory_order_release);
+        return d;
+    }
+    return atomic_load_explicit(&cf->l1_overlap_depth, memory_order_acquire);
 }
 
 /**
@@ -13346,7 +13489,7 @@ static int tidesdb_apply_dca(tidesdb_column_family_t *cf)
      * the largest level is empty (data has not propagated down yet), and N_L ~ 0 would collapse
      * every capacity to the write-buffer floor -- which pins the compaction target-level selection
      * at X and self-merges the first level forever, never draining downward. use the largest
-     * NON-EMPTY level instead: once the tree has quiesced this is the largest level itself
+     * NON-EMPTY level instead,once the tree has quiesced this is the largest level itself
      * (matching the paper and preserving the durable space-amp bound), but while the tree fills it
      * tracks a populated level so capacities stay sized to real data and the target selection can
      * route data down. */
@@ -18512,6 +18655,266 @@ static void tidesdb_unified_immutable_drop_queue_ref(void *data, void *context)
 }
 
 /**
+ * tidesdb_flush_partition_splits
+ * choose ascending split keys that carve the key space into narrow flush partitions aligned to the
+ * largest non-empty level's per-sstable min_keys. the split count targets one partition per
+ * TDB_FLUSH_PARTITION_TARGET_BYTES of memtable data, bounded by max_parts and by the number of
+ * available boundaries. a btree cf, an empty tree, or too little data returns 0 (flush as a single
+ * whole-memtable sstable). the caller frees each returned key and the two arrays.
+ * @return number of split keys (0 => no partitioning)
+ */
+static int tidesdb_flush_partition_splits(tidesdb_column_family_t *cf, size_t memtable_bytes,
+                                          int max_parts, uint8_t ***out_keys, size_t **out_sizes)
+{
+    *out_keys = NULL;
+    *out_sizes = NULL;
+    if (cf->config.use_btree || max_parts < 2) return 0;
+
+    /* the largest non-empty level below L1 supplies the boundaries the L1->largest merge partitions
+     * by; aligning flush slices to them makes each slice overlap only its own target partition */
+    const int num_levels = atomic_load_explicit(&cf->num_active_levels, memory_order_acquire);
+    tidesdb_level_t *largest = NULL;
+    for (int i = num_levels - 1; i >= 1; i--)
+    {
+        if (atomic_load_explicit(&cf->levels[i]->current_size, memory_order_relaxed) > 0)
+        {
+            largest = cf->levels[i];
+            break;
+        }
+    }
+    if (!largest) return 0;
+
+    skip_list_comparator_fn cmp = NULL;
+    void *cctx = NULL;
+    tidesdb_resolve_comparator(cf->db, &cf->config, &cmp, &cctx);
+    if (!cmp) return 0;
+
+    /* copy the min_keys out under array_readers so a concurrent compaction cannot retire the array
+     * or free a key while we read it -- we never mutate the level from the flush path */
+    atomic_fetch_add_explicit(&largest->array_readers, 1, memory_order_acq_rel);
+    const int n = atomic_load_explicit(&largest->num_sstables, memory_order_acquire);
+    tidesdb_sstable_t **ssts = atomic_load_explicit(&largest->sstables, memory_order_acquire);
+    uint8_t **keys = (n > 0) ? malloc((size_t)n * sizeof(*keys)) : NULL;
+    size_t *sizes = (n > 0) ? malloc((size_t)n * sizeof(*sizes)) : NULL;
+    int nk = 0;
+    if (keys && sizes)
+    {
+        for (int i = 0; i < n; i++)
+        {
+            tidesdb_sstable_t *s = ssts ? ssts[i] : NULL;
+            if (!s || !s->min_key || s->min_key_size == 0) continue;
+            uint8_t *cp = malloc(s->min_key_size);
+            if (!cp) continue;
+            memcpy(cp, s->min_key, s->min_key_size);
+            keys[nk] = cp;
+            sizes[nk] = s->min_key_size;
+            nk++;
+        }
+    }
+    atomic_fetch_sub_explicit(&largest->array_readers, 1, memory_order_release);
+
+    if (nk < 2)
+    {
+        for (int i = 0; i < nk; i++) free(keys[i]);
+        free(keys);
+        free(sizes);
+        return 0;
+    }
+
+    /* insertion sort ascending (nk is the largest level's file count, small) */
+    for (int i = 1; i < nk; i++)
+    {
+        uint8_t *k = keys[i];
+        size_t ks = sizes[i];
+        int j = i - 1;
+        while (j >= 0 && cmp(keys[j], sizes[j], k, ks, cctx) > 0)
+        {
+            keys[j + 1] = keys[j];
+            sizes[j + 1] = sizes[j];
+            j--;
+        }
+        keys[j + 1] = k;
+        sizes[j + 1] = ks;
+    }
+
+    /* collapse duplicate min_keys so split points are strictly ascending */
+    int u = 1;
+    for (int i = 1; i < nk; i++)
+    {
+        if (cmp(keys[i], sizes[i], keys[u - 1], sizes[u - 1], cctx) != 0)
+        {
+            keys[u] = keys[i];
+            sizes[u] = sizes[i];
+            u++;
+        }
+        else
+            free(keys[i]);
+    }
+    nk = u;
+
+    int parts = (int)(memtable_bytes / TDB_FLUSH_PARTITION_TARGET_BYTES);
+    if (parts < 1) parts = 1;
+    if (parts > max_parts) parts = max_parts;
+    if (parts > nk) parts = nk; /* need parts-1 internal splits, each a distinct boundary */
+    if (parts < 2)
+    {
+        for (int i = 0; i < nk; i++) free(keys[i]);
+        free(keys);
+        free(sizes);
+        return 0;
+    }
+
+    const int want = parts - 1;
+    uint8_t **sk = malloc((size_t)want * sizeof(*sk));
+    size_t *ss = malloc((size_t)want * sizeof(*ss));
+    if (!sk || !ss)
+    {
+        free(sk);
+        free(ss);
+        for (int i = 0; i < nk; i++) free(keys[i]);
+        free(keys);
+        free(sizes);
+        return 0;
+    }
+
+    /* evenly spaced split points, forced strictly increasing so no slice is degenerate */
+    int prev = -1, m = 0;
+    for (int k = 1; k <= want; k++)
+    {
+        int idx = (int)(((int64_t)k * nk) / parts);
+        if (idx <= prev) idx = prev + 1;
+        if (idx >= nk) break;
+        sk[m] = keys[idx];
+        ss[m] = sizes[idx];
+        keys[idx] = NULL; /* ownership transferred to the split arrays */
+        prev = idx;
+        m++;
+    }
+
+    for (int i = 0; i < nk; i++) free(keys[i]); /* free the non-selected copies (NULLs skipped) */
+    free(keys);
+    free(sizes);
+
+    if (m == 0)
+    {
+        free(sk);
+        free(ss);
+        return 0;
+    }
+    *out_keys = sk;
+    *out_sizes = ss;
+    return m;
+}
+
+/**
+ * tidesdb_flush_write_l1_partitions
+ * write a memtable to disk as up to max_parts narrow L1 sstables aligned to the largest level's
+ * boundaries (see TDB_FLUSH_PARTITION_TARGET_BYTES). each output is synced and its write handles
+ * closed; the caller owns the returned refs, adds them to L1, and commits the manifest once. on any
+ * write error every file produced this attempt is removed and the error is returned so the caller
+ * retries the whole flush with fresh ids (the WAL is still intact). first_id names the first slice;
+ * later slices draw fresh ids. empty slices produce no sstable.
+ * @return TDB_SUCCESS with *out_count sstables, or an error with *out_count == 0
+ */
+static int tidesdb_flush_write_l1_partitions(tidesdb_column_family_t *cf, skip_list_t *memtable,
+                                             uint64_t first_id, size_t memtable_bytes,
+                                             tidesdb_sstable_t **out_ssts, int *out_count,
+                                             int max_parts)
+{
+    tidesdb_t *db = cf->db;
+    *out_count = 0;
+
+    uint8_t **splits = NULL;
+    size_t *split_sizes = NULL;
+    const int nsplits =
+        tidesdb_flush_partition_splits(cf, memtable_bytes, max_parts, &splits, &split_sizes);
+    const int nparts = nsplits + 1;
+
+    char sst_path[MAX_FILE_PATH_LENGTH];
+    snprintf(sst_path, sizeof(sst_path), "%s" PATH_SEPARATOR TDB_LEVEL_PREFIX "1", cf->directory);
+
+    int rc = TDB_SUCCESS;
+    int produced = 0;
+    for (int i = 0; i < nparts; i++)
+    {
+        const uint8_t *lo = (i == 0) ? NULL : splits[i - 1];
+        const size_t lo_sz = (i == 0) ? 0 : split_sizes[i - 1];
+        const uint8_t *hi = (i == nparts - 1) ? NULL : splits[i];
+        const size_t hi_sz = (i == nparts - 1) ? 0 : split_sizes[i];
+
+        const uint64_t id = (i == 0) ? first_id : atomic_fetch_add(&cf->next_sstable_id, 1);
+        tidesdb_sstable_t *sst = tidesdb_sstable_create(db, sst_path, id, &cf->config);
+        if (!sst)
+        {
+            rc = TDB_ERR_MEMORY;
+            break;
+        }
+
+        const int wr = tidesdb_sstable_write_from_memtable_ex(db, cf, sst, memtable, NULL, 0, 0, lo,
+                                                              lo_sz, hi, hi_sz);
+        if (wr != TDB_SUCCESS)
+        {
+            tidesdb_sstable_unref(db, sst);
+            rc = wr;
+            break;
+        }
+
+        /* an empty slice (no keys in [lo,hi)) leaves a zero-entry sstable -- discard its files */
+        if (sst->num_entries == 0)
+        {
+            remove(sst->klog_path);
+            remove(sst->vlog_path);
+            tidesdb_sstable_unref(db, sst);
+            continue;
+        }
+
+        atomic_fetch_add_explicit(&cf->flush_bytes_written, sst->klog_size + sst->vlog_size,
+                                  memory_order_relaxed);
+
+        /* durability barrier before the WAL is deleted, then close write handles so readers reopen
+         * on demand (mirrors the single-sstable flush path) */
+        tidesdb_block_managers_t bms;
+        if (tidesdb_sstable_get_block_managers(db, sst, &bms) == TDB_SUCCESS)
+            tidesdb_sstable_sync_barrier(cf->config.sync_mode, bms.klog_bm, bms.vlog_bm);
+        atomic_thread_fence(memory_order_seq_cst);
+
+        const int had_open_bms = (sst->klog_bm != NULL);
+        if (sst->klog_bm)
+        {
+            block_manager_close(sst->klog_bm);
+            sst->klog_bm = NULL;
+        }
+        if (sst->vlog_bm)
+        {
+            block_manager_close(sst->vlog_bm);
+            sst->vlog_bm = NULL;
+        }
+        if (had_open_bms) atomic_fetch_sub(&db->num_open_sstables, 1);
+
+        out_ssts[produced++] = sst;
+    }
+
+    for (int i = 0; i < nsplits; i++) free(splits[i]);
+    free(splits);
+    free(split_sizes);
+
+    if (rc != TDB_SUCCESS)
+    {
+        /* remove every file this attempt produced; the whole flush retries with fresh ids */
+        for (int i = 0; i < produced; i++)
+        {
+            remove(out_ssts[i]->klog_path);
+            remove(out_ssts[i]->vlog_path);
+            tidesdb_sstable_unref(db, out_ssts[i]);
+        }
+        return rc;
+    }
+
+    *out_count = produced;
+    return TDB_SUCCESS;
+}
+
+/**
  * tidesdb_flush_worker_thread
  * worker thread that processes flush work items from the queue
  */
@@ -18705,42 +19108,69 @@ static void *tidesdb_flush_worker_thread(void *arg)
             continue;
         }
 
-        char sst_path[MAX_FILE_PATH_LENGTH];
-        snprintf(sst_path, sizeof(sst_path), "%s" PATH_SEPARATOR TDB_LEVEL_PREFIX "1",
-                 cf->directory);
-
-        /* once we create the sstable, we must complete the flush to avoid leaking it */
-        tidesdb_sstable_t *sst = tidesdb_sstable_create(db, sst_path, work->sst_id, &cf->config);
-        if (!sst)
-        {
-            TDB_DEBUG_LOG(TDB_LOG_ERROR, "CF '%s' SSTable %" PRIu64 " creation failed", cf->name,
-                          work->sst_id);
-
-            tidesdb_immutable_memtable_unref(imm);
-            atomic_fetch_sub_explicit(&db->active_flushes, 1, memory_order_release);
-            free(work);
-            atomic_fetch_sub_explicit(&db->flush_pending_count, 1, memory_order_release);
-            atomic_fetch_sub_explicit(&cf->flush_pending_count, 1, memory_order_release);
-            continue;
-        }
-
-        /* we branch based on use_btree config */
+        /* partition the flush into narrow boundary-aligned L1 sstables so the L1->largest merge
+         * reads each one only within its own partition, instead of re-reading a single keyspace-
+         * wide flush file once per partition (the dominant compaction read-amplification source).
+         * a btree cf has no range-slice writer and an empty/shallow tree has no boundaries, so both
+         * fall back to a single whole-memtable sstable. all partitions are independent L1 sstables
+         * (base l1, partition -1), so recovery already reconstructs them with no changes. */
+        tidesdb_sstable_t *flush_ssts[TDB_MAX_FLUSH_PARTITIONS];
+        int num_flush_ssts = 0;
         int write_result;
+
         if (cf->config.use_btree)
         {
-            write_result = tidesdb_sstable_write_from_memtable_btree(db, cf, sst, memtable);
+            char sst_path[MAX_FILE_PATH_LENGTH];
+            snprintf(sst_path, sizeof(sst_path), "%s" PATH_SEPARATOR TDB_LEVEL_PREFIX "1",
+                     cf->directory);
+            tidesdb_sstable_t *sst =
+                tidesdb_sstable_create(db, sst_path, work->sst_id, &cf->config);
+            if (!sst)
+                write_result = TDB_ERR_MEMORY;
+            else
+            {
+                write_result = tidesdb_sstable_write_from_memtable_btree(db, cf, sst, memtable);
+                if (write_result == TDB_SUCCESS)
+                {
+                    atomic_fetch_add_explicit(&cf->flush_bytes_written,
+                                              sst->klog_size + sst->vlog_size,
+                                              memory_order_relaxed);
+                    tidesdb_block_managers_t bms;
+                    if (tidesdb_sstable_get_block_managers(db, sst, &bms) == TDB_SUCCESS)
+                        tidesdb_sstable_sync_barrier(cf->config.sync_mode, bms.klog_bm,
+                                                     bms.vlog_bm);
+                    atomic_thread_fence(memory_order_seq_cst);
+                    const int had_open_bms = (sst->klog_bm != NULL);
+                    if (sst->klog_bm)
+                    {
+                        block_manager_close(sst->klog_bm);
+                        sst->klog_bm = NULL;
+                    }
+                    if (sst->vlog_bm)
+                    {
+                        block_manager_close(sst->vlog_bm);
+                        sst->vlog_bm = NULL;
+                    }
+                    if (had_open_bms) atomic_fetch_sub(&db->num_open_sstables, 1);
+                    flush_ssts[num_flush_ssts++] = sst;
+                }
+                else
+                    tidesdb_sstable_unref(db, sst);
+            }
         }
         else
         {
-            write_result = tidesdb_sstable_write_from_memtable(db, cf, sst, memtable);
+            write_result = tidesdb_flush_write_l1_partitions(
+                cf, memtable, work->sst_id, skip_list_get_size(memtable), flush_ssts,
+                &num_flush_ssts, TDB_MAX_FLUSH_PARTITIONS);
         }
+
         if (write_result != TDB_SUCCESS)
         {
+            /* the writer already removed any partial files and released their refs */
             TDB_DEBUG_LOG(TDB_LOG_INFO,
                           "CF '%s' SSTable %" PRIu64 " write failed (error: %d), will retry",
                           cf->name, work->sst_id, write_result);
-
-            tidesdb_sstable_unref(cf->db, sst);
 
             usleep(TDB_FLUSH_RETRY_DELAY_US);
 
@@ -18763,48 +19193,7 @@ static void *tidesdb_flush_worker_thread(void *arg)
             continue;
         }
 
-        /* write-amplification -- on-disk bytes this flush produced (klog + vlog, framing,
-         * index and bloom blobs included). klog_size/vlog_size are finalized by the footer
-         * write inside the writer above. one flushed L1 sstable per flush on the per-cf path */
-        atomic_fetch_add_explicit(&cf->flush_bytes_written, sst->klog_size + sst->vlog_size,
-                                  memory_order_relaxed);
         atomic_fetch_add_explicit(&cf->flush_count, 1, memory_order_relaxed);
-
-        /* durability barrier before the WAL is deleted FULL/INTERVAL fsync the sstable here, so
-         * a crash can never lose flushed data that the WAL no longer holds. NONE skips (the WAL is
-         * likewise unsynced under NONE, so the contract is uniform) */
-        tidesdb_block_managers_t bms;
-        if (tidesdb_sstable_get_block_managers(db, sst, &bms) == TDB_SUCCESS)
-        {
-            tidesdb_sstable_sync_barrier(cf->config.sync_mode, bms.klog_bm, bms.vlog_bm);
-        }
-
-        /* we ensure all writes are visible before making sstable discoverable */
-        atomic_thread_fence(memory_order_seq_cst);
-
-        /* we close write handles before adding to level
-         * readers will reopen files on-demand through tidesdb_sstable_ensure_open
-         * this prevents file locking issues where readers cannot open files
-         * that are still held open by the flush worker */
-        {
-            /* num_open_sstables is keyed on the klog (the vlog is opened lazily and not
-             * separately counted), so the decrement fires iff the klog was open */
-            const int had_open_bms = (sst->klog_bm != NULL);
-            if (sst->klog_bm)
-            {
-                block_manager_close(sst->klog_bm);
-                sst->klog_bm = NULL;
-            }
-            if (sst->vlog_bm)
-            {
-                block_manager_close(sst->vlog_bm);
-                sst->vlog_bm = NULL;
-            }
-            if (had_open_bms)
-            {
-                atomic_fetch_sub(&db->num_open_sstables, 1);
-            }
-        }
 
         /* we re-check marked_for_deletion after I/O -- if the CF is being dropped,
          * skip level-add, manifest commit, and compaction trigger. the CF directory
@@ -18814,9 +19203,9 @@ static void *tidesdb_flush_worker_thread(void *arg)
         {
             TDB_DEBUG_LOG(TDB_LOG_INFO,
                           "CF '%s' marked for deletion after flush I/O, skipping level-add "
-                          "for SSTable %" PRIu64,
-                          cf->name, work->sst_id);
-            tidesdb_sstable_unref(cf->db, sst);
+                          "for %d SSTable(s)",
+                          cf->name, num_flush_ssts);
+            for (int i = 0; i < num_flush_ssts; i++) tidesdb_sstable_unref(cf->db, flush_ssts[i]);
             if (wal)
             {
                 block_manager_close(wal);
@@ -18831,64 +19220,33 @@ static void *tidesdb_flush_worker_thread(void *arg)
             continue;
         }
 
-        /* out-of-order L1 insertion check. concurrent flush threads finish out of id order, so a
-         * lower-max_seq sstable can land after a higher one. this is benign, both point reads and
-         * the merge-heap iterators resolve versions by per-entry seq, never by L1 array position
-         * (the array is append-only and unsorted). logged at DEBUG as a flush-concurrency signal
-         * only -- it is not a correctness violation. one line per out-of-order add (not per pair)
-         * to avoid an O(n) burst when an old sstable lands behind many newer ones. */
-        if (atomic_load_explicit(&cf->levels[0]->num_sstables, memory_order_acquire) > 0)
+        /* add every partition to L1 (array index 0) and record it in the manifest, then commit the
+         * manifest once for the whole flush so the crash window is a single commit -- identical to
+         * the single-sstable path. reads and the merge heap resolve versions by per-entry seq, so
+         * the append-only unsorted L1 array tolerates the partitions landing in any order. */
+        for (int i = 0; i < num_flush_ssts; i++)
         {
-            /* hold array_readers while scanning the lock-free sstable array so a concurrent
-             * level_add_sstable (flush or compaction) cannot retire and free it under us */
-            atomic_fetch_add_explicit(&cf->levels[0]->array_readers, 1, memory_order_acq_rel);
-            int num_existing =
-                atomic_load_explicit(&cf->levels[0]->num_sstables, memory_order_acquire);
-            tidesdb_sstable_t **existing_ssts =
-                atomic_load_explicit(&cf->levels[0]->sstables, memory_order_acquire);
-            for (int i = 0; existing_ssts && i < num_existing; i++)
-            {
-                if (existing_ssts[i] && existing_ssts[i]->max_seq >= sst->max_seq)
-                {
-                    TDB_DEBUG_LOG(TDB_LOG_DEBUG,
-                                  "CF '%s' SSTable %" PRIu64 " (max_seq=%" PRIu64
-                                  ") added to L1 out of seq order behind SSTable %" PRIu64
-                                  " (max_seq=%" PRIu64 ") -- benign, reads resolve by seq",
-                                  cf->name, work->sst_id, sst->max_seq, existing_ssts[i]->id,
-                                  existing_ssts[i]->max_seq);
-                    break;
-                }
-            }
-            atomic_fetch_sub_explicit(&cf->levels[0]->array_readers, 1, memory_order_release);
+            tidesdb_level_add_sstable(cf->levels[0], flush_ssts[i]);
+            tidesdb_manifest_add_sstable(
+                cf->manifest, 1, flush_ssts[i]->id, flush_ssts[i]->num_entries,
+                flush_ssts[i]->klog_size + flush_ssts[i]->vlog_size, flush_ssts[i]->partition);
+            TDB_DEBUG_LOG(TDB_LOG_INFO,
+                          "CF '%s' flushed SSTable %" PRIu64 " (max_seq=%" PRIu64
+                          ") to level %d (array index 0), partition %d/%d",
+                          cf->name, flush_ssts[i]->id, flush_ssts[i]->max_seq,
+                          cf->levels[0]->level_num, i + 1, num_flush_ssts);
         }
-
-        /* we add sstable to level 1 (array index 0) -- load levels atomically */
-
-        /* levels array is fixed, access directly */
-        tidesdb_level_add_sstable(cf->levels[0], sst);
         tidesdb_bump_sstable_layout_version(cf);
-
         atomic_thread_fence(memory_order_release);
 
-        TDB_DEBUG_LOG(TDB_LOG_INFO,
-                      "CF '%s' flushed SSTable %" PRIu64 " (max_seq=%" PRIu64
-                      ") to level %d (array index 0)",
-                      cf->name, work->sst_id, sst->max_seq, cf->levels[0]->level_num);
-
-        /* we commit sstable to manifest before deleting WAL and before triggering compaction
-         * this ensures crash recovery knows which sstables are complete
-         * we must commit manifest before triggering compaction to avoid deadlock
-         * where flush worker holds manifest lock while compaction worker waits for it */
-        tidesdb_manifest_add_sstable(cf->manifest, 1, work->sst_id, sst->num_entries,
-                                     sst->klog_size + sst->vlog_size, sst->partition);
         atomic_store(&cf->manifest->sequence, atomic_load(&cf->next_sstable_id));
         int manifest_result = tidesdb_manifest_commit(cf->manifest, cf->manifest->path,
                                                       cf->config.sync_mode != TDB_SYNC_NONE);
         if (manifest_result != 0)
         {
             TDB_DEBUG_LOG(TDB_LOG_ERROR,
-                          "CF '%s' failed to commit manifest for SSTable %" PRIu64 " (error: %d)",
-                          cf->name, work->sst_id, manifest_result);
+                          "CF '%s' failed to commit manifest for %d flushed SSTable(s) (error: %d)",
+                          cf->name, num_flush_ssts, manifest_result);
         }
         else
         {
@@ -18902,10 +19260,9 @@ static void *tidesdb_flush_worker_thread(void *arg)
          * cf->levels[0] (level_num=1) is TidesDB's first disk level, equivalent to RocksDB's rLevel
          * 0 in the spooky paper -- where memtable flushes land as overlapping runs. when its data
          * exceeds its (DCA-adjusted) capacity we run the compaction workflow, which picks what to
-         * merge from the level capacities. the L1 *file count* is NOT a compaction trigger: it is
-         * the read-amplification signal that backpressure paces writes on via
-         * l1_file_count_trigger, so a flushed-file pileup bounds ingestion rather than kicking a
-         * redundant compaction. */
+         * merge from the level capacities. the L1 *file count* is not a compaction trigger, it is
+         * the read-amplification signal (as overlap depth) that backpressure paces writes on, so a
+         * flushed-file pileup bounds ingestion rather than kicking a redundant compaction. */
         int num_l1_sstables =
             atomic_load_explicit(&cf->levels[0]->num_sstables, memory_order_acquire);
         size_t level1_size =
@@ -18997,8 +19354,8 @@ static void *tidesdb_flush_worker_thread(void *arg)
         free(density_min_key);
         free(density_max_key);
 
-        /* we release our reference -- the level now owns it */
-        tidesdb_sstable_unref(cf->db, sst);
+        /* we release our references -- the level now owns each partition */
+        for (int i = 0; i < num_flush_ssts; i++) tidesdb_sstable_unref(cf->db, flush_ssts[i]);
 
         /* delete the WAL only once the sstable is durably recorded in the manifest.
          * a failed commit leaves the sstable in-memory only (and not in the persisted
@@ -23134,6 +23491,8 @@ int tidesdb_create_column_family(tidesdb_t *db, const char *name,
 
     atomic_init(&cf->next_sstable_id, 0);
     atomic_init(&cf->sstable_layout_version, 0);
+    atomic_init(&cf->l1_overlap_depth, 0);
+    atomic_init(&cf->l1_overlap_ver, UINT64_MAX);
     atomic_init(&cf->is_compacting, 0);
     atomic_init(&cf->is_flushing, 0);
     atomic_init(&cf->flush_pending_count, 0);
@@ -24854,7 +25213,7 @@ static int tidesdb_apply_backpressure(tidesdb_column_family_t *cf)
 
     const int unified = (cf->db && cf->db->unified_mt.enabled);
 
-    /* L0 depth is the flush backlog -- memtables frozen but not yet flushed. deliberately NOT the
+    /* L0 depth is the flush backlog -- memtables frozen but not yet flushed. deliberately not the
      * immutable queue length, which also counts already-flushed memtables a concurrent reader is
      * pinning against reaper reclamation; throttling on those stalls writes for a GC backlog, not
      * flush pressure. see tdb_cf_flush_backlog. */
@@ -24892,7 +25251,7 @@ static int tidesdb_apply_backpressure(tidesdb_column_family_t *cf)
 
     /* the immutable (L0) queue depth is the backpressure signal -- it grows only when flush falls
      * behind, normalized so 1.0 is the stall threshold. the active memtable's fill is deliberately
-     * NOT part of it: the active always rises to its rotation point and back every cycle, so pacing
+     * not part of it, the active always rises to its rotation point and back every cycle, so pacing
      * on it would throttle normal operation. the active memtable keeps only its hard ceiling below,
      * as a rotation-stalled backstop. */
     const double p = effective_stall > 0 ? (double)l0_queue_depth / (double)effective_stall : 0.0;
@@ -25108,23 +25467,24 @@ static int tidesdb_apply_backpressure(tidesdb_column_family_t *cf)
         paced = 1;
     }
 
-    /* overlapping first-level (L1) read-amplification pacing. l1_file_count_trigger bounds how many
-     * overlapping flushed files may accumulate at the first sorted level before writes are paced --
-     * a point/range read must consult every overlapping file, so this file count IS read-amp, and
-     * pacing on it keeps reads fast when compaction is transiently behind. compaction itself is
-     * capacity-driven (Spooky); the file count is purely this backpressure signal. the delay rises
+    /* overlapping first-level (L1) read-amplification pacing. l1_file_count_trigger bounds the L1
+     * overlap depth -- the number of overlapping flushed files a point/range read must consult for
+     * a single key -- before writes are paced, so reads stay fast when compaction is transiently
+     * behind. the raw file count is not the signal, flush partitioning splits one flush into
+     * several narrow tiling sstables that raise the count without raising per-key overlap, so
+     * pacing keys on the overlap depth (cached, recomputed only on a layout change). compaction
+     * itself is capacity-driven (Spooky); depth is purely this backpressure signal. the delay rises
      * monotonically with the overflow past the trigger, scaled by the trigger itself so it is the
      * only knob, and ingestion settles where it matches the compaction drain rate. it is not
      * flush-heartbeat coupled -- L1 drains via compaction, not flush. */
     if (cf->levels && cf->levels[0])
     {
         const int l1_trigger = tdb_cf_effective_l1_trigger(cf);
-        const int l1_count =
-            atomic_load_explicit(&cf->levels[0]->num_sstables, memory_order_acquire);
-        if (l1_trigger > 0 && l1_count > l1_trigger)
+        const int l1_depth = tidesdb_l1_overlap_depth_cached(cf);
+        if (l1_trigger > 0 && l1_depth > l1_trigger)
         {
             const double f =
-                1.0 - (double)l1_trigger / (double)l1_count; /* 0 at trigger, ->1 above */
+                1.0 - (double)l1_trigger / (double)l1_depth; /* 0 at trigger, ->1 above */
             const unsigned int d = (unsigned int)(TDB_BACKPRESSURE_RAMP_MAX_DELAY_US * f * f);
             if (d > 0)
             {
@@ -25777,7 +26137,7 @@ int tidesdb_txn_put(tidesdb_txn_t *txn, tidesdb_column_family_t *cf, const uint8
  * recorded into the transaction's read set. tidesdb_txn_get passes 1 (the tracking contract the
  * isolation levels rely on); tidesdb_txn_get_notrack / tidesdb_txn_contains pass 0 so an existence
  * probe -- a PK-uniqueness check on insert -- does not pollute the write-write reservation base or
- * add a rw-antidependency the caller never intended. visibility is unchanged either way: the read
+ * add a rw-antidependency the caller never intended. visibility is unchanged either way,the read
  * still resolves at the transaction's snapshot. */
 static int tidesdb_txn_get_impl(tidesdb_txn_t *txn, tidesdb_column_family_t *cf, const uint8_t *key,
                                 const size_t key_size, uint8_t **value, size_t *value_size,
@@ -28115,7 +28475,8 @@ static int tidesdb_unified_write_cf_sstable(tidesdb_t *db, tidesdb_column_family
                                                           TDB_UNIFIED_CF_PREFIX_SIZE, entry_count);
     else
         wr = tidesdb_sstable_write_from_memtable_ex(db, cf, sst, unified_sl, seg_prefix,
-                                                    TDB_UNIFIED_CF_PREFIX_SIZE, entry_count);
+                                                    TDB_UNIFIED_CF_PREFIX_SIZE, entry_count, NULL,
+                                                    0, NULL, 0);
 
     if (wr != TDB_SUCCESS)
     {
@@ -28669,7 +29030,7 @@ static int tidesdb_unified_memtable_rotate(tidesdb_t *db)
      * queue for the commit path (it hard-blocks committers at the stall threshold, below this cap),
      * so this is only reachable from a rotate that bypasses it -- the reaper's memory-pressure
      * rotate or recovery. those are periodic or single-threaded and cannot run the queue away, so
-     * we log an overshoot rather than poll-sleep here: a wait held under the single-rotator CAS
+     * we log an overshoot rather than poll-sleep here, a wait held under the single-rotator CAS
      * would stall every committer for no benefit. */
     if (queue_size(db->unified_mt.immutables) >= tdb_unified_immutable_hard_cap(db) &&
         tdb_log_throttle(db, &db->unified_mt.last_ceiling_stall_log_sec,

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -371,24 +371,23 @@ typedef tidesdb_memtable_t tidesdb_immutable_memtable_t;
 #define TDB_BACKPRESSURE_STALL_MAX_ITERATIONS                                                    \
     1000 /* ~10s poll budget at STALL_CHECK_INTERVAL_US; L0 stall counts consecutive no-progress \
             polls, memory-pressure stall counts total */
-#define TDB_BACKPRESSURE_HIGH_DELAY_US            2000 /* 2ms for high pressure */
-#define TDB_BACKPRESSURE_ELEVATED_DELAY_US        200 /* 0.2ms yield for elevated memory pressure */
-#define TDB_BACKPRESSURE_MODERATE_DELAY_US        500 /* 0.5ms for moderate pressure */
-#define TDB_BACKPRESSURE_HIGH_THRESHOLD_RATIO     0.8 /* 80% of stall threshold */
-#define TDB_BACKPRESSURE_MODERATE_THRESHOLD_RATIO 0.5 /* 50% of stall threshold */
-#define TDB_BACKPRESSURE_L1_HIGH_MULTIPLIER       4   /* 4x L1 trigger = high  */
-#define TDB_BACKPRESSURE_L1_MODERATE_MULTIPLIER   3   /* 3x L1 trigger = moderate */
+#define TDB_BACKPRESSURE_HIGH_DELAY_US     2000 /* 2ms yield for high memory pressure */
+#define TDB_BACKPRESSURE_ELEVATED_DELAY_US 200  /* 0.2ms yield for elevated memory pressure */
 /* active memtable hard ceiling as a multiple of write_buffer_size. the
  * commit-time threshold check allows up to 1.5x for batching headroom; this
  * leaves a small overshoot margin above that before apply_backpressure
  * stalls the writer until rotation completes */
 #define TDB_BACKPRESSURE_ACTIVE_MT_CEILING_MULT 2
-/* proportional pre-throttle on the active-memtable ceiling. instead of a binary wall (no delay
- * below the ceiling, then a multi-second block at it) the writer is paced by a convex ramp once the
- * active passes RAMP_LO_RATIO of the ceiling, reaching RAMP_MAX_DELAY_US right at the ceiling. this
- * lets flush catch up before the hard stall, turning the latency cliff into a gentle rise. */
-#define TDB_BACKPRESSURE_RAMP_LO_RATIO     0.75
+/* proportional pre-throttle driven by a single normalized pressure scalar (the worse of the
+ * L0-queue and active-memtable fill fractions). instead of binary walls the writer is paced by one
+ * convex ramp that starts at RAMP_KNEE of the ceiling and reaches RAMP_MAX_DELAY_US of budget right
+ * at it, so flush catches up before the hard stall and the latency cliff becomes a gentle rise. the
+ * ramp wait is progress-coupled -- polled in RAMP_POLL_US quanta and cut short the moment a flush
+ * advances the heartbeat -- so a bursty writer barely pauses while a saturated one paces down to
+ * the drain rate. */
+#define TDB_BACKPRESSURE_RAMP_KNEE         0.5
 #define TDB_BACKPRESSURE_RAMP_MAX_DELAY_US 4000
+#define TDB_BACKPRESSURE_RAMP_POLL_US      100
 
 /* backpressure stall warnings (ceiling stall, immutable-queue-critical) are emitted from the
  * write/flush hot paths -- a per-event log floods under sustained backpressure (every stalling
@@ -24229,8 +24228,11 @@ static int tidesdb_flush_memtable_internal(tidesdb_column_family_t *cf,
         }
     }
 
-    /* we sync CF directory to persist new WAL file entry */
-    if (new_wal) tdb_sync_directory(cf->directory);
+    /* persist the new WAL's directory entry so crash recovery can find it -- but only when the CF
+     * asks for durability. under TDB_SYNC_NONE a crash may lose recent writes anyway, so the
+     * synchronous directory fsync (on the rotation critical path, blocking every writer behind the
+     * single rotator) buys nothing and is skipped. */
+    if (new_wal && cf->config.sync_mode != TDB_SYNC_NONE) tdb_sync_directory(cf->directory);
 
     /* we create new tidesdb_memtable_t structure pairing skip_list and wal */
     tidesdb_memtable_t *new_mt = malloc(sizeof(tidesdb_memtable_t));
@@ -24815,23 +24817,85 @@ static int tidesdb_apply_backpressure(tidesdb_column_family_t *cf)
 {
     if (!cf) return TDB_ERR_INVALID_ARGS;
 
-    /* L0 depth -- in unified mode every write lands in the shared unified
-     * memtable, so the per-CF immutable queue stays empty and the unified
-     * immutable queue is the one to watch */
-    queue_t *l0_queue = (cf->db && cf->db->unified_mt.enabled && cf->db->unified_mt.immutables)
-                            ? cf->db->unified_mt.immutables
-                            : cf->immutable_memtables;
+    const int unified = (cf->db && cf->db->unified_mt.enabled);
+
+    /* L0 depth -- in unified mode every write lands in the shared unified memtable, so the per-CF
+     * immutable queue stays empty and the unified immutable queue is the one to watch */
+    queue_t *l0_queue = (unified && cf->db->unified_mt.immutables) ? cf->db->unified_mt.immutables
+                                                                   : cf->immutable_memtables;
     const size_t l0_queue_depth = queue_size(l0_queue);
-
-    /* we check L1 file count */
-    int l1_file_count = atomic_load_explicit(&cf->levels[0]->num_sstables, memory_order_acquire);
-
     const size_t effective_stall = tdb_cf_effective_stall(cf);
-    const int effective_l1_trigger = tdb_cf_effective_l1_trigger(cf);
 
-    /** l0 queue exceeds threshold -- force blocking flush of all immutables
-     *  this prevents unbounded memory growth when flush worker falls behind */
-    int l0_delayed = 0; /* track if L0/L1 already applied a delay */
+    /* active memtable fill against its ceiling (2x write_buffer_size), unified or per-CF. this and
+     * the L0 queue are the two memory backstops. L1 file count intentionally does not gate writes
+     * -- compaction is structurally slower than flush inflow, so L1 settles at a workload-dependent
+     * count and gating on it converts a compaction-throughput limit into a stop-start stall that
+     * starves flushing. */
+    size_t ceiling = 0;
+    size_t active_size = 0;
+    if (unified && cf->db->unified_mt.write_buffer_size > 0)
+    {
+        ceiling = TDB_BACKPRESSURE_ACTIVE_MT_CEILING_MULT * cf->db->unified_mt.write_buffer_size;
+        tidesdb_memtable_t *umt = NULL;
+        if (tidesdb_active_memtable_try_ref(&cf->db->unified_mt.active_mt_readers,
+                                            &cf->db->unified_mt.active, &umt))
+        {
+            if (umt->skip_list) active_size = (size_t)skip_list_get_size(umt->skip_list);
+            tidesdb_immutable_memtable_unref(umt);
+        }
+    }
+    else if (!unified && cf->config.write_buffer_size > 0)
+    {
+        ceiling = TDB_BACKPRESSURE_ACTIVE_MT_CEILING_MULT * cf->config.write_buffer_size;
+        tidesdb_memtable_t *amt = NULL;
+        if (tidesdb_active_memtable_try_ref(&cf->active_mt_readers, &cf->active_memtable, &amt))
+        {
+            if (amt->skip_list) active_size = (size_t)skip_list_get_size(amt->skip_list);
+            tidesdb_immutable_memtable_unref(amt);
+        }
+    }
+
+    /* the immutable (L0) queue depth is the backpressure signal -- it grows only when flush falls
+     * behind, normalized so 1.0 is the stall threshold. the active memtable's fill is deliberately
+     * NOT part of it: the active always rises to its rotation point and back every cycle, so pacing
+     * on it would throttle normal operation. the active memtable keeps only its hard ceiling below,
+     * as a rotation-stalled backstop. */
+    const double p = effective_stall > 0 ? (double)l0_queue_depth / (double)effective_stall : 0.0;
+
+    int paced = 0;
+
+    /* graduated pacing below the stall threshold. the delay budget rises quadratically from the
+     * knee up to 1.0, and the wait is progress-coupled -- it returns the instant a flush advances
+     * the heartbeat, so a bursty writer barely pauses while a saturated one paces down to the drain
+     * rate. */
+    if (cf->db && p > TDB_BACKPRESSURE_RAMP_KNEE && p < 1.0)
+    {
+        const double f = (p - TDB_BACKPRESSURE_RAMP_KNEE) / (1.0 - TDB_BACKPRESSURE_RAMP_KNEE);
+        const unsigned int budget_us = (unsigned int)(TDB_BACKPRESSURE_RAMP_MAX_DELAY_US * f * f);
+        if (budget_us > 0)
+        {
+            const uint64_t start_hb =
+                atomic_load_explicit(&cf->db->flush_heartbeat, memory_order_relaxed);
+            unsigned int waited = 0;
+            while (waited < budget_us)
+            {
+                unsigned int quantum = budget_us - waited;
+                if (quantum > TDB_BACKPRESSURE_RAMP_POLL_US)
+                    quantum = TDB_BACKPRESSURE_RAMP_POLL_US;
+                usleep(quantum);
+                waited += quantum;
+                if (atomic_load_explicit(&cf->db->flush_heartbeat, memory_order_relaxed) !=
+                    start_hb)
+                    break;
+            }
+            paced = 1;
+        }
+    }
+
+    /** L0 queue at or over its stall threshold -- hard block until the flush worker drains it
+     * below, bounding memtable memory. a saturated system paces here; only a genuinely wedged flush
+     * engine (no progress for TDB_BACKPRESSURE_STALL_MAX_ITERATIONS polls) fails the commit with
+     * BUSY. */
     if (l0_queue_depth >= effective_stall)
     {
         TDB_DEBUG_LOG(TDB_LOG_WARN,
@@ -24881,237 +24945,138 @@ static int tidesdb_apply_backpressure(tidesdb_column_family_t *cf)
 
         TDB_DEBUG_LOG(TDB_LOG_INFO, "CF '%s' L0 queue stall resolved after %dms", cf->name,
                       total_iterations * (TDB_BACKPRESSURE_STALL_CHECK_INTERVAL_US / 1000));
-        l0_delayed = 1;
+        paced = 1;
     }
 
-    /* L1 file count does not gate writes. compaction (L1->L2+) is serialized per CF and is
-     * structurally slower than flush inflow, so L1 settles at a workload-dependent count; blocking
-     * the write/flush pipeline on it only converts a compaction-throughput limit into a stop-start
-     * stall and starves flushing (which is independent of compaction). the L1 graduated *delays*
-     * below pace writes gently without stopping them, memtable memory is bounded by the L0 queue
-     * stall and the active-memtable ceiling, and the open-fd working set is bounded by the reader
-     * fd reserve plus the reaper -- none of which need L1 file count as a write gate. */
-
-    /* per-cf active memtable ceiling. tidesdb_flush_memtable_internal silently
-     * defers the rotate when the active_flushes slot cap is reached, so the L0
-     * queue stall and L1 file-count delays above are not enough to bound the
-     * active memtable when writes outpace the flush slots. stall the writer
-     * here when the active exceeds ACTIVE_MT_CEILING_MULT x write_buffer_size
-     * until rotation completes. unified mode uses its own branch below */
-    if (cf->db && !cf->db->unified_mt.enabled && cf->config.write_buffer_size > 0)
+    /** per-CF active memtable at or over its ceiling. tidesdb_flush_memtable_internal silently
+     * defers the rotate when the active_flushes slot cap is reached, so the L0 queue stall alone
+     * does not bound the active memtable when writes outpace the flush slots -- stall the writer
+     * here until rotation completes. */
+    if (!unified && ceiling > 0 && active_size >= ceiling)
     {
-        const size_t ceiling =
-            TDB_BACKPRESSURE_ACTIVE_MT_CEILING_MULT * cf->config.write_buffer_size;
-        size_t active_size = 0;
-        tidesdb_memtable_t *amt = NULL;
-        if (tidesdb_active_memtable_try_ref(&cf->active_mt_readers, &cf->active_memtable, &amt))
+        if (tdb_log_throttle(cf->db, &cf->last_ceiling_stall_log_sec,
+                             TDB_BACKPRESSURE_STALL_LOG_INTERVAL_SEC))
+            TDB_DEBUG_LOG(TDB_LOG_WARN,
+                          "CF '%s' active memtable ceiling stall %zu bytes >= %zu (%dx wbuf)",
+                          cf->name, active_size, ceiling, TDB_BACKPRESSURE_ACTIVE_MT_CEILING_MULT);
+
+        /* kick a force-flush so rotation runs as soon as a slot frees, instead of waiting for the
+         * reaper's deferred-flush retry cycle. if the slot cap is hit this returns SUCCESS after
+         * setting flush_deferred=1 */
+        if (!atomic_load_explicit(&cf->is_flushing, memory_order_relaxed))
+            tidesdb_flush_memtable_internal(cf, 0, 1);
+
+        int total_iterations = 0;
+        int no_progress = 0;
+        size_t best_size = active_size;
+        uint64_t last_heartbeat =
+            atomic_load_explicit(&cf->db->flush_heartbeat, memory_order_relaxed);
+        while (1)
         {
-            if (amt->skip_list) active_size = (size_t)skip_list_get_size(amt->skip_list);
-            tidesdb_immutable_memtable_unref(amt);
-        }
-        const size_t ramp_lo = (size_t)((double)ceiling * TDB_BACKPRESSURE_RAMP_LO_RATIO);
-        if (active_size > ramp_lo && active_size < ceiling)
-        {
-            const double f = (double)(active_size - ramp_lo) / (double)(ceiling - ramp_lo);
-            const unsigned int d = (unsigned int)(TDB_BACKPRESSURE_RAMP_MAX_DELAY_US * f * f);
-            if (d > 0)
+            size_t cur_size = 0;
+            tidesdb_memtable_t *cur_amt = NULL;
+            if (tidesdb_active_memtable_try_ref(&cf->active_mt_readers, &cf->active_memtable,
+                                                &cur_amt))
             {
-                usleep(d);
-                l0_delayed = 1;
+                if (cur_amt->skip_list) cur_size = (size_t)skip_list_get_size(cur_amt->skip_list);
+                tidesdb_immutable_memtable_unref(cur_amt);
             }
-        }
-        if (active_size >= ceiling)
-        {
-            if (tdb_log_throttle(cf->db, &cf->last_ceiling_stall_log_sec,
-                                 TDB_BACKPRESSURE_STALL_LOG_INTERVAL_SEC))
-                TDB_DEBUG_LOG(TDB_LOG_WARN,
-                              "CF '%s' active memtable ceiling stall %zu bytes >= %zu (%dx wbuf)",
-                              cf->name, active_size, ceiling,
-                              TDB_BACKPRESSURE_ACTIVE_MT_CEILING_MULT);
+            if (cur_size < ceiling) break;
 
-            /* kick a force-flush so rotation runs as soon as a slot frees, instead
-             * of waiting for the reaper's deferred-flush retry cycle. if the slot
-             * cap is hit this returns SUCCESS after setting flush_deferred=1 */
-            if (!atomic_load_explicit(&cf->is_flushing, memory_order_relaxed))
-                tidesdb_flush_memtable_internal(cf, 0, 1);
+            usleep(TDB_BACKPRESSURE_STALL_CHECK_INTERVAL_US);
+            total_iterations++;
 
-            int total_iterations = 0;
-            int no_progress = 0;
-            size_t best_size = active_size;
-            uint64_t last_heartbeat =
+            const uint64_t cur_heartbeat =
                 atomic_load_explicit(&cf->db->flush_heartbeat, memory_order_relaxed);
-            while (1)
+            if (cur_size < best_size || cur_heartbeat != last_heartbeat)
             {
-                size_t cur_size = 0;
-                tidesdb_memtable_t *cur_amt = NULL;
-                if (tidesdb_active_memtable_try_ref(&cf->active_mt_readers, &cf->active_memtable,
-                                                    &cur_amt))
-                {
-                    if (cur_amt->skip_list)
-                        cur_size = (size_t)skip_list_get_size(cur_amt->skip_list);
-                    tidesdb_immutable_memtable_unref(cur_amt);
-                }
-                if (cur_size < ceiling) break;
-
-                usleep(TDB_BACKPRESSURE_STALL_CHECK_INTERVAL_US);
-                total_iterations++;
-
-                const uint64_t cur_heartbeat =
-                    atomic_load_explicit(&cf->db->flush_heartbeat, memory_order_relaxed);
-                if (cur_size < best_size || cur_heartbeat != last_heartbeat)
-                {
-                    best_size = cur_size;
-                    last_heartbeat = cur_heartbeat;
-                    no_progress = 0;
-                }
-                else if (++no_progress >= TDB_BACKPRESSURE_STALL_MAX_ITERATIONS)
-                {
-                    TDB_DEBUG_LOG(TDB_LOG_ERROR,
-                                  "CF '%s' active memtable ceiling stall, no rotate progress for "
-                                  "%dms - flush engine appears wedged",
-                                  cf->name,
-                                  no_progress * (TDB_BACKPRESSURE_STALL_CHECK_INTERVAL_US / 1000));
-                    return TDB_ERR_BUSY;
-                }
+                best_size = cur_size;
+                last_heartbeat = cur_heartbeat;
+                no_progress = 0;
             }
-
-            TDB_DEBUG_LOG(TDB_LOG_INFO, "CF '%s' active memtable ceiling stall resolved after %dms",
-                          cf->name,
-                          total_iterations * (TDB_BACKPRESSURE_STALL_CHECK_INTERVAL_US / 1000));
-            l0_delayed = 1;
+            else if (++no_progress >= TDB_BACKPRESSURE_STALL_MAX_ITERATIONS)
+            {
+                TDB_DEBUG_LOG(TDB_LOG_ERROR,
+                              "CF '%s' active memtable ceiling stall, no rotate progress for "
+                              "%dms - flush engine appears wedged",
+                              cf->name,
+                              no_progress * (TDB_BACKPRESSURE_STALL_CHECK_INTERVAL_US / 1000));
+                return TDB_ERR_BUSY;
+            }
         }
+
+        TDB_DEBUG_LOG(TDB_LOG_INFO, "CF '%s' active memtable ceiling stall resolved after %dms",
+                      cf->name,
+                      total_iterations * (TDB_BACKPRESSURE_STALL_CHECK_INTERVAL_US / 1000));
+        paced = 1;
     }
 
-    /* unified active memtable ceiling. tidesdb_unified_memtable_rotate runs
-     * under a single-rotator CAS on unified_mt.is_flushing -- every writer
-     * that loses the CAS skips the rotate and proceeds, so a burst of writers
-     * crossing the threshold simultaneously can pile data into the active
-     * before the winner publishes the new one. same shape as the per-cf
-     * stall above but rotation is kicked through the same CAS+rotate path
-     * tidesdb_txn_commit uses, not through flush_memtable_internal */
-    if (cf->db && cf->db->unified_mt.enabled && cf->db->unified_mt.write_buffer_size > 0)
+    /** unified active memtable at or over its ceiling. rotation runs under the single-rotator CAS
+     * on unified_mt.is_flushing -- a writer that loses the CAS skips the rotate and blocks below
+     * until the winner publishes the new active, rather than through flush_memtable_internal. */
+    if (unified && ceiling > 0 && active_size >= ceiling)
     {
-        const size_t u_ceiling =
-            TDB_BACKPRESSURE_ACTIVE_MT_CEILING_MULT * cf->db->unified_mt.write_buffer_size;
-        size_t u_size = 0;
-        tidesdb_memtable_t *umt = NULL;
-        if (tidesdb_active_memtable_try_ref(&cf->db->unified_mt.active_mt_readers,
-                                            &cf->db->unified_mt.active, &umt))
-        {
-            if (umt->skip_list) u_size = (size_t)skip_list_get_size(umt->skip_list);
-            tidesdb_immutable_memtable_unref(umt);
-        }
-        const size_t u_ramp_lo = (size_t)((double)u_ceiling * TDB_BACKPRESSURE_RAMP_LO_RATIO);
-        if (u_size > u_ramp_lo && u_size < u_ceiling)
-        {
-            const double f = (double)(u_size - u_ramp_lo) / (double)(u_ceiling - u_ramp_lo);
-            const unsigned int d = (unsigned int)(TDB_BACKPRESSURE_RAMP_MAX_DELAY_US * f * f);
-            if (d > 0)
-            {
-                usleep(d);
-                l0_delayed = 1;
-            }
-        }
-        if (u_size >= u_ceiling)
-        {
-            if (tdb_log_throttle(cf->db, &cf->db->unified_mt.last_ceiling_stall_log_sec,
-                                 TDB_BACKPRESSURE_STALL_LOG_INTERVAL_SEC))
-                TDB_DEBUG_LOG(TDB_LOG_WARN,
-                              "Unified active memtable ceiling stall %zu bytes >= %zu (%dx wbuf)",
-                              u_size, u_ceiling, TDB_BACKPRESSURE_ACTIVE_MT_CEILING_MULT);
+        if (tdb_log_throttle(cf->db, &cf->db->unified_mt.last_ceiling_stall_log_sec,
+                             TDB_BACKPRESSURE_STALL_LOG_INTERVAL_SEC))
+            TDB_DEBUG_LOG(TDB_LOG_WARN,
+                          "Unified active memtable ceiling stall %zu bytes >= %zu (%dx wbuf)",
+                          active_size, ceiling, TDB_BACKPRESSURE_ACTIVE_MT_CEILING_MULT);
 
-            int expected = 0;
-            if (atomic_compare_exchange_strong_explicit(&cf->db->unified_mt.is_flushing, &expected,
-                                                        1, memory_order_acquire,
-                                                        memory_order_relaxed))
-            {
-                tidesdb_unified_memtable_rotate(cf->db);
-                atomic_store_explicit(&cf->db->unified_mt.is_flushing, 0, memory_order_release);
-            }
+        int expected = 0;
+        if (atomic_compare_exchange_strong_explicit(&cf->db->unified_mt.is_flushing, &expected, 1,
+                                                    memory_order_acquire, memory_order_relaxed))
+        {
+            tidesdb_unified_memtable_rotate(cf->db);
+            atomic_store_explicit(&cf->db->unified_mt.is_flushing, 0, memory_order_release);
+        }
 
-            int total_iterations = 0;
-            int no_progress = 0;
-            size_t best_size = u_size;
-            uint64_t last_heartbeat =
+        int total_iterations = 0;
+        int no_progress = 0;
+        size_t best_size = active_size;
+        uint64_t last_heartbeat =
+            atomic_load_explicit(&cf->db->flush_heartbeat, memory_order_relaxed);
+        while (1)
+        {
+            size_t cur_size = 0;
+            tidesdb_memtable_t *cur_umt = NULL;
+            if (tidesdb_active_memtable_try_ref(&cf->db->unified_mt.active_mt_readers,
+                                                &cf->db->unified_mt.active, &cur_umt))
+            {
+                if (cur_umt->skip_list) cur_size = (size_t)skip_list_get_size(cur_umt->skip_list);
+                tidesdb_immutable_memtable_unref(cur_umt);
+            }
+            if (cur_size < ceiling) break;
+
+            usleep(TDB_BACKPRESSURE_STALL_CHECK_INTERVAL_US);
+            total_iterations++;
+
+            const uint64_t cur_heartbeat =
                 atomic_load_explicit(&cf->db->flush_heartbeat, memory_order_relaxed);
-            while (1)
+            if (cur_size < best_size || cur_heartbeat != last_heartbeat)
             {
-                size_t cur_size = 0;
-                tidesdb_memtable_t *cur_umt = NULL;
-                if (tidesdb_active_memtable_try_ref(&cf->db->unified_mt.active_mt_readers,
-                                                    &cf->db->unified_mt.active, &cur_umt))
-                {
-                    if (cur_umt->skip_list)
-                        cur_size = (size_t)skip_list_get_size(cur_umt->skip_list);
-                    tidesdb_immutable_memtable_unref(cur_umt);
-                }
-                if (cur_size < u_ceiling) break;
-
-                usleep(TDB_BACKPRESSURE_STALL_CHECK_INTERVAL_US);
-                total_iterations++;
-
-                const uint64_t cur_heartbeat =
-                    atomic_load_explicit(&cf->db->flush_heartbeat, memory_order_relaxed);
-                if (cur_size < best_size || cur_heartbeat != last_heartbeat)
-                {
-                    best_size = cur_size;
-                    last_heartbeat = cur_heartbeat;
-                    no_progress = 0;
-                }
-                else if (++no_progress >= TDB_BACKPRESSURE_STALL_MAX_ITERATIONS)
-                {
-                    TDB_DEBUG_LOG(TDB_LOG_ERROR,
-                                  "unified active memtable ceiling stall: no rotate progress for "
-                                  "%dms - flush engine appears wedged",
-                                  no_progress * (TDB_BACKPRESSURE_STALL_CHECK_INTERVAL_US / 1000));
-                    return TDB_ERR_BUSY;
-                }
+                best_size = cur_size;
+                last_heartbeat = cur_heartbeat;
+                no_progress = 0;
             }
+            else if (++no_progress >= TDB_BACKPRESSURE_STALL_MAX_ITERATIONS)
+            {
+                TDB_DEBUG_LOG(TDB_LOG_ERROR,
+                              "unified active memtable ceiling stall: no rotate progress for "
+                              "%dms - flush engine appears wedged",
+                              no_progress * (TDB_BACKPRESSURE_STALL_CHECK_INTERVAL_US / 1000));
+                return TDB_ERR_BUSY;
+            }
+        }
 
-            TDB_DEBUG_LOG(TDB_LOG_INFO, "Unified active memtable ceiling stall resolved after %dms",
-                          total_iterations * (TDB_BACKPRESSURE_STALL_CHECK_INTERVAL_US / 1000));
-            l0_delayed = 1;
-        }
-    }
-
-    /* L0/L1 graduated delays. skip if any stall above already paced this
-     * commit */
-    if (!l0_delayed)
-    {
-        if (l0_queue_depth >=
-                (size_t)((double)effective_stall * TDB_BACKPRESSURE_HIGH_THRESHOLD_RATIO) ||
-            l1_file_count >= (effective_l1_trigger * TDB_BACKPRESSURE_L1_HIGH_MULTIPLIER))
-        {
-            /** high pressure -- TDB_BACKPRESSURE_HIGH_THRESHOLD_RATIO of stall threshold or
-             *  TDB_BACKPRESSURE_L1_HIGH_MULTIPLIER x effective L1 trigger */
-            usleep(TDB_BACKPRESSURE_HIGH_DELAY_US);
-            if (tdb_log_throttle(cf->db, &cf->last_backpressure_log_sec,
-                                 TDB_BACKPRESSURE_STALL_LOG_INTERVAL_SEC))
-                TDB_DEBUG_LOG(TDB_LOG_INFO, "CF '%s' high backpressure L0=%zu L1=%d - %dus delay",
-                              cf->name, l0_queue_depth, l1_file_count,
-                              TDB_BACKPRESSURE_HIGH_DELAY_US);
-            l0_delayed = 1;
-        }
-        else if (l0_queue_depth >= (size_t)((double)effective_stall *
-                                            TDB_BACKPRESSURE_MODERATE_THRESHOLD_RATIO) ||
-                 l1_file_count >= (effective_l1_trigger * TDB_BACKPRESSURE_L1_MODERATE_MULTIPLIER))
-        {
-            /** moderate pressure -- TDB_BACKPRESSURE_MODERATE_THRESHOLD_RATIO of stall threshold or
-             *  TDB_BACKPRESSURE_L1_MODERATE_MULTIPLIER x effective L1 trigger */
-            usleep(TDB_BACKPRESSURE_MODERATE_DELAY_US);
-            if (tdb_log_throttle(cf->db, &cf->last_backpressure_log_sec,
-                                 TDB_BACKPRESSURE_STALL_LOG_INTERVAL_SEC))
-                TDB_DEBUG_LOG(TDB_LOG_INFO,
-                              "CF '%s' moderate backpressure L0=%zu L1=%d - %dus delay", cf->name,
-                              l0_queue_depth, l1_file_count, TDB_BACKPRESSURE_MODERATE_DELAY_US);
-            l0_delayed = 1;
-        }
+        TDB_DEBUG_LOG(TDB_LOG_INFO, "Unified active memtable ceiling stall resolved after %dms",
+                      total_iterations * (TDB_BACKPRESSURE_STALL_CHECK_INTERVAL_US / 1000));
+        paced = 1;
     }
 
     /**** global memory pressure (computed by reaper every Nms, single atomic_load)
-     ***  critical blocking and self-help flushes always fire regardless of L0 delay.
-     **   high/elevated delays are skipped if L0/L1 already applied a delay to avoid
-     *    double-sleeping on the same commit (the L0 delay already throttled ingestion). */
+     ***  critical blocking and self-help flushes always fire regardless of the pressure curve.
+     **   high/elevated yields are skipped if the curve above already paced this commit, to avoid
+     *    double-sleeping on the same commit. */
     if (cf->db)
     {
         int pressure = atomic_load_explicit(&cf->db->memory_pressure_level, memory_order_relaxed);
@@ -25148,16 +25113,17 @@ static int tidesdb_apply_backpressure(tidesdb_column_family_t *cf)
         }
         else if (pressure >= TDB_MEMORY_PRESSURE_HIGH)
         {
-            /* high -- we force flush this CF; skip delay if L0 already throttled */
+            /* high -- we force flush this CF; skip delay if the pressure curve already throttled */
             tidesdb_flush_memtable_internal(cf, 0, 1);
-            if (!l0_delayed) usleep(TDB_BACKPRESSURE_HIGH_DELAY_US);
+            if (!paced) usleep(TDB_BACKPRESSURE_HIGH_DELAY_US);
         }
         else if (pressure >= TDB_MEMORY_PRESSURE_ELEVATED)
         {
-            /* elevated -- proactive flush + tiny yield (skip yield if L0 already throttled) */
+            /* elevated -- proactive flush + tiny yield (skip yield if the curve already throttled)
+             */
             if (!atomic_load_explicit(&cf->is_flushing, memory_order_relaxed))
                 tidesdb_flush_memtable_internal(cf, 0, 0);
-            if (!l0_delayed) usleep(TDB_BACKPRESSURE_ELEVATED_DELAY_US);
+            if (!paced) usleep(TDB_BACKPRESSURE_ELEVATED_DELAY_US);
         }
     }
 
@@ -28617,8 +28583,11 @@ static int tidesdb_unified_memtable_rotate(tidesdb_t *db)
         return TDB_ERR_IO;
     }
 
-    /* we sync db directory to persist new unified WAL file entry */
-    tdb_sync_directory(db->db_path);
+    /* persist the new WAL's directory entry so crash recovery can find it -- but only when the
+     * unified WAL asks for durability. under TDB_SYNC_NONE a crash may lose recent writes anyway,
+     * so the synchronous directory fsync (held on the single-rotator path, stalling every committer
+     * behind the rotation) buys nothing and is skipped. */
+    if (db->config.unified_memtable_sync_mode != TDB_SYNC_NONE) tdb_sync_directory(db->db_path);
 
     tidesdb_memtable_t *new_mt = malloc(sizeof(tidesdb_memtable_t));
     if (!new_mt)
@@ -28635,30 +28604,17 @@ static int tidesdb_unified_memtable_rotate(tidesdb_t *db)
     atomic_init(&new_mt->writers, 0);
     atomic_init(&new_mt->flushed, 0);
 
-    /* enforce a hard cap on the shared immutable queue so it cannot grow unbounded when a rotation
-     * is driven from a path that bypasses the apply_backpressure ladder. mirrors the per-CF cap in
-     * tidesdb_flush_memtable_internal -- block briefly to let the flush workers drain, a
-     * last-resort safety net above the graduated stall. */
-    {
-        const size_t hard_cap = tdb_unified_immutable_hard_cap(db);
-        if (queue_size(db->unified_mt.immutables) >= hard_cap)
-        {
-            TDB_DEBUG_LOG(TDB_LOG_WARN,
-                          "Unified immutable queue at hard cap %zu, blocking until drained",
-                          hard_cap);
-            int wait_iters = 0;
-            while (queue_size(db->unified_mt.immutables) >= hard_cap &&
-                   wait_iters < TDB_IMMUTABLE_HARD_CAP_MAX_WAIT)
-            {
-                usleep(TDB_IMMUTABLE_HARD_CAP_WAIT_US);
-                wait_iters++;
-            }
-            if (wait_iters >= TDB_IMMUTABLE_HARD_CAP_MAX_WAIT)
-                TDB_DEBUG_LOG(TDB_LOG_ERROR,
-                              "Unified immutable queue hard cap wait timeout after %d ms",
-                              wait_iters * (TDB_IMMUTABLE_HARD_CAP_WAIT_US / 1000));
-        }
-    }
+    /* the graduated backpressure ladder in apply_backpressure already bounds the shared immutable
+     * queue for the commit path (it hard-blocks committers at the stall threshold, below this cap),
+     * so this is only reachable from a rotate that bypasses it -- the reaper's memory-pressure
+     * rotate or recovery. those are periodic or single-threaded and cannot run the queue away, so
+     * we log an overshoot rather than poll-sleep here: a wait held under the single-rotator CAS
+     * would stall every committer for no benefit. */
+    if (queue_size(db->unified_mt.immutables) >= tdb_unified_immutable_hard_cap(db) &&
+        tdb_log_throttle(db, &db->unified_mt.last_ceiling_stall_log_sec,
+                         TDB_BACKPRESSURE_STALL_LOG_INTERVAL_SEC))
+        TDB_DEBUG_LOG(TDB_LOG_WARN, "Unified immutable queue overshoot %zu >= soft cap %zu",
+                      queue_size(db->unified_mt.immutables), tdb_unified_immutable_hard_cap(db));
 
     /* enqueue old onto the immutable queue before swapping the active pointer. this eliminates the
      * read visibility gap where a reader loads the new (empty) active and then walks the immutable

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -10945,20 +10945,30 @@ static int tidesdb_compute_l1_overlap_depth(tidesdb_column_family_t *cf)
     tidesdb_resolve_comparator(cf->db, &cf->config, &cmp, &ctx);
     if (!cmp) return 0;
 
-    /* array_readers pins the sstable array and its entries against a concurrent retire while we
-     * read their boundary keys (same guard the flush out-of-order scan uses) */
+    /* array_readers only pins the sstable ARRAY against retire, it does not stop a concurrent
+     * compaction from unref'ing an individual sstable and freeing its boundary keys. the events
+     * below point straight at those key buffers and outlive the array_readers window, so take a
+     * real reference on each sstable first and hold it until the sweep is done. a failed try_ref
+     * means the sstable is already being reclaimed, so skip it. */
     atomic_fetch_add_explicit(&lvl->array_readers, 1, memory_order_acq_rel);
     const int n = atomic_load_explicit(&lvl->num_sstables, memory_order_acquire);
     tidesdb_sstable_t **ssts = atomic_load_explicit(&lvl->sstables, memory_order_acquire);
 
     tidesdb_overlap_event_t *ev = (n > 0) ? malloc((size_t)(2 * n) * sizeof(*ev)) : NULL;
-    int m = 0;
-    if (ev)
+    tidesdb_sstable_t **pinned = (n > 0) ? malloc((size_t)n * sizeof(*pinned)) : NULL;
+    int m = 0, num_pinned = 0;
+    if (ev && pinned)
     {
         for (int i = 0; i < n; i++)
         {
             tidesdb_sstable_t *s = ssts ? ssts[i] : NULL;
-            if (!s || !s->min_key || !s->max_key) continue;
+            if (!s || !tidesdb_sstable_try_ref(s)) continue;
+            if (!s->min_key || !s->max_key)
+            {
+                tidesdb_sstable_unref(cf->db, s);
+                continue;
+            }
+            pinned[num_pinned++] = s;
             ev[m].key = s->min_key;
             ev[m].size = s->min_key_size;
             ev[m].delta = 1;
@@ -10971,8 +10981,10 @@ static int tidesdb_compute_l1_overlap_depth(tidesdb_column_family_t *cf)
     }
     atomic_fetch_sub_explicit(&lvl->array_readers, 1, memory_order_release);
 
-    if (!ev || m == 0)
+    if (!ev || !pinned || m == 0)
     {
+        for (int i = 0; i < num_pinned; i++) tidesdb_sstable_unref(cf->db, pinned[i]);
+        free(pinned);
         free(ev);
         return (n > 0) ? 1 : 0; /* alloc failure -- fall back to a conservative depth of 1 */
     }
@@ -11004,6 +11016,9 @@ static int tidesdb_compute_l1_overlap_depth(tidesdb_column_family_t *cf)
         if (depth > max_depth) max_depth = depth;
     }
     free(ev);
+    /* the events pointed into these sstables' key buffers, so release the pins only now */
+    for (int i = 0; i < num_pinned; i++) tidesdb_sstable_unref(cf->db, pinned[i]);
+    free(pinned);
     return max_depth;
 }
 
@@ -13487,12 +13502,12 @@ static int tidesdb_apply_dca(tidesdb_column_family_t *cf)
 
     /* DCA reference size. the paper uses the largest level's data size N_L. but during ingestion
      * the largest level is empty (data has not propagated down yet), and N_L ~ 0 would collapse
-     * every capacity to the write-buffer floor -- which pins the compaction target-level selection
-     * at X and self-merges the first level forever, never draining downward. use the largest
-     * NON-EMPTY level instead,once the tree has quiesced this is the largest level itself
-     * (matching the paper and preserving the durable space-amp bound), but while the tree fills it
-     * tracks a populated level so capacities stay sized to real data and the target selection can
-     * route data down. */
+     * every capacity to the write-buffer floor, which pins the compaction target-level selection at
+     * X and self-merges the first level forever, never draining downward. use the largest NON-EMPTY
+     * level instead. once the tree has quiesced this is the largest level itself, matching the
+     * paper and preserving the durable space-amp bound, and if the largest level holds only a
+     * sliver during a transition the collapsed capacities make the fuller shallower levels read as
+     * over-capacity and drain downward, which is the right response, not a stall. */
     size_t N_L = 0;
     for (int i = num_levels - 1; i >= 0; i--)
     {
@@ -18109,13 +18124,27 @@ int tidesdb_trigger_compaction(tidesdb_column_family_t *cf, int full_compaction)
             /* else multi-level but largest under capacity -- we leave the shrink to the collapse
              * rule below rather than merging into an underfull largest and re-triggering */
         }
-        else
+        else if (X > 1)
         {
             TDB_DEBUG_LOG(TDB_LOG_INFO, "Dividing merge at level %d", X);
             result = tidesdb_dividing_merge(cf, X - 1); /* convert to 0-indexed */
         }
+        else
+        {
+            /* X==1 is a degenerate dividing level, the first sorted level itself. a dividing merge
+             * here just re-partitions L1 in place, spending I/O to keep the data at L1 while the
+             * partitioned merge below is what actually drains it to the largest level. that
+             * in-place churn holds data at L1 and lets it pile, so skip straight to the drain --
+             * the partitioned merge reads whatever L1 layout exists and needs no pre-consolidation.
+             */
+            TDB_DEBUG_LOG(
+                TDB_LOG_INFO,
+                "CF '%s' degenerate dividing level X=1, draining L1 to largest instead of "
+                "consolidating in place",
+                cf->name);
+        }
     }
-    else
+    else if (X > 1)
     {
         TDB_DEBUG_LOG(TDB_LOG_WARN, "Target_lvl > X, defaulting to dividing merge");
         result = tidesdb_dividing_merge(cf, X - 1); /* convert to 0-indexed */
@@ -18689,8 +18718,10 @@ static int tidesdb_flush_partition_splits(tidesdb_column_family_t *cf, size_t me
     tidesdb_resolve_comparator(cf->db, &cf->config, &cmp, &cctx);
     if (!cmp) return 0;
 
-    /* copy the min_keys out under array_readers so a concurrent compaction cannot retire the array
-     * or free a key while we read it -- we never mutate the level from the flush path */
+    /* copy the min_keys out so we never mutate the level from the flush path. array_readers only
+     * pins the array against retire, not the individual sstables, so a concurrent compaction can
+     * unref one and free its min_key mid-copy -- take a real reference across each copy and drop it
+     * straight after. a failed try_ref means the sstable is already being reclaimed, so skip it. */
     atomic_fetch_add_explicit(&largest->array_readers, 1, memory_order_acq_rel);
     const int n = atomic_load_explicit(&largest->num_sstables, memory_order_acquire);
     tidesdb_sstable_t **ssts = atomic_load_explicit(&largest->sstables, memory_order_acquire);
@@ -18702,13 +18733,19 @@ static int tidesdb_flush_partition_splits(tidesdb_column_family_t *cf, size_t me
         for (int i = 0; i < n; i++)
         {
             tidesdb_sstable_t *s = ssts ? ssts[i] : NULL;
-            if (!s || !s->min_key || s->min_key_size == 0) continue;
-            uint8_t *cp = malloc(s->min_key_size);
-            if (!cp) continue;
-            memcpy(cp, s->min_key, s->min_key_size);
-            keys[nk] = cp;
-            sizes[nk] = s->min_key_size;
-            nk++;
+            if (!s || !tidesdb_sstable_try_ref(s)) continue;
+            if (s->min_key && s->min_key_size > 0)
+            {
+                uint8_t *cp = malloc(s->min_key_size);
+                if (cp)
+                {
+                    memcpy(cp, s->min_key, s->min_key_size);
+                    keys[nk] = cp;
+                    sizes[nk] = s->min_key_size;
+                    nk++;
+                }
+            }
+            tidesdb_sstable_unref(cf->db, s);
         }
     }
     atomic_fetch_sub_explicit(&largest->array_readers, 1, memory_order_release);
@@ -25664,40 +25701,47 @@ static int tidesdb_txn_add_to_read_set(tidesdb_txn_t *txn, tidesdb_column_family
             new_cap = txn->read_set_capacity + TDB_TXN_READ_SET_BATCH_GROW;
         }
 
+        /* growth reallocs arrays a cross-transaction dangerous-structure check may be walking, so
+         * swap the pointers under the write lock rather than out from under a reader. a partial
+         * failure keeps whichever arrays did grow and leaves the capacity unchanged, as before. */
+        pthread_rwlock_wrlock(&txn->conflict_lock);
+        int grow_failed = 0;
+
         uint8_t **new_keys = realloc(txn->read_keys, new_cap * sizeof(uint8_t *));
-        if (!new_keys) return -1;
-
-        size_t *new_sizes = realloc(txn->read_key_sizes, new_cap * sizeof(size_t));
-        if (!new_sizes)
+        if (!new_keys)
+            grow_failed = 1;
+        else
         {
-            /* new_keys succeeded, so we need to keep it */
-            txn->read_keys = new_keys;
-            return -1;
-        }
+            txn->read_keys = new_keys; /* keep it even if a later realloc fails */
 
-        uint64_t *new_seqs = realloc(txn->read_seqs, new_cap * sizeof(uint64_t));
-        if (!new_seqs)
-        {
-            txn->read_keys = new_keys;
-            txn->read_key_sizes = new_sizes;
-            return -1;
-        }
+            size_t *new_sizes = realloc(txn->read_key_sizes, new_cap * sizeof(size_t));
+            if (!new_sizes)
+                grow_failed = 1;
+            else
+            {
+                txn->read_key_sizes = new_sizes;
 
-        tidesdb_column_family_t **new_cfs =
-            realloc(txn->read_cfs, new_cap * sizeof(tidesdb_column_family_t *));
-        if (!new_cfs)
-        {
-            txn->read_keys = new_keys;
-            txn->read_key_sizes = new_sizes;
-            txn->read_seqs = new_seqs;
-            return -1;
-        }
+                uint64_t *new_seqs = realloc(txn->read_seqs, new_cap * sizeof(uint64_t));
+                if (!new_seqs)
+                    grow_failed = 1;
+                else
+                {
+                    txn->read_seqs = new_seqs;
 
-        txn->read_keys = new_keys;
-        txn->read_key_sizes = new_sizes;
-        txn->read_seqs = new_seqs;
-        txn->read_cfs = new_cfs;
-        txn->read_set_capacity = new_cap;
+                    tidesdb_column_family_t **new_cfs =
+                        realloc(txn->read_cfs, new_cap * sizeof(tidesdb_column_family_t *));
+                    if (!new_cfs)
+                        grow_failed = 1;
+                    else
+                    {
+                        txn->read_cfs = new_cfs;
+                        txn->read_set_capacity = new_cap;
+                    }
+                }
+            }
+        }
+        pthread_rwlock_unlock(&txn->conflict_lock);
+        if (grow_failed) return -1;
     }
 
     /* we utilize arena allocation for read keys to reduce malloc overhead */
@@ -25765,7 +25809,12 @@ static int tidesdb_txn_add_to_read_set(tidesdb_txn_t *txn, tidesdb_column_family
     txn->read_seqs[txn->read_set_count] = seq;
     txn->read_cfs[txn->read_set_count] = cf;
 
+    /* publish the new entry under the write lock so a concurrent dangerous-structure check never
+     * observes a count that outruns the initialized slots */
+    pthread_rwlock_wrlock(&txn->conflict_lock);
     txn->read_set_count++;
+    pthread_rwlock_unlock(&txn->conflict_lock);
+
     if (txn->read_set_count == TDB_TXN_READ_HASH_THRESHOLD && !txn->read_set_hash)
     {
         txn->read_set_hash = tidesdb_read_set_hash_create();
@@ -25876,10 +25925,18 @@ int tidesdb_txn_begin_with_isolation(tidesdb_t *db, const tidesdb_isolation_leve
 
     (*txn)->commit_seq = 0;
 
+    if (pthread_rwlock_init(&(*txn)->conflict_lock, NULL) != 0)
+    {
+        free(*txn);
+        *txn = NULL;
+        return TDB_ERR_MEMORY;
+    }
+
     (*txn)->ops_capacity = TDB_INITIAL_TXN_OPS_CAPACITY;
     (*txn)->ops = calloc((*txn)->ops_capacity, sizeof(tidesdb_txn_op_t));
     if (!(*txn)->ops)
     {
+        pthread_rwlock_destroy(&(*txn)->conflict_lock);
         free(*txn);
         *txn = NULL;
         return TDB_ERR_MEMORY;
@@ -26070,11 +26127,17 @@ int tidesdb_txn_put(tidesdb_txn_t *txn, tidesdb_column_family_t *cf, const uint8
 
         if (new_capacity <= txn->ops_capacity) return TDB_ERR_TOO_LARGE;
 
+        /* the realloc moves the array a cross-transaction conflict check may be walking, so swap
+         * the pointer under the write lock rather than out from under a reader */
+        pthread_rwlock_wrlock(&txn->conflict_lock);
         tidesdb_txn_op_t *new_ops = realloc(txn->ops, new_capacity * sizeof(tidesdb_txn_op_t));
+        if (new_ops)
+        {
+            txn->ops = new_ops;
+            txn->ops_capacity = new_capacity;
+        }
+        pthread_rwlock_unlock(&txn->conflict_lock);
         if (!new_ops) return TDB_ERR_MEMORY;
-
-        txn->ops = new_ops;
-        txn->ops_capacity = new_capacity;
     }
 
     tidesdb_txn_op_t *op = &txn->ops[txn->num_ops];
@@ -26105,7 +26168,11 @@ int tidesdb_txn_put(tidesdb_txn_t *txn, tidesdb_column_family_t *cf, const uint8
     op->is_delete = 0;
     op->cf = cf;
 
+    /* publish the new op under the write lock so a concurrent serializable conflict check never
+     * observes a count that outruns the initialized entries */
+    pthread_rwlock_wrlock(&txn->conflict_lock);
     txn->num_ops++;
+    pthread_rwlock_unlock(&txn->conflict_lock);
 
     /* account this op's coalesced key+value buffer (threshold-batched, off the hot path) */
     txn->mem_bytes += (int64_t)(op->key_size + op->value_size);
@@ -26904,11 +26971,17 @@ static int tidesdb_txn_delete_internal(tidesdb_txn_t *txn, tidesdb_column_family
 
         if (new_capacity <= txn->ops_capacity) return TDB_ERR_TOO_LARGE;
 
+        /* the realloc moves the array a cross-transaction conflict check may be walking, so swap
+         * the pointer under the write lock rather than out from under a reader */
+        pthread_rwlock_wrlock(&txn->conflict_lock);
         tidesdb_txn_op_t *new_ops = realloc(txn->ops, new_capacity * sizeof(tidesdb_txn_op_t));
+        if (new_ops)
+        {
+            txn->ops = new_ops;
+            txn->ops_capacity = new_capacity;
+        }
+        pthread_rwlock_unlock(&txn->conflict_lock);
         if (!new_ops) return TDB_ERR_MEMORY;
-
-        txn->ops = new_ops;
-        txn->ops_capacity = new_capacity;
     }
 
     tidesdb_txn_op_t *op = &txn->ops[txn->num_ops];
@@ -26926,7 +26999,11 @@ static int tidesdb_txn_delete_internal(tidesdb_txn_t *txn, tidesdb_column_family
     op->is_single_delete = is_single_delete;
     op->cf = cf;
 
+    /* publish the new op under the write lock so a concurrent serializable conflict check never
+     * observes a count that outruns the initialized entries */
+    pthread_rwlock_wrlock(&txn->conflict_lock);
     txn->num_ops++;
+    pthread_rwlock_unlock(&txn->conflict_lock);
 
     /* account this op's key buffer (value_size is 0 for deletes) */
     txn->mem_bytes += (int64_t)(op->key_size + op->value_size);
@@ -27026,6 +27103,7 @@ void tidesdb_txn_free(tidesdb_txn_t *txn)
     free(txn->savepoint_names);
 
     free(txn->cfs);
+    pthread_rwlock_destroy(&txn->conflict_lock);
     free(txn);
 }
 
@@ -27055,19 +27133,27 @@ int tidesdb_txn_reset(tidesdb_txn_t *txn, const tidesdb_isolation_level_t isolat
         tidesdb_txn_remove_from_active_list(txn);
     }
 
-    /* we free op key/value data but keep the ops array itself */
-    for (int i = 0; i < txn->num_ops; i++)
+    /* we free op key/value data but keep the ops array itself. drop the count to zero before
+     * freeing so a cross-transaction conflict check can never walk into a buffer we are releasing,
+     * and hold the write lock across the whole retirement so one already scanning finishes first.
+     */
+    pthread_rwlock_wrlock(&txn->conflict_lock);
+    const int retired_ops = txn->num_ops;
+    txn->num_ops = 0;
+    for (int i = 0; i < retired_ops; i++)
     {
         free(txn->ops[i].key); /* coalesced buffer owns key+value */
         txn->ops[i].key = NULL;
         txn->ops[i].value = NULL;
     }
-    txn->num_ops = 0;
+    pthread_rwlock_unlock(&txn->conflict_lock);
 
-    /* we reset read set but keep arrays allocated, we also free arena buffers to avoid leaks */
+    /* we reset read set but keep arrays allocated, we also free arena buffers to avoid leaks. the
+     * read keys point into these arenas, so drop the count to zero and release the arenas under the
+     * write lock -- a cross-transaction dangerous-structure check must not be left walking keys
+     * that live in a buffer we are freeing. */
+    pthread_rwlock_wrlock(&txn->conflict_lock);
     txn->read_set_count = 0;
-
-    /* we free individual arena buffers but keep the pointer array for reuse */
     for (int i = 0; i < txn->read_key_arena_count; i++)
     {
         free(txn->read_key_arenas[i]);
@@ -27075,6 +27161,7 @@ int tidesdb_txn_reset(tidesdb_txn_t *txn, const tidesdb_isolation_level_t isolat
     }
     txn->read_key_arena_count = 0;
     txn->read_key_arena_used = 0;
+    pthread_rwlock_unlock(&txn->conflict_lock);
 
     /* return this txn's published memory to the global counter and reset the accumulator */
     if (txn->mem_published)
@@ -27499,6 +27586,11 @@ static int tidesdb_txn_check_ssi_conflicts(tidesdb_txn_t *txn)
         if (other == txn || other->is_committed || other->is_aborted) continue;
         if (other->isolation_level != TDB_ISOLATION_SERIALIZABLE) continue;
 
+        /* the peer's owner thread appends to, reallocs and truncates its own op array while we scan
+         * it, so hold its read lock. the active-list rdlock above keeps the transaction struct
+         * alive, but only this keeps the array itself from moving or its buffers from being freed
+         * mid-scan. */
+        pthread_rwlock_rdlock(&other->conflict_lock);
         if (txn->read_set_hash && txn->read_set_count >= TDB_TXN_READ_HASH_THRESHOLD)
         {
             for (int w = 0; w < other->num_ops && !txn->has_rw_conflict_out; w++)
@@ -27531,6 +27623,7 @@ static int tidesdb_txn_check_ssi_conflicts(tidesdb_txn_t *txn)
                 }
             }
         }
+        pthread_rwlock_unlock(&other->conflict_lock);
     }
 
     /* we check for dangerous structures */
@@ -27540,13 +27633,18 @@ static int tidesdb_txn_check_ssi_conflicts(tidesdb_txn_t *txn)
     {
         for (int i = 0; i < count && !conflict; i++)
         {
-            const tidesdb_txn_t *other = active[i];
+            /* not const -- we take this peer's conflict_lock to walk its read set safely */
+            tidesdb_txn_t *other = active[i];
             if (other == txn || other->is_committed || other->is_aborted ||
                 !other->has_rw_conflict_in || !other->has_rw_conflict_out)
             {
                 continue;
             }
 
+            /* the peer's owner grows its read set by realloc and frees the arenas its read keys
+             * point into, so hold its read lock while we walk them. our own ops need no guard --
+             * this thread owns them. */
+            pthread_rwlock_rdlock(&other->conflict_lock);
             for (int w = 0; w < txn->num_ops && !conflict; w++)
             {
                 const tidesdb_txn_op_t *op = &txn->ops[w];
@@ -27560,6 +27658,7 @@ static int tidesdb_txn_check_ssi_conflicts(tidesdb_txn_t *txn)
                     }
                 }
             }
+            pthread_rwlock_unlock(&other->conflict_lock);
         }
     }
 
@@ -29333,10 +29432,14 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
                                       block_manager_framed_size((uint32_t)uwal_size),
                                       memory_order_relaxed);
 
-            /* buffered WAL -- block until the single flush thread has pwritten this record to the
-             * page cache before the commit returns, matching the process-crash durability the
-             * direct path provides synchronously. no-op on a non-buffered WAL. */
-            if (block_manager_wait_durable(umt->wal, uwal_end) != 0)
+            /* buffered WAL -- for FULL/INTERVAL, block until the single flush thread has pwritten
+             * this record to the page cache before the commit returns, matching the process-crash
+             * durability the direct path provides synchronously. NONE means no sync, so the record
+             * is staged in the ring and the flush thread pwrites it asynchronously while the commit
+             * returns without waiting, and an acked write is durable only once its sstable lands.
+             * no-op on a non-buffered WAL. */
+            if (txn->db->config.unified_memtable_sync_mode != TDB_SYNC_NONE &&
+                block_manager_wait_durable(umt->wal, uwal_end) != 0)
             {
                 if (uwal_batch != uwal_stack_buf) free(uwal_batch);
                 atomic_fetch_sub_explicit(&umt->writers, 1, memory_order_release);
@@ -29600,11 +29703,14 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
                                       block_manager_framed_size((uint32_t)wal_size),
                                       memory_order_relaxed);
 
-            /* buffered WAL -- wait for the single flush thread to make this record durable (page
-             * cache, and fdatasync'd when the CF sync mode is FULL) before applying to the
-             * memtable, matching the durability the direct path provides inline. no-op on a direct
-             * WAL. */
-            if (block_manager_wait_durable(
+            /* buffered WAL -- for FULL/INTERVAL, wait for the single flush thread to make this
+             * record durable (page cache, and fdatasync'd when FULL) before applying to the
+             * memtable, matching the durability the direct path provides inline. NONE means no
+             * sync, so the record is staged in the ring and pwritten asynchronously while the
+             * commit returns without waiting, and an acked write is durable only once its sstable
+             * lands. no-op on a direct WAL. */
+            if (cf->config.sync_mode != TDB_SYNC_NONE &&
+                block_manager_wait_durable(
                     wal, (uint64_t)wal_result + block_manager_framed_size((uint32_t)wal_size)) != 0)
             {
                 if (wal_is_heap) free(wal_batch);
@@ -29875,18 +29981,24 @@ int tidesdb_txn_rollback_to_savepoint(tidesdb_txn_t *txn, const char *name)
     const int saved_num_ops = txn->savepoint_op_counts[savepoint_idx];
     const int saved_num_cfs = txn->savepoint_cf_counts[savepoint_idx];
 
-    /* we free ops appended after the savepoint */
+    /* we free ops appended after the savepoint. truncate the count first so a cross-transaction
+     * conflict check cannot walk into a buffer we are releasing, and hold the write lock across the
+     * whole retirement so one already scanning finishes before the frees land. */
     int64_t freed_bytes = 0;
-    for (int i = saved_num_ops; i < txn->num_ops; i++)
+    pthread_rwlock_wrlock(&txn->conflict_lock);
+    const int truncated_from = txn->num_ops;
+    txn->num_ops = saved_num_ops;
+    for (int i = saved_num_ops; i < truncated_from; i++)
     {
         freed_bytes += (int64_t)(txn->ops[i].key_size + txn->ops[i].value_size);
         free(txn->ops[i].key); /* coalesced buffer owns key+value */
+        txn->ops[i].key = NULL;
+        txn->ops[i].value = NULL;
     }
+    pthread_rwlock_unlock(&txn->conflict_lock);
     txn->mem_bytes -= freed_bytes;
     tidesdb_txn_mem_publish(txn);
 
-    /* we truncate back to savepoint */
-    txn->num_ops = saved_num_ops;
     txn->num_cfs = saved_num_cfs;
 
     /* the last-cf cache may point at a cf that the truncation just dropped from

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -18994,8 +18994,16 @@ static void *tidesdb_flush_worker_thread(void *arg)
             break;
         }
 
-        TDB_DEBUG_LOG(TDB_LOG_INFO, "Flush worker has received work for SSTable %" PRIu64,
-                      work->sst_id);
+        /* a unified split task carries the WAL generation in sst_id, not an sstable id -- the
+         * sstable id is drawn later by the unified writer. logging it as an sstable id makes the
+         * two id spaces look like they collide when reading a failure log, so name it correctly. */
+        if (work->unified_sl || work->unified_barrier)
+            TDB_DEBUG_LOG(TDB_LOG_INFO,
+                          "Flush worker has received unified work for WAL gen %" PRIu64,
+                          work->sst_id);
+        else
+            TDB_DEBUG_LOG(TDB_LOG_INFO, "Flush worker has received work for SSTable %" PRIu64,
+                          work->sst_id);
 
         /* flush progress heartbeat -- a picked-up work item is forward progress */
         atomic_fetch_add_explicit(&db->flush_heartbeat, 1, memory_order_relaxed);

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -18859,6 +18859,10 @@ static int tidesdb_flush_write_l1_partitions(tidesdb_column_family_t *cf, skip_l
                                              int max_parts)
 {
     tidesdb_t *db = cf->db;
+    /* the flush worker only ever reaches here with an open cf, but stating it lets the optimizer
+     * see db is non-null when this inlines -- gcc otherwise assumes it may be address zero and
+     * warns that the num_open_sstables decrement below writes into a zero-sized region */
+    if (!db) return TDB_ERR_INVALID_ARGS;
     *out_count = 0;
 
     uint8_t **splits = NULL;
@@ -29319,6 +29323,25 @@ static int tidesdb_txn_reserve_writes(tidesdb_txn_t *txn)
     return TDB_SUCCESS;
 }
 
+/**
+ * tdb_commit_needs_durable_wal
+ * whether a commit must block until the flush thread has pwritten its wal record to the file. any
+ * sync mode above NONE needs it for the durability it promises. wal_sync_on_commit needs it too
+ * even under NONE, because its per-commit upload ships the file's bytes -- a record still staged in
+ * the buffered-append ring would be acked but absent from the object store, so a hard kill would
+ * lose an acked write and break the rpo=0 contract. plain NONE with no such upload skips the wait,
+ * since nothing reads the file before the sstable lands.
+ * @param db database instance
+ * @param sync_mode the wal's configured sync mode
+ * @return 1 when the commit must wait for durability, 0 when it may return immediately
+ */
+static inline int tdb_commit_needs_durable_wal(const tidesdb_t *db, const int sync_mode)
+{
+    if (sync_mode != TDB_SYNC_NONE) return 1;
+    return db && db->object_store && db->config.object_store_config &&
+           db->config.object_store_config->wal_sync_on_commit;
+}
+
 int tidesdb_txn_commit(tidesdb_txn_t *txn)
 {
     if (!txn || txn->is_committed || txn->is_aborted) return TDB_ERR_INVALID_ARGS;
@@ -29432,13 +29455,14 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
                                       block_manager_framed_size((uint32_t)uwal_size),
                                       memory_order_relaxed);
 
-            /* buffered WAL -- for FULL/INTERVAL, block until the single flush thread has pwritten
-             * this record to the page cache before the commit returns, matching the process-crash
-             * durability the direct path provides synchronously. NONE means no sync, so the record
-             * is staged in the ring and the flush thread pwrites it asynchronously while the commit
-             * returns without waiting, and an acked write is durable only once its sstable lands.
-             * no-op on a non-buffered WAL. */
-            if (txn->db->config.unified_memtable_sync_mode != TDB_SYNC_NONE &&
+            /* buffered WAL -- block until the single flush thread has pwritten this record to the
+             * page cache before the commit returns, matching the process-crash durability the
+             * direct path provides synchronously. plain NONE skips the wait, so the record is
+             * staged in the ring and pwritten asynchronously while the commit returns, and an acked
+             * write is durable only once its sstable lands. wal_sync_on_commit still waits even
+             * under NONE because its upload ships the file's bytes, and a record left in the ring
+             * would be acked but missing from the object store. no-op on a non-buffered WAL. */
+            if (tdb_commit_needs_durable_wal(txn->db, txn->db->config.unified_memtable_sync_mode) &&
                 block_manager_wait_durable(umt->wal, uwal_end) != 0)
             {
                 if (uwal_batch != uwal_stack_buf) free(uwal_batch);
@@ -29703,13 +29727,14 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
                                       block_manager_framed_size((uint32_t)wal_size),
                                       memory_order_relaxed);
 
-            /* buffered WAL -- for FULL/INTERVAL, wait for the single flush thread to make this
-             * record durable (page cache, and fdatasync'd when FULL) before applying to the
-             * memtable, matching the durability the direct path provides inline. NONE means no
-             * sync, so the record is staged in the ring and pwritten asynchronously while the
-             * commit returns without waiting, and an acked write is durable only once its sstable
-             * lands. no-op on a direct WAL. */
-            if (cf->config.sync_mode != TDB_SYNC_NONE &&
+            /* buffered WAL -- wait for the single flush thread to make this record durable (page
+             * cache, and fdatasync'd when FULL) before applying to the memtable, matching the
+             * durability the direct path provides inline. plain NONE skips the wait, so the record
+             * is staged in the ring and pwritten asynchronously while the commit returns, and an
+             * acked write is durable only once its sstable lands. wal_sync_on_commit still waits
+             * even under NONE because its upload ships the file's bytes, and a record left in the
+             * ring would be acked but missing from the object store. no-op on a direct WAL. */
+            if (tdb_commit_needs_durable_wal(cf->db, cf->config.sync_mode) &&
                 block_manager_wait_durable(
                     wal, (uint64_t)wal_result + block_manager_framed_size((uint32_t)wal_size)) != 0)
             {

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -1855,6 +1855,29 @@ static inline size_t tdb_cf_effective_stall(const tidesdb_column_family_t *cf)
 }
 
 /**
+ * tdb_cf_flush_backlog
+ * the flush backlog backpressure throttles on -- memtables that have been frozen and enqueued for
+ * flush but whose flush has not yet completed. this is deliberately NOT the immutable queue length:
+ * that queue also holds memtables already flushed (their data durable in an sstable) that a
+ * concurrent reader's snapshot is pinning against reaper reclamation, and throttling writes on
+ * those would stall for a reader-blocked GC backlog rather than real flush pressure. the
+ * flush_pending_count is incremented when a memtable's flush is enqueued at rotation and
+ * decremented when its flush completes, independent of reclamation, so a flushed-but-pinned
+ * memtable does not count.
+ * @param cf column family
+ * @return unflushed backlog depth (0 if none)
+ */
+static inline size_t tdb_cf_flush_backlog(const tidesdb_column_family_t *cf)
+{
+    /* unified mode shares one flush queue db-wide; per-CF mode has its own per-CF counter */
+    const int backlog =
+        (cf->db && cf->db->unified_mt.enabled)
+            ? atomic_load_explicit(&cf->db->flush_pending_count, memory_order_acquire)
+            : atomic_load_explicit(&cf->flush_pending_count, memory_order_acquire);
+    return backlog > 0 ? (size_t)backlog : 0;
+}
+
+/**
  * tdb_cf_immutable_hard_cap
  * last-resort ceiling on the immutable-queue depth, the configured L0 stall
  * threshold plus headroom for in-flight freezes. derived from config so that
@@ -13319,9 +13342,20 @@ static int tidesdb_apply_dca(tidesdb_column_family_t *cf)
         return TDB_SUCCESS;
     }
 
-    /* we get data size at largest level */
-    tidesdb_level_t *largest = cf->levels[num_levels - 1];
-    size_t N_L = atomic_load(&largest->current_size);
+    /* DCA reference size. the paper uses the largest level's data size N_L. but during ingestion
+     * the largest level is empty (data has not propagated down yet), and N_L ~ 0 would collapse
+     * every capacity to the write-buffer floor -- which pins the compaction target-level selection
+     * at X and self-merges the first level forever, never draining downward. use the largest
+     * NON-EMPTY level instead: once the tree has quiesced this is the largest level itself
+     * (matching the paper and preserving the durable space-amp bound), but while the tree fills it
+     * tracks a populated level so capacities stay sized to real data and the target selection can
+     * route data down. */
+    size_t N_L = 0;
+    for (int i = num_levels - 1; i >= 0; i--)
+    {
+        N_L = atomic_load_explicit(&cf->levels[i]->current_size, memory_order_relaxed);
+        if (N_L > 0) break;
+    }
 
     /* we update capacities C_i = N_L / T^(L-i)
      * paper uses 1-based level numbering (level 1, 2, 3...)
@@ -15568,10 +15602,18 @@ static int tidesdb_dividing_merge(tidesdb_column_family_t *cf, int target_level)
     /* we get number of sstables being merged */
     size_t num_sstables_to_merge = queue_size(sstables_to_delete);
 
-    /* if no boundaries, do a simple full merge */
+    /* no boundaries means the largest level (the boundary source) is empty -- the tree cannot carve
+     * partition boundaries yet. depositing the merged run back at target_level (self-merging the
+     * first level in place) would leave the largest level empty forever, so data never descends and
+     * the boundaries never materialize -- a vicious cycle that pins read amplification. instead
+     * bootstrap the tree by full-merging every level down INTO the empty largest level, populating
+     * it as one run. the next flush's dividing merge then finds real boundaries and normal
+     * partitioned spooky resumes. this bootstrap only fires while the largest level is empty (right
+     * after a level is added), so it is rare. */
     if (num_boundaries == 0)
     {
-        int result = tidesdb_full_preemptive_merge(cf, 0, target_level, target_level);
+        const int nl = atomic_load_explicit(&cf->num_active_levels, memory_order_acquire);
+        int result = tidesdb_full_preemptive_merge(cf, 0, nl - 1, nl - 1);
 
         while (!queue_is_empty(sstables_to_delete))
         {
@@ -18856,12 +18898,14 @@ static void *tidesdb_flush_worker_thread(void *arg)
             tdb_objstore_upload_manifest(db, cf);
         }
 
-        /* we check file count in addition to size
-         * cf->levels[0] (level_num=1) is TidesDB's first disk level, equivalent to
-         * RocksDB's rLevel 0 in the spooky paper. this is where memtable flushes land.
-         * files at this level have overlapping key ranges, so reads must check all files.
-         * trigger compaction at the α file-count trigger (configurable, default 4) to prevent
-         * read amplification. */
+        /* compaction is triggered the Spooky way -- capacity-driven, evaluated after each flush.
+         * cf->levels[0] (level_num=1) is TidesDB's first disk level, equivalent to RocksDB's rLevel
+         * 0 in the spooky paper -- where memtable flushes land as overlapping runs. when its data
+         * exceeds its (DCA-adjusted) capacity we run the compaction workflow, which picks what to
+         * merge from the level capacities. the L1 *file count* is NOT a compaction trigger: it is
+         * the read-amplification signal that backpressure paces writes on via
+         * l1_file_count_trigger, so a flushed-file pileup bounds ingestion rather than kicking a
+         * redundant compaction. */
         int num_l1_sstables =
             atomic_load_explicit(&cf->levels[0]->num_sstables, memory_order_acquire);
         size_t level1_size =
@@ -18872,16 +18916,7 @@ static void *tidesdb_flush_worker_thread(void *arg)
         int should_compact = 0;
         const char *trigger_reason = NULL;
 
-        const int effective_file_trigger = tdb_cf_effective_l1_trigger(cf);
-
-        /* file count trigger at level 1 */
-        if (num_l1_sstables >= effective_file_trigger)
-        {
-            should_compact = 1;
-            trigger_reason = "file count";
-        }
-
-        else if (level1_size >= level1_capacity)
+        if (level1_size >= level1_capacity)
         {
             should_compact = 1;
             trigger_reason = "size";
@@ -18930,9 +18965,9 @@ static void *tidesdb_flush_worker_thread(void *arg)
             {
                 TDB_DEBUG_LOG(TDB_LOG_INFO,
                               "CF '%s' level %d (first disk level) triggering compaction (%s): "
-                              "files=%d (trigger=%d), size=%zu (capacity=%zu)",
-                              cf->name, cf->levels[0]->level_num, trigger_reason, num_l1_sstables,
-                              cf->config.l1_file_count_trigger, level1_size, level1_capacity);
+                              "size=%zu (capacity=%zu), files=%d (read-amp signal)",
+                              cf->name, cf->levels[0]->level_num, trigger_reason, level1_size,
+                              level1_capacity, num_l1_sstables);
             }
 
             /* if the density witness fired and the dense sstable is above the
@@ -24819,11 +24854,11 @@ static int tidesdb_apply_backpressure(tidesdb_column_family_t *cf)
 
     const int unified = (cf->db && cf->db->unified_mt.enabled);
 
-    /* L0 depth -- in unified mode every write lands in the shared unified memtable, so the per-CF
-     * immutable queue stays empty and the unified immutable queue is the one to watch */
-    queue_t *l0_queue = (unified && cf->db->unified_mt.immutables) ? cf->db->unified_mt.immutables
-                                                                   : cf->immutable_memtables;
-    const size_t l0_queue_depth = queue_size(l0_queue);
+    /* L0 depth is the flush backlog -- memtables frozen but not yet flushed. deliberately NOT the
+     * immutable queue length, which also counts already-flushed memtables a concurrent reader is
+     * pinning against reaper reclamation; throttling on those stalls writes for a GC backlog, not
+     * flush pressure. see tdb_cf_flush_backlog. */
+    const size_t l0_queue_depth = tdb_cf_flush_backlog(cf);
     const size_t effective_stall = tdb_cf_effective_stall(cf);
 
     /* active memtable fill against its ceiling (2x write_buffer_size), unified or per-CF. this and
@@ -24913,15 +24948,15 @@ static int tidesdb_apply_backpressure(tidesdb_column_family_t *cf)
          *  writer here instead of failing the commit. */
         int total_iterations = 0;
         int no_progress = 0;
-        size_t best_depth = queue_size(l0_queue);
+        size_t best_depth = tdb_cf_flush_backlog(cf);
         uint64_t last_heartbeat =
             atomic_load_explicit(&cf->db->flush_heartbeat, memory_order_relaxed);
-        while (queue_size(l0_queue) >= effective_stall)
+        while (tdb_cf_flush_backlog(cf) >= effective_stall)
         {
             usleep(TDB_BACKPRESSURE_STALL_CHECK_INTERVAL_US);
             total_iterations++;
 
-            const size_t cur_depth = queue_size(l0_queue);
+            const size_t cur_depth = tdb_cf_flush_backlog(cf);
             const uint64_t cur_heartbeat =
                 atomic_load_explicit(&cf->db->flush_heartbeat, memory_order_relaxed);
 
@@ -25071,6 +25106,32 @@ static int tidesdb_apply_backpressure(tidesdb_column_family_t *cf)
         TDB_DEBUG_LOG(TDB_LOG_INFO, "Unified active memtable ceiling stall resolved after %dms",
                       total_iterations * (TDB_BACKPRESSURE_STALL_CHECK_INTERVAL_US / 1000));
         paced = 1;
+    }
+
+    /* overlapping first-level (L1) read-amplification pacing. l1_file_count_trigger bounds how many
+     * overlapping flushed files may accumulate at the first sorted level before writes are paced --
+     * a point/range read must consult every overlapping file, so this file count IS read-amp, and
+     * pacing on it keeps reads fast when compaction is transiently behind. compaction itself is
+     * capacity-driven (Spooky); the file count is purely this backpressure signal. the delay rises
+     * monotonically with the overflow past the trigger, scaled by the trigger itself so it is the
+     * only knob, and ingestion settles where it matches the compaction drain rate. it is not
+     * flush-heartbeat coupled -- L1 drains via compaction, not flush. */
+    if (cf->levels && cf->levels[0])
+    {
+        const int l1_trigger = tdb_cf_effective_l1_trigger(cf);
+        const int l1_count =
+            atomic_load_explicit(&cf->levels[0]->num_sstables, memory_order_acquire);
+        if (l1_trigger > 0 && l1_count > l1_trigger)
+        {
+            const double f =
+                1.0 - (double)l1_trigger / (double)l1_count; /* 0 at trigger, ->1 above */
+            const unsigned int d = (unsigned int)(TDB_BACKPRESSURE_RAMP_MAX_DELAY_US * f * f);
+            if (d > 0)
+            {
+                usleep(d);
+                paced = 1;
+            }
+        }
     }
 
     /**** global memory pressure (computed by reaper every Nms, single atomic_load)
@@ -33658,6 +33719,10 @@ int tidesdb_get_stats(tidesdb_column_family_t *cf, tidesdb_stats_t **stats)
         tidesdb_immutable_memtable_unref(active_mt_struct);
     }
     (*stats)->memtable_size = active_mt_size;
+    /* per-cf L0 queue depth -- the frozen memtables awaiting flush that backpressure throttles on.
+     * empty in unified mode, where the shared queue is reported db-wide as unified_immutable_count.
+     */
+    (*stats)->immutable_count = (int)queue_size(cf->immutable_memtables);
 
     (*stats)->level_sizes = malloc((*stats)->num_levels * sizeof(size_t));
     (*stats)->level_num_sstables = malloc((*stats)->num_levels * sizeof(int));

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -183,11 +183,6 @@ typedef tidesdb_memtable_t tidesdb_immutable_memtable_t;
 #define TDB_ITER_STACK_KEY_SIZE     256
 #define TDB_BACKUP_COPY_BUFFER_SIZE (256 * 1024)
 
-/* shift used to combine two uint32_t halves (sq_hi, sq_lo) back into the original uint64_t
- * abs_seq stored in the block index. inverse of the (uint32_t)val / (uint32_t)(val >> 32)
- * split at write time. */
-#define TDB_U64_HI_LO_SHIFT 32
-
 /* initial capacity (and grow floor) for the iterator's double-buffered pop arena that
  * lets merge_heap_pop materialise borrowed kvs without malloc. capacity grows to fit
  * larger kvs but never shrinks below this. */
@@ -220,9 +215,6 @@ typedef tidesdb_memtable_t tidesdb_immutable_memtable_t;
 #define TDB_RECOVER_IMM_SCAN_STACK 64 /* stack slots for the recovery max-seq immutable scan */
 #define TDB_STACK_COMMIT_HOOK_OPS  16 /* stack slots for commit hook operations */
 #define TDB_STACK_ITER_SOURCES     16 /* stack slots for iterator temp_sources */
-
-/* default column family config values */
-#define TDB_INITIAL_BLOCK_INDEX_CAPACITY 16
 
 /* worst-case bytes for a LEB128 varint encoding of a uint64_t -- 7 data bits per byte plus
  * a continuation bit, ceil(64/7) = 10 */
@@ -364,6 +356,8 @@ typedef tidesdb_memtable_t tidesdb_immutable_memtable_t;
 /* default L0/L1 management configuration */
 #define TDB_DEFAULT_L1_FILE_COUNT_TRIGGER    4
 #define TDB_DEFAULT_L0_QUEUE_STALL_THRESHOLD 10
+/* db-level L0 stall threshold for the shared unified immutable queue (unified mode) */
+#define TDB_DEFAULT_UNIFIED_L0_QUEUE_STALL_THRESHOLD 10
 
 /* default tombstone density trigger configuration -- 0.0 disables the check, an sstable
  * must hold at least TDB_DEFAULT_TOMBSTONE_DENSITY_MIN_ENTRIES entries before its density
@@ -1810,13 +1804,16 @@ static inline size_t tdb_cf_effective_stall(const tidesdb_column_family_t *cf)
     if (stall < 1) stall = 1;
     if (cf->db)
     {
-        /* unified mode has a single shared immutable queue, so the per-CF memory-budget split
-         * below does not apply -- use the configured value. its memory is unified_wbuf x depth
-         * regardless of CF count, so no division is needed. note apply_backpressure runs per
-         * committing CF, so this shared queue is paced by whichever CF is committing -- per-CF
-         * thresholds that differ pace it inconsistently (the depth is bounded by the largest of
-         * them); with the default threshold across CFs it stalls coherently at one depth. */
-        if (cf->db->unified_mt.enabled) return stall;
+        /* unified mode has a single shared immutable queue bounded by one db-level threshold, so
+         * every committing CF paces it against the same value -- no per-CF drift. its memory is
+         * unified_wbuf x depth regardless of CF count, so the per-CF memory-budget split below does
+         * not apply. */
+        if (cf->db->unified_mt.enabled)
+        {
+            size_t ustall = (size_t)cf->db->config.unified_memtable_l0_queue_stall_threshold;
+            if (ustall < 1) ustall = 1;
+            return ustall;
+        }
 
         const int num_cfs = cf->db->num_column_families;
         if (num_cfs > 1)
@@ -1848,6 +1845,22 @@ static inline size_t tdb_cf_effective_stall(const tidesdb_column_family_t *cf)
 static inline size_t tdb_cf_immutable_hard_cap(const tidesdb_column_family_t *cf)
 {
     size_t stall = (size_t)cf->config.l0_queue_stall_threshold;
+    if (stall < 1) stall = 1;
+    return stall + TDB_IMM_QUEUE_HEADROOM;
+}
+
+/**
+ * tdb_unified_immutable_hard_cap
+ * last-resort ceiling on the shared unified immutable-queue depth, the db-level unified L0 stall
+ * threshold plus the same freeze headroom as the per-CF cap. the unified rotate path enforces this
+ * so the shared queue is bounded even when a rotation is driven from a path that bypasses the
+ * apply_backpressure ladder (the reaper's memory-pressure rotate, the ceiling-stall rotate).
+ * @param db database
+ * @return hard-cap depth, always greater than the unified stall threshold
+ */
+static inline size_t tdb_unified_immutable_hard_cap(const tidesdb_t *db)
+{
+    size_t stall = (size_t)db->config.unified_memtable_l0_queue_stall_threshold;
     if (stall < 1) stall = 1;
     return stall + TDB_IMM_QUEUE_HEADROOM;
 }
@@ -2914,7 +2927,6 @@ tidesdb_column_family_config_t tidesdb_default_column_family_config(void)
         .use_btree = 0,
         .commit_hook_fn = NULL,
         .commit_hook_ctx = NULL,
-        .object_target_file_size = 0, /* reserved, not used */
         .object_lazy_compaction = 0,
         .object_prefetch_compaction = 1};
 
@@ -2949,6 +2961,7 @@ tidesdb_config_t tidesdb_default_config(void)
         .unified_memtable_skip_list_probability = 0,
         .unified_memtable_sync_mode = 0,
         .unified_memtable_sync_interval_us = 0,
+        .unified_memtable_l0_queue_stall_threshold = TDB_DEFAULT_UNIFIED_L0_QUEUE_STALL_THRESHOLD,
         .object_store = NULL,
         .object_store_config = NULL,
         .max_concurrent_flushes = 0,       /* 0 = pin to resolved num_flush_threads */
@@ -5110,7 +5123,11 @@ static int tdb_objstore_download_if_missing(const tidesdb_t *db, const char *loc
         }
     }
 
-    if (db->local_cache) tdb_local_cache_track(db->local_cache, local_path);
+    /* track the just-downloaded object in the bounded local cache (evict + re-fetch on a miss) only
+     * when cache_on_read is set; otherwise the local copy stays pinned on disk. */
+    if (db->local_cache &&
+        (!db->config.object_store_config || db->config.object_store_config->cache_on_read))
+        tdb_local_cache_track(db->local_cache, local_path);
     return 0;
 }
 
@@ -5493,6 +5510,11 @@ static void tdb_objstore_upload_manifest(tidesdb_t *db, tidesdb_column_family_t 
      * it would obsolete the primary's real-data sstables. mirrors the sstable-upload gate in
      * tidesdb_level_add_sstable; promotion clears replica_mode before any primary write. */
     if (atomic_load_explicit(&db->replica_mode, memory_order_acquire)) return;
+
+    /* the operator can opt out of publishing the manifest to the object store. sstables and WALs
+     * still upload; only the manifest object is withheld (e.g. an external process owns it). */
+    if (db->config.object_store_config && !db->config.object_store_config->sync_manifest_to_object)
+        return;
 
     if (tdb_objstore_fencing_enabled(db))
     {
@@ -10334,8 +10356,13 @@ static int tidesdb_level_add_sstable(tidesdb_level_t *level, tidesdb_sstable_t *
     {
         if (!atomic_load_explicit(&sst->db->replica_mode, memory_order_acquire))
         {
-            tdb_objstore_upload_file_sync(sst->db, sst->klog_path, 1);
-            tdb_objstore_upload_file_sync(sst->db, sst->vlog_path, 1);
+            /* track the freshly uploaded sstable in the bounded local cache (so it can be evicted
+             * and re-fetched on a miss) only when cache_on_write is set; otherwise the local copy
+             * stays pinned on disk. */
+            const int track = !sst->db->config.object_store_config ||
+                              sst->db->config.object_store_config->cache_on_write;
+            tdb_objstore_upload_file_sync(sst->db, sst->klog_path, track);
+            tdb_objstore_upload_file_sync(sst->db, sst->vlog_path, track);
         }
         else if (sst->db->local_cache)
         {
@@ -19930,12 +19957,21 @@ static void *tidesdb_reaper_thread(void *arg)
                 }
                 else if (level >= TDB_MEMORY_PRESSURE_CRITICAL)
                 {
-                    /* critical -- force-flush every CF that holds data. flushing an empty active
-                     * sheds nothing and only churns an immutable + a post-flush compaction, so skip
-                     * those; any CF with data is flushed so memory still drains across all of them.
+                    /* critical -- force-flush every CF that holds data. collect the victims under
+                     * the list lock and flush after releasing it, the same collect-then-release
+                     * shape the deferred-flush and HIGH-victim paths use, so a flush never runs
+                     * while holding cf_list_lock (which would block CF create/drop). flushing an
+                     * empty active sheds nothing and only churns an immutable + a post-flush
+                     * compaction, so skip those. bounded per cycle; sustained pressure re-fires and
+                     * drains the rest.
                      */
+                    tidesdb_column_family_t *crit_cfs[TDB_REAPER_DEFERRED_FLUSH_BATCH];
+                    size_t crit_sizes[TDB_REAPER_DEFERRED_FLUSH_BATCH];
+                    int crit_count = 0;
                     pthread_rwlock_rdlock(&db->cf_list_lock);
-                    for (int i = 0; i < db->num_column_families; i++)
+                    for (int i = 0; i < db->num_column_families &&
+                                    crit_count < TDB_REAPER_DEFERRED_FLUSH_BATCH;
+                         i++)
                     {
                         tidesdb_column_family_t *victim = db->column_families[i];
                         if (!victim) continue;
@@ -19952,14 +19988,27 @@ static void *tidesdb_reaper_thread(void *arg)
                         }
                         if (vsize == 0) continue;
 
+                        crit_cfs[crit_count] = victim;
+                        crit_sizes[crit_count] = vsize;
+                        crit_count++;
+                    }
+                    pthread_rwlock_unlock(&db->cf_list_lock);
+
+                    for (int i = 0; i < crit_count; i++)
+                    {
+                        /* skip a CF already at the immutable hard cap so flush_memtable_internal
+                         * does not usleep-block the reaper up to 5s waiting for it to drain -- a
+                         * later cycle retries once flushes have made room. */
+                        if (queue_size(crit_cfs[i]->immutable_memtables) >=
+                            tdb_cf_immutable_hard_cap(crit_cfs[i]))
+                            continue;
                         TDB_DEBUG_LOG(TDB_LOG_WARN,
                                       "Memory pressure CRITICAL flushing CF '%s' (%zu bytes, "
                                       "global %" PRId64 "/%zu bytes, %.1f%%)",
-                                      victim->name, vsize, total_mem_bytes, mem_limit,
+                                      crit_cfs[i]->name, crit_sizes[i], total_mem_bytes, mem_limit,
                                       ratio * 100.0);
-                        tidesdb_flush_memtable_internal(victim, 0, 1);
+                        tidesdb_flush_memtable_internal(crit_cfs[i], 0, 1);
                     }
-                    pthread_rwlock_unlock(&db->cf_list_lock);
                 }
                 else if (flush_victim && flush_victim_size > 0)
                 {
@@ -20113,10 +20162,17 @@ static void *tidesdb_reaper_thread(void *arg)
          * where the scan loop may take longer due to scheduler behavior */
         int shutdown_requested = 0;
         pthread_rwlock_rdlock(&db->cf_list_lock);
-        for (int i = 0; i < db->num_column_families && !shutdown_requested &&
-                        candidate_count < candidate_capacity;
-             i++)
+        /* resume from where the last scan left off and wrap, so eviction sweeps every CF across
+         * cycles instead of always restarting at CF 0 and starving later CFs of fd reclamation */
+        const int reap_num_cfs = db->num_column_families;
+        int reap_start_cf = db->reap_scan_cursor;
+        if (reap_start_cf < 0 || reap_start_cf >= reap_num_cfs) reap_start_cf = 0;
+        int reap_last_cf = reap_start_cf;
+        for (int c = 0;
+             c < reap_num_cfs && !shutdown_requested && candidate_count < candidate_capacity; c++)
         {
+            const int i = (reap_start_cf + c) % reap_num_cfs;
+            reap_last_cf = i;
             tidesdb_column_family_t *cf = db->column_families[i];
             if (!cf) continue;
 
@@ -20194,6 +20250,8 @@ static void *tidesdb_reaper_thread(void *arg)
                 atomic_fetch_sub_explicit(&lvl->array_readers, 1, memory_order_release);
             }
         }
+        /* advance the resume cursor just past the last CF we started this scan */
+        if (reap_num_cfs > 0) db->reap_scan_cursor = (reap_last_cf + 1) % reap_num_cfs;
         pthread_rwlock_unlock(&db->cf_list_lock);
 
         /* if shutdown was requested during scan, release any acquired refs and exit */
@@ -21030,6 +21088,12 @@ int tidesdb_open(const tidesdb_config_t *config, tidesdb_t **db)
         (*db)->unified_mt.write_buffer_size = config->unified_memtable_write_buffer_size > 0
                                                   ? config->unified_memtable_write_buffer_size
                                                   : TDB_DEFAULT_WRITE_BUFFER_SIZE;
+
+        /* resolve the shared-queue stall threshold once so the backpressure ladder and the rotate
+         * hard cap read one coherent db-level value */
+        if ((*db)->config.unified_memtable_l0_queue_stall_threshold <= 0)
+            (*db)->config.unified_memtable_l0_queue_stall_threshold =
+                TDB_DEFAULT_UNIFIED_L0_QUEUE_STALL_THRESHOLD;
 
         (*db)->unified_mt.immutables = queue_new();
         if (!(*db)->unified_mt.immutables)
@@ -25300,6 +25364,22 @@ int tidesdb_txn_begin(tidesdb_t *db, tidesdb_txn_t **txn)
 }
 
 /**
+ * tidesdb_txn_begin_cf
+ * begins a transaction at a column family's configured default isolation level. the transaction
+ * is still database-scoped and may touch any column family; the cf only supplies the initial
+ * isolation level.
+ * @param db database handle
+ * @param cf column family whose default isolation level to use
+ * @param txn output transaction handle
+ * @return TDB_SUCCESS or error code
+ */
+int tidesdb_txn_begin_cf(tidesdb_t *db, tidesdb_column_family_t *cf, tidesdb_txn_t **txn)
+{
+    if (!cf) return TDB_ERR_INVALID_ARGS;
+    return tidesdb_txn_begin_with_isolation(db, cf->config.default_isolation_level, txn);
+}
+
+/**
  * tidesdb_txn_begin_with_isolation
  * begins a new transaction with specified isolation level
  *
@@ -28436,7 +28516,7 @@ static int tidesdb_unified_memtable_rotate(tidesdb_t *db)
     /* skip rotating an empty active -- some callers (the reaper's memory-pressure rotate, the
      * apply_backpressure ceiling path) invoke this without first checking that the active holds
      * data. when writes are blocked under sustained pressure the active is empty, and rotating it
-     * anyway churns empty immutables onto the unbounded unified immutable queue, allocates a fresh
+     * anyway churns empty immutables onto the shared unified immutable queue, allocates a fresh
      * arena and a new WAL file with a directory sync, and enqueues an empty flush -- all of which
      * sheds nothing. the caller holds the single-rotator is_flushing CAS, so old_mt cannot be
      * swapped/freed here; a concurrent writer appending one entry at most defers this rotate one
@@ -28497,6 +28577,31 @@ static int tidesdb_unified_memtable_rotate(tidesdb_t *db)
     atomic_init(&new_mt->refcount, 1);
     atomic_init(&new_mt->writers, 0);
     atomic_init(&new_mt->flushed, 0);
+
+    /* enforce a hard cap on the shared immutable queue so it cannot grow unbounded when a rotation
+     * is driven from a path that bypasses the apply_backpressure ladder. mirrors the per-CF cap in
+     * tidesdb_flush_memtable_internal -- block briefly to let the flush workers drain, a
+     * last-resort safety net above the graduated stall. */
+    {
+        const size_t hard_cap = tdb_unified_immutable_hard_cap(db);
+        if (queue_size(db->unified_mt.immutables) >= hard_cap)
+        {
+            TDB_DEBUG_LOG(TDB_LOG_WARN,
+                          "Unified immutable queue at hard cap %zu, blocking until drained",
+                          hard_cap);
+            int wait_iters = 0;
+            while (queue_size(db->unified_mt.immutables) >= hard_cap &&
+                   wait_iters < TDB_IMMUTABLE_HARD_CAP_MAX_WAIT)
+            {
+                usleep(TDB_IMMUTABLE_HARD_CAP_WAIT_US);
+                wait_iters++;
+            }
+            if (wait_iters >= TDB_IMMUTABLE_HARD_CAP_MAX_WAIT)
+                TDB_DEBUG_LOG(TDB_LOG_ERROR,
+                              "Unified immutable queue hard cap wait timeout after %d ms",
+                              wait_iters * (TDB_IMMUTABLE_HARD_CAP_WAIT_US / 1000));
+        }
+    }
 
     /* enqueue old onto the immutable queue before swapping the active pointer. this eliminates the
      * read visibility gap where a reader loads the new (empty) active and then walks the immutable
@@ -28747,7 +28852,7 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
             if (!tidesdb_active_memtable_try_ref(&txn->db->unified_mt.active_mt_readers,
                                                  &txn->db->unified_mt.active, &umt))
             {
-                if (++umt_attempts >= TDB_ACTIVE_REF_MAX_ATTEMPTS) return TDB_ERR_UNKNOWN;
+                if (++umt_attempts >= TDB_ACTIVE_REF_MAX_ATTEMPTS) return TDB_ERR_BUSY;
                 continue;
             }
             /* mark this writer in-flight before the revalidate, mirroring the
@@ -28760,7 +28865,7 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
                 break;
             atomic_fetch_sub_explicit(&umt->writers, 1, memory_order_release);
             atomic_fetch_sub_explicit(&umt->refcount, 1, memory_order_release);
-            if (++umt_attempts >= TDB_ACTIVE_REF_MAX_ATTEMPTS) return TDB_ERR_UNKNOWN;
+            if (++umt_attempts >= TDB_ACTIVE_REF_MAX_ATTEMPTS) return TDB_ERR_BUSY;
         }
 
         /* we serialize unified WAL batch */
@@ -29009,9 +29114,10 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
             }
             if (++acquire_attempts >= TDB_ACTIVE_REF_MAX_ATTEMPTS)
             {
-                /* active is rotating faster than we can latch it -- fail the
-                 * commit; cleanup releases the memtables latched for earlier CFs */
-                result = TDB_ERR_UNKNOWN;
+                /* active is rotating faster than we can latch it -- give up this
+                 * commit with a retryable busy; cleanup releases the memtables
+                 * latched for earlier CFs. transient contention, not a failure */
+                result = TDB_ERR_BUSY;
                 goto cleanup;
             }
         }

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -1746,8 +1746,11 @@ static tidesdb_kv_pair_t *tidesdb_kv_pair_create(const uint8_t *key, size_t key_
 static void tidesdb_kv_pair_free(tidesdb_kv_pair_t *kv);
 static int tidesdb_iter_kv_visible(tidesdb_iter_t *iter, tidesdb_kv_pair_t *kv);
 static int tidesdb_sstable_ensure_open(tidesdb_t *db, tidesdb_sstable_t *sst);
-static int tidesdb_sstable_ensure_klog_open(tidesdb_t *db, tidesdb_sstable_t *sst);
-static int tidesdb_sstable_ensure_vlog_open(tidesdb_t *db, tidesdb_sstable_t *sst);
+static int tidesdb_sstable_ensure_open_for_write(tidesdb_t *db, tidesdb_sstable_t *sst);
+static int tidesdb_sstable_ensure_klog_open(tidesdb_t *db, tidesdb_sstable_t *sst,
+                                            int download_missing);
+static int tidesdb_sstable_ensure_vlog_open(tidesdb_t *db, tidesdb_sstable_t *sst,
+                                            int download_missing);
 static int wait_for_open(tidesdb_t *db);
 
 /**
@@ -4352,7 +4355,7 @@ static int tidesdb_vlog_read_value(const tidesdb_t *db, tidesdb_sstable_t *sst,
     /* the vlog is opened lazily on first non-inline value read. the const cast is safe:
      * opening the vlog mutates sst (not db's logical state) and does not touch
      * num_open_sstables, which is keyed on the klog. */
-    if (tidesdb_sstable_ensure_vlog_open((tidesdb_t *)db, sst) != 0)
+    if (tidesdb_sstable_ensure_vlog_open((tidesdb_t *)db, sst, 1) != 0)
     {
         return TDB_ERR_IO;
     }
@@ -6528,9 +6531,15 @@ static void tdb_objstore_delete_listed_cb(const char *key, const size_t size, vo
  * pinned sstable instead of two.
  * @param db database instance
  * @param sst sstable whose klog to ensure open
+ * @param download_missing pull the klog from the object store when it is not local. correct for a
+ *                         read re-opening an evicted sstable, but a fresh flush/merge output must
+ *                         pass 0 -- it is creating the file, and a same-named object left by a
+ *                         fenced peer (e.g. a zombie primary that reused the id) would otherwise be
+ *                         downloaded and the new blocks appended onto that stale content
  * @return 0 on success, -1 on error
  */
-static int tidesdb_sstable_ensure_klog_open(tidesdb_t *db, tidesdb_sstable_t *sst)
+static int tidesdb_sstable_ensure_klog_open(tidesdb_t *db, tidesdb_sstable_t *sst,
+                                            int download_missing)
 {
     if (!db || !sst) return -1;
     if (!sst->config || !sst->klog_path) return -1;
@@ -6541,7 +6550,7 @@ static int tidesdb_sstable_ensure_klog_open(tidesdb_t *db, tidesdb_sstable_t *ss
         return 0; /* already open */
     }
 
-    if (db->object_store)
+    if (db->object_store && download_missing)
     {
         if (tdb_objstore_download_if_missing(db, sst->klog_path) != 0) return -1;
     }
@@ -6580,16 +6589,19 @@ static int tidesdb_sstable_ensure_klog_open(tidesdb_t *db, tidesdb_sstable_t *ss
  * (see tidesdb_sstable_ensure_klog_open) and is closed alongside the klog by the reaper.
  * @param db database instance
  * @param sst sstable whose vlog to ensure open
+ * @param download_missing pull the vlog from the object store when it is not local; a fresh
+ *                         flush/merge output passes 0 (see tidesdb_sstable_ensure_klog_open)
  * @return 0 on success, -1 on error
  */
-static int tidesdb_sstable_ensure_vlog_open(tidesdb_t *db, tidesdb_sstable_t *sst)
+static int tidesdb_sstable_ensure_vlog_open(tidesdb_t *db, tidesdb_sstable_t *sst,
+                                            int download_missing)
 {
     if (!db || !sst) return -1;
     if (!sst->config || !sst->vlog_path) return -1;
 
     if (sst->vlog_bm) return 0; /* already open */
 
-    if (db->object_store)
+    if (db->object_store && download_missing)
     {
         if (tdb_objstore_download_if_missing(db, sst->vlog_path) != 0) return -1;
     }
@@ -6632,8 +6644,25 @@ static int tidesdb_sstable_ensure_vlog_open(tidesdb_t *db, tidesdb_sstable_t *ss
  */
 static int tidesdb_sstable_ensure_open(tidesdb_t *db, tidesdb_sstable_t *sst)
 {
-    if (tidesdb_sstable_ensure_klog_open(db, sst) != 0) return -1;
-    if (tidesdb_sstable_ensure_vlog_open(db, sst) != 0) return -1;
+    if (tidesdb_sstable_ensure_klog_open(db, sst, 1) != 0) return -1;
+    if (tidesdb_sstable_ensure_vlog_open(db, sst, 1) != 0) return -1;
+    return 0;
+}
+
+/**
+ * tidesdb_sstable_ensure_open_for_write
+ * open both block managers for a freshly created sstable that is about to be written (flush or
+ * merge output). identical to tidesdb_sstable_ensure_open except it never downloads from the object
+ * store -- the sstable is being created locally, so a same-named remote object is stale (a fenced
+ * peer that reused the id) and must not be pulled down and appended onto.
+ * @param db database instance
+ * @param sst sstable being created
+ * @return 0 on success, -1 on error
+ */
+static int tidesdb_sstable_ensure_open_for_write(tidesdb_t *db, tidesdb_sstable_t *sst)
+{
+    if (tidesdb_sstable_ensure_klog_open(db, sst, 0) != 0) return -1;
+    if (tidesdb_sstable_ensure_vlog_open(db, sst, 0) != 0) return -1;
     return 0;
 }
 
@@ -8055,7 +8084,7 @@ static int tidesdb_sstable_write_from_memtable_btree_ex(tidesdb_t *db, tidesdb_c
                   "SSTable %" PRIu64 " writing from memtable using B+tree (%d entries)", sst->id,
                   num_entries);
 
-    if (tidesdb_sstable_ensure_open(db, sst) != 0)
+    if (tidesdb_sstable_ensure_open_for_write(db, sst) != 0)
     {
         TDB_DEBUG_LOG(TDB_LOG_ERROR, "SSTable %" PRIu64 " failed to ensure open", sst->id);
         return TDB_ERR_IO;
@@ -8711,7 +8740,7 @@ static int tidesdb_sstable_write_from_memtable_ex(tidesdb_t *db, tidesdb_column_
                   sst->id, num_entries);
 
     /* we ensure sstable is open and get block managers */
-    if (tidesdb_sstable_ensure_open(db, sst) != 0)
+    if (tidesdb_sstable_ensure_open_for_write(db, sst) != 0)
     {
         TDB_DEBUG_LOG(TDB_LOG_ERROR, "SSTable %" PRIu64 " failed to ensure open", sst->id);
         return TDB_ERR_IO;
@@ -11812,7 +11841,7 @@ static tidesdb_merge_source_t *tidesdb_merge_source_from_sstable_klog(tidesdb_t 
 
     /* scan sources open the klog only; the vlog is opened on demand by
      * tidesdb_vlog_read_value when a value misses the inline klog payload */
-    if (tidesdb_sstable_ensure_klog_open(db, sst) != 0)
+    if (tidesdb_sstable_ensure_klog_open(db, sst, 1) != 0)
     {
         tidesdb_sstable_unref(db, sst);
         free(source);
@@ -12236,7 +12265,7 @@ static tidesdb_merge_source_t *tidesdb_merge_source_from_sstable_lazy(tidesdb_t 
 
     /* scan sources open the klog only; the vlog is opened on demand by
      * tidesdb_vlog_read_value when a value misses the inline klog payload */
-    if (tidesdb_sstable_ensure_klog_open(db, sst) != 0)
+    if (tidesdb_sstable_ensure_klog_open(db, sst, 1) != 0)
     {
         tidesdb_sstable_unref(db, sst);
         free(source);

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -161,26 +161,18 @@ typedef tidesdb_memtable_t tidesdb_immutable_memtable_t;
  * btree_root_offset(8) + btree_first_leaf(8) + btree_last_leaf(8) +
  * btree_node_count(8) + btree_height(4) */
 #define TDB_SSTABLE_METADATA_BTREE_SIZE 36
-/* chunked-aux descriptor appended after tombstone_count when SSTABLE_FLAG_CHUNKED_AUX
- * is set, bloom_blob_offset(8) + bloom_blob_size(8) + index_blob_offset(8) +
- * index_blob_size(8) */
+/* pre-blocked-format chunked-aux descriptor. no longer written; deserialize only skips it (this
+ * many bytes) when SSTABLE_FLAG_CHUNKED_AUX is set, so an older sstable's footer still parses */
 #define TDB_SSTABLE_METADATA_CHUNKED_AUX_SIZE 32
 /* distinct-key count appended after the chunked-aux descriptor when SSTABLE_FLAG_DISTINCT_KEYS
  * is set, distinct_key_count(8) */
 #define TDB_SSTABLE_METADATA_DISTINCT_KEYS_SIZE 8
+/* blocked-aux directory descriptor appended after the distinct-key count when
+ * SSTABLE_FLAG_BLOCKED_AUX is set, bloom_dir_offset(8) + bloom_dir_size(8) +
+ * index_dir_offset(8) + index_dir_size(8) */
+#define TDB_SSTABLE_METADATA_BLOCKED_AUX_SIZE 32
 #define TDB_SSTABLE_METADATA_FIXED_SIZE \
     (TDB_SSTABLE_METADATA_HEADER_SIZE + TDB_SSTABLE_METADATA_CHECKSUM_SIZE)
-/* the largest payload a single block can frame -- the block manager's on-disk
- * size field is a uint32, so block_manager_block_create rejects anything larger.
- * a bloom-filter or block-index footer blob at or below this is written as one
- * block, no chunking, SSTABLE_FLAG_CHUNKED_AUX stays clear, and the footer is
- * byte-identical to (and readable by) older binaries. every bloom that can exist
- * (m <= UINT32_MAX, ~900MB serialized) and every block index is well under this,
- * so chunking is dormant for all real data today -- it only splits a blob that
- * genuinely cannot fit one block, reachable only if bloom m is ever widened past
- * 32-bit. chunking at any smaller size would needlessly fragment real footers and
- * flip those sstables to the forward-incompatible chunked format for no benefit. */
-#define TDB_AUX_BLOCK_CHUNK_MAX ((uint64_t)UINT32_MAX)
 /* sentinel for tidesdb_sstable_t.tombstone_count when the footer was written before
  * SSTABLE_FLAG_TOMBSTONE_COUNT existed. trigger and stats code skip such sstables. */
 #define TDB_TOMBSTONE_COUNT_UNKNOWN UINT64_MAX
@@ -514,14 +506,6 @@ typedef tidesdb_memtable_t tidesdb_immutable_memtable_t;
 /* klog block configuration */
 #define TDB_KLOG_BLOCK_INITIAL_CAPACITY 512
 
-/* block index validation */
-#define TDB_BLOCK_INDEX_PREFIX_MIN 4
-#define TDB_BLOCK_INDEX_PREFIX_MAX 256
-#define TDB_BLOCK_INDEX_MAX_COUNT  INT_MAX
-
-/* empty block index placeholder ( 4 byte LE count (0) followed by 1 byte prefix_len ) */
-#define TDB_EMPTY_BLOCK_INDEX_SIZE 5
-
 /* merge and serialization configuration */
 #define TDB_MERGE_MIN_ESTIMATED_ENTRIES 100
 #define TDB_KLOG_DELTA_SEQ_MAX_DIFF     1000000
@@ -685,31 +669,6 @@ typedef struct
     uint8_t *data_ref;
     tidesdb_kv_arena_t kv_arena;
 } tidesdb_klog_block_t;
-
-/**
- * tidesdb_block_index_t
- * compact block index for fast key lookups
- * stores min/max key prefixes and file positions for each block
- * @param min_key_prefixes array of minimum key prefixes
- * @param max_key_prefixes array of maximum key prefixes
- * @param file_positions array of file positions for each block
- * @param count number of blocks indexed
- * @param capacity capacity of arrays
- * @param prefix_len length of key prefix stored
- * @param comparator comparator function for key ordering
- * @param comparator_ctx comparator context
- */
-struct tidesdb_block_index_t
-{
-    uint8_t *min_key_prefixes;
-    uint8_t *max_key_prefixes;
-    uint64_t *file_positions;
-    uint32_t count;
-    uint32_t capacity;
-    uint8_t prefix_len;
-    tidesdb_comparator_fn comparator;
-    void *comparator_ctx;
-};
 
 /**
  * tidesdb_vlog_block_t
@@ -1655,25 +1614,6 @@ static tidesdb_sstable_t *tidesdb_sstable_create(tidesdb_t *db, const char *base
                                                  const tidesdb_column_family_config_t *config);
 static void tidesdb_sstable_free(tidesdb_sstable_t *sst);
 
-static void compact_block_index_free(tidesdb_block_index_t *index);
-static int compact_block_index_find_predecessor(const tidesdb_block_index_t *index,
-                                                const uint8_t *key, size_t key_len,
-                                                uint64_t *file_position);
-static int compact_block_index_find_slot(const tidesdb_block_index_t *index, const uint8_t *key,
-                                         size_t key_len, int64_t *slot);
-static uint32_t compact_block_index_run_length(const tidesdb_block_index_t *index,
-                                               const uint8_t *key, size_t key_len,
-                                               int64_t start_slot);
-static int compact_block_index_add(tidesdb_block_index_t *index, const uint8_t *min_key,
-                                   size_t min_key_len, const uint8_t *max_key, size_t max_key_len,
-                                   uint64_t file_position);
-static tidesdb_block_index_t *compact_block_index_create(uint32_t initial_capacity,
-                                                         uint8_t prefix_len,
-                                                         tidesdb_comparator_fn comparator,
-                                                         void *comparator_ctx);
-static uint8_t *compact_block_index_serialize(const tidesdb_block_index_t *index, size_t *out_size);
-static tidesdb_block_index_t *compact_block_index_deserialize(const uint8_t *data,
-                                                              size_t data_size);
 static void tidesdb_sstable_ref(tidesdb_sstable_t *sst);
 static int tidesdb_sstable_try_ref(tidesdb_sstable_t *sst);
 static void tidesdb_sstable_unref(const tidesdb_t *db, tidesdb_sstable_t *sst);
@@ -1688,7 +1628,6 @@ static int tidesdb_sstable_get_seq(tidesdb_t *db, tidesdb_sstable_t *sst, const 
 static int tidesdb_sstable_load(tidesdb_t *db, tidesdb_sstable_t *sst);
 static tidesdb_level_t *tidesdb_level_create(int level_num, size_t capacity);
 static void tidesdb_level_free(const tidesdb_t *db, tidesdb_level_t *level);
-static int64_t tidesdb_sstable_aux_memory_bytes(const tidesdb_sstable_t *sst);
 static int tidesdb_level_add_sstable(tidesdb_level_t *level, tidesdb_sstable_t *sst);
 static int tidesdb_level_remove_sstable(const tidesdb_t *db, tidesdb_level_t *level,
                                         tidesdb_sstable_t *sst);
@@ -1739,20 +1678,18 @@ static int tidesdb_compact_steer_to_bottom(tidesdb_column_family_t *cf, uint8_t 
                                            size_t max_key_size);
 static int tdb_partitioned_merge_finalize_sst(tidesdb_column_family_t *cf, tidesdb_sstable_t *sst,
                                               block_manager_t *klog_bm, block_manager_t *vlog_bm,
-                                              bloom_filter_t *bloom,
-                                              tidesdb_block_index_t *block_indexes,
+                                              blocked_bloom_builder_t *bloom_builder,
+                                              blocked_index_builder_t *index_builder,
                                               uint64_t entry_count, uint64_t tombstone_count,
                                               uint64_t distinct_key_count, uint64_t klog_block_num,
                                               uint64_t vlog_block_num, uint64_t max_seq,
                                               int end_level, int partition);
-static int tidesdb_sstable_write_from_heap_btree(tidesdb_column_family_t *cf,
-                                                 tidesdb_sstable_t *sst, tidesdb_merge_heap_t *heap,
-                                                 block_manager_t *klog_bm, block_manager_t *vlog_bm,
-                                                 bloom_filter_t *bloom, queue_t *sstables_to_delete,
-                                                 int is_largest_level, const uint8_t *range_start,
-                                                 size_t range_start_size, const uint8_t *range_end,
-                                                 size_t range_end_size,
-                                                 uint64_t oldest_unflushed_seq);
+static int tidesdb_sstable_write_from_heap_btree(
+    tidesdb_column_family_t *cf, tidesdb_sstable_t *sst, tidesdb_merge_heap_t *heap,
+    block_manager_t *klog_bm, block_manager_t *vlog_bm, blocked_bloom_builder_t *bloom_builder,
+    queue_t *sstables_to_delete, int is_largest_level, const uint8_t *range_start,
+    size_t range_start_size, const uint8_t *range_end, size_t range_end_size,
+    uint64_t oldest_unflushed_seq);
 static int tidesdb_trigger_compaction(tidesdb_column_family_t *cf, int full_compaction);
 static int tidesdb_enqueue_compaction(tidesdb_column_family_t *cf, int full_compaction);
 static int tidesdb_enqueue_compaction_force(tidesdb_column_family_t *cf, int full_compaction);
@@ -2441,16 +2378,21 @@ static int tidesdb_validate_kv_size(tidesdb_t *db, const size_t key_size, const 
     0x02 /* footer carries an 8-byte tombstone_count after the \
           * btree section (or after max_key when use_btree=0)  \
           * and before the trailing checksum */
-#define SSTABLE_FLAG_CHUNKED_AUX                                          \
-    0x04 /* footer carries a 32-byte chunked-aux descriptor (bloom blob   \
-          * offset+size, index blob offset+size) after tombstone_count.   \
-          * present when a bloom/index blob spans multiple blocks; absent \
-          * sstables locate bloom/index by trailing-block navigation */
+#define SSTABLE_FLAG_CHUNKED_AUX                                             \
+    0x04 /* pre-blocked-format flag -- footer carried a 32-byte chunked-aux  \
+          * descriptor after tombstone_count. no longer written; deserialize \
+          * only skips those bytes so an older sstable's footer still parses */
 #define SSTABLE_FLAG_DISTINCT_KEYS                                            \
     0x08 /* footer carries an 8-byte distinct_key_count after the chunked-aux \
           * descriptor (or after tombstone_count when it is absent) and       \
           * before the trailing checksum. always set for sstables produced by \
           * this build; absent on older sstables, whose count reads UNKNOWN */
+#define SSTABLE_FLAG_BLOCKED_AUX                                             \
+    0x10 /* footer carries a 32-byte blocked-aux directory descriptor (bloom \
+          * dir offset+size, index dir offset+size) after the distinct-key   \
+          * count. present when the bloom filter and block index use the     \
+          * paged blocked-aux format; an older sstable without it has no     \
+          * resident aux and reads by full scan until compaction rewrites it */
 
 /**
  * sstable_metadata_serialize
@@ -2476,14 +2418,14 @@ static int sstable_metadata_serialize(tidesdb_sstable_t *sst, uint8_t **out_data
 
     const size_t tombstone_meta_size = TDB_SSTABLE_METADATA_TOMBSTONE_SIZE;
 
-    const size_t chunked_aux_size = sst->aux_chunked ? TDB_SSTABLE_METADATA_CHUNKED_AUX_SIZE : 0;
-
     /* this build always records the distinct-key count */
     const size_t distinct_keys_size = TDB_SSTABLE_METADATA_DISTINCT_KEYS_SIZE;
 
+    const size_t blocked_aux_size = sst->blocked_aux ? TDB_SSTABLE_METADATA_BLOCKED_AUX_SIZE : 0;
+
     const size_t total_size = header_size + sst->min_key_size + sst->max_key_size +
-                              btree_meta_size + tombstone_meta_size + chunked_aux_size +
-                              distinct_keys_size + checksum_size;
+                              btree_meta_size + tombstone_meta_size + distinct_keys_size +
+                              blocked_aux_size + checksum_size;
 
     uint8_t *data = malloc(total_size);
     if (!data) return -1;
@@ -2521,9 +2463,9 @@ static int sstable_metadata_serialize(tidesdb_sstable_t *sst, uint8_t **out_data
     {
         flags |= SSTABLE_FLAG_BTREE;
     }
-    if (sst->aux_chunked)
+    if (sst->blocked_aux)
     {
-        flags |= SSTABLE_FLAG_CHUNKED_AUX;
+        flags |= SSTABLE_FLAG_BLOCKED_AUX;
     }
     encode_uint32_le_compat(ptr, flags);
     ptr += 4;
@@ -2557,22 +2499,22 @@ static int sstable_metadata_serialize(tidesdb_sstable_t *sst, uint8_t **out_data
     encode_uint64_le_compat(ptr, sst->tombstone_count);
     ptr += 8;
 
-    /* chunked-aux descriptor (only when SSTABLE_FLAG_CHUNKED_AUX is set) */
-    if (sst->aux_chunked)
-    {
-        encode_uint64_le_compat(ptr, sst->bloom_blob_offset);
-        ptr += 8;
-        encode_uint64_le_compat(ptr, sst->bloom_blob_size);
-        ptr += 8;
-        encode_uint64_le_compat(ptr, sst->index_blob_offset);
-        ptr += 8;
-        encode_uint64_le_compat(ptr, sst->index_blob_size);
-        ptr += 8;
-    }
-
     /* distinct-key count (SSTABLE_FLAG_DISTINCT_KEYS always set by this build) */
     encode_uint64_le_compat(ptr, sst->distinct_key_count);
     ptr += 8;
+
+    /* blocked-aux directory descriptor (only when SSTABLE_FLAG_BLOCKED_AUX is set) */
+    if (sst->blocked_aux)
+    {
+        encode_uint64_le_compat(ptr, sst->bloom_dir_offset);
+        ptr += 8;
+        encode_uint64_le_compat(ptr, sst->bloom_dir_size);
+        ptr += 8;
+        encode_uint64_le_compat(ptr, sst->index_dir_offset);
+        ptr += 8;
+        encode_uint64_le_compat(ptr, sst->index_dir_size);
+        ptr += 8;
+    }
 
     /* we compute and append checksum over everything except the checksum field itself */
     const size_t checksum_data_size = total_size - checksum_size;
@@ -2640,6 +2582,7 @@ static int sstable_metadata_deserialize(const uint8_t *data, const size_t data_s
     const int has_tombstone_count = (flags & SSTABLE_FLAG_TOMBSTONE_COUNT) ? 1 : 0;
     const int has_chunked_aux = (flags & SSTABLE_FLAG_CHUNKED_AUX) ? 1 : 0;
     const int has_distinct_keys = (flags & SSTABLE_FLAG_DISTINCT_KEYS) ? 1 : 0;
+    const int has_blocked_aux = (flags & SSTABLE_FLAG_BLOCKED_AUX) ? 1 : 0;
 
     /* we calculate expected size based on which optional sections the flags promise */
     size_t btree_meta_size = 0;
@@ -2657,9 +2600,11 @@ static int sstable_metadata_deserialize(const uint8_t *data, const size_t data_s
     const size_t distinct_keys_size =
         has_distinct_keys ? TDB_SSTABLE_METADATA_DISTINCT_KEYS_SIZE : 0;
 
+    const size_t blocked_aux_size = has_blocked_aux ? TDB_SSTABLE_METADATA_BLOCKED_AUX_SIZE : 0;
+
     const size_t expected_size = TDB_SSTABLE_METADATA_FIXED_SIZE + min_key_size + max_key_size +
                                  btree_meta_size + tombstone_meta_size + chunked_aux_size +
-                                 distinct_keys_size;
+                                 distinct_keys_size + blocked_aux_size;
     if (data_size != expected_size)
     {
         TDB_DEBUG_LOG(TDB_LOG_FATAL, "SSTable metadata size mismatch (expected: %zu, got: %zu)",
@@ -2762,19 +2707,9 @@ static int sstable_metadata_deserialize(const uint8_t *data, const size_t data_s
 
     if (has_chunked_aux)
     {
-        sst->aux_chunked = 1;
-        sst->bloom_blob_offset = decode_uint64_le_compat(ptr);
-        ptr += 8;
-        sst->bloom_blob_size = decode_uint64_le_compat(ptr);
-        ptr += 8;
-        sst->index_blob_offset = decode_uint64_le_compat(ptr);
-        ptr += 8;
-        sst->index_blob_size = decode_uint64_le_compat(ptr);
-        ptr += 8;
-    }
-    else
-    {
-        sst->aux_chunked = 0;
+        /* skip a pre-blocked-format chunked-aux descriptor; such an sstable has no paged readers
+         * and reads by full scan until compaction rewrites it in the blocked format */
+        ptr += TDB_SSTABLE_METADATA_CHUNKED_AUX_SIZE;
     }
 
     if (has_distinct_keys)
@@ -2785,6 +2720,23 @@ static int sstable_metadata_deserialize(const uint8_t *data, const size_t data_s
     else
     {
         sst->distinct_key_count = TDB_DISTINCT_KEYS_UNKNOWN;
+    }
+
+    if (has_blocked_aux)
+    {
+        sst->blocked_aux = 1;
+        sst->bloom_dir_offset = decode_uint64_le_compat(ptr);
+        ptr += 8;
+        sst->bloom_dir_size = decode_uint64_le_compat(ptr);
+        ptr += 8;
+        sst->index_dir_offset = decode_uint64_le_compat(ptr);
+        ptr += 8;
+        sst->index_dir_size = decode_uint64_le_compat(ptr);
+        ptr += 8;
+    }
+    else
+    {
+        sst->blocked_aux = 0;
     }
 
     return 0;
@@ -2944,8 +2896,6 @@ tidesdb_column_family_config_t tidesdb_default_column_family_config(void)
         .enable_bloom_filter = 1,
         .bloom_fpr = TDB_DEFAULT_BLOOM_FPR,
         .enable_block_indexes = 1,
-        .index_sample_ratio = TDB_DEFAULT_INDEX_SAMPLE_RATIO,
-        .block_index_prefix_len = TDB_DEFAULT_BLOCK_INDEX_PREFIX_LEN,
         .sync_mode = TDB_SYNC_NONE,
         .sync_interval_us = TDB_DEFAULT_SYNC_INTERVAL_US,
         .comparator_fn_cached = NULL,
@@ -6894,8 +6844,8 @@ static void tidesdb_sstable_free(tidesdb_sstable_t *sst)
     free(sst->max_key);
     free(sst->config);
 
-    if (sst->bloom_filter) bloom_filter_free(sst->bloom_filter);
-    if (sst->block_indexes) compact_block_index_free(sst->block_indexes);
+    blocked_bloom_reader_free(sst->bloom_reader);
+    blocked_index_reader_free(sst->index_reader);
 
     free(sst);
 }
@@ -7723,21 +7673,17 @@ static int tidesdb_write_vlog_entry(const tidesdb_sstable_t *sst, block_manager_
  * @param sst sstable
  * @param klog_bm klog block manager
  * @param block klog block to flush
- * @param block_indexes optional block index to update
+ * @param index_builder optional blocked block index builder to record this block in
  * @param block_first_key first key in block
  * @param block_first_key_size size of first key
- * @param block_last_key last key in block
- * @param block_last_key_size size of last key
  * @param klog_block_num block counter (incremented on success)
  * @return TDB_SUCCESS on success, error code on failure
  */
 static int tidesdb_flush_klog_block(const tidesdb_sstable_t *sst, block_manager_t *klog_bm,
                                     tidesdb_klog_block_t *block,
-                                    tidesdb_block_index_t *block_indexes,
+                                    blocked_index_builder_t *index_builder,
                                     const uint8_t *block_first_key,
-                                    const size_t block_first_key_size,
-                                    const uint8_t *block_last_key, const size_t block_last_key_size,
-                                    uint64_t *klog_block_num)
+                                    const size_t block_first_key_size, uint64_t *klog_block_num)
 {
     if (block->num_entries == 0) return TDB_SUCCESS;
 
@@ -7783,14 +7729,11 @@ static int tidesdb_flush_klog_block(const tidesdb_sstable_t *sst, block_manager_
     block_manager_block_write(klog_bm, klog_block);
     block_manager_block_release(klog_block);
 
-    /* we add to index if enabled and sampling matches */
-    if (block_indexes && block_first_key && block_last_key)
+    /* record every block by its first key so a lookup routes to exactly one block */
+    if (block_first_key)
     {
-        if (*klog_block_num % sst->config->index_sample_ratio == 0)
-        {
-            compact_block_index_add(block_indexes, block_first_key, block_first_key_size,
-                                    block_last_key, block_last_key_size, block_file_position);
-        }
+        blocked_index_builder_add(index_builder, block_first_key, block_first_key_size,
+                                  block_file_position);
     }
 
     (*klog_block_num)++;
@@ -7799,227 +7742,230 @@ static int tidesdb_flush_klog_block(const tidesdb_sstable_t *sst, block_manager_
 }
 
 /**
- * tidesdb_sstable_write_aux_blob
- * writes a footer aux blob (serialized bloom filter or block index) as one or
- * more consecutive blocks, each at most TDB_AUX_BLOCK_CHUNK_MAX bytes, so no
- * single block exceeds the block manager's framing/read limits regardless of
- * total blob size. a blob at or below the chunk size is written as exactly one
- * block (identical on-disk layout to the pre-chunking single-block writes).
- * @param bm klog block manager
- * @param data blob bytes (size > 0)
- * @param size blob size in bytes
- * @param out_offset receives the offset of the first chunk
- * @return TDB_SUCCESS, or TDB_ERR_IO on a write failure
+ * tidesdb_blocked_aux_write
+ * write sink for the blocked bloom and block index builders. each finalized partition, leaf, or
+ * directory is appended to the klog as one block after the sstable's data blocks; the returned
+ * offset is recorded in the directory and, for a top-level directory, in the sstable footer.
+ * @param ctx the klog block manager
+ * @param data blob bytes
+ * @param size blob length
+ * @param out_offset receives the block's file offset
+ * @return 0 on success, -1 on a write failure
  */
-static int tidesdb_sstable_write_aux_blob(block_manager_t *bm, const uint8_t *data, uint64_t size,
-                                          uint64_t *out_offset)
+static int tidesdb_blocked_aux_write(void *ctx, const uint8_t *data, size_t size,
+                                     uint64_t *out_offset)
 {
-    if (!bm || !data || size == 0 || !out_offset) return TDB_ERR_INVALID_ARGS;
+    block_manager_t *bm = (block_manager_t *)ctx;
+    block_manager_block_t *blk = block_manager_block_create(size, data);
+    if (!blk) return -1;
+    const int64_t off = block_manager_block_write(bm, blk);
+    block_manager_block_release(blk);
+    if (off < 0) return -1;
+    *out_offset = (uint64_t)off;
+    return 0;
+}
 
-    int64_t start = -1;
-    uint64_t written = 0;
-    while (written < size)
+/* the fetch pin is a clock-cache entry (bit 0 clear, heap-aligned) or, when no cache holds the
+ * blob, the block-manager block read directly (low bit set so release frees the right kind) */
+#define TDB_AUX_PIN_BLOCK_TAG ((uintptr_t)1)
+
+/**
+ * tidesdb_blocked_aux_fetch
+ * read source for the blocked bloom and block index readers. serves a partition, leaf, or directory
+ * blob by its klog block offset, pinned through the block cache so a hot aux blob stays resident
+ * and is evicted under the cache budget. on a cache miss it reads the block from the sstable's
+ * klog, populates the cache, and re-pins from it; with no cache it hands back the block itself.
+ * @param ctx the sstable (tidesdb_sstable_t *)
+ * @param offset klog offset of the blob's block
+ * @param size expected blob length
+ * @param out_data receives the blob bytes, valid until release
+ * @param out_pin receives the pin to hand to release
+ * @return 0 on success, -1 on failure (treated by the reader as may-be-present / full scan)
+ */
+static int tidesdb_blocked_aux_fetch(void *ctx, uint64_t offset, uint32_t size,
+                                     const uint8_t **out_data, void **out_pin)
+{
+    tidesdb_sstable_t *sst = (tidesdb_sstable_t *)ctx;
+    tidesdb_t *db = sst->db;
+    const int cacheable =
+        db && db->clock_cache && sst->cf_name[0] != '\0' && sst->klog_filename != NULL;
+
+    if (cacheable)
     {
-        const uint64_t remaining = size - written;
-        const uint64_t chunk =
-            (remaining > TDB_AUX_BLOCK_CHUNK_MAX) ? TDB_AUX_BLOCK_CHUNK_MAX : remaining;
-        block_manager_block_t *blk = block_manager_block_create(chunk, data + written);
-        if (!blk) return TDB_ERR_IO;
-        const int64_t off = block_manager_block_write(bm, blk);
-        block_manager_block_release(blk);
-        if (off < 0) return TDB_ERR_IO;
-        if (start < 0) start = off;
-        written += chunk;
+        size_t sz = 0;
+        clock_cache_entry_t *entry = NULL;
+        const uint8_t *data = tidesdb_cache_raw_block_get_pinned(
+            db, sst->cf_name, sst->klog_filename, offset, &sz, &entry);
+        if (data && sz == size)
+        {
+            *out_data = data;
+            *out_pin = entry;
+            return 0;
+        }
+        if (data) clock_cache_release(entry);
     }
 
-    *out_offset = (uint64_t)start;
-    return TDB_SUCCESS;
+    block_manager_t *klog_bm = atomic_load_explicit(&sst->klog_bm, memory_order_acquire);
+    if (!klog_bm) return -1;
+
+    block_manager_cursor_t *cur = NULL;
+    if (block_manager_cursor_init(&cur, klog_bm) != 0) return -1;
+    if (block_manager_cursor_goto(cur, offset) != 0)
+    {
+        block_manager_cursor_free(cur);
+        return -1;
+    }
+    block_manager_block_t *blk = block_manager_cursor_read(cur);
+    block_manager_cursor_free(cur);
+    if (!blk) return -1;
+    if (blk->size != size)
+    {
+        block_manager_block_release(blk);
+        return -1;
+    }
+
+    if (cacheable)
+    {
+        /* populate the cache and re-pin from it so the pin is a uniform cache entry */
+        tidesdb_cache_raw_block_put(db, sst->cf_name, sst->klog_filename, offset, blk->data,
+                                    blk->size);
+        size_t sz = 0;
+        clock_cache_entry_t *entry = NULL;
+        const uint8_t *data = tidesdb_cache_raw_block_get_pinned(
+            db, sst->cf_name, sst->klog_filename, offset, &sz, &entry);
+        if (data && sz == size)
+        {
+            block_manager_block_release(blk);
+            *out_data = data;
+            *out_pin = entry;
+            return 0;
+        }
+        if (data) clock_cache_release(entry);
+    }
+
+    *out_data = blk->data;
+    *out_pin = (void *)((uintptr_t)blk | TDB_AUX_PIN_BLOCK_TAG);
+    return 0;
 }
 
 /**
- * tidesdb_sstable_read_aux_blob
- * reassembles a chunked footer aux blob into a single buffer by reading
- * consecutive blocks starting at offset until total bytes are gathered. refuses
- * (NULL + warning, not a crash) if total exceeds the database memory-safety
- * budget so a corrupt or pathological size cannot drive the process into OOM.
- * @param db database (for the memory budget)
- * @param bm klog block manager
- * @param offset offset of the first chunk
- * @param total total logical blob size in bytes
- * @return malloc'd buffer of `total` bytes (caller frees), or NULL
+ * tidesdb_blocked_aux_release
+ * release a pin returned by tidesdb_blocked_aux_fetch.
+ * @param ctx unused
+ * @param pin the pin
  */
-static uint8_t *tidesdb_sstable_read_aux_blob(tidesdb_t *db, block_manager_t *bm, uint64_t offset,
-                                              uint64_t total)
+static void tidesdb_blocked_aux_release(void *ctx, void *pin)
 {
-    if (!bm || total == 0) return NULL;
+    (void)ctx;
+    const uintptr_t p = (uintptr_t)pin;
+    if (p & TDB_AUX_PIN_BLOCK_TAG)
+        block_manager_block_release((block_manager_block_t *)(p & ~TDB_AUX_PIN_BLOCK_TAG));
+    else
+        clock_cache_release((clock_cache_entry_t *)pin);
+}
 
-    const size_t budget =
-        db ? atomic_load_explicit(&db->resolved_memory_limit, memory_order_relaxed) : 0;
-    if (budget > 0 && total > (uint64_t)budget / TDB_MEMORY_MAX_BLOCK_FRACTION_DENOM)
+/**
+ * tidesdb_sstable_open_blocked_readers
+ * open the paged blocked bloom filter and block index readers for a blocked-aux sstable from the
+ * directory locators in its footer. a no-op for a non-blocked sstable or one already opened. the
+ * readers page their partitions through the block cache via tidesdb_blocked_aux_fetch, so call this
+ * only once the sstable's klog_bm is published and its comparator resolved.
+ * @param sst the sstable
+ */
+static void tidesdb_sstable_open_blocked_readers(tidesdb_sstable_t *sst)
+{
+    if (!sst || !sst->blocked_aux || !sst->config) return;
+
+    void *cmp_ctx = sst->cached_comparator_ctx;
+
+    if (sst->config->enable_bloom_filter && sst->bloom_dir_size > 0 &&
+        sst->bloom_dir_size <= UINT32_MAX && !sst->bloom_reader)
     {
-        TDB_DEBUG_LOG(TDB_LOG_WARN,
-                      "aux blob of %" PRIu64
-                      " bytes exceeds memory-safety budget (%zu) -- skipping",
-                      total, budget);
-        return NULL;
-    }
-    if (total > SIZE_MAX) return NULL; /* 32-bit host guard */
-
-    uint8_t *buf = malloc((size_t)total);
-    if (!buf) return NULL;
-
-    block_manager_cursor_t *cur = NULL;
-    if (block_manager_cursor_init(&cur, bm) != 0 || block_manager_cursor_goto(cur, offset) != 0)
-    {
-        if (cur) block_manager_cursor_free(cur);
-        free(buf);
-        return NULL;
-    }
-
-    uint64_t got = 0;
-    while (got < total)
-    {
-        block_manager_block_t *blk = block_manager_cursor_read(cur);
-        if (!blk || got + blk->size > total)
-        {
-            if (blk) block_manager_block_release(blk);
-            block_manager_cursor_free(cur);
-            free(buf);
-            return NULL;
-        }
-        memcpy(buf + got, blk->data, blk->size);
-        got += blk->size;
-        block_manager_block_release(blk);
-        if (got < total && block_manager_cursor_next(cur) != 0)
-        {
-            block_manager_cursor_free(cur);
-            free(buf);
-            return NULL;
-        }
+        blocked_bloom_reader_open(&sst->bloom_reader, sst->bloom_dir_offset,
+                                  (uint32_t)sst->bloom_dir_size,
+                                  (blocked_bloom_comparator_fn)sst->cached_comparator_fn, cmp_ctx,
+                                  tidesdb_blocked_aux_fetch, tidesdb_blocked_aux_release, sst);
     }
 
-    block_manager_cursor_free(cur);
-    return buf;
+    if (!sst->config->use_btree && sst->index_dir_size > 0 && sst->index_dir_size <= UINT32_MAX &&
+        !sst->index_reader)
+    {
+        blocked_index_reader_open(&sst->index_reader, sst->index_dir_offset,
+                                  (uint32_t)sst->index_dir_size,
+                                  (blocked_index_comparator_fn)sst->cached_comparator_fn, cmp_ctx,
+                                  tidesdb_blocked_aux_fetch, tidesdb_blocked_aux_release, sst);
+    }
 }
 
 /**
  * tidesdb_sstable_write_footer_aux
- * writes the block index (optional) and bloom filter footer blobs for sst,
- * chunk-aware in that a blob larger than TDB_AUX_BLOCK_CHUNK_MAX is split across
- * consecutive blocks and the chunked-aux descriptor (offset+size) is recorded on
- * sst, so a bloom/index of any size (incl. >4GB) round-trips; a small blob is
- * written as a single block (byte-identical to the legacy footer). ownership of
- * block_indexes and bloom transfers to sst. callers write the metadata block
- * afterward -- metadata serialize reads sst->aux_chunked and the offsets. shared
- * by every flush and merge writer so they all get chunking uniformly.
+ * finalize the blocked bloom filter and block index builders for sst, writing their partitions,
+ * leaves, and top-level directories to the klog after the data blocks and recording the directory
+ * locators on sst. the builders keep only the directories out of the block cache; the partitions
+ * are paged back on demand at read time. callers write the metadata block afterward -- metadata
+ * serialize reads sst->blocked_aux and the directory locators. takes ownership of both builders and
+ * frees them before returning. shared by every flush and merge writer.
  * @param sst sstable being written
- * @param klog_bm klog block manager
- * @param block_indexes block index (NULL -> empty placeholder); used iff write_index
- * @param bloom bloom filter (NULL -> empty placeholder)
- * @param write_index 1 to emit an index block (block format), 0 for btree (bloom only)
+ * @param klog_bm klog block manager (unused directly -- the builders hold it as their write sink)
+ * @param index_builder block index builder (NULL when disabled); finalized iff write_index
+ * @param bloom_builder bloom filter builder (NULL when disabled)
+ * @param write_index 1 to emit the index directory (block format), 0 for btree (bloom only)
  */
 static void tidesdb_sstable_write_footer_aux(tidesdb_sstable_t *sst, block_manager_t *klog_bm,
-                                             tidesdb_block_index_t *block_indexes,
-                                             bloom_filter_t *bloom, int write_index)
+                                             blocked_index_builder_t *index_builder,
+                                             blocked_bloom_builder_t *bloom_builder,
+                                             int write_index)
 {
-    uint64_t index_off = 0;
-    uint64_t bloom_off = 0;
-    size_t index_size = 0;
-    size_t bloom_size = 0;
-    int index_chunked = 0;
+    (void)klog_bm;
 
-    /* index first, then bloom -- matches the legacy trailing-block order
-     * (index, bloom, metadata) used by the non-chunked read path */
-    if (write_index)
+    if (write_index && index_builder)
     {
-        uint8_t index_placeholder[TDB_EMPTY_BLOCK_INDEX_SIZE];
-        uint8_t *index_data = NULL;
-        uint8_t *index_owned = NULL;
-        if (block_indexes)
+        uint64_t dir_off = 0;
+        uint32_t dir_size = 0;
+        if (blocked_index_builder_finish(index_builder, &dir_off, &dir_size, NULL) == 0)
         {
-            sst->block_indexes = block_indexes;
-            index_data = compact_block_index_serialize(block_indexes, &index_size);
-            index_owned = index_data;
+            sst->index_dir_offset = dir_off;
+            sst->index_dir_size = dir_size;
+            sst->blocked_aux = 1;
         }
-        if (!index_data)
+    }
+
+    if (bloom_builder)
+    {
+        uint64_t dir_off = 0;
+        uint32_t dir_size = 0;
+        if (blocked_bloom_builder_finish(bloom_builder, &dir_off, &dir_size, NULL) == 0)
         {
-            encode_uint32_le_compat(index_placeholder, 0);
-            index_placeholder[sizeof(uint32_t)] = TDB_DEFAULT_BLOCK_INDEX_PREFIX_LEN;
-            index_data = index_placeholder;
-            index_size = TDB_EMPTY_BLOCK_INDEX_SIZE;
+            sst->bloom_dir_offset = dir_off;
+            sst->bloom_dir_size = dir_size;
+            sst->blocked_aux = 1;
         }
-        tidesdb_sstable_write_aux_blob(klog_bm, index_data, index_size, &index_off);
-        /* a size_t blob cannot exceed the 4 GB single-block limit on a 32-bit build, so only
-           compare where size_t is wide enough; otherwise index_chunked stays 0 */
-#if SIZE_MAX > UINT32_MAX
-        index_chunked = (index_size > TDB_AUX_BLOCK_CHUNK_MAX);
-#endif
-        free(index_owned);
     }
 
-    uint8_t bloom_placeholder[1] = {0};
-    uint8_t *bloom_data = NULL;
-    uint8_t *bloom_owned = NULL;
-    if (bloom)
-    {
-        bloom_data = bloom_filter_serialize(bloom, &bloom_size);
-        bloom_owned = bloom_data;
-        sst->bloom_filter = bloom;
-    }
-    if (!bloom_data)
-    {
-        bloom_data = bloom_placeholder;
-        bloom_size = 1;
-    }
-    tidesdb_sstable_write_aux_blob(klog_bm, bloom_data, bloom_size, &bloom_off);
-    free(bloom_owned);
-
-    int bloom_chunked = 0;
-#if SIZE_MAX > UINT32_MAX
-    bloom_chunked = (bloom_size > TDB_AUX_BLOCK_CHUNK_MAX);
-#endif
-    if (index_chunked || bloom_chunked)
-    {
-        sst->aux_chunked = 1;
-        sst->index_blob_offset = write_index ? index_off : 0;
-        sst->index_blob_size = write_index ? index_size : 0;
-        sst->bloom_blob_offset = bloom_off;
-        sst->bloom_blob_size = bloom_size;
-        TDB_DEBUG_LOG(TDB_LOG_INFO,
-                      "SSTable %" PRIu64 " footer aux chunked (index %zu B, bloom %zu B)", sst->id,
-                      write_index ? index_size : (size_t)0, bloom_size);
-    }
+    blocked_index_builder_free(index_builder);
+    blocked_bloom_builder_free(bloom_builder);
 }
 
 /**
  * tidesdb_sstable_write_footer
- * write index, bloom filter, and metadata blocks to klog
- * @param sst sstable (block_indexes and bloom_filter assigned here)
+ * write the blocked bloom filter, block index, and metadata blocks to klog
+ * @param sst sstable being written
  * @param klog_bm klog block manager
  * @param vlog_bm vlog block manager
- * @param block_indexes block indexes (ownership transferred to sst)
- * @param bloom bloom filter (ownership transferred to sst)
+ * @param index_builder block index builder (finalized here)
+ * @param bloom_builder bloom filter builder (finalized here)
  * @return TDB_SUCCESS on success
  */
 static int tidesdb_sstable_write_footer(tidesdb_sstable_t *sst, block_manager_t *klog_bm,
                                         block_manager_t *vlog_bm,
-                                        tidesdb_block_index_t *block_indexes, bloom_filter_t *bloom)
+                                        blocked_index_builder_t *index_builder,
+                                        blocked_bloom_builder_t *bloom_builder)
 {
     /* we capture klog file offset where data blocks end */
     block_manager_get_size(klog_bm, &sst->klog_data_end_offset);
 
-    /* we write index block */
-    if (block_indexes)
-    {
-        TDB_DEBUG_LOG(TDB_LOG_INFO,
-                      "SSTable " TDB_U64_FMT " block indexes built - %" PRIu32
-                      " samples, " TDB_U64_FMT " total blocks",
-                      TDB_U64_CAST(sst->id), block_indexes->count,
-                      TDB_U64_CAST(sst->num_klog_blocks));
-    }
-
-    /* write the index + bloom footer blobs (chunk-aware, shared with the merge writers) */
-    tidesdb_sstable_write_footer_aux(sst, klog_bm, block_indexes, bloom, 1);
+    /* finalize the blocked index + bloom directories after the data blocks (block format) */
+    tidesdb_sstable_write_footer_aux(sst, klog_bm, index_builder, bloom_builder, 1);
 
     /* we write metadata block */
     uint64_t klog_size_before_metadata;
@@ -8117,14 +8063,15 @@ static int tidesdb_sstable_write_from_memtable_btree_ex(tidesdb_t *db, tidesdb_c
         return TDB_ERR_MEMORY;
     }
 
-    /* we create bloom filter if enabled */
-    bloom_filter_t *bloom = NULL;
+    /* we create the bloom filter builder if enabled */
+    blocked_bloom_builder_t *bloom_builder = NULL;
     if (sst->config->enable_bloom_filter)
     {
-        if (bloom_filter_new(&bloom, sst->config->bloom_fpr, num_entries) != 0)
+        if (blocked_bloom_builder_new(&bloom_builder, sst->config->bloom_fpr, 0,
+                                      tidesdb_blocked_aux_write, klog_bm) != 0)
         {
-            TDB_DEBUG_LOG(TDB_LOG_ERROR, "SSTable %" PRIu64 " failed to create bloom filter",
-                          sst->id);
+            TDB_DEBUG_LOG(TDB_LOG_ERROR,
+                          "SSTable %" PRIu64 " failed to create bloom filter builder", sst->id);
             btree_builder_free(builder);
             return TDB_ERR_MEMORY;
         }
@@ -8134,7 +8081,7 @@ static int tidesdb_sstable_write_from_memtable_btree_ex(tidesdb_t *db, tidesdb_c
     skip_list_cursor_t *cursor = NULL;
     if (skip_list_cursor_init(&cursor, memtable) != 0)
     {
-        if (bloom) bloom_filter_free(bloom);
+        blocked_bloom_builder_free(bloom_builder);
         btree_builder_free(builder);
         return TDB_ERR_MEMORY;
     }
@@ -8252,17 +8199,14 @@ static int tidesdb_sstable_write_from_memtable_btree_ex(tidesdb_t *db, tidesdb_c
                  * wal is retained, rather than committing a btree with a dropped committed key */
                 TDB_DEBUG_LOG(TDB_LOG_ERROR, "SSTable %" PRIu64 " failed to add entry to btree",
                               sst->id);
-                if (bloom) bloom_filter_free(bloom);
+                blocked_bloom_builder_free(bloom_builder);
                 btree_builder_free(builder);
                 tidesdb_distinct_counter_free(&distinct);
                 return TDB_ERR_MEMORY;
             }
 
-            /* we add to bloom filter */
-            if (bloom)
-            {
-                bloom_filter_add(bloom, key, key_size);
-            }
+            /* we add to the bloom filter builder */
+            blocked_bloom_builder_add(bloom_builder, key, key_size);
 
             if (seq > max_seq) max_seq = seq;
             entry_count++;
@@ -8283,7 +8227,7 @@ static int tidesdb_sstable_write_from_memtable_btree_ex(tidesdb_t *db, tidesdb_c
     {
         TDB_DEBUG_LOG(TDB_LOG_INFO, "CF '%s' aborting btree flush write for SSTable %" PRIu64,
                       cf->name, sst->id);
-        if (bloom) bloom_filter_free(bloom);
+        blocked_bloom_builder_free(bloom_builder);
         btree_builder_free(builder);
         tidesdb_distinct_counter_free(&distinct);
         return TDB_SUCCESS;
@@ -8294,7 +8238,7 @@ static int tidesdb_sstable_write_from_memtable_btree_ex(tidesdb_t *db, tidesdb_c
     if (btree_builder_finish(builder, &tree) != 0)
     {
         TDB_DEBUG_LOG(TDB_LOG_ERROR, "SSTable %" PRIu64 " failed to finish btree", sst->id);
-        if (bloom) bloom_filter_free(bloom);
+        blocked_bloom_builder_free(bloom_builder);
         btree_builder_free(builder);
         tidesdb_distinct_counter_free(&distinct);
         return TDB_ERR_IO;
@@ -8336,8 +8280,8 @@ static int tidesdb_sstable_write_from_memtable_btree_ex(tidesdb_t *db, tidesdb_c
     btree_builder_free(builder);
     tidesdb_distinct_counter_free(&distinct);
 
-    /* write the bloom footer blob (chunk-aware, no index block in btree format) */
-    tidesdb_sstable_write_footer_aux(sst, klog_bm, NULL, bloom, 0);
+    /* finalize the bloom directory (btree format has no block index) */
+    tidesdb_sstable_write_footer_aux(sst, klog_bm, NULL, bloom_builder, 0);
 
     uint64_t klog_size_before_metadata;
     uint64_t vlog_size_before_metadata;
@@ -8413,14 +8357,14 @@ static uint64_t tidesdb_cf_oldest_unflushed_seq(tidesdb_column_family_t *cf)
  * @param heap merge heap containing entries
  * @param klog_bm klog block manager (already open)
  * @param vlog_bm vlog block manager (already open)
- * @param bloom bloom filter (optional, may be NULL)
+ * @param bloom_builder bloom filter builder (optional, may be NULL)
  * @param sstables_to_delete queue for corrupted sstables
  * @param is_largest_level whether this is the largest level
  * @return 0 on success, error code on failure
  */
 static int tidesdb_sstable_write_from_heap_btree(
     tidesdb_column_family_t *cf, tidesdb_sstable_t *sst, tidesdb_merge_heap_t *heap,
-    block_manager_t *klog_bm, block_manager_t *vlog_bm, bloom_filter_t *bloom,
+    block_manager_t *klog_bm, block_manager_t *vlog_bm, blocked_bloom_builder_t *bloom_builder,
     queue_t *sstables_to_delete, const int is_largest_level, const uint8_t *range_start,
     size_t range_start_size, const uint8_t *range_end, size_t range_end_size,
     uint64_t oldest_unflushed_seq)
@@ -8553,10 +8497,7 @@ static int tidesdb_sstable_write_from_heap_btree(
 
             if (!sd_pair_drop && !tombstone_drop && !ttl_drop)
             {
-                if (bloom)
-                {
-                    bloom_filter_add(bloom, pending->key, pending->entry.key_size);
-                }
+                blocked_bloom_builder_add(bloom_builder, pending->key, pending->entry.key_size);
 
                 uint64_t vlog_offset = 0;
                 if (pending->entry.value_size >= cf->config.klog_value_threshold && pending->value)
@@ -8675,8 +8616,8 @@ static int tidesdb_sstable_write_from_heap_btree(
     block_manager_get_size(klog_bm, &sst->klog_size);
     block_manager_get_size(vlog_bm, &sst->vlog_size);
 
-    /* write the bloom footer blob (chunk-aware, no index block in btree format) */
-    tidesdb_sstable_write_footer_aux(sst, klog_bm, NULL, bloom, 0);
+    /* finalize the bloom directory (btree format has no block index) */
+    tidesdb_sstable_write_footer_aux(sst, klog_bm, NULL, bloom_builder, 0);
 
     uint8_t *metadata = NULL;
     size_t metadata_size = 0;
@@ -8753,10 +8694,10 @@ static int tidesdb_sstable_write_from_memtable_ex(tidesdb_t *db, tidesdb_column_
         return TDB_ERR_IO;
     }
 
-    /* we create bloom filter and block indexes */
+    /* we create the blocked bloom filter and block index builders */
     int result = TDB_SUCCESS;
-    bloom_filter_t *bloom = NULL;
-    tidesdb_block_index_t *block_indexes = NULL;
+    blocked_bloom_builder_t *bloom_builder = NULL;
+    blocked_index_builder_t *index_builder = NULL;
     /* distinct key counter declared before the first goto cleanup so every cleanup path frees an
      * initialized counter */
     tidesdb_distinct_counter_t distinct;
@@ -8766,7 +8707,6 @@ static int tidesdb_sstable_write_from_memtable_ex(tidesdb_t *db, tidesdb_column_
     uint8_t *first_key = NULL;
     uint8_t *last_key = NULL;
     uint8_t *block_first_key = NULL;
-    uint8_t *block_last_key = NULL;
 
     /* we resolve comparator once for the entire flush operation */
     skip_list_comparator_fn comparator_fn = NULL;
@@ -8775,15 +8715,15 @@ static int tidesdb_sstable_write_from_memtable_ex(tidesdb_t *db, tidesdb_column_
 
     if (sst->config->enable_bloom_filter)
     {
-        if (bloom_filter_new(&bloom, sst->config->bloom_fpr, num_entries) != 0)
+        if (blocked_bloom_builder_new(&bloom_builder, sst->config->bloom_fpr, 0,
+                                      tidesdb_blocked_aux_write, bms.klog_bm) != 0)
         {
-            TDB_DEBUG_LOG(TDB_LOG_ERROR, "SSTable %" PRIu64 " failed to create bloom filter",
-                          sst->id);
+            TDB_DEBUG_LOG(TDB_LOG_ERROR,
+                          "SSTable %" PRIu64 " failed to create bloom filter builder", sst->id);
             return TDB_ERR_MEMORY;
         }
-        TDB_DEBUG_LOG(TDB_LOG_INFO,
-                      "SSTable %" PRIu64 " bloom filter created (fpr: %.4f, entries: %d)", sst->id,
-                      sst->config->bloom_fpr, num_entries);
+        TDB_DEBUG_LOG(TDB_LOG_INFO, "SSTable %" PRIu64 " bloom filter builder created (fpr: %.4f)",
+                      sst->id, sst->config->bloom_fpr);
     }
     else
     {
@@ -8792,18 +8732,15 @@ static int tidesdb_sstable_write_from_memtable_ex(tidesdb_t *db, tidesdb_column_
 
     if (sst->config->enable_block_indexes && !sst->config->use_btree)
     {
-        uint32_t initial_capacity = (num_entries / sst->config->index_sample_ratio) + 1;
-        block_indexes = compact_block_index_create(
-            initial_capacity, sst->config->block_index_prefix_len, comparator_fn, comparator_ctx);
-        if (!block_indexes)
+        if (blocked_index_builder_new(&index_builder, 0, tidesdb_blocked_aux_write, bms.klog_bm) !=
+            0)
         {
-            TDB_DEBUG_LOG(TDB_LOG_ERROR, "SSTable %" PRIu64 " failed to create block indexes",
+            TDB_DEBUG_LOG(TDB_LOG_ERROR, "SSTable %" PRIu64 " failed to create block index builder",
                           sst->id);
             result = TDB_ERR_MEMORY;
             goto cleanup;
         }
-        TDB_DEBUG_LOG(TDB_LOG_INFO, "SSTable %" PRIu64 " block indexes enabled (sample ratio: %d)",
-                      sst->id, sst->config->index_sample_ratio);
+        TDB_DEBUG_LOG(TDB_LOG_INFO, "SSTable %" PRIu64 " block index builder enabled", sst->id);
     }
     else
     {
@@ -8833,7 +8770,6 @@ static int tidesdb_sstable_write_from_memtable_ex(tidesdb_t *db, tidesdb_column_
     uint64_t tombstone_count = 0;
     uint64_t max_seq = 0;
     size_t block_first_key_size = 0;
-    size_t block_last_key_size = 0;
 
     /* seek into the cf's prefix run for a unified segment, else start at the first key */
     const int positioned = seg_prefix
@@ -8842,7 +8778,6 @@ static int tidesdb_sstable_write_from_memtable_ex(tidesdb_t *db, tidesdb_column_
     if (positioned)
     {
         size_t block_first_key_capacity = 0;
-        size_t block_last_key_capacity = 0;
         size_t first_key_capacity = 0;
         size_t last_key_capacity = 0;
         /* we use stack-allocated KV pair to avoid malloc/free per entry */
@@ -8954,25 +8889,12 @@ static int tidesdb_sstable_write_from_memtable_ex(tidesdb_t *db, tidesdb_column_
                     }
                 }
 
-                /* we reuse block_last_key buffer with capacity tracking */
-                if (key_size > block_last_key_capacity)
-                {
-                    free(block_last_key);
-                    block_last_key = malloc(key_size);
-                    block_last_key_capacity = block_last_key ? key_size : 0;
-                }
-                if (block_last_key)
-                {
-                    memcpy(block_last_key, key, key_size);
-                    block_last_key_size = key_size;
-                }
-
                 /* we flush full klog block */
                 if (tidesdb_klog_block_is_full(current_klog_block, TDB_KLOG_BLOCK_SIZE))
                 {
-                    result = tidesdb_flush_klog_block(
-                        sst, bms.klog_bm, current_klog_block, block_indexes, block_first_key,
-                        block_first_key_size, block_last_key, block_last_key_size, &klog_block_num);
+                    result = tidesdb_flush_klog_block(sst, bms.klog_bm, current_klog_block,
+                                                      index_builder, block_first_key,
+                                                      block_first_key_size, &klog_block_num);
                     if (result != TDB_SUCCESS)
                     {
                         TDB_DEBUG_LOG(TDB_LOG_ERROR, "SSTable %" PRIu64 " klog block flush failed",
@@ -8982,15 +8904,14 @@ static int tidesdb_sstable_write_from_memtable_ex(tidesdb_t *db, tidesdb_column_
 
                     tidesdb_klog_block_reset(current_klog_block);
 
-                    /* we reset sizes but keep buffers for reuse */
+                    /* we reset the size but keep the buffer for reuse */
                     block_first_key_size = 0;
-                    block_last_key_size = 0;
                 }
 
                 /* we track max sequence */
                 if (seq > max_seq) max_seq = seq;
 
-                if (bloom) bloom_filter_add(bloom, key, key_size);
+                blocked_bloom_builder_add(bloom_builder, key, key_size);
 
                 /* we reuse first_key buffer with capacity tracking */
                 if (first_key_size == 0)
@@ -9038,9 +8959,8 @@ static int tidesdb_sstable_write_from_memtable_ex(tidesdb_t *db, tidesdb_column_
     /* we flush remaining klog block */
     if (current_klog_block && current_klog_block->num_entries > 0)
     {
-        result = tidesdb_flush_klog_block(sst, bms.klog_bm, current_klog_block, block_indexes,
-                                          block_first_key, block_first_key_size, block_last_key,
-                                          block_last_key_size, &klog_block_num);
+        result = tidesdb_flush_klog_block(sst, bms.klog_bm, current_klog_block, index_builder,
+                                          block_first_key, block_first_key_size, &klog_block_num);
         if (result != TDB_SUCCESS)
         {
             TDB_DEBUG_LOG(TDB_LOG_ERROR, "SSTable %" PRIu64 " final klog block flush failed",
@@ -9050,9 +8970,7 @@ static int tidesdb_sstable_write_from_memtable_ex(tidesdb_t *db, tidesdb_column_
     }
 
     free(block_first_key);
-    free(block_last_key);
     block_first_key = NULL;
-    block_last_key = NULL;
 
     tidesdb_klog_block_free(current_klog_block);
     current_klog_block = NULL;
@@ -9074,11 +8992,12 @@ static int tidesdb_sstable_write_from_memtable_ex(tidesdb_t *db, tidesdb_column_
     last_key = NULL;
 
     /* we write footer (index, bloom, metadata) */
-    result = tidesdb_sstable_write_footer(sst, bms.klog_bm, bms.vlog_bm, block_indexes, bloom);
+    result =
+        tidesdb_sstable_write_footer(sst, bms.klog_bm, bms.vlog_bm, index_builder, bloom_builder);
 
-    /* ownership transferred to sst via footer */
-    block_indexes = NULL;
-    bloom = NULL;
+    /* the footer finalized and freed the builders */
+    index_builder = NULL;
+    bloom_builder = NULL;
 
     tidesdb_distinct_counter_free(&distinct);
     return result;
@@ -9087,12 +9006,11 @@ cleanup:
     tidesdb_distinct_counter_free(&distinct);
     if (cursor) skip_list_cursor_free(cursor);
     if (current_klog_block) tidesdb_klog_block_free(current_klog_block);
-    if (bloom) bloom_filter_free(bloom);
-    if (block_indexes) compact_block_index_free(block_indexes);
+    blocked_bloom_builder_free(bloom_builder);
+    blocked_index_builder_free(index_builder);
     free(first_key);
     free(last_key);
     free(block_first_key);
-    free(block_last_key);
     return result;
 }
 
@@ -9166,10 +9084,10 @@ static int tidesdb_sstable_get_btree(tidesdb_t *db, tidesdb_sstable_t *sst, cons
         if (min_cmp < 0 || max_cmp > 0) return TDB_ERR_NOT_FOUND;
     }
 
-    if (sst->bloom_filter)
+    if (sst->bloom_reader)
     {
         PROFILE_INC(db, bloom_checks);
-        if (!bloom_filter_contains(sst->bloom_filter, key, key_size))
+        if (blocked_bloom_reader_maybe_contains(sst->bloom_reader, key, key_size) == 0)
         {
             return TDB_ERR_NOT_FOUND;
         }
@@ -9347,10 +9265,10 @@ static int tidesdb_sstable_get(tidesdb_t *db, tidesdb_sstable_t *sst, const uint
     /* we check bloom filter for early exit (after range check since bloom is more expensive).
      * skip_bloom is set when boundary search at L1+ already identified this sstable,
      * making the bloom check redundant. */
-    if (sst->bloom_filter && !skip_bloom)
+    if (sst->bloom_reader && !skip_bloom)
     {
         PROFILE_INC(db, bloom_checks);
-        if (!bloom_filter_contains(sst->bloom_filter, key, key_size))
+        if (blocked_bloom_reader_maybe_contains(sst->bloom_reader, key, key_size) == 0)
         {
             return TDB_ERR_NOT_FOUND;
         }
@@ -9361,32 +9279,23 @@ static int tidesdb_sstable_get(tidesdb_t *db, tidesdb_sstable_t *sst, const uint
     const char *cf_name = sst->cf_name;
     const int has_cf_name = (cf_name[0] != '\0');
 
-    /* we utilize block indexes to find the target klog block.
-     * when block index covers all blocks (index_sample_ratio == 1), we do a
-     * single-block lookup -- no scan loop needed. this eliminates the O(N) scan
-     * that was the #1 source of slow reads (each scanned block triggers decompress
-     * + deserialize + cache_put). */
+    /* we utilize the block index to find the target klog block. the blocked index covers every
+     * block, so a lookup is a single-block position -- no scan loop needed. this eliminates the
+     * O(N) scan that was the #1 source of slow reads (each scanned block triggers decompress +
+     * deserialize + cache_put). */
     uint64_t start_file_position = 0;
     int block_index_definitive = 0;
     uint64_t block_index_run_len = 0;
-    if (sst->block_indexes && sst->block_indexes->count > 0)
+    if (sst->index_reader)
     {
-        int64_t start_slot = 0;
-        if (compact_block_index_find_slot(sst->block_indexes, key, key_size, &start_slot) == 0)
+        /* the blocked index stores full block first-keys, so a lookup routes to exactly one
+         * candidate block -- there is no lossy prefix run, and a hit is definitive */
+        uint64_t block_off = 0;
+        if (blocked_index_reader_find(sst->index_reader, key, key_size, &block_off, NULL) == 1)
         {
-            start_file_position = sst->block_indexes->file_positions[start_slot];
-            /* the prefix index is lossy -- keys sharing a prefix longer than
-             * prefix_len span multiple blocks with identical min/max prefixes.
-             * the run length is how many consecutive blocks the lookup must
-             * scan to be definitive, not just the first */
-            block_index_run_len =
-                compact_block_index_run_length(sst->block_indexes, key, key_size, start_slot);
-            /* block index covers all blocks when count matches num_klog_blocks
-             * (index_sample_ratio == 1). in this case the lookup is definitive:
-             * scanning the prefix-colliding run is enough -- if the key isn't in
-             * any block of the run, it's not in the sstable. */
-            block_index_definitive =
-                (sst->block_indexes->count >= sst->num_klog_blocks && start_file_position > 0);
+            start_file_position = block_off;
+            block_index_run_len = 1;
+            block_index_definitive = (start_file_position > 0);
         }
     }
 
@@ -9932,113 +9841,6 @@ static int tidesdb_sstable_load(tidesdb_t *db, tidesdb_sstable_t *sst)
     return TDB_ERR_CORRUPTION;
 
 load_bloom_and_index:; /* empty statement for C89/C90 compatibility */
-    /* load bloom filter and index from last blocks */
-    /* [klog blocks...] [index block] [bloom filter block] [metadata block] */
-
-    if (sst->aux_chunked)
-    {
-        /* chunked footer -- bloom and index are located by explicit offset+size
-         * and may span multiple blocks. reassemble each via read_aux_blob, which
-         * refuses (NULL) an oversized blob rather than risking OOM. an unreadable
-         * blob degrades gracefully (no bloom -> full block scan; no index ->
-         * sequential scan). */
-        if (sst->config && sst->config->enable_bloom_filter && sst->bloom_blob_size > 0)
-        {
-            uint8_t *bloom_buf = tidesdb_sstable_read_aux_blob(db, klog_bm, sst->bloom_blob_offset,
-                                                               sst->bloom_blob_size);
-            if (bloom_buf)
-            {
-                sst->bloom_filter = bloom_filter_deserialize(bloom_buf, sst->bloom_blob_size);
-                free(bloom_buf);
-            }
-            else
-            {
-                sst->bloom_filter = NULL;
-            }
-        }
-        else
-        {
-            sst->bloom_filter = NULL;
-        }
-
-        if (sst->config && !sst->config->use_btree && sst->index_blob_size > 0)
-        {
-            uint8_t *index_buf = tidesdb_sstable_read_aux_blob(db, klog_bm, sst->index_blob_offset,
-                                                               sst->index_blob_size);
-            if (index_buf)
-            {
-                sst->block_indexes =
-                    compact_block_index_deserialize(index_buf, sst->index_blob_size);
-                if (sst->block_indexes)
-                {
-                    sst->block_indexes->comparator = sst->config->comparator_fn_cached;
-                    sst->block_indexes->comparator_ctx = sst->config->comparator_ctx_cached;
-                }
-                free(index_buf);
-            }
-        }
-    }
-    else
-    {
-        block_manager_cursor_t *cursor;
-        if (block_manager_cursor_init(&cursor, klog_bm) != 0)
-        {
-            block_manager_close(klog_bm);
-            block_manager_close(vlog_bm);
-            return TDB_ERR_IO;
-        }
-
-        /* we go to last block (metadata) and skip it */
-        if (block_manager_cursor_goto_last(cursor) == 0)
-        {
-            /* we skip metadata block, go to bloom filter */
-            if (block_manager_cursor_prev(cursor) == 0)
-            {
-                block_manager_block_t *bloom_block = block_manager_cursor_read(cursor);
-                if (bloom_block)
-                {
-                    if (bloom_block->size > 0 && sst->config && sst->config->enable_bloom_filter)
-                    {
-                        sst->bloom_filter =
-                            bloom_filter_deserialize(bloom_block->data, bloom_block->size);
-                    }
-                    else
-                    {
-                        sst->bloom_filter = NULL;
-                    }
-                    block_manager_block_release(bloom_block);
-                }
-
-                /* go to index block -- skip for btree mode which uses its own
-                 * B+tree traversal and does not need block indexes */
-                if (block_manager_cursor_prev(cursor) == 0)
-                {
-                    block_manager_block_t *index_block = block_manager_cursor_read(cursor);
-                    if (index_block)
-                    {
-                        if (index_block->size > 0 && !sst->config->use_btree)
-                        {
-                            sst->block_indexes = compact_block_index_deserialize(index_block->data,
-                                                                                 index_block->size);
-
-                            /* we use cached comparator from config (already resolved during CF
-                             * creation) this avoids hash table lookup for every sst during
-                             * recovery */
-                            if (sst->block_indexes)
-                            {
-                                sst->block_indexes->comparator = sst->config->comparator_fn_cached;
-                                sst->block_indexes->comparator_ctx =
-                                    sst->config->comparator_ctx_cached;
-                            }
-                        }
-                        block_manager_block_release(index_block);
-                    }
-                }
-            }
-        }
-
-        block_manager_cursor_free(cursor);
-    }
 
     /* we keep block managers open and store them in the sstable
      * they will be managed by the cache and closed when the sstable is evicted or freed */
@@ -10063,6 +9865,10 @@ load_bloom_and_index:; /* empty statement for C89/C90 compatibility */
             sst->is_reverse = (min_max_cmp > 0);
         }
     }
+
+    /* open the paged blocked bloom and block index readers now that klog_bm and the comparator are
+     * set; a no-op for a non-blocked sstable */
+    tidesdb_sstable_open_blocked_readers(sst);
 
     /* we track that this file is now open */
     if (db)
@@ -10130,12 +9936,6 @@ static void tidesdb_level_free(const tidesdb_t *db, tidesdb_level_t *level)
     {
         if (ssts[i])
         {
-            /* freeing the level drops these sstables without going through
-             * tidesdb_level_remove_sstable, so decrement the aux memory total here */
-            if (db)
-                atomic_fetch_sub_explicit(&((tidesdb_t *)db)->sstable_aux_memory_bytes,
-                                          tidesdb_sstable_aux_memory_bytes(ssts[i]),
-                                          memory_order_relaxed);
             tidesdb_sstable_unref(db, ssts[i]);
         }
     }
@@ -10455,31 +10255,6 @@ static void tidesdb_defer_removed_sst_unref(tidesdb_t *db, tidesdb_level_t *leve
 }
 
 /**
- * tidesdb_sstable_aux_memory_bytes
- * resident bloom filter + block index memory of one sstable. bloom filters and
- * block indexes are immutable for the sstable's lifetime, so this is stable
- * between level add and level remove and the running total stays exact.
- * @param sst sstable
- * @return bloom filter + block index bytes
- */
-static int64_t tidesdb_sstable_aux_memory_bytes(const tidesdb_sstable_t *sst)
-{
-    int64_t bytes = 0;
-    if (sst->bloom_filter)
-    {
-        bytes +=
-            (int64_t)(sst->bloom_filter->size_in_words * sizeof(uint64_t) + sizeof(bloom_filter_t));
-    }
-    if (sst->block_indexes)
-    {
-        bytes += (int64_t)((size_t)sst->block_indexes->count *
-                               (sst->block_indexes->prefix_len * 2 + sizeof(uint64_t)) +
-                           sizeof(tidesdb_block_index_t));
-    }
-    return bytes;
-}
-
-/**
  * tidesdb_level_add_sstable
  * add an sstable to a level
  * @param level level to add sstable to
@@ -10565,10 +10340,6 @@ static int tidesdb_level_add_sstable(tidesdb_level_t *level, tidesdb_sstable_t *
 
                 atomic_fetch_add_explicit(&level->current_size, sst->klog_size + sst->vlog_size,
                                           memory_order_relaxed);
-                atomic_fetch_add_explicit(&sst->db->sstable_aux_memory_bytes,
-                                          tidesdb_sstable_aux_memory_bytes(sst),
-                                          memory_order_relaxed);
-
                 tidesdb_sstable_t **prev_retired = atomic_exchange_explicit(
                     &level->retired_sstables_arr, old_arr, memory_order_acq_rel);
                 tidesdb_retire_array(sst->db, prev_retired, level);
@@ -10601,10 +10372,6 @@ static int tidesdb_level_add_sstable(tidesdb_level_t *level, tidesdb_sstable_t *
 
                 atomic_fetch_add_explicit(&level->current_size, sst->klog_size + sst->vlog_size,
                                           memory_order_relaxed);
-                atomic_fetch_add_explicit(&sst->db->sstable_aux_memory_bytes,
-                                          tidesdb_sstable_aux_memory_bytes(sst),
-                                          memory_order_relaxed);
-
                 tidesdb_sstable_t **prev_retired = atomic_exchange_explicit(
                     &level->retired_sstables_arr, old_arr, memory_order_acq_rel);
                 tidesdb_retire_array(sst->db, prev_retired, level);
@@ -10709,8 +10476,6 @@ static int tidesdb_level_remove_sstable(const tidesdb_t *db, tidesdb_level_t *le
             /* success! we update size */
             atomic_fetch_sub_explicit(&level->current_size, sst->klog_size + sst->vlog_size,
                                       memory_order_relaxed);
-            atomic_fetch_sub_explicit(&((tidesdb_t *)db)->sstable_aux_memory_bytes,
-                                      tidesdb_sstable_aux_memory_bytes(sst), memory_order_relaxed);
 
             /* we unref old array's surviving sstables immediately (safe--new array holds refs)
              * but skip the removed sstable -- readers may still hold raw pointers from old array
@@ -10870,9 +10635,6 @@ static int tidesdb_level_remove_sstables_batch(const tidesdb_t *db, tidesdb_leve
                 out_removed[j] = 1;
                 atomic_fetch_sub_explicit(&level->current_size,
                                           to_remove[j]->klog_size + to_remove[j]->vlog_size,
-                                          memory_order_relaxed);
-                atomic_fetch_sub_explicit(&((tidesdb_t *)db)->sstable_aux_memory_bytes,
-                                          tidesdb_sstable_aux_memory_bytes(to_remove[j]),
                                           memory_order_relaxed);
                 tidesdb_defer_removed_sst_unref((tidesdb_t *)db, level, to_remove[j]);
             }
@@ -14379,52 +14141,36 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
             break;
         }
 
-        bloom_filter_t *bloom = NULL;
-        tidesdb_block_index_t *block_indexes = NULL;
+        blocked_bloom_builder_t *bloom_builder = NULL;
+        blocked_index_builder_t *index_builder = NULL;
 
         if (new_sst->config->enable_bloom_filter)
         {
-            if (bloom_filter_new(&bloom, new_sst->config->bloom_fpr, (int)estimated_entries) == 0)
+            if (blocked_bloom_builder_new(&bloom_builder, new_sst->config->bloom_fpr, 0,
+                                          tidesdb_blocked_aux_write, klog_bm) != 0)
             {
-                TDB_DEBUG_LOG(TDB_LOG_INFO, "Bloom filter created (estimated entries: %" PRIu64 ")",
-                              estimated_entries);
+                TDB_DEBUG_LOG(TDB_LOG_ERROR, "Bloom filter builder creation failed");
+                bloom_builder = NULL;
             }
-            else
-            {
-                TDB_DEBUG_LOG(TDB_LOG_ERROR, "Bloom filter creation failed");
-                bloom = NULL;
-            }
-        }
-        else
-        {
-            TDB_DEBUG_LOG(TDB_LOG_INFO, "Bloom filter disabled");
         }
 
         if (new_sst->config->enable_block_indexes && !cf->config.use_btree)
         {
-            block_indexes = compact_block_index_create(estimated_entries,
-                                                       new_sst->config->block_index_prefix_len,
-                                                       comparator_fn, comparator_ctx);
-            if (block_indexes)
+            if (blocked_index_builder_new(&index_builder, 0, tidesdb_blocked_aux_write, klog_bm) !=
+                0)
             {
-                TDB_DEBUG_LOG(TDB_LOG_INFO, "Block indexes created");
+                TDB_DEBUG_LOG(TDB_LOG_ERROR, "Block index builder creation failed");
+                index_builder = NULL;
             }
-            else
-            {
-                TDB_DEBUG_LOG(TDB_LOG_ERROR, "Block indexes builder creation failed");
-            }
-        }
-        else
-        {
-            TDB_DEBUG_LOG(TDB_LOG_INFO, "Block indexes disabled");
         }
 
         /* we branch to btree output if use_btree is enabled */
         if (cf->config.use_btree)
         {
             int btree_result = tidesdb_sstable_write_from_heap_btree(
-                cf, new_sst, heap, klog_bm, vlog_bm, bloom, sstables_to_delete, is_largest_level,
-                range_start, range_start_size, range_end, range_end_size, c->oldest_unflushed_seq);
+                cf, new_sst, heap, klog_bm, vlog_bm, bloom_builder, sstables_to_delete,
+                is_largest_level, range_start, range_start_size, range_end, range_end_size,
+                c->oldest_unflushed_seq);
             block_manager_close(klog_bm);
             block_manager_close(vlog_bm);
             tidesdb_merge_heap_free(heap);
@@ -14438,7 +14184,7 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
                 break;
             }
 
-            bloom = NULL;
+            bloom_builder = NULL;
             goto merge_complete;
         }
 
@@ -14448,11 +14194,9 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
         uint64_t vlog_block_num = 0;
         uint64_t max_seq = 0;
 
-        /* we track first and last key of current block for block index */
+        /* we track the first key of the current block for the block index */
         uint8_t *block_first_key = NULL;
         size_t block_first_key_size = 0;
-        uint8_t *block_last_key = NULL;
-        size_t block_last_key_size = 0;
 
         /* snapshot floor -- see tidesdb_sstable_write_from_heap_btree for rationale */
         const uint64_t min_snapshot_seq = tidesdb_min_active_snapshot_seq(cf->db);
@@ -14604,15 +14348,6 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
                         }
                     }
 
-                    /* we always update last key of block */
-                    free(block_last_key);
-                    block_last_key = malloc(pending->entry.key_size);
-                    if (block_last_key)
-                    {
-                        memcpy(block_last_key, pending->key, pending->entry.key_size);
-                        block_last_key_size = pending->entry.key_size;
-                    }
-
                     if (tidesdb_klog_block_is_full(current_klog_block, TDB_KLOG_BLOCK_SIZE))
                     {
                         uint8_t *klog_data;
@@ -14646,15 +14381,11 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
                                 block_manager_block_write(klog_bm, klog_block);
                                 block_manager_block_release(klog_block);
 
-                                if (block_indexes && block_first_key && block_last_key)
+                                if (block_first_key)
                                 {
-                                    if (klog_block_num % cf->config.index_sample_ratio == 0)
-                                    {
-                                        compact_block_index_add(block_indexes, block_first_key,
-                                                                block_first_key_size,
-                                                                block_last_key, block_last_key_size,
-                                                                block_file_position);
-                                    }
+                                    blocked_index_builder_add(index_builder, block_first_key,
+                                                              block_first_key_size,
+                                                              block_file_position);
                                 }
 
                                 klog_block_num++;
@@ -14665,9 +14396,7 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
                         tidesdb_klog_block_reset(current_klog_block);
 
                         free(block_first_key);
-                        free(block_last_key);
                         block_first_key = NULL;
-                        block_last_key = NULL;
                     }
 
                     if (pending->entry.seq > max_seq)
@@ -14675,10 +14404,7 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
                         max_seq = pending->entry.seq;
                     }
 
-                    if (bloom)
-                    {
-                        bloom_filter_add(bloom, pending->key, pending->entry.key_size);
-                    }
+                    blocked_bloom_builder_add(bloom_builder, pending->key, pending->entry.key_size);
 
                     if (!new_sst->min_key)
                     {
@@ -14721,9 +14447,8 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
             if (pending) tidesdb_kv_pair_free(pending);
             tidesdb_klog_block_free(current_klog_block);
             free(block_first_key);
-            free(block_last_key);
-            if (bloom) bloom_filter_free(bloom);
-            if (block_indexes) compact_block_index_free(block_indexes);
+            blocked_bloom_builder_free(bloom_builder);
+            blocked_index_builder_free(index_builder);
             tidesdb_merge_heap_free(heap);
             if (klog_bm) block_manager_close(klog_bm);
             if (vlog_bm) block_manager_close(vlog_bm);
@@ -14765,14 +14490,10 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
                     block_manager_block_write(klog_bm, klog_block);
                     block_manager_block_release(klog_block);
 
-                    if (block_indexes && block_first_key && block_last_key)
+                    if (block_first_key)
                     {
-                        if (klog_block_num % cf->config.index_sample_ratio == 0)
-                        {
-                            compact_block_index_add(block_indexes, block_first_key,
-                                                    block_first_key_size, block_last_key,
-                                                    block_last_key_size, block_file_position);
-                        }
+                        blocked_index_builder_add(index_builder, block_first_key,
+                                                  block_first_key_size, block_file_position);
                     }
 
                     klog_block_num++;
@@ -14782,7 +14503,6 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
         }
 
         free(block_first_key);
-        free(block_last_key);
 
         tidesdb_klog_block_free(current_klog_block);
 
@@ -14796,10 +14516,10 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
          * structure) */
         if (new_sst->num_entries > 0)
         {
-            /* write index + bloom footer blobs (chunk-aware, shared helper) */
-            tidesdb_sstable_write_footer_aux(new_sst, klog_bm, block_indexes, bloom, 1);
-            block_indexes = NULL;
-            bloom = NULL;
+            /* finalize the blocked index and bloom directories (shared helper) */
+            tidesdb_sstable_write_footer_aux(new_sst, klog_bm, index_builder, bloom_builder, 1);
+            index_builder = NULL;
+            bloom_builder = NULL;
         }
 
         /* we get file sizes before metadata write for serialization */
@@ -14874,8 +14594,8 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
          * post-join teardown unrefs inputs without touching the manifest */
         if (tidesdb_cf_abort_requested(cf))
         {
-            if (bloom) bloom_filter_free(bloom);
-            if (block_indexes) compact_block_index_free(block_indexes);
+            blocked_bloom_builder_free(bloom_builder);
+            blocked_index_builder_free(index_builder);
             remove(new_sst->klog_path);
             remove(new_sst->vlog_path);
             tidesdb_sstable_unref(cf->db, new_sst);
@@ -14946,8 +14666,8 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
         else
         {
             TDB_DEBUG_LOG(TDB_LOG_INFO, "Skipping empty SSTable %" PRIu64 " (0 entries)", sst_id);
-            if (bloom) bloom_filter_free(bloom);
-            if (block_indexes) compact_block_index_free(block_indexes);
+            blocked_bloom_builder_free(bloom_builder);
+            blocked_index_builder_free(index_builder);
             remove(new_sst->klog_path);
             remove(new_sst->vlog_path);
             tidesdb_sstable_unref(cf->db, new_sst);
@@ -15081,29 +14801,31 @@ static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t
     if (estimated_entries < TDB_MERGE_MIN_ESTIMATED_ENTRIES)
         estimated_entries = TDB_MERGE_MIN_ESTIMATED_ENTRIES;
 
-    bloom_filter_t *bloom = NULL;
-    tidesdb_block_index_t *block_indexes = NULL;
+    blocked_bloom_builder_t *bloom_builder = NULL;
+    blocked_index_builder_t *index_builder = NULL;
 
     if (new_sst->config->enable_bloom_filter)
     {
-        if (bloom_filter_new(&bloom, new_sst->config->bloom_fpr, (int)estimated_entries) != 0)
+        if (blocked_bloom_builder_new(&bloom_builder, new_sst->config->bloom_fpr, 0,
+                                      tidesdb_blocked_aux_write, klog_bm) != 0)
         {
-            bloom = NULL;
+            bloom_builder = NULL;
         }
     }
 
     if (new_sst->config->enable_block_indexes && !cf->config.use_btree)
     {
-        block_indexes =
-            compact_block_index_create(estimated_entries, new_sst->config->block_index_prefix_len,
-                                       comparator_fn, comparator_ctx);
+        if (blocked_index_builder_new(&index_builder, 0, tidesdb_blocked_aux_write, klog_bm) != 0)
+        {
+            index_builder = NULL;
+        }
     }
 
     if (cf->config.use_btree)
     {
         int btree_result = tidesdb_sstable_write_from_heap_btree(
-            cf, new_sst, heap, klog_bm, vlog_bm, bloom, sstables_to_delete, is_largest_level, NULL,
-            0, NULL, 0, oldest_unflushed_seq);
+            cf, new_sst, heap, klog_bm, vlog_bm, bloom_builder, sstables_to_delete,
+            is_largest_level, NULL, 0, NULL, 0, oldest_unflushed_seq);
         block_manager_close(klog_bm);
         block_manager_close(vlog_bm);
         tidesdb_merge_heap_free(heap);
@@ -15133,7 +14855,7 @@ static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t
             return btree_result;
         }
 
-        bloom = NULL;
+        bloom_builder = NULL;
         goto merge_complete;
     }
 
@@ -15145,8 +14867,6 @@ static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t
 
     uint8_t *block_first_key = NULL;
     size_t block_first_key_size = 0;
-    uint8_t *block_last_key = NULL;
-    size_t block_last_key_size = 0;
 
     tidesdb_kv_pair_t *pending = NULL;
     int pending_is_single_delete = 0;
@@ -15256,14 +14976,6 @@ static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t
                     }
                 }
 
-                free(block_last_key);
-                block_last_key = malloc(pending->entry.key_size);
-                if (block_last_key)
-                {
-                    memcpy(block_last_key, pending->key, pending->entry.key_size);
-                    block_last_key_size = pending->entry.key_size;
-                }
-
                 if (tidesdb_klog_block_is_full(current_klog_block, TDB_KLOG_BLOCK_SIZE))
                 {
                     uint8_t *klog_data;
@@ -15296,14 +15008,11 @@ static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t
                             block_manager_block_write(klog_bm, klog_block);
                             block_manager_block_release(klog_block);
 
-                            if (block_indexes && block_first_key && block_last_key)
+                            if (block_first_key)
                             {
-                                if (klog_block_num % cf->config.index_sample_ratio == 0)
-                                {
-                                    compact_block_index_add(
-                                        block_indexes, block_first_key, block_first_key_size,
-                                        block_last_key, block_last_key_size, block_file_position);
-                                }
+                                blocked_index_builder_add(index_builder, block_first_key,
+                                                          block_first_key_size,
+                                                          block_file_position);
                             }
 
                             klog_block_num++;
@@ -15314,14 +15023,12 @@ static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t
                     tidesdb_klog_block_reset(current_klog_block);
 
                     free(block_first_key);
-                    free(block_last_key);
                     block_first_key = NULL;
-                    block_last_key = NULL;
                 }
 
                 if (pending->entry.seq > max_seq) max_seq = pending->entry.seq;
 
-                if (bloom) bloom_filter_add(bloom, pending->key, pending->entry.key_size);
+                blocked_bloom_builder_add(bloom_builder, pending->key, pending->entry.key_size);
 
                 if (!new_sst->min_key)
                 {
@@ -15363,9 +15070,8 @@ static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t
         if (pending) tidesdb_kv_pair_free(pending);
         tidesdb_klog_block_free(current_klog_block);
         free(block_first_key);
-        free(block_last_key);
-        if (bloom) bloom_filter_free(bloom);
-        if (block_indexes) compact_block_index_free(block_indexes);
+        blocked_bloom_builder_free(bloom_builder);
+        blocked_index_builder_free(index_builder);
         tidesdb_merge_heap_free(heap);
         if (klog_bm) block_manager_close(klog_bm);
         if (vlog_bm) block_manager_close(vlog_bm);
@@ -15413,14 +15119,10 @@ static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t
                 block_manager_block_write(klog_bm, klog_block);
                 block_manager_block_release(klog_block);
 
-                if (block_indexes && block_first_key && block_last_key)
+                if (block_first_key)
                 {
-                    if (klog_block_num % cf->config.index_sample_ratio == 0)
-                    {
-                        compact_block_index_add(block_indexes, block_first_key,
-                                                block_first_key_size, block_last_key,
-                                                block_last_key_size, block_file_position);
-                    }
+                    blocked_index_builder_add(index_builder, block_first_key, block_first_key_size,
+                                              block_file_position);
                 }
 
                 klog_block_num++;
@@ -15430,7 +15132,6 @@ static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t
     }
 
     free(block_first_key);
-    free(block_last_key);
 
     tidesdb_klog_block_free(current_klog_block);
 
@@ -15442,10 +15143,10 @@ static int tidesdb_targeted_merge(tidesdb_column_family_t *cf, tidesdb_sstable_t
 
     if (new_sst->num_entries > 0)
     {
-        /* write index + bloom footer blobs (chunk-aware, shared helper) */
-        tidesdb_sstable_write_footer_aux(new_sst, klog_bm, block_indexes, bloom, 1);
-        block_indexes = NULL; /* ownership transferred; local must not double-free on abort */
-        bloom = NULL;         /* same as block_indexes */
+        /* finalize the blocked index and bloom directories (shared helper) */
+        tidesdb_sstable_write_footer_aux(new_sst, klog_bm, index_builder, bloom_builder, 1);
+        index_builder = NULL; /* finalized and freed by the footer; do not double-free on abort */
+        bloom_builder = NULL;
     }
 
     uint64_t klog_size_before_metadata;
@@ -15507,8 +15208,8 @@ merge_complete:;
 
     if (tidesdb_cf_abort_requested(cf))
     {
-        if (bloom) bloom_filter_free(bloom);
-        if (block_indexes) compact_block_index_free(block_indexes);
+        blocked_bloom_builder_free(bloom_builder);
+        blocked_index_builder_free(index_builder);
         remove(new_sst->klog_path);
         remove(new_sst->vlog_path);
         tidesdb_sstable_unref(cf->db, new_sst);
@@ -15564,8 +15265,8 @@ merge_complete:;
     }
     else
     {
-        if (bloom) bloom_filter_free(bloom);
-        if (block_indexes) compact_block_index_free(block_indexes);
+        blocked_bloom_builder_free(bloom_builder);
+        blocked_index_builder_free(index_builder);
         remove(new_sst->klog_path);
         remove(new_sst->vlog_path);
         tidesdb_sstable_unref(cf->db, new_sst);
@@ -16032,36 +15733,31 @@ static int tidesdb_dividing_merge_partition(void *vctx, int partition)
         uint8_t *last_key = NULL;
         size_t last_key_size = 0;
 
-        bloom_filter_t *bloom = NULL;
-        tidesdb_block_index_t *block_indexes = NULL;
+        blocked_bloom_builder_t *bloom_builder = NULL;
+        blocked_index_builder_t *index_builder = NULL;
 
-        /* we track first and last key of current block for block index */
+        /* we track the first key of the current block for the block index */
         uint8_t *block_first_key = NULL;
         size_t block_first_key_size = 0;
-        uint8_t *block_last_key = NULL;
-        size_t block_last_key_size = 0;
 
         if (cf->config.enable_bloom_filter)
         {
-            if (bloom_filter_new(&bloom, cf->config.bloom_fpr, (int)partition_entries) == 0)
-            {
-                TDB_DEBUG_LOG(TDB_LOG_INFO,
-                              "Partition %d bloom filter created (estimated entries: %" PRIu64 ")",
-                              partition, partition_entries);
-            }
-            else
+            if (blocked_bloom_builder_new(&bloom_builder, cf->config.bloom_fpr, 0,
+                                          tidesdb_blocked_aux_write, klog_bm) != 0)
             {
                 TDB_DEBUG_LOG(TDB_LOG_ERROR, "Partition %d bloom filter creation failed",
                               partition);
-                bloom = NULL;
+                bloom_builder = NULL;
             }
         }
 
         if (cf->config.enable_block_indexes && !cf->config.use_btree)
         {
-            block_indexes =
-                compact_block_index_create(partition_entries, cf->config.block_index_prefix_len,
-                                           comparator_fn, comparator_ctx);
+            if (blocked_index_builder_new(&index_builder, 0, tidesdb_blocked_aux_write, klog_bm) !=
+                0)
+            {
+                index_builder = NULL;
+            }
         }
 
         /* we branch to btree output if use_btree is enabled.
@@ -16075,13 +15771,14 @@ static int tidesdb_dividing_merge_partition(void *vctx, int partition)
             klog_block = NULL;
 
             int btree_result = tidesdb_sstable_write_from_heap_btree(
-                cf, new_sst, partition_heap, klog_bm, vlog_bm, bloom, NULL, is_largest_level,
-                range_start, range_start_size, range_end, range_end_size, c->oldest_unflushed_seq);
+                cf, new_sst, partition_heap, klog_bm, vlog_bm, bloom_builder, NULL,
+                is_largest_level, range_start, range_start_size, range_end, range_end_size,
+                c->oldest_unflushed_seq);
             block_manager_close(klog_bm);
             block_manager_close(vlog_bm);
             tidesdb_merge_heap_free(partition_heap);
 
-            bloom = NULL;
+            bloom_builder = NULL;
 
             if (btree_result != TDB_SUCCESS)
             {
@@ -16203,10 +15900,7 @@ static int tidesdb_dividing_merge_partition(void *vctx, int partition)
                         last_key_size = pending->entry.key_size;
                     }
 
-                    if (bloom)
-                    {
-                        bloom_filter_add(bloom, pending->key, pending->entry.key_size);
-                    }
+                    blocked_bloom_builder_add(bloom_builder, pending->key, pending->entry.key_size);
 
                     /* large values go to the output vlog -- without recording a
                      * fresh offset here the entry is neither inline nor in vlog
@@ -16271,15 +15965,6 @@ static int tidesdb_dividing_merge_partition(void *vctx, int partition)
                         }
                     }
 
-                    /* we always update last key of block */
-                    free(block_last_key);
-                    block_last_key = malloc(pending->entry.key_size);
-                    if (block_last_key)
-                    {
-                        memcpy(block_last_key, pending->key, pending->entry.key_size);
-                        block_last_key_size = pending->entry.key_size;
-                    }
-
                     if (tidesdb_klog_block_is_full(klog_block, TDB_KLOG_BLOCK_SIZE))
                     {
                         uint8_t *klog_data;
@@ -16312,15 +15997,11 @@ static int tidesdb_dividing_merge_partition(void *vctx, int partition)
                                 block_manager_block_write(klog_bm, klog_bm_block);
                                 block_manager_block_release(klog_bm_block);
 
-                                if (block_indexes && block_first_key && block_last_key)
+                                if (block_first_key)
                                 {
-                                    if (klog_block_num % cf->config.index_sample_ratio == 0)
-                                    {
-                                        compact_block_index_add(block_indexes, block_first_key,
-                                                                block_first_key_size,
-                                                                block_last_key, block_last_key_size,
-                                                                block_file_position);
-                                    }
+                                    blocked_index_builder_add(index_builder, block_first_key,
+                                                              block_first_key_size,
+                                                              block_file_position);
                                 }
 
                                 klog_block_num++;
@@ -16333,9 +16014,7 @@ static int tidesdb_dividing_merge_partition(void *vctx, int partition)
 
                         /* we reset block tracking for new block */
                         free(block_first_key);
-                        free(block_last_key);
                         block_first_key = NULL;
-                        block_last_key = NULL;
                     }
 
                     /* we track maximum sequence number */
@@ -16393,16 +16072,11 @@ static int tidesdb_dividing_merge_partition(void *vctx, int partition)
                     block_manager_block_write(klog_bm, block);
                     block_manager_block_release(block);
 
-                    /* we add final block to index after writing with correct file position */
-                    if (block_indexes && block_first_key && block_last_key)
+                    /* we add the final block to the index after writing, with its file position */
+                    if (block_first_key)
                     {
-                        /* we sample every Nth block (ratio validated to be >= 1) */
-                        if (klog_block_num % cf->config.index_sample_ratio == 0)
-                        {
-                            compact_block_index_add(block_indexes, block_first_key,
-                                                    block_first_key_size, block_last_key,
-                                                    block_last_key_size, block_file_position);
-                        }
+                        blocked_index_builder_add(index_builder, block_first_key,
+                                                  block_first_key_size, block_file_position);
                     }
 
                     klog_block_num++;
@@ -16412,7 +16086,6 @@ static int tidesdb_dividing_merge_partition(void *vctx, int partition)
         }
 
         free(block_first_key);
-        free(block_last_key);
 
         tidesdb_klog_block_free(klog_block);
 
@@ -16436,10 +16109,11 @@ static int tidesdb_dividing_merge_partition(void *vctx, int partition)
          * structure) */
         if (entry_count > 0)
         {
-            /* write index + bloom footer blobs (chunk-aware, shared helper) */
-            tidesdb_sstable_write_footer_aux(new_sst, klog_bm, block_indexes, bloom, 1);
-            block_indexes = NULL; /* ownership transferred; local must not double-free on abort */
-            bloom = NULL;         /* ownership transferred; local must not double-free on abort */
+            /* finalize the blocked index and bloom directories (shared helper) */
+            tidesdb_sstable_write_footer_aux(new_sst, klog_bm, index_builder, bloom_builder, 1);
+            index_builder =
+                NULL; /* finalized and freed by the footer; do not double-free on abort */
+            bloom_builder = NULL;
         }
 
         /* we get file sizes before metadata write for serialization */
@@ -16495,8 +16169,8 @@ static int tidesdb_dividing_merge_partition(void *vctx, int partition)
         if (entry_count > 0 && tidesdb_cf_abort_requested(cf))
         {
             /* drop fired during this partition's merge; do not publish the partition output */
-            if (bloom) bloom_filter_free(bloom);
-            if (block_indexes) compact_block_index_free(block_indexes);
+            blocked_bloom_builder_free(bloom_builder);
+            blocked_index_builder_free(index_builder);
             remove(new_sst->klog_path);
             remove(new_sst->vlog_path);
             tidesdb_sstable_unref(cf->db, new_sst);
@@ -16567,8 +16241,8 @@ static int tidesdb_dividing_merge_partition(void *vctx, int partition)
                           "Partition %d skipping empty SSTable %" PRIu64 " (0 entries)", partition,
                           new_sst->id);
 
-            if (bloom) bloom_filter_free(bloom);
-            if (block_indexes) compact_block_index_free(block_indexes);
+            blocked_bloom_builder_free(bloom_builder);
+            blocked_index_builder_free(index_builder);
 
             remove(new_sst->klog_path);
             remove(new_sst->vlog_path);
@@ -16593,8 +16267,8 @@ static int tidesdb_dividing_merge_partition(void *vctx, int partition)
  * @param sst sstable to finalize (takes ownership, caller must not use after)
  * @param klog_bm klog block manager (closed on return)
  * @param vlog_bm vlog block manager (closed on return)
- * @param bloom bloom filter (ownership transferred to sst)
- * @param block_indexes block index (ownership transferred to sst)
+ * @param bloom_builder bloom filter builder (finalized here)
+ * @param index_builder block index builder (finalized here)
  * @param entry_count number of entries written
  * @param tombstone_count number of tombstones
  * @param klog_block_num number of klog blocks written
@@ -16606,8 +16280,9 @@ static int tidesdb_dividing_merge_partition(void *vctx, int partition)
  */
 static int tdb_partitioned_merge_finalize_sst(
     tidesdb_column_family_t *cf, tidesdb_sstable_t *sst, block_manager_t *klog_bm,
-    block_manager_t *vlog_bm, bloom_filter_t *bloom, tidesdb_block_index_t *block_indexes,
-    const uint64_t entry_count, const uint64_t tombstone_count, const uint64_t distinct_key_count,
+    block_manager_t *vlog_bm, blocked_bloom_builder_t *bloom_builder,
+    blocked_index_builder_t *index_builder, const uint64_t entry_count,
+    const uint64_t tombstone_count, const uint64_t distinct_key_count,
     const uint64_t klog_block_num, const uint64_t vlog_block_num, const uint64_t max_seq,
     const int end_level, const int partition)
 {
@@ -16622,9 +16297,8 @@ static int tdb_partitioned_merge_finalize_sst(
 
     if (entry_count > 0)
     {
-        /* write index + bloom footer blobs (chunk-aware, shared helper). ownership
-         * of block_indexes/bloom transfers to sst inside the helper. */
-        tidesdb_sstable_write_footer_aux(sst, klog_bm, block_indexes, bloom, 1);
+        /* finalize the blocked index and bloom directories (shared helper) */
+        tidesdb_sstable_write_footer_aux(sst, klog_bm, index_builder, bloom_builder, 1);
     }
 
     uint64_t klog_size_before_metadata;
@@ -16725,8 +16399,8 @@ static int tdb_partitioned_merge_finalize_sst(
     }
     else
     {
-        if (bloom) bloom_filter_free(bloom);
-        if (block_indexes) compact_block_index_free(block_indexes);
+        blocked_bloom_builder_free(bloom_builder);
+        blocked_index_builder_free(index_builder);
         remove(sst->klog_path);
         remove(sst->vlog_path);
         tidesdb_sstable_unref(cf->db, sst);
@@ -17298,34 +16972,28 @@ static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
                 break;
             }
 
-            bloom_filter_t *bloom = NULL;
-            tidesdb_block_index_t *block_indexes = NULL;
+            blocked_bloom_builder_t *bloom_builder = NULL;
+            blocked_index_builder_t *index_builder = NULL;
 
             if (cf->config.enable_bloom_filter)
             {
-                if (bloom_filter_new(&bloom, cf->config.bloom_fpr, (int)estimated_entries) == 0)
-                {
-                    TDB_DEBUG_LOG(
-                        TDB_LOG_INFO,
-                        "Partitioned merge partition %d bloom filter created (estimated entries: "
-                        "%" PRIu64 ")",
-                        partition, estimated_entries);
-                }
-                else
+                if (blocked_bloom_builder_new(&bloom_builder, cf->config.bloom_fpr, 0,
+                                              tidesdb_blocked_aux_write, klog_bm) != 0)
                 {
                     TDB_DEBUG_LOG(TDB_LOG_ERROR,
                                   "Partitioned merge partition %d bloom filter creation failed",
                                   partition);
-                    bloom = NULL;
+                    bloom_builder = NULL;
                 }
             }
 
             if (cf->config.enable_block_indexes && !cf->config.use_btree)
             {
-                /* we reuse comparator_fn and comparator_ctx from outer scope */
-                block_indexes =
-                    compact_block_index_create(estimated_entries, cf->config.block_index_prefix_len,
-                                               comparator_fn, comparator_ctx);
+                if (blocked_index_builder_new(&index_builder, 0, tidesdb_blocked_aux_write,
+                                              klog_bm) != 0)
+                {
+                    index_builder = NULL;
+                }
             }
 
             /* btree output. is_largest_level mirrors the non-btree branch
@@ -17333,13 +17001,14 @@ static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
             if (cf->config.use_btree)
             {
                 int btree_result = tidesdb_sstable_write_from_heap_btree(
-                    cf, new_sst, heap, klog_bm, vlog_bm, bloom, NULL, reap_tombstones, range_start,
-                    range_start_size, range_end, range_end_size, c->oldest_unflushed_seq);
+                    cf, new_sst, heap, klog_bm, vlog_bm, bloom_builder, NULL, reap_tombstones,
+                    range_start, range_start_size, range_end, range_end_size,
+                    c->oldest_unflushed_seq);
                 block_manager_close(klog_bm);
                 block_manager_close(vlog_bm);
                 tidesdb_merge_heap_free(heap);
 
-                bloom = NULL;
+                bloom_builder = NULL;
 
                 if (btree_result != TDB_SUCCESS)
                 {
@@ -17385,11 +17054,9 @@ static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
             uint8_t *last_key = NULL;
             size_t last_key_size = 0;
 
-            /* we track first and last key of current block for block index */
+            /* we track the first key of the current block for the block index */
             uint8_t *block_first_key = NULL;
             size_t block_first_key_size = 0;
-            uint8_t *block_last_key = NULL;
-            size_t block_last_key_size = 0;
 
             /* we track last key for duplicate detection */
             uint8_t *last_seen_key = NULL;
@@ -17526,10 +17193,7 @@ static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
                     free(compressed);
                 }
 
-                if (bloom)
-                {
-                    bloom_filter_add(bloom, kv->key, kv->entry.key_size);
-                }
+                blocked_bloom_builder_add(bloom_builder, kv->key, kv->entry.key_size);
 
                 /* we check if this is first entry in a new block (before adding) */
                 int is_first_entry_in_block = (klog_block->num_entries == 0);
@@ -17553,15 +17217,6 @@ static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
                         memcpy(block_first_key, kv->key, kv->entry.key_size);
                         block_first_key_size = kv->entry.key_size;
                     }
-                }
-
-                /* we always update last key of block */
-                free(block_last_key);
-                block_last_key = malloc(kv->entry.key_size);
-                if (block_last_key)
-                {
-                    memcpy(block_last_key, kv->key, kv->entry.key_size);
-                    block_last_key_size = kv->entry.key_size;
                 }
 
                 /** we track maximum sequence number */
@@ -17606,16 +17261,12 @@ static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
                             block_manager_block_write(klog_bm, block);
                             block_manager_block_release(block);
 
-                            /* we add completed block to index after writing with file position */
-                            if (block_indexes && block_first_key && block_last_key)
+                            /* we record the block by its first key after writing */
+                            if (block_first_key)
                             {
-                                /* we sample every Nth block (ratio validated to be >= 1) */
-                                if (klog_block_num % cf->config.index_sample_ratio == 0)
-                                {
-                                    compact_block_index_add(
-                                        block_indexes, block_first_key, block_first_key_size,
-                                        block_last_key, block_last_key_size, block_file_position);
-                                }
+                                blocked_index_builder_add(index_builder, block_first_key,
+                                                          block_first_key_size,
+                                                          block_file_position);
                             }
 
                             klog_block_num++;
@@ -17627,9 +17278,7 @@ static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
 
                     /* we reset block tracking for new block */
                     free(block_first_key);
-                    free(block_last_key);
                     block_first_key = NULL;
-                    block_last_key = NULL;
 
                     /*** spooky file_max splits if output exceeds C_X, finalize this
                      **  sstable and start a new one within the same partition.
@@ -17654,9 +17303,9 @@ static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
                                           file_max);
 
                             tdb_partitioned_merge_finalize_sst(
-                                cf, new_sst, klog_bm, vlog_bm, bloom, block_indexes, entry_count,
-                                tombstone_count, distinct.distinct, klog_block_num, vlog_block_num,
-                                max_seq, end_level, partition);
+                                cf, new_sst, klog_bm, vlog_bm, bloom_builder, index_builder,
+                                entry_count, tombstone_count, distinct.distinct, klog_block_num,
+                                vlog_block_num, max_seq, end_level, partition);
 
                             /* we create replacement sst for remaining entries in this partition */
                             uint64_t split_id = atomic_fetch_add(&cf->next_sstable_id, 1);
@@ -17685,13 +17334,13 @@ static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
                                         break;
                                 }
                                 /* the prior split was already finalized (it consumed klog_bm,
-                                 * vlog_bm, bloom, block_indexes), so NULL them before the post-loop
-                                 * finalize guard runs -- otherwise it would double-free/close them.
-                                 * abort so the sources are preserved (no data loss; retried). */
+                                 * vlog_bm, and freed the builders), so NULL them before the
+                                 * post-loop finalize guard runs -- otherwise it would
+                                 * double-free/close them. abort so the sources are preserved. */
                                 klog_bm = NULL;
                                 vlog_bm = NULL;
-                                bloom = NULL;
-                                block_indexes = NULL;
+                                bloom_builder = NULL;
+                                index_builder = NULL;
                                 aborted = 1;
                                 break;
                             }
@@ -17719,37 +17368,37 @@ static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
                                 new_sst = NULL;
                                 klog_bm = NULL;
                                 vlog_bm = NULL;
-                                bloom =
-                                    NULL; /* consumed by the prior finalize -- don't reuse/free */
-                                block_indexes = NULL;
+                                bloom_builder = NULL; /* consumed by the prior finalize */
+                                index_builder = NULL;
                                 aborted = 1;
                                 break;
                             }
 
-                            bloom = NULL;
-                            block_indexes = NULL;
+                            bloom_builder = NULL;
+                            index_builder = NULL;
                             if (cf->config.enable_bloom_filter)
                             {
-                                /* bloom_filter_new nulls bloom on failure
-                                 * (see contract in src/bloom_filter.c), so a
-                                 * miss here leaves bloom NULL and the merge
-                                 * loop skips bloom_filter_add */
-                                if (bloom_filter_new(&bloom, cf->config.bloom_fpr,
-                                                     (int)estimated_entries) != 0)
+                                /* a miss here leaves bloom_builder NULL and the merge loop's add
+                                 * becomes a no-op, so the split sstable is written without a bloom
+                                 */
+                                if (blocked_bloom_builder_new(&bloom_builder, cf->config.bloom_fpr,
+                                                              0, tidesdb_blocked_aux_write,
+                                                              klog_bm) != 0)
                                 {
                                     TDB_DEBUG_LOG(
                                         TDB_LOG_WARN,
-                                        "Partitioned merge partition %d bloom_filter_new "
-                                        "failed on file_max split (estimated_entries=%" PRIu64
-                                        "), continuing without bloom for this split sstable",
-                                        partition, estimated_entries);
+                                        "Partitioned merge partition %d bloom builder creation "
+                                        "failed on file_max split, continuing without a bloom",
+                                        partition);
                                 }
                             }
                             if (cf->config.enable_block_indexes && !cf->config.use_btree)
                             {
-                                block_indexes = compact_block_index_create(
-                                    estimated_entries, cf->config.block_index_prefix_len,
-                                    comparator_fn, comparator_ctx);
+                                if (blocked_index_builder_new(
+                                        &index_builder, 0, tidesdb_blocked_aux_write, klog_bm) != 0)
+                                {
+                                    index_builder = NULL;
+                                }
                             }
 
                             /* we reset per-sst counters */
@@ -17806,14 +17455,10 @@ static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
                         block_manager_block_write(klog_bm, block);
                         block_manager_block_release(block);
 
-                        if (block_indexes && block_first_key && block_last_key)
+                        if (block_first_key)
                         {
-                            if (klog_block_num % cf->config.index_sample_ratio == 0)
-                            {
-                                compact_block_index_add(block_indexes, block_first_key,
-                                                        block_first_key_size, block_last_key,
-                                                        block_last_key_size, block_file_position);
-                            }
+                            blocked_index_builder_add(index_builder, block_first_key,
+                                                      block_first_key_size, block_file_position);
                         }
 
                         klog_block_num++;
@@ -17824,7 +17469,6 @@ static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
 
             tidesdb_klog_block_free(klog_block);
             free(block_first_key);
-            free(block_last_key);
 
             /* we assign min/max keys and finalize via helper -- unless an output open aborted the
              * merge, in which case we must not finalize through a NULL block manager. release this
@@ -17837,8 +17481,8 @@ static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
                 new_sst->max_key = last_key;
                 new_sst->max_key_size = last_key_size;
 
-                tdb_partitioned_merge_finalize_sst(cf, new_sst, klog_bm, vlog_bm, bloom,
-                                                   block_indexes, entry_count, tombstone_count,
+                tdb_partitioned_merge_finalize_sst(cf, new_sst, klog_bm, vlog_bm, bloom_builder,
+                                                   index_builder, entry_count, tombstone_count,
                                                    distinct.distinct, klog_block_num,
                                                    vlog_block_num, max_seq, end_level, partition);
             }
@@ -17846,8 +17490,8 @@ static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
             {
                 free(first_key);
                 free(last_key);
-                if (bloom) bloom_filter_free(bloom);
-                if (block_indexes) compact_block_index_free(block_indexes);
+                blocked_bloom_builder_free(bloom_builder);
+                blocked_index_builder_free(index_builder);
                 if (klog_bm) block_manager_close(klog_bm);
                 if (vlog_bm) block_manager_close(vlog_bm);
                 if (new_sst) tidesdb_sstable_unref(cf->db, new_sst);
@@ -20075,9 +19719,7 @@ static void *tidesdb_reaper_thread(void *arg)
                         atomic_load_explicit(&cf->immutable_bytes, memory_order_relaxed);
                 }
 
-                /* count sstables per cf for the compaction victim heuristic. bloom
-                 * filter and block index memory is not summed here -- it is tracked
-                 * by the sstable_aux_memory_bytes running total and added once below */
+                /* count sstables per cf for the compaction victim heuristic */
                 int total_cf_ssts = 0;
                 int num_levels = atomic_load_explicit(&cf->num_active_levels, memory_order_acquire);
                 for (int lv = 0; lv < num_levels && lv < TDB_MAX_LEVELS; lv++)
@@ -20135,10 +19777,8 @@ static void *tidesdb_reaper_thread(void *arg)
                 }
             }
 
-            /* bloom filter + block index memory across every sstable, maintained
-             * as a running total at level add and remove */
-            total_mem_bytes +=
-                atomic_load_explicit(&db->sstable_aux_memory_bytes, memory_order_relaxed);
+            /* bloom filter and block index memory is not summed separately -- the blocked aux lives
+             * in the block cache and is counted by the cache stats below */
 
             /* we add cache memory */
             if (db->clock_cache)
@@ -22960,19 +22600,6 @@ int tidesdb_create_column_family(tidesdb_t *db, const char *name,
         tidesdb_unimap_resolve(db, name, &cf->unified_cf_index, &unimap_is_new);
         TDB_DEBUG_LOG(TDB_LOG_INFO, "CF '%s' assigned unified_cf_index=%u", name,
                       cf->unified_cf_index);
-    }
-
-    /* we validate and fix index_sample_ratio (must be at least 1 to avoid division by zero) */
-    if (cf->config.index_sample_ratio < 1)
-    {
-        cf->config.index_sample_ratio = TDB_DEFAULT_INDEX_SAMPLE_RATIO;
-    }
-
-    /* we validate and fix block_index_prefix_len */
-    if (cf->config.block_index_prefix_len < TDB_BLOCK_INDEX_PREFIX_MIN ||
-        cf->config.block_index_prefix_len > TDB_BLOCK_INDEX_PREFIX_MAX)
-    {
-        cf->config.block_index_prefix_len = TDB_DEFAULT_BLOCK_INDEX_PREFIX_LEN;
     }
 
     /**** we validate write_buffer_size against resolved_memory_limit to prevent
@@ -31042,9 +30669,11 @@ static void tidesdb_iter_seek_sstable_source_forward(const tidesdb_iter_t *iter,
 
     /* we use block index to find starting position */
     uint64_t block_position = 0;
-    if (sst->block_indexes && sst->block_indexes->count > 0)
+    if (sst->index_reader)
     {
-        compact_block_index_find_predecessor(sst->block_indexes, key, key_size, &block_position);
+        uint64_t block_off = 0;
+        if (blocked_index_reader_find(sst->index_reader, key, key_size, &block_off, NULL) == 1)
+            block_position = block_off;
     }
 
     if (block_position > 0)
@@ -31442,9 +31071,11 @@ static void tidesdb_iter_seek_sstable_source_backward(const tidesdb_iter_t *iter
 
     /* we use block index to find starting position */
     uint64_t block_position = 0;
-    if (sst->block_indexes && sst->block_indexes->count > 0)
+    if (sst->index_reader)
     {
-        compact_block_index_find_predecessor(sst->block_indexes, key, key_size, &block_position);
+        uint64_t block_off = 0;
+        if (blocked_index_reader_find(sst->index_reader, key, key_size, &block_off, NULL) == 1)
+            block_position = block_off;
     }
 
     if (block_position > 0)
@@ -34680,33 +34311,25 @@ int tidesdb_range_cost(tidesdb_column_family_t *cf, const uint8_t *key_a, const 
                     ? TDB_RANGE_COST_COMPRESSION_WEIGHT
                     : 1.0;
 
-            if (sst->block_indexes && sst->block_indexes->count > 0)
+            if (sst->index_reader)
             {
-                /* we use block index slots to estimate block span */
-                int64_t slot_a = 0, slot_b = 0;
+                /* the blocked index covers every block, so the ordinal span of the two ends is the
+                 * exact block span -- no sample-ratio scaling */
+                uint64_t off_a = 0, ord_a = 0, off_b = 0, ord_b = 0;
                 const int found_a =
-                    compact_block_index_find_slot(sst->block_indexes, lo, lo_size, &slot_a);
+                    blocked_index_reader_find(sst->index_reader, lo, lo_size, &off_a, &ord_a);
                 const int found_b =
-                    compact_block_index_find_slot(sst->block_indexes, hi, hi_size, &slot_b);
-
-                if (found_a == 0 && found_b == 0)
+                    blocked_index_reader_find(sst->index_reader, hi, hi_size, &off_b, &ord_b);
+                if (found_a == 1 && found_b == 1)
                 {
-                    int64_t sampled_blocks = (slot_b - slot_a) + 1;
-                    if (sampled_blocks < 1) sampled_blocks = 1;
-
-                    /* we scale by index_sample_ratio to get actual block count */
-                    const int sample_ratio = (sst->config && sst->config->index_sample_ratio > 0)
-                                                 ? sst->config->index_sample_ratio
-                                                 : 1;
-                    est_blocks = (double)sampled_blocks * (double)sample_ratio;
-
-                    /* we clamp to actual block count */
+                    int64_t blocks = (int64_t)ord_b - (int64_t)ord_a + 1;
+                    if (blocks < 1) blocks = 1;
+                    est_blocks = (double)blocks;
                     if (est_blocks > (double)sst->num_klog_blocks)
                         est_blocks = (double)sst->num_klog_blocks;
                 }
                 else
                 {
-                    /* we fallback to full sstable if slot search failed */
                     est_blocks = (double)sst->num_klog_blocks;
                 }
             }
@@ -35792,8 +35415,6 @@ int tidesdb_clone_column_family(tidesdb_t *db, const char *src_name, const char 
 #define TDB_INI_KEY_ENABLE_BLOOM_FILTER           "enable_bloom_filter"
 #define TDB_INI_KEY_BLOOM_FPR                     "bloom_fpr"
 #define TDB_INI_KEY_ENABLE_BLOCK_INDEXES          "enable_block_indexes"
-#define TDB_INI_KEY_INDEX_SAMPLE_RATIO            "index_sample_ratio"
-#define TDB_INI_KEY_BLOCK_INDEX_PREFIX_LEN        "block_index_prefix_len"
 #define TDB_INI_KEY_SYNC_MODE                     "sync_mode"
 #define TDB_INI_KEY_SYNC_INTERVAL_US              "sync_interval_us"
 #define TDB_INI_KEY_SKIP_LIST_MAX_LEVEL           "skip_list_max_level"
@@ -35892,14 +35513,6 @@ static int ini_config_handler(void *user, const char *section, const char *name,
     else if (strcmp(name, TDB_INI_KEY_ENABLE_BLOCK_INDEXES) == 0)
     {
         ctx->config->enable_block_indexes = (int)strtol(value, NULL, 10);
-    }
-    else if (strcmp(name, TDB_INI_KEY_INDEX_SAMPLE_RATIO) == 0)
-    {
-        ctx->config->index_sample_ratio = (int)strtol(value, NULL, 10);
-    }
-    else if (strcmp(name, TDB_INI_KEY_BLOCK_INDEX_PREFIX_LEN) == 0)
-    {
-        ctx->config->block_index_prefix_len = (int)strtol(value, NULL, 10);
     }
     else if (strcmp(name, TDB_INI_KEY_SYNC_MODE) == 0)
     {
@@ -36033,8 +35646,6 @@ int tidesdb_cf_config_save_to_ini(const char *ini_file, const char *section_name
     fprintf(fp, TDB_INI_KEY_ENABLE_BLOOM_FILTER " = %d\n", config->enable_bloom_filter);
     fprintf(fp, TDB_INI_KEY_BLOOM_FPR " = %f\n", config->bloom_fpr);
     fprintf(fp, TDB_INI_KEY_ENABLE_BLOCK_INDEXES " = %d\n", config->enable_block_indexes);
-    fprintf(fp, TDB_INI_KEY_INDEX_SAMPLE_RATIO " = %d\n", config->index_sample_ratio);
-    fprintf(fp, TDB_INI_KEY_BLOCK_INDEX_PREFIX_LEN " = %d\n", config->block_index_prefix_len);
     fprintf(fp, TDB_INI_KEY_SYNC_MODE " = %d\n", config->sync_mode);
     fprintf(fp, TDB_INI_KEY_SYNC_INTERVAL_US " = %" PRIu64 "\n", config->sync_interval_us);
     fprintf(fp, TDB_INI_KEY_SKIP_LIST_MAX_LEVEL " = %d\n", config->skip_list_max_level);
@@ -36090,8 +35701,6 @@ int tidesdb_cf_update_runtime_config(tidesdb_column_family_t *cf,
     cf->config.enable_bloom_filter = new_config->enable_bloom_filter;
     cf->config.bloom_fpr = new_config->bloom_fpr;
     cf->config.enable_block_indexes = new_config->enable_block_indexes;
-    cf->config.index_sample_ratio = new_config->index_sample_ratio;
-    cf->config.block_index_prefix_len = new_config->block_index_prefix_len;
     cf->config.compression_algorithm = new_config->compression_algorithm;
     cf->config.write_buffer_size = new_config->write_buffer_size;
     cf->config.level_size_ratio = new_config->level_size_ratio;
@@ -36143,436 +35752,6 @@ int tidesdb_cf_set_commit_hook(tidesdb_column_family_t *cf, tidesdb_commit_hook_
     cf->config.commit_hook_ctx = ctx;
 
     return TDB_SUCCESS;
-}
-
-/**
- * compact_block_index_create
- * creates a new block index for fast key-to-block lookups in sstables
- * @param initial_capacity initial number of index entries
- * @param prefix_len length of key prefixes to store
- * @param comparator comparator function for key ordering
- * @param comparator_ctx context for comparator
- * @return new block index, or NULL on failure
- */
-static tidesdb_block_index_t *compact_block_index_create(uint32_t initial_capacity,
-                                                         uint8_t prefix_len,
-                                                         const tidesdb_comparator_fn comparator,
-                                                         void *comparator_ctx)
-{
-    if (initial_capacity == 0) initial_capacity = TDB_INITIAL_BLOCK_INDEX_CAPACITY;
-    if (prefix_len < TDB_BLOCK_INDEX_PREFIX_MIN) prefix_len = TDB_DEFAULT_BLOCK_INDEX_PREFIX_LEN;
-
-    tidesdb_block_index_t *index = calloc(1, sizeof(tidesdb_block_index_t));
-    if (!index) return NULL;
-
-    index->min_key_prefixes = malloc(initial_capacity * prefix_len);
-    index->max_key_prefixes = malloc(initial_capacity * prefix_len);
-    index->file_positions = malloc(initial_capacity * sizeof(uint64_t));
-
-    if (!index->min_key_prefixes || !index->max_key_prefixes || !index->file_positions)
-    {
-        compact_block_index_free(index);
-        return NULL;
-    }
-
-    index->capacity = initial_capacity;
-    index->count = 0;
-    index->prefix_len = prefix_len;
-    index->comparator = comparator;
-    index->comparator_ctx = comparator_ctx;
-
-    return index;
-}
-
-/**
- * compact_block_index_serialize
- * serializes a block index to a byte buffer for writing to disk
- * @param index block index to serialize
- * @param out_size output parameter for serialized size
- * @return serialized data (caller must free), or NULL on failure
- */
-static uint8_t *compact_block_index_serialize(const tidesdb_block_index_t *index, size_t *out_size)
-{
-    if (!index || !out_size) return NULL;
-
-    /** header
-     *  count (4) + prefix_len (1) + file_positions (varint) + min/max prefixes */
-    const size_t max_size = sizeof(uint32_t) + sizeof(uint8_t) +
-                            index->count * 10 +                   /* file_positions (varint) */
-                            index->count * index->prefix_len * 2; /* min + max prefixes */
-
-    uint8_t *data = malloc(max_size);
-    if (!data) return NULL;
-
-    uint8_t *ptr = data;
-
-    /** header
-     *  count + prefix_len */
-    encode_uint32_le_compat(ptr, index->count);
-    ptr += sizeof(uint32_t);
-    *ptr++ = index->prefix_len;
-
-    /* delta encode + varint compress file_positions */
-    if (index->count > 0)
-    {
-        /* first file position stored as-is */
-        ptr += encode_varint(ptr, index->file_positions[0]);
-
-        /* remaining file positions stored as deltas */
-        for (uint32_t i = 1; i < index->count; i++)
-        {
-            const uint64_t delta = index->file_positions[i] - index->file_positions[i - 1];
-            ptr += encode_varint(ptr, delta);
-        }
-    }
-
-    const size_t prefix_bytes = index->count * index->prefix_len;
-    memcpy(ptr, index->min_key_prefixes, prefix_bytes);
-    ptr += prefix_bytes;
-    memcpy(ptr, index->max_key_prefixes, prefix_bytes);
-    ptr += prefix_bytes;
-
-    /* we calc actual size and shrink buffer */
-    const size_t actual_size = ptr - data;
-    uint8_t *final_data = realloc(data, actual_size);
-    if (!final_data)
-    {
-        /* realloc failed, but the original data is still valid */
-        *out_size = actual_size;
-        return data;
-    }
-
-    *out_size = actual_size;
-    return final_data;
-}
-
-/**
- * compact_block_index_deserialize
- * deserializes a block index from a byte buffer read from disk
- * @param data serialized data
- * @param data_size size of serialized data
- * @return deserialized block index, or NULL on failure
- */
-static tidesdb_block_index_t *compact_block_index_deserialize(const uint8_t *data,
-                                                              const size_t data_size)
-{
-    if (!data || data_size < sizeof(uint32_t) + sizeof(uint8_t)) return NULL;
-
-    const uint8_t *ptr = data;
-    const uint8_t *end = data + data_size;
-
-    /* we read header
-     * count + prefix_len */
-    const uint32_t count = decode_uint32_le_compat(ptr);
-    ptr += sizeof(uint32_t);
-    const uint8_t prefix_len = *ptr++;
-
-    if (prefix_len < TDB_BLOCK_INDEX_PREFIX_MIN)
-    {
-        TDB_DEBUG_LOG(
-            TDB_LOG_WARN,
-            "Block index deserialization failed with invalid prefix_len=%u (must be %d-%d)",
-            prefix_len, TDB_BLOCK_INDEX_PREFIX_MIN, TDB_BLOCK_INDEX_PREFIX_MAX);
-        return NULL; /* invalid format */
-    }
-
-    if (count > TDB_BLOCK_INDEX_MAX_COUNT)
-    {
-        TDB_DEBUG_LOG(TDB_LOG_WARN, "Block index deserialization failed with unreasonable count=%u",
-                      count);
-        return NULL;
-    }
-
-    tidesdb_block_index_t *index = calloc(1, sizeof(tidesdb_block_index_t));
-    if (!index) return NULL;
-
-    if (count == 0)
-    {
-        index->count = 0;
-        index->capacity = 0;
-        index->prefix_len = prefix_len;
-        index->min_key_prefixes = NULL;
-        index->max_key_prefixes = NULL;
-        index->file_positions = NULL;
-        return index;
-    }
-
-    index->min_key_prefixes = malloc(count * prefix_len);
-    index->max_key_prefixes = malloc(count * prefix_len);
-    index->file_positions = malloc(count * sizeof(uint64_t));
-
-    if (!index->min_key_prefixes || !index->max_key_prefixes || !index->file_positions)
-    {
-        compact_block_index_free(index);
-        return NULL;
-    }
-
-    /* we decode file_positions (delta-encoded varints) */
-    if (count > 0)
-    {
-        uint64_t value;
-
-        int bytes_read = decode_varint(ptr, &value, (int)(end - ptr));
-        if (bytes_read < 0) goto error;
-        index->file_positions[0] = value;
-        ptr += bytes_read;
-
-        /* remaining file positions (deltas) */
-        for (uint32_t i = 1; i < count; i++)
-        {
-            uint64_t delta;
-            bytes_read = decode_varint(ptr, &delta, (int)(end - ptr));
-            if (bytes_read < 0) goto error;
-            ptr += bytes_read;
-            index->file_positions[i] = index->file_positions[i - 1] + delta;
-        }
-    }
-
-    const size_t prefix_bytes = count * prefix_len;
-    if (ptr + prefix_bytes > end) goto error;
-    memcpy(index->min_key_prefixes, ptr, prefix_bytes);
-    ptr += prefix_bytes;
-
-    if (ptr + prefix_bytes > end) goto error;
-    memcpy(index->max_key_prefixes, ptr, prefix_bytes);
-    ptr += prefix_bytes;
-
-    index->count = count;
-    index->capacity = count;
-    index->prefix_len = prefix_len;
-    index->comparator = NULL;
-    index->comparator_ctx = NULL;
-
-    return index;
-
-error:
-    compact_block_index_free(index);
-    return NULL;
-}
-
-/**
- * compact_block_index_add
- * add a new entry to the block index
- * @param index block index
- * @param min_key minimum key in block
- * @param min_key_len length of minimum key
- * @param max_key maximum key in block
- * @param max_key_len length of maximum key
- * @param file_position position of block in file
- * @return 0 on success, -1 on error
- */
-static int compact_block_index_add(tidesdb_block_index_t *index, const uint8_t *min_key,
-                                   const size_t min_key_len, const uint8_t *max_key,
-                                   const size_t max_key_len, const uint64_t file_position)
-{
-    if (!index || !min_key || !max_key) return -1;
-
-    if (index->count >= index->capacity)
-    {
-        const uint32_t new_capacity = index->capacity * 2;
-
-        /** we must handle realloc failures carefully to avoid memory leaks
-         *  if any realloc fails, we keep the original pointers intact */
-        uint8_t *new_min = realloc(index->min_key_prefixes, new_capacity * index->prefix_len);
-        if (!new_min) return -1;
-        index->min_key_prefixes = new_min;
-
-        uint8_t *new_max = realloc(index->max_key_prefixes, new_capacity * index->prefix_len);
-        if (!new_max) return -1;
-        index->max_key_prefixes = new_max;
-
-        uint64_t *new_positions = realloc(index->file_positions, new_capacity * sizeof(uint64_t));
-        if (!new_positions) return -1;
-        index->file_positions = new_positions;
-
-        index->capacity = new_capacity;
-    }
-
-    const size_t min_copy_len = (min_key_len < index->prefix_len) ? min_key_len : index->prefix_len;
-    const size_t max_copy_len = (max_key_len < index->prefix_len) ? max_key_len : index->prefix_len;
-
-    uint8_t *min_dest = index->min_key_prefixes + (index->count * index->prefix_len);
-    uint8_t *max_dest = index->max_key_prefixes + (index->count * index->prefix_len);
-
-    memcpy(min_dest, min_key, min_copy_len);
-    if (min_copy_len < index->prefix_len)
-    {
-        memset(min_dest + min_copy_len, 0, index->prefix_len - min_copy_len);
-    }
-
-    memcpy(max_dest, max_key, max_copy_len);
-    if (max_copy_len < index->prefix_len)
-    {
-        memset(max_dest + max_copy_len, 0, index->prefix_len - max_copy_len);
-    }
-
-    index->file_positions[index->count] = file_position;
-    index->count++;
-
-    return 0;
-}
-
-/**
- * compact_block_index_find_slot
- * finds the leftmost block that could contain the given key using binary search
- *
- * the block index is lossy, it stores only the first prefix_len bytes of each
- * block's min/max key. when several keys share a prefix longer than prefix_len
- * they can span multiple klog blocks that all have identical min/max prefixes.
- * returning the rightmost prefix match would overshoot the block that actually
- * holds the key, so this finds the leftmost block whose max prefix is >= the
- * search prefix -- the first block that could hold the key or a key after it.
- * callers needing a definitive answer scan the prefix-colliding run forward
- * from here via compact_block_index_run_length.
- *
- * @param index the block index to search
- * @param key the search key
- * @param key_len length of the search key
- * @param slot output parameter for the found slot number
- * @return 0 on success, -1 if no suitable slot found
- */
-static int compact_block_index_find_slot(const tidesdb_block_index_t *index, const uint8_t *key,
-                                         const size_t key_len, int64_t *slot)
-{
-    if (!index || !key || index->count == 0 || !slot) return -1;
-
-    uint8_t search_prefix[TDB_BLOCK_INDEX_PREFIX_MAX];
-    const size_t copy_len = (key_len < index->prefix_len) ? key_len : index->prefix_len;
-    memcpy(search_prefix, key, copy_len);
-    if (copy_len < index->prefix_len)
-    {
-        memset(search_prefix + copy_len, 0, index->prefix_len - copy_len);
-    }
-
-    int64_t left = 0;
-    int64_t right = (int64_t)index->count - 1;
-    int64_t candidate = -1;
-
-    while (left <= right)
-    {
-        const int64_t mid = left + (right - left) / 2;
-        const uint8_t *mid_max_prefix = index->max_key_prefixes + (mid * index->prefix_len);
-
-        int cmp_max;
-        if (index->comparator)
-        {
-            cmp_max = index->comparator(search_prefix, index->prefix_len, mid_max_prefix,
-                                        index->prefix_len, index->comparator_ctx);
-        }
-        else
-        {
-            cmp_max = memcmp(search_prefix, mid_max_prefix, index->prefix_len);
-        }
-
-        if (cmp_max <= 0)
-        {
-            /* search_prefix <= max_prefix[mid] -- mid could hold the key; keep it
-             * and look left for an earlier block that also could */
-            candidate = mid;
-            right = mid - 1;
-        }
-        else
-        {
-            /* search_prefix > max_prefix[mid] -- the key sorts past this block */
-            left = mid + 1;
-        }
-    }
-
-    /* if no block has max_prefix >= search_prefix the key sorts past every
-     * indexed block; fall back to the last block so iterators position at the
-     * end and point lookups scan it and find nothing */
-    *slot = (candidate >= 0) ? candidate : (int64_t)index->count - 1;
-    return 0;
-}
-
-/**
- * compact_block_index_find_predecessor
- * thin wrapper over compact_block_index_find_slot that returns the file
- * position of the leftmost block that could contain the key
- *
- * @param index the block index to search
- * @param key the search key
- * @param key_len length of the search key
- * @param file_position output parameter for the found block file position
- * @return 0 on success, -1 if no suitable block found
- */
-static int compact_block_index_find_predecessor(const tidesdb_block_index_t *index,
-                                                const uint8_t *key, const size_t key_len,
-                                                uint64_t *file_position)
-{
-    int64_t slot = 0;
-    if (compact_block_index_find_slot(index, key, key_len, &slot) != 0) return -1;
-    *file_position = index->file_positions[slot];
-    return 0;
-}
-
-/**
- * compact_block_index_run_length
- * counts the prefix-colliding run starting at start_slot -- the number of
- * consecutive blocks whose min prefix is <= the search prefix. because the
- * prefix index is lossy a definitive point lookup must scan every block in
- * this run, not just the first, since the index cannot tell which one holds
- * the key. returns at least 1 so the caller always scans the starting block.
- *
- * @param index the block index to search
- * @param key the search key
- * @param key_len length of the search key
- * @param start_slot leftmost candidate slot from compact_block_index_find_slot
- * @return number of consecutive candidate blocks, 0 if start_slot is invalid
- */
-static uint32_t compact_block_index_run_length(const tidesdb_block_index_t *index,
-                                               const uint8_t *key, const size_t key_len,
-                                               const int64_t start_slot)
-{
-    if (!index || !key || start_slot < 0 || (uint32_t)start_slot >= index->count) return 0;
-
-    uint8_t search_prefix[TDB_BLOCK_INDEX_PREFIX_MAX];
-    const size_t copy_len = (key_len < index->prefix_len) ? key_len : index->prefix_len;
-    memcpy(search_prefix, key, copy_len);
-    if (copy_len < index->prefix_len)
-    {
-        memset(search_prefix + copy_len, 0, index->prefix_len - copy_len);
-    }
-
-    uint32_t run = 0;
-    for (uint32_t s = (uint32_t)start_slot; s < index->count; s++)
-    {
-        const uint8_t *min_prefix = index->min_key_prefixes + (s * index->prefix_len);
-        int cmp_min;
-        if (index->comparator)
-        {
-            cmp_min = index->comparator(min_prefix, index->prefix_len, search_prefix,
-                                        index->prefix_len, index->comparator_ctx);
-        }
-        else
-        {
-            cmp_min = memcmp(min_prefix, search_prefix, index->prefix_len);
-        }
-
-        /* min_prefix > search_prefix -- the key sorts before this block, so it
-         * cannot be in this block or any later one; the run ends here */
-        if (cmp_min > 0) break;
-        run++;
-    }
-
-    /* a gap (start_slot's min prefix already past the search prefix) still scans
-     * one block so the in-block search can report not found consistently */
-    if (run == 0) run = 1;
-    return run;
-}
-
-/**
- * compact_block_index_free
- * free a block index
- * @param index block index to free
- */
-static void compact_block_index_free(tidesdb_block_index_t *index)
-{
-    if (!index) return;
-    free(index->min_key_prefixes);
-    free(index->max_key_prefixes);
-    free(index->file_positions);
-    free(index);
 }
 
 #ifdef TDB_ENABLE_READ_PROFILING

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -1106,6 +1106,30 @@ static int tidesdb_bm_open(tidesdb_t *db, block_manager_t **bm, const char *path
 }
 
 /**
+ * tidesdb_bm_open_buffered
+ * the buffered-append counterpart of tidesdb_bm_open, used for an active WAL whose committers copy
+ * their record into a staging ring and let a single flush thread do the pwrite. same EMFILE/ENFILE
+ * backpressure and retry policy.
+ * @param db database instance (for waking the reaper)
+ * @param bm out-- opened buffered block manager
+ * @param path file path
+ * @param sync_mode block-manager sync mode (already converted)
+ * @return 0 on success, -1 on failure (errno set)
+ */
+static int tidesdb_bm_open_buffered(tidesdb_t *db, block_manager_t **bm, const char *path,
+                                    int sync_mode)
+{
+    for (int attempt = 0;; attempt++)
+    {
+        if (block_manager_open_buffered(bm, path, sync_mode, 0) == 0) return 0;
+        if ((errno != EMFILE && errno != ENFILE) || attempt >= TDB_BM_OPEN_EMFILE_MAX_RETRIES)
+            return -1;
+        tidesdb_wake_reaper(db);
+        usleep(TDB_BM_OPEN_EMFILE_BACKOFF_US);
+    }
+}
+
+/**
  * tidesdb_sstable_sync_barrier
  * durability barrier for a freshly built sstable -- flushes the klog and vlog so they are on disk
  * before the manifest commit publishes them. honored only when sync is on FULL and INTERVAL both
@@ -21191,15 +21215,31 @@ int tidesdb_open(const tidesdb_config_t *config, tidesdb_t **db)
                  "%s" PATH_SEPARATOR TDB_UNIFIED_WAL_PREFIX TDB_U64_FMT TDB_WAL_EXT, (*db)->db_path,
                  TDB_U64_CAST(active_uwal_gen));
 
+        /* buffered append -- committers copy their WAL record into a staging ring in parallel and
+         * a single flush thread pwrites the released runs, so appends never serialize on the inode
+         * write lock the way per-commit pwritev on one file does */
         block_manager_t *uwal = NULL;
-        int uwal_open_failed = (block_manager_open(&uwal, uwal_path, umt_sync_mode) != 0);
+        int uwal_open_failed =
+            (block_manager_open_buffered(&uwal, uwal_path, umt_sync_mode, 0) != 0);
         if (!uwal_open_failed)
         {
             /* adopt an existing uwal -- validate (permissive) to trim the
              * preallocation tail; a fresh db's uwal_0.log gets truncated empty */
             if (have_existing_uwal)
+            {
                 uwal_open_failed = (block_manager_validate_last_block(
                                         uwal, BLOCK_MANAGER_PERMISSIVE_BLOCK_VALIDATION) != 0);
+                /* validate trimmed current_file_size to the logical end; realign the flush and
+                 * group-durability watermarks the flush thread and group sync read from (no
+                 * appends have started, so the flush thread is quiesced) */
+                if (!uwal_open_failed)
+                {
+                    const uint64_t sz =
+                        atomic_load_explicit(&uwal->current_file_size, memory_order_acquire);
+                    atomic_store_explicit(&uwal->buf_flushed, sz, memory_order_release);
+                    atomic_store_explicit(&uwal->group_durable_size, sz, memory_order_release);
+                }
+            }
             else
                 uwal_open_failed = (block_manager_truncate(uwal) != 0);
         }
@@ -22273,7 +22313,7 @@ int tidesdb_promote_to_primary(tidesdb_t *db)
                      db->db_path, TDB_U64_CAST(gen));
 
             block_manager_t *new_wal = NULL;
-            if (block_manager_open(&new_wal, uwal_path, TDB_SYNC_FULL) == 0)
+            if (block_manager_open_buffered(&new_wal, uwal_path, TDB_SYNC_FULL, 0) == 0)
             {
                 block_manager_truncate(new_wal);
                 umt->wal = new_wal;
@@ -22882,7 +22922,9 @@ int tidesdb_create_column_family(tidesdb_t *db, const char *name,
                  "%s" PATH_SEPARATOR TDB_WAL_PREFIX TDB_U64_FMT TDB_WAL_EXT, cf->directory,
                  TDB_U64_CAST(active_wal_id));
 
-        if (block_manager_open(&new_wal, wal_path, config->sync_mode) != 0)
+        /* buffered append -- committers stage their WAL record and one flush thread pwrites, so
+         * concurrent commits to this CF never serialize on the WAL file's inode write lock */
+        if (block_manager_open_buffered(&new_wal, wal_path, config->sync_mode, 0) != 0)
         {
             queue_free(cf->immutable_memtables);
             skip_list_free(new_memtable);
@@ -22909,6 +22951,12 @@ int tidesdb_create_column_family(tidesdb_t *db, const char *name,
                 free(cf);
                 return TDB_ERR_IO;
             }
+            /* validate trimmed current_file_size to the logical end; realign the buffered flush and
+             * group-durability watermarks (no appends yet, so the flush thread is quiesced) */
+            const uint64_t sz =
+                atomic_load_explicit(&new_wal->current_file_size, memory_order_acquire);
+            atomic_store_explicit(&new_wal->buf_flushed, sz, memory_order_release);
+            atomic_store_explicit(&new_wal->group_durable_size, sz, memory_order_release);
         }
         else if (block_manager_truncate(new_wal) != 0)
         {
@@ -23648,7 +23696,7 @@ int tidesdb_rename_column_family(tidesdb_t *db, const char *old_name, const char
                      "%s" PATH_SEPARATOR TDB_WAL_PREFIX TDB_U64_FMT TDB_WAL_EXT, cf->directory,
                      TDB_U64_CAST(old_wal_id));
             block_manager_t *reopened = NULL;
-            block_manager_open(&reopened, wal_path, cf->config.sync_mode);
+            block_manager_open_buffered(&reopened, wal_path, cf->config.sync_mode, 0);
             atomic_store_explicit(&active_mt->wal, reopened, memory_order_release);
         }
         atomic_store_explicit(&cf->marked_for_deletion, 0, memory_order_release);
@@ -23666,7 +23714,7 @@ int tidesdb_rename_column_family(tidesdb_t *db, const char *old_name, const char
         if (wal_written > 0 && (size_t)wal_written < sizeof(new_wal_path))
         {
             block_manager_t *reopened = NULL;
-            if (block_manager_open(&reopened, new_wal_path, cf->config.sync_mode) != 0)
+            if (block_manager_open_buffered(&reopened, new_wal_path, cf->config.sync_mode, 0) != 0)
             {
                 TDB_DEBUG_LOG(TDB_LOG_ERROR, "Failed to reopen WAL at %s after rename",
                               new_wal_path);
@@ -24156,8 +24204,10 @@ static int tidesdb_flush_memtable_internal(tidesdb_column_family_t *cf,
                  "%s" PATH_SEPARATOR TDB_WAL_PREFIX TDB_U64_FMT TDB_WAL_EXT, cf->directory,
                  TDB_U64_CAST(wal_id));
 
-        if (tidesdb_bm_open(cf->db, &new_wal, wal_path, convert_sync_mode(cf->config.sync_mode)) !=
-            0)
+        /* buffered append -- committers stage their WAL record and one flush thread pwrites, so
+         * concurrent commits to this CF never serialize on the WAL file's inode write lock */
+        if (tidesdb_bm_open_buffered(cf->db, &new_wal, wal_path,
+                                     convert_sync_mode(cf->config.sync_mode)) != 0)
         {
             TDB_DEBUG_LOG(TDB_LOG_WARN, "CF '%s' failed to open new WAL '%s', %s", cf->name,
                           wal_path, strerror(errno));
@@ -28477,10 +28527,14 @@ static int tidesdb_unified_wal_group_sync(tidesdb_t *db, block_manager_t *wal, u
             continue;
         }
 
-        /* leader -- capture the high-water, fsync once, publish */
+        /* leader -- capture the high-water, fsync once, publish. on a buffered WAL the
+         * fdatasync only makes durable what the flush thread has already pwritten, so the
+         * high-water is the flushed offset, not the reservation watermark -- records reserved
+         * but still sitting in the staging ring are not yet in the page cache. */
         wal->group_sync_active = 1;
         const uint64_t flush_to =
-            atomic_load_explicit(&wal->current_file_size, memory_order_acquire);
+            wal->buffered ? atomic_load_explicit(&wal->buf_flushed, memory_order_acquire)
+                          : atomic_load_explicit(&wal->current_file_size, memory_order_acquire);
         pthread_mutex_unlock(&db->unified_mt.wal_group_sync_lock);
 
         const int rc = block_manager_escalate_fsync(wal);
@@ -28551,8 +28605,11 @@ static int tidesdb_unified_memtable_rotate(tidesdb_t *db)
              "%s" PATH_SEPARATOR TDB_UNIFIED_WAL_PREFIX TDB_U64_FMT TDB_WAL_EXT, db->db_path,
              TDB_U64_CAST(new_gen));
 
+    /* buffered append -- concurrent committers copy their WAL record into a staging ring in
+     * parallel and a single flush thread pwrites the released runs, so appends never contend the
+     * inode write lock the way per-commit pwritev on one file does */
     block_manager_t *new_wal = NULL;
-    if (block_manager_open(&new_wal, uwal_path, umt_sync_mode) != 0 ||
+    if (block_manager_open_buffered(&new_wal, uwal_path, umt_sync_mode, 0) != 0 ||
         block_manager_truncate(new_wal) != 0)
     {
         if (new_wal) block_manager_close(new_wal);
@@ -28882,19 +28939,32 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
 
         /** we write to unified WAL using raw write to avoid malloc/memcpy/free
          *  per commit. the wal_batch buffer (stack or heap) is written directly. */
+        uint64_t uwal_end = 0;
         if (uwal_batch && umt->wal)
         {
-            int64_t wal_result = block_manager_write_raw(umt->wal, uwal_batch, (uint32_t)uwal_size);
-            if (wal_result < 0)
+            int64_t wal_off = block_manager_write_raw(umt->wal, uwal_batch, (uint32_t)uwal_size);
+            if (wal_off < 0)
             {
                 if (uwal_batch != uwal_stack_buf) free(uwal_batch);
                 atomic_fetch_sub_explicit(&umt->writers, 1, memory_order_release);
                 atomic_fetch_sub_explicit(&umt->refcount, 1, memory_order_release);
                 return TDB_ERR_IO;
             }
+            uwal_end = (uint64_t)wal_off + block_manager_framed_size((uint32_t)uwal_size);
             atomic_fetch_add_explicit(&txn->db->uwal_bytes_written,
                                       block_manager_framed_size((uint32_t)uwal_size),
                                       memory_order_relaxed);
+
+            /* buffered WAL -- block until the single flush thread has pwritten this record to the
+             * page cache before the commit returns, matching the process-crash durability the
+             * direct path provides synchronously. no-op on a non-buffered WAL. */
+            if (block_manager_wait_durable(umt->wal, uwal_end) != 0)
+            {
+                if (uwal_batch != uwal_stack_buf) free(uwal_batch);
+                atomic_fetch_sub_explicit(&umt->writers, 1, memory_order_release);
+                atomic_fetch_sub_explicit(&umt->refcount, 1, memory_order_release);
+                return TDB_ERR_IO;
+            }
         }
 
         if (uwal_batch && uwal_batch != uwal_stack_buf) free(uwal_batch);
@@ -28902,11 +28972,9 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
         /* group-commit durability -- one fdatasync per batch of concurrent committers.
          * runs while writers is still held so a rotation cannot swap this WAL out from under
          * us. only when configured FULL; INTERVAL is handled by the sync worker, NONE skips. */
-        if (txn->db->config.unified_memtable_sync_mode == TDB_SYNC_FULL && umt->wal)
+        if (txn->db->config.unified_memtable_sync_mode == TDB_SYNC_FULL && umt->wal && uwal_end)
         {
-            const uint64_t my_end =
-                atomic_load_explicit(&umt->wal->current_file_size, memory_order_acquire);
-            if (tidesdb_unified_wal_group_sync(txn->db, umt->wal, my_end) != 0)
+            if (tidesdb_unified_wal_group_sync(txn->db, umt->wal, uwal_end) != 0)
             {
                 atomic_fetch_sub_explicit(&umt->writers, 1, memory_order_release);
                 atomic_fetch_sub_explicit(&umt->refcount, 1, memory_order_release);
@@ -29153,6 +29221,17 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
             atomic_fetch_add_explicit(&cf->wal_bytes_written,
                                       block_manager_framed_size((uint32_t)wal_size),
                                       memory_order_relaxed);
+
+            /* buffered WAL -- wait for the single flush thread to make this record durable (page
+             * cache, and fdatasync'd when the CF sync mode is FULL) before applying to the
+             * memtable, matching the durability the direct path provides inline. no-op on a direct
+             * WAL. */
+            if (block_manager_wait_durable(
+                    wal, (uint64_t)wal_result + block_manager_framed_size((uint32_t)wal_size)) != 0)
+            {
+                if (wal_is_heap) free(wal_batch);
+                goto cleanup_error_io;
+            }
         }
 
         if (wal_is_heap) free(wal_batch);

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -5707,12 +5707,24 @@ static void tdb_replica_sync_manifests(tidesdb_t *db, uint64_t lease_epoch)
             tidesdb_manifest_entry_t *rme = &remote_manifest->entries[r];
             if (tidesdb_manifest_has_sstable(cf->manifest, rme->level, rme->id)) continue;
 
-            char sst_base[MAX_FILE_PATH_LENGTH];
-            snprintf(sst_base, sizeof(sst_base), "%s" PATH_SEPARATOR TDB_LEVEL_PREFIX "%d",
+            /* we ensure the level directory exists */
+            char level_dir[MAX_FILE_PATH_LENGTH];
+            snprintf(level_dir, sizeof(level_dir), "%s" PATH_SEPARATOR TDB_LEVEL_PREFIX "%d",
                      cf->directory, rme->level);
+            mkdir(level_dir, TDB_DIR_PERMISSIONS);
 
-            /* we ensure level directory exists */
-            mkdir(sst_base, TDB_DIR_PERMISSIONS);
+            /* rebuild the filename the primary wrote and uploaded -- a partitioned merge output
+             * carries its shard (L<level>P<partition>), a flush output does not. reconstructing the
+             * non-partitioned name for a partitioned sstable would look for a file that is not in
+             * the bucket and leave an empty local sstable. */
+            char sst_base[MAX_FILE_PATH_LENGTH];
+            if (rme->partition >= 0)
+                snprintf(sst_base, sizeof(sst_base),
+                         "%s" PATH_SEPARATOR TDB_LEVEL_PREFIX "%d" TDB_LEVEL_PARTITION_PREFIX "%d",
+                         cf->directory, rme->level, rme->partition);
+            else
+                snprintf(sst_base, sizeof(sst_base), "%s" PATH_SEPARATOR TDB_LEVEL_PREFIX "%d",
+                         cf->directory, rme->level);
 
             tidesdb_sstable_t *sst = tidesdb_sstable_create(db, sst_base, rme->id, &cf->config);
             if (!sst) continue;
@@ -5751,7 +5763,7 @@ static void tdb_replica_sync_manifests(tidesdb_t *db, uint64_t lease_epoch)
             {
                 tidesdb_level_add_sstable(cf->levels[level_idx], sst);
                 tidesdb_manifest_add_sstable(cf->manifest, rme->level, rme->id, rme->num_entries,
-                                             rme->size_bytes);
+                                             rme->size_bytes, rme->partition);
 
                 uint64_t cur_next =
                     atomic_load_explicit(&cf->next_sstable_id, memory_order_relaxed);
@@ -6704,6 +6716,18 @@ static tidesdb_sstable_t *tidesdb_sstable_create(tidesdb_t *db, const char *base
         const char *last_back = strrchr(sst->klog_path, '\\');
         const char *last_sep = (last_fwd > last_back) ? last_fwd : last_back;
         sst->klog_filename = last_sep ? last_sep + 1 : sst->klog_path;
+    }
+
+    /* the partition shard is encoded in the filename for a partitioned merge output
+     * (L<level>P<partition>_<id>); a flush output has none. record it so the manifest can carry it
+     * and a manifest-driven rebuild reconstructs the same name. */
+    {
+        int parsed_level, parsed_partition;
+        unsigned long long parsed_id;
+        sst->partition = tdb_parse_sstable_partitioned(sst->klog_filename, &parsed_level,
+                                                       &parsed_partition, &parsed_id)
+                             ? parsed_partition
+                             : MANIFEST_NO_PARTITION;
     }
 
     return sst;
@@ -7944,6 +7968,12 @@ static void tidesdb_sstable_write_footer_aux(tidesdb_sstable_t *sst, block_manag
 
     blocked_index_builder_free(index_builder);
     blocked_bloom_builder_free(bloom_builder);
+
+    /* open the paged bloom and index readers on the freshly written sstable so reads route through
+     * the block index immediately. without this a just-flushed sstable has null readers until it is
+     * evicted and reloaded, forcing every lookup down the full-scan fallback (matching how load
+     * opens them via tidesdb_sstable_open_blocked_readers). */
+    tidesdb_sstable_open_blocked_readers(sst);
 }
 
 /**
@@ -14643,7 +14673,8 @@ static int tidesdb_full_preemptive_shard(void *vctx, int shard)
 
                 tidesdb_manifest_add_sstable(cf->manifest, cf->levels[target_idx]->level_num,
                                              new_sst->id, new_sst->num_entries,
-                                             new_sst->klog_size + new_sst->vlog_size);
+                                             new_sst->klog_size + new_sst->vlog_size,
+                                             new_sst->partition);
                 atomic_store(&cf->manifest->sequence, atomic_load(&cf->next_sstable_id));
                 int manifest_result = tidesdb_manifest_commit(
                     cf->manifest, cf->manifest->path, cf->config.sync_mode != TDB_SYNC_NONE);
@@ -15252,9 +15283,9 @@ merge_complete:;
             tidesdb_level_add_sstable(cf->levels[target_idx], new_sst);
             tidesdb_bump_sstable_layout_version(cf);
 
-            tidesdb_manifest_add_sstable(cf->manifest, cf->levels[target_idx]->level_num,
-                                         new_sst->id, new_sst->num_entries,
-                                         new_sst->klog_size + new_sst->vlog_size);
+            tidesdb_manifest_add_sstable(
+                cf->manifest, cf->levels[target_idx]->level_num, new_sst->id, new_sst->num_entries,
+                new_sst->klog_size + new_sst->vlog_size, new_sst->partition);
             atomic_store(&cf->manifest->sequence, atomic_load(&cf->next_sstable_id));
             tidesdb_manifest_commit(cf->manifest, cf->manifest->path,
                                     cf->config.sync_mode != TDB_SYNC_NONE);
@@ -15802,9 +15833,9 @@ static int tidesdb_dividing_merge_partition(void *vctx, int partition)
             pthread_mutex_lock(&cf->compaction_commit_lock);
             tidesdb_level_add_sstable(cf->levels[target_level], new_sst);
             tidesdb_bump_sstable_layout_version(cf);
-            tidesdb_manifest_add_sstable(cf->manifest, cf->levels[target_level]->level_num,
-                                         new_sst->id, new_sst->num_entries,
-                                         new_sst->klog_size + new_sst->vlog_size);
+            tidesdb_manifest_add_sstable(
+                cf->manifest, cf->levels[target_level]->level_num, new_sst->id,
+                new_sst->num_entries, new_sst->klog_size + new_sst->vlog_size, new_sst->partition);
             pthread_mutex_unlock(&cf->compaction_commit_lock);
             tidesdb_sstable_unref(cf->db, new_sst);
             continue;
@@ -16217,7 +16248,8 @@ static int tidesdb_dividing_merge_partition(void *vctx, int partition)
 
                 tidesdb_manifest_add_sstable(cf->manifest, cf->levels[target_idx]->level_num,
                                              new_sst->id, new_sst->num_entries,
-                                             new_sst->klog_size + new_sst->vlog_size);
+                                             new_sst->klog_size + new_sst->vlog_size,
+                                             new_sst->partition);
                 atomic_store(&cf->manifest->sequence, atomic_load(&cf->next_sstable_id));
                 int manifest_result = tidesdb_manifest_commit(
                     cf->manifest, cf->manifest->path, cf->config.sync_mode != TDB_SYNC_NONE);
@@ -16376,7 +16408,8 @@ static int tdb_partitioned_merge_finalize_sst(
         tidesdb_bump_sstable_layout_version(cf);
 
         tidesdb_manifest_add_sstable(cf->manifest, cf->levels[target_idx]->level_num, sst->id,
-                                     sst->num_entries, sst->klog_size + sst->vlog_size);
+                                     sst->num_entries, sst->klog_size + sst->vlog_size,
+                                     sst->partition);
         atomic_store(&cf->manifest->sequence, atomic_load(&cf->next_sstable_id));
         const int manifest_result = tidesdb_manifest_commit(cf->manifest, cf->manifest->path,
                                                             cf->config.sync_mode != TDB_SYNC_NONE);
@@ -17032,9 +17065,9 @@ static int tidesdb_partitioned_merge_partition(void *vctx, int partition)
                 pthread_mutex_lock(&cf->compaction_commit_lock);
                 tidesdb_level_add_sstable(cf->levels[end_idx], new_sst);
                 tidesdb_bump_sstable_layout_version(cf);
-                tidesdb_manifest_add_sstable(cf->manifest, cf->levels[end_idx]->level_num,
-                                             new_sst->id, new_sst->num_entries,
-                                             new_sst->klog_size + new_sst->vlog_size);
+                tidesdb_manifest_add_sstable(
+                    cf->manifest, cf->levels[end_idx]->level_num, new_sst->id, new_sst->num_entries,
+                    new_sst->klog_size + new_sst->vlog_size, new_sst->partition);
                 pthread_mutex_unlock(&cf->compaction_commit_lock);
                 tidesdb_sstable_unref(cf->db, new_sst);
                 continue;
@@ -18726,7 +18759,7 @@ static void *tidesdb_flush_worker_thread(void *arg)
          * we must commit manifest before triggering compaction to avoid deadlock
          * where flush worker holds manifest lock while compaction worker waits for it */
         tidesdb_manifest_add_sstable(cf->manifest, 1, work->sst_id, sst->num_entries,
-                                     sst->klog_size + sst->vlog_size);
+                                     sst->klog_size + sst->vlog_size, sst->partition);
         atomic_store(&cf->manifest->sequence, atomic_load(&cf->next_sstable_id));
         int manifest_result = tidesdb_manifest_commit(cf->manifest, cf->manifest->path,
                                                       cf->config.sync_mode != TDB_SYNC_NONE);
@@ -27963,7 +27996,7 @@ static int tidesdb_unified_write_cf_sstable(tidesdb_t *db, tidesdb_column_family
     tidesdb_bump_sstable_layout_version(cf);
 
     tidesdb_manifest_add_sstable(cf->manifest, 1, sst_id, sst->num_entries,
-                                 sst->klog_size + sst->vlog_size);
+                                 sst->klog_size + sst->vlog_size, sst->partition);
     atomic_store(&cf->manifest->sequence, atomic_load(&cf->next_sstable_id));
     const int manifest_result = tidesdb_manifest_commit(cf->manifest, cf->manifest->path,
                                                         cf->config.sync_mode != TDB_SYNC_NONE);
@@ -32560,7 +32593,7 @@ static void tidesdb_recover_single_sstable(tidesdb_column_family_t *cf, const st
             /* self-heal -- this sstable was on disk but missing from the recovered manifest, so add
              * it back so the rebuilt manifest reflects the on-disk set */
             tidesdb_manifest_add_sstable(cf->manifest, level_num, sst_id, sst->num_entries,
-                                         sst->klog_size + sst->vlog_size);
+                                         sst->klog_size + sst->vlog_size, sst->partition);
         }
     }
     else
@@ -32669,10 +32702,17 @@ static int tidesdb_recover_sstables(tidesdb_column_family_t *cf)
             {
                 tidesdb_manifest_entry_t *me = &cf->manifest->entries[i];
 
-                /* we construct sst path from level + id */
+                /* we construct the sst path from level + id, restoring the partition shard for a
+                 * partitioned merge output so the download key matches the uploaded filename */
                 char sst_base[MAX_FILE_PATH_LENGTH];
-                snprintf(sst_base, sizeof(sst_base), "%s" PATH_SEPARATOR TDB_LEVEL_PREFIX "%d",
-                         cf->directory, me->level);
+                if (me->partition >= 0)
+                    snprintf(sst_base, sizeof(sst_base),
+                             "%s" PATH_SEPARATOR TDB_LEVEL_PREFIX "%d" TDB_LEVEL_PARTITION_PREFIX
+                             "%d",
+                             cf->directory, me->level, me->partition);
+                else
+                    snprintf(sst_base, sizeof(sst_base), "%s" PATH_SEPARATOR TDB_LEVEL_PREFIX "%d",
+                             cf->directory, me->level);
 
                 tidesdb_sstable_t *sst =
                     tidesdb_sstable_create(cf->db, sst_base, me->id, &cf->config);

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -576,6 +576,14 @@ struct tidesdb_column_family_t
     _Atomic(int) num_active_levels;
     _Atomic(uint64_t) next_sstable_id;
     _Atomic(uint64_t) sstable_layout_version;
+    /* cached L1 overlap depth (max sstables covering any one key = the point-read cost, the true
+     * read-amp signal backpressure paces on) with the layout version it was computed at. flush
+     * partitioning makes the raw L1 file count a poor read-amp proxy -- narrow tiling files inflate
+     * the count without raising per-key overlap -- so pacing keys on depth, recomputed only when
+     * the layout version moves. l1_overlap_ver starts at UINT64_MAX so the first read recomputes.
+     */
+    _Atomic(int) l1_overlap_depth;
+    _Atomic(uint64_t) l1_overlap_ver;
     _Atomic(int) is_compacting;
     _Atomic(int) is_flushing;
     _Atomic(int) flush_pending_count;

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -1072,6 +1072,17 @@ struct tidesdb_txn_t
     uint64_t txn_id;
     uint64_t snapshot_seq;
     uint64_t commit_seq;
+    /* the op array and the read set are written only by the owning thread but READ by other
+     * transactions -- the serializable rw-antidependency check walks a concurrent transaction's
+     * ops, and the dangerous-structure check walks its read set. both grow by realloc and are
+     * truncated on reset or savepoint rollback, so an unguarded reader can dereference a freed
+     * array, not merely read a torn count. conflict_lock makes that publication safe. the owner
+     * write-locks it across any mutation of ops/num_ops or the read set, a cross-transaction reader
+     * read-locks the transaction it is scanning. uncontended in the common case, since only the
+     * owner writes and readers appear only during a serializable commit's conflict check. the owner
+     * never takes the active-transaction registry lock while holding this, so there is no
+     * lock-order inversion with the reader, which holds the registry read lock first. */
+    pthread_rwlock_t conflict_lock;
     tidesdb_txn_op_t *ops;
     int num_ops;
     int ops_capacity;

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -21,6 +21,8 @@
 
 #include "alloc.h"
 #include "block_manager.h"
+#include "blocked_bloom_filter.h"
+#include "blocked_index.h"
 #include "bloom_filter.h"
 #include "btree.h"
 #include "clock_cache.h"
@@ -224,8 +226,6 @@ typedef enum
 #define TDB_DEFAULT_MAX_CONCURRENT_FLUSHES TDB_DEFAULT_FLUSH_THREAD_POOL_SIZE
 #define TDB_DEFAULT_BLOOM_FPR              0.01
 #define TDB_DEFAULT_KLOG_VALUE_THRESHOLD   512
-#define TDB_DEFAULT_INDEX_SAMPLE_RATIO     1
-#define TDB_DEFAULT_BLOCK_INDEX_PREFIX_LEN 16
 #define TDB_DEFAULT_MIN_DISK_SPACE         (100 * 1024 * 1024)
 #if defined(__OpenBSD__)
 #define TDB_DEFAULT_MAX_OPEN_SSTABLES 64 /* x2 OpenBSD has lower default fd limits */
@@ -300,7 +300,6 @@ typedef struct tidesdb_kv_pair_t tidesdb_kv_pair_t;
 typedef struct tidesdb_commit_status_t tidesdb_commit_status_t;
 typedef struct tidesdb_level_t tidesdb_level_t;
 typedef struct tidesdb_sstable_t tidesdb_sstable_t;
-typedef struct tidesdb_block_index_t tidesdb_block_index_t;
 typedef struct tidesdb_memtable_t tidesdb_memtable_t;
 typedef struct tidesdb_deferred_free_node_t tidesdb_deferred_free_node_t;
 typedef struct tidesdb_t tidesdb_t;
@@ -370,8 +369,6 @@ typedef struct tidesdb_stats_t tidesdb_stats_t;
  * @param enable_bloom_filter enable bloom filter
  * @param bloom_fpr bloom filter false positive rate
  * @param enable_block_indexes enable block indexes
- * @param index_sample_ratio index sample ratio
- * @param block_index_prefix_len block index prefix length
  * @param sync_mode sync mode
  * @param sync_interval_us sync interval in microseconds
  * @param comparator_name name of comparator
@@ -412,8 +409,6 @@ typedef struct tidesdb_column_family_config_t
     int enable_bloom_filter;
     double bloom_fpr;
     int enable_block_indexes;
-    int index_sample_ratio;
-    int block_index_prefix_len;
     int sync_mode;
     uint64_t sync_interval_us;
     char comparator_name[TDB_MAX_COMPARATOR_NAME];
@@ -709,8 +704,12 @@ struct tidesdb_sstable_t
     uint64_t klog_size;
     uint64_t vlog_size;
     uint64_t max_seq;
-    bloom_filter_t *bloom_filter;
-    tidesdb_block_index_t *block_indexes;
+    /* paged aux -- the blocked bloom filter and block index keep only a small directory resident
+     * and page their partitions through the block cache. present when the sstable was written in
+     * the blocked-aux format (SSTABLE_FLAG_BLOCKED_AUX); NULL for older sstables, whose reads fall
+     * back to a full scan until compaction rewrites them. */
+    blocked_bloom_reader_t *bloom_reader;
+    blocked_index_reader_t *index_reader;
     _Atomic(int) refcount;
     /* opened lazily by tidesdb_sstable_ensure_open and published by CAS, so the
      * pointers are _Atomic -- readers acquire-load them and so observe the fully
@@ -731,17 +730,14 @@ struct tidesdb_sstable_t
     void *cached_comparator_ctx;
     int is_reverse;
     uint64_t cache_key_prefix;
-    /* chunked footer aux blobs -- when a bloom filter or block index footer blob
-     * exceeds the single-block chunk size it is written as multiple consecutive
-     * blocks and located by explicit offset+size instead of trailing-block
-     * navigation. aux_chunked is set (and the offsets persisted in metadata) only
-     * for such sstables; legacy/small sstables leave it 0 and use the original
-     * trailing-block read path. */
-    int aux_chunked;
-    uint64_t bloom_blob_offset;
-    uint64_t bloom_blob_size;
-    uint64_t index_blob_offset;
-    uint64_t index_blob_size;
+    /* blocked-aux directory locators -- persisted in metadata under SSTABLE_FLAG_BLOCKED_AUX and
+     * handed to blocked_bloom_reader_open / blocked_index_reader_open at load. blocked_aux is set
+     * for sstables written in this format. */
+    int blocked_aux;
+    uint64_t bloom_dir_offset;
+    uint64_t bloom_dir_size;
+    uint64_t index_dir_offset;
+    uint64_t index_dir_size;
 };
 
 /**
@@ -821,10 +817,6 @@ struct tidesdb_level_t
  * @param total_memory total system memory in bytes
  * @param resolved_memory_limit resolved global memory limit in bytes
  * @param cached_memtable_bytes cached total memtable + cache memory (updated by reaper)
- * @param sstable_aux_memory_bytes running total of bloom filter + block index
- *                                 memory across every sstable currently in a
- *                                 level, maintained at level add and remove so
- *                                 the reaper does not rescan every sstable
  * @param memory_pressure_level cached pressure level 0=normal 1=elevated 2=high 3=critical
  * @param txn_memory_bytes bytes held by in-flight transactions
  * @param flush_pending_count number of pending flush operations (queued + in-flight)
@@ -912,7 +904,6 @@ struct tidesdb_t
     uint64_t total_memory;
     _Atomic(size_t) resolved_memory_limit;
     _Atomic(int64_t) cached_memtable_bytes;
-    _Atomic(int64_t) sstable_aux_memory_bytes;
     _Atomic(int64_t) txn_memory_bytes;
     _Atomic(int) memory_pressure_level;
     _Atomic(int) flush_pending_count;

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -1142,6 +1142,10 @@ struct tidesdb_iter_t
  * statistics for database column family
  * @param num_levels number of levels
  * @param memtable_size size of memtable
+ * @param immutable_count number of immutable (frozen, awaiting-flush) memtables queued for this
+ *                        cf -- the per-cf L0 queue depth backpressure throttles on. always 0 in
+ *                        unified mode, where the shared queue is reported db-wide in
+ *                        tidesdb_db_stats_t.unified_immutable_count
  * @param level_sizes sizes of each level
  * @param level_num_sstables number of sstables in each level
  * @param config column family configuration
@@ -1173,6 +1177,7 @@ struct tidesdb_stats_t
 {
     int num_levels;
     size_t memtable_size;
+    int immutable_count;
     size_t *level_sizes;
     int *level_num_sstables;
     tidesdb_column_family_config_t *config;

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -391,8 +391,6 @@ typedef struct tidesdb_stats_t tidesdb_stats_t;
  * @param use_btree use btree for klog, faster reads depending on workload
  * @param commit_hook_fn optional commit hook callback (NULL = disabled, runtime-only)
  * @param commit_hook_ctx optional user context passed to commit hook (runtime-only)
- * @param object_target_file_size reserved for API compatibility, not used (file_max is derived from
- * level geometry per spooky algorithm 2)
  * @param object_lazy_compaction lazy compaction flag (1 = less aggressive, 0 = aggressive)
  * @param object_prefetch_compaction prefetch compaction flag (1 = download all inputs before merge,
  * 0 = stream)
@@ -426,7 +424,6 @@ typedef struct tidesdb_column_family_config_t
     int use_btree;
     tidesdb_commit_hook_fn commit_hook_fn;
     void *commit_hook_ctx;
-    size_t object_target_file_size; /* reserved, not used */
     int object_lazy_compaction;
     int object_prefetch_compaction;
 } tidesdb_column_family_config_t;
@@ -468,6 +465,10 @@ typedef struct tidesdb_comparator_entry_t
  * @param unified_memtable_skip_list_probability skip list probability (0 = default 0.25)
  * @param unified_memtable_sync_mode sync mode for unified WAL (default TDB_SYNC_NONE)
  * @param unified_memtable_sync_interval_us sync interval for unified WAL (0 = default)
+ * @param unified_memtable_l0_queue_stall_threshold immutable-queue depth at which writer
+ *                               backpressure hard-stalls in unified mode. the shared unified
+ *                               immutable queue is db-wide, so it is bounded by this one db-level
+ *                               value rather than a per-column-family threshold. 0 = default
  * @param object_store object store instance (NULL = local only, default)
  * @param object_store_config object store configuration (NULL = use defaults)
  * @param max_concurrent_flushes global semaphore on the number of in-flight memtable flushes
@@ -500,6 +501,7 @@ typedef struct tidesdb_config_t
     float unified_memtable_skip_list_probability;
     int unified_memtable_sync_mode;
     uint64_t unified_memtable_sync_interval_us;
+    int unified_memtable_l0_queue_stall_threshold;
     tidesdb_objstore_t *object_store;
     tidesdb_objstore_config_t *object_store_config;
     int max_concurrent_flushes;
@@ -884,6 +886,9 @@ struct tidesdb_t
     _Atomic(int) reaper_active;
     pthread_mutex_t reaper_thread_mutex;
     pthread_cond_t reaper_thread_cond;
+    /* column-family index the next fd-eviction scan resumes from, so the scan sweeps every CF
+     * across cycles instead of always restarting at the front. reaper-thread-only, no atomic. */
+    int reap_scan_cursor;
     clock_cache_t *clock_cache;
     /* created lazily after worker threads are running, so the pointer is
      * _Atomic -- btree_cache_lock still serializes the one-time creation */
@@ -1498,6 +1503,19 @@ int tidesdb_txn_begin(tidesdb_t *db, tidesdb_txn_t **txn);
  */
 int tidesdb_txn_begin_with_isolation(tidesdb_t *db, tidesdb_isolation_level_t isolation,
                                      tidesdb_txn_t **txn);
+
+/**
+ * tidesdb_txn_begin_cf
+ * begins a transaction at a column family's configured default isolation level
+ * (tidesdb_column_family_config_t.default_isolation_level). the transaction is still
+ * database-scoped and may touch any column family; the cf only supplies the initial isolation
+ * level.
+ * @param db database handle
+ * @param cf column family whose default isolation level to use
+ * @param txn pointer to transaction handle
+ * @return 0 on success, -n on failure
+ */
+int tidesdb_txn_begin_cf(tidesdb_t *db, tidesdb_column_family_t *cf, tidesdb_txn_t **txn);
 
 /**
  * tidesdb_txn_put

--- a/src/tidesdb.h
+++ b/src/tidesdb.h
@@ -685,6 +685,10 @@ struct tidesdb_column_family_t
 struct tidesdb_sstable_t
 {
     uint64_t id;
+    /* partition shard index parsed from the klog filename (L<level>P<partition>_<id>), or
+     * MANIFEST_NO_PARTITION for a non-partitioned flush output. recorded in the manifest so a
+     * node reconstructing the sstable from the manifest rebuilds the same filename. */
+    int partition;
     char *klog_path;
     const char *klog_filename;
     char *vlog_path;

--- a/test/block_manager__tests.c
+++ b/test/block_manager__tests.c
@@ -3702,6 +3702,293 @@ void test_block_manager_max_safe_block_bytes_refusal(void)
     (void)remove(path);
 }
 
+/* buffered-append mode -- write through block_manager_open_buffered (staging ring + flush thread),
+ * then reopen on the direct path to prove the on-disk bytes are identical and every record survives
+ */
+
+void test_block_manager_buffered_roundtrip(void)
+{
+    const char *path = "test_buffered_roundtrip.db";
+    (void)remove(path);
+
+    block_manager_t *bm = NULL;
+    ASSERT_TRUE(block_manager_open_buffered(&bm, path, BLOCK_MANAGER_SYNC_NONE, 0) == 0);
+    ASSERT_TRUE(bm != NULL);
+    ASSERT_EQ(bm->buffered, 1);
+
+    const int num_records = 500;
+    for (int i = 0; i < num_records; i++)
+    {
+        char data[48];
+        snprintf(data, sizeof(data), "buffered_record_%d", i);
+        const uint32_t size = (uint32_t)(strlen(data) + 1);
+        int64_t off = block_manager_write_raw(bm, data, size);
+        ASSERT_TRUE(off >= 0);
+        /* wait for the flush thread to make this record durable before moving on */
+        ASSERT_TRUE(
+            block_manager_wait_durable(bm, (uint64_t)off + block_manager_framed_size(size)) == 0);
+    }
+
+    /* get_size reports the flushed extent on a buffered handle -- everything is durable here */
+    uint64_t flushed_size = 0;
+    ASSERT_TRUE(block_manager_get_size(bm, &flushed_size) == 0);
+    ASSERT_TRUE(flushed_size > BLOCK_MANAGER_HEADER_SIZE);
+    ASSERT_TRUE(block_manager_close(bm) == 0);
+
+    /* reopen on the direct path and read every record back */
+    bm = NULL;
+    ASSERT_TRUE(block_manager_open(&bm, path, BLOCK_MANAGER_SYNC_NONE) == 0);
+    ASSERT_EQ(bm->buffered, 0);
+
+    uint64_t reopen_size = 0;
+    ASSERT_TRUE(block_manager_get_size(bm, &reopen_size) == 0);
+    ASSERT_EQ(reopen_size, flushed_size);
+
+    block_manager_cursor_t *cursor = NULL;
+    ASSERT_TRUE(block_manager_cursor_init(&cursor, bm) == 0);
+    ASSERT_TRUE(block_manager_cursor_goto_first(cursor) == 0);
+
+    int read = 0;
+    do
+    {
+        block_manager_block_t *block = block_manager_cursor_read(cursor);
+        if (!block) break;
+        char expected[48];
+        snprintf(expected, sizeof(expected), "buffered_record_%d", read);
+        ASSERT_EQ(strcmp((char *)block->data, expected), 0);
+        read++;
+        block_manager_block_free(block);
+    } while (block_manager_cursor_next(cursor) == 0);
+    block_manager_cursor_free(cursor);
+
+    ASSERT_EQ(read, num_records);
+    ASSERT_TRUE(block_manager_close(bm) == 0);
+    (void)remove(path);
+}
+
+typedef struct
+{
+    block_manager_t *bm;
+    int thread_id;
+    int num_records;
+    int records_per_thread;
+} buffered_writer_args_t;
+
+static void *buffered_writer_thread(void *arg)
+{
+    buffered_writer_args_t *a = (buffered_writer_args_t *)arg;
+    for (int i = 0; i < a->records_per_thread; i++)
+    {
+        /* payload carries a globally unique index so read-back can prove exactly-once */
+        const uint32_t idx = (uint32_t)(a->thread_id * a->records_per_thread + i);
+        uint8_t data[32];
+        memset(data, 0, sizeof(data));
+        memcpy(data, &idx, sizeof(idx));
+        int64_t off = block_manager_write_raw(a->bm, data, (uint32_t)sizeof(data));
+        if (off < 0) continue;
+        (void)block_manager_wait_durable(a->bm,
+                                         (uint64_t)off + block_manager_framed_size(sizeof(data)));
+    }
+    return NULL;
+}
+
+void test_block_manager_buffered_concurrent(void)
+{
+    const char *path = "test_buffered_concurrent.db";
+    (void)remove(path);
+
+    const int num_threads = 8;
+    const int records_per_thread = 2000;
+    const int total = num_threads * records_per_thread;
+
+    block_manager_t *bm = NULL;
+    /* SYNC_FULL exercises the flush thread's fdatasync path under concurrency */
+    ASSERT_TRUE(block_manager_open_buffered(&bm, path, BLOCK_MANAGER_SYNC_FULL, 0) == 0);
+
+    pthread_t threads[8];
+    buffered_writer_args_t args[8];
+    for (int i = 0; i < num_threads; i++)
+    {
+        args[i].bm = bm;
+        args[i].thread_id = i;
+        args[i].num_records = total;
+        args[i].records_per_thread = records_per_thread;
+        ASSERT_TRUE(pthread_create(&threads[i], NULL, buffered_writer_thread, &args[i]) == 0);
+    }
+    for (int i = 0; i < num_threads; i++) ASSERT_TRUE(pthread_join(threads[i], NULL) == 0);
+
+    ASSERT_TRUE(block_manager_close(bm) == 0);
+
+    /* reopen direct and confirm every index appears exactly once */
+    bm = NULL;
+    ASSERT_TRUE(block_manager_open(&bm, path, BLOCK_MANAGER_SYNC_NONE) == 0);
+
+    uint8_t *seen = calloc((size_t)total, 1);
+    ASSERT_TRUE(seen != NULL);
+
+    block_manager_cursor_t *cursor = NULL;
+    ASSERT_TRUE(block_manager_cursor_init(&cursor, bm) == 0);
+    ASSERT_TRUE(block_manager_cursor_goto_first(cursor) == 0);
+
+    int count = 0;
+    do
+    {
+        block_manager_block_t *block = block_manager_cursor_read(cursor);
+        if (!block) break;
+        ASSERT_EQ(block->size, (uint64_t)32);
+        uint32_t idx = 0;
+        memcpy(&idx, block->data, sizeof(idx));
+        ASSERT_TRUE(idx < (uint32_t)total);
+        ASSERT_EQ(seen[idx], 0); /* no duplicates */
+        seen[idx] = 1;
+        count++;
+        block_manager_block_free(block);
+    } while (block_manager_cursor_next(cursor) == 0);
+    block_manager_cursor_free(cursor);
+
+    ASSERT_EQ(count, total);
+    for (int i = 0; i < total; i++) ASSERT_EQ(seen[i], 1); /* none missing */
+    free(seen);
+
+    ASSERT_TRUE(block_manager_close(bm) == 0);
+    (void)remove(path);
+}
+
+void test_block_manager_buffered_ring_wraparound(void)
+{
+    const char *path = "test_buffered_wrap.db";
+    (void)remove(path);
+
+    /* a 1 MB ring (the floor) with 4 KB records forces many full wraparounds */
+    block_manager_t *bm = NULL;
+    ASSERT_TRUE(block_manager_open_buffered(&bm, path, BLOCK_MANAGER_SYNC_NONE, 1) == 0);
+
+    const int num_records = 1500;
+    const uint32_t rec_size = 4096;
+    uint8_t *data = malloc(rec_size);
+    ASSERT_TRUE(data != NULL);
+
+    for (int i = 0; i < num_records; i++)
+    {
+        memset(data, 0, rec_size);
+        memcpy(data, &i, sizeof(i)); /* first 4 bytes = sequence number */
+        int64_t off = block_manager_write_raw(bm, data, rec_size);
+        ASSERT_TRUE(off >= 0);
+        ASSERT_TRUE(block_manager_wait_durable(
+                        bm, (uint64_t)off + block_manager_framed_size(rec_size)) == 0);
+    }
+    free(data);
+    ASSERT_TRUE(block_manager_close(bm) == 0);
+
+    bm = NULL;
+    ASSERT_TRUE(block_manager_open(&bm, path, BLOCK_MANAGER_SYNC_NONE) == 0);
+    block_manager_cursor_t *cursor = NULL;
+    ASSERT_TRUE(block_manager_cursor_init(&cursor, bm) == 0);
+    ASSERT_TRUE(block_manager_cursor_goto_first(cursor) == 0);
+
+    int read = 0;
+    do
+    {
+        block_manager_block_t *block = block_manager_cursor_read(cursor);
+        if (!block) break;
+        ASSERT_EQ(block->size, (uint64_t)rec_size);
+        int seq = 0;
+        memcpy(&seq, block->data, sizeof(seq));
+        ASSERT_EQ(seq, read); /* records land in append order */
+        read++;
+        block_manager_block_free(block);
+    } while (block_manager_cursor_next(cursor) == 0);
+    block_manager_cursor_free(cursor);
+
+    ASSERT_EQ(read, num_records);
+    ASSERT_TRUE(block_manager_close(bm) == 0);
+    (void)remove(path);
+}
+
+void test_block_manager_buffered_oversized_record(void)
+{
+    const char *path = "test_buffered_oversized.db";
+    (void)remove(path);
+
+    /* 1 MB ring floor; a 1.5 MB record cannot be staged and takes the oversized direct-write path.
+     * bracket it with small records to prove ordering and the flushed watermark stay consistent. */
+    block_manager_t *bm = NULL;
+    ASSERT_TRUE(block_manager_open_buffered(&bm, path, BLOCK_MANAGER_SYNC_FULL, 1) == 0);
+
+    const uint32_t big_size = 1536 * 1024;
+    uint8_t *big = malloc(big_size);
+    ASSERT_TRUE(big != NULL);
+    for (uint32_t i = 0; i < big_size; i++) big[i] = (uint8_t)(i * 31 + 7);
+
+    char small[32];
+    /* three small records, then the oversized one, then three more */
+    for (int i = 0; i < 3; i++)
+    {
+        snprintf(small, sizeof(small), "pre_%d", i);
+        int64_t off = block_manager_write_raw(bm, small, (uint32_t)(strlen(small) + 1));
+        ASSERT_TRUE(off >= 0);
+    }
+    int64_t big_off = block_manager_write_raw(bm, big, big_size);
+    ASSERT_TRUE(big_off >= 0);
+    ASSERT_TRUE(block_manager_wait_durable(
+                    bm, (uint64_t)big_off + block_manager_framed_size(big_size)) == 0);
+    for (int i = 0; i < 3; i++)
+    {
+        snprintf(small, sizeof(small), "post_%d", i);
+        int64_t off = block_manager_write_raw(bm, small, (uint32_t)(strlen(small) + 1));
+        ASSERT_TRUE(off >= 0);
+        ASSERT_TRUE(block_manager_wait_durable(
+                        bm, (uint64_t)off + block_manager_framed_size(strlen(small) + 1)) == 0);
+    }
+    ASSERT_TRUE(block_manager_close(bm) == 0);
+
+    /* reopen direct, verify the seven records read back in order with intact contents */
+    bm = NULL;
+    ASSERT_TRUE(block_manager_open(&bm, path, BLOCK_MANAGER_SYNC_NONE) == 0);
+    block_manager_cursor_t *cursor = NULL;
+    ASSERT_TRUE(block_manager_cursor_init(&cursor, bm) == 0);
+    ASSERT_TRUE(block_manager_cursor_goto_first(cursor) == 0);
+
+    int idx = 0;
+    do
+    {
+        block_manager_block_t *block = block_manager_cursor_read(cursor);
+        if (!block) break;
+        if (idx < 3)
+        {
+            char expected[32];
+            snprintf(expected, sizeof(expected), "pre_%d", idx);
+            ASSERT_EQ(strcmp((char *)block->data, expected), 0);
+        }
+        else if (idx == 3)
+        {
+            ASSERT_EQ(block->size, (uint64_t)big_size);
+            int mismatch = 0;
+            for (uint32_t i = 0; i < big_size; i++)
+                if (((uint8_t *)block->data)[i] != (uint8_t)(i * 31 + 7))
+                {
+                    mismatch = 1;
+                    break;
+                }
+            ASSERT_EQ(mismatch, 0);
+        }
+        else
+        {
+            char expected[32];
+            snprintf(expected, sizeof(expected), "post_%d", idx - 4);
+            ASSERT_EQ(strcmp((char *)block->data, expected), 0);
+        }
+        idx++;
+        block_manager_block_free(block);
+    } while (block_manager_cursor_next(cursor) == 0);
+    block_manager_cursor_free(cursor);
+    free(big);
+
+    ASSERT_EQ(idx, 7);
+    ASSERT_TRUE(block_manager_close(bm) == 0);
+    (void)remove(path);
+}
+
 int main(int argc, char **argv)
 {
     INIT_TEST_FILTER(argc, argv);
@@ -3774,6 +4061,11 @@ int main(int argc, char **argv)
     RUN_TEST(test_block_manager_permissive_validation_truncates_prealloc_tail, tests_passed);
     RUN_TEST(test_block_manager_large_block_read_roundtrip, tests_passed);
     RUN_TEST(test_block_manager_max_safe_block_bytes_refusal, tests_passed);
+
+    RUN_TEST(test_block_manager_buffered_roundtrip, tests_passed);
+    RUN_TEST(test_block_manager_buffered_concurrent, tests_passed);
+    RUN_TEST(test_block_manager_buffered_ring_wraparound, tests_passed);
+    RUN_TEST(test_block_manager_buffered_oversized_record, tests_passed);
 
     srand((unsigned int)time(NULL)); /* NOLINT(cert-msc51-cpp) */
     RUN_TEST(benchmark_block_manager, tests_passed);

--- a/test/block_manager__tests.c
+++ b/test/block_manager__tests.c
@@ -3920,12 +3920,13 @@ void test_block_manager_buffered_oversized_record(void)
     ASSERT_TRUE(big != NULL);
     for (uint32_t i = 0; i < big_size; i++) big[i] = (uint8_t)(i * 31 + 7);
 
-    char small[32];
+    /* 'small' is a macro in the MSVC RPC headers, so name the record buffer plainly */
+    char rec[32];
     /* three small records, then the oversized one, then three more */
     for (int i = 0; i < 3; i++)
     {
-        snprintf(small, sizeof(small), "pre_%d", i);
-        int64_t off = block_manager_write_raw(bm, small, (uint32_t)(strlen(small) + 1));
+        snprintf(rec, sizeof(rec), "pre_%d", i);
+        int64_t off = block_manager_write_raw(bm, rec, (uint32_t)(strlen(rec) + 1));
         ASSERT_TRUE(off >= 0);
     }
     int64_t big_off = block_manager_write_raw(bm, big, big_size);
@@ -3934,11 +3935,11 @@ void test_block_manager_buffered_oversized_record(void)
                     bm, (uint64_t)big_off + block_manager_framed_size(big_size)) == 0);
     for (int i = 0; i < 3; i++)
     {
-        snprintf(small, sizeof(small), "post_%d", i);
-        int64_t off = block_manager_write_raw(bm, small, (uint32_t)(strlen(small) + 1));
+        snprintf(rec, sizeof(rec), "post_%d", i);
+        int64_t off = block_manager_write_raw(bm, rec, (uint32_t)(strlen(rec) + 1));
         ASSERT_TRUE(off >= 0);
         ASSERT_TRUE(block_manager_wait_durable(
-                        bm, (uint64_t)off + block_manager_framed_size(strlen(small) + 1)) == 0);
+                        bm, (uint64_t)off + block_manager_framed_size(strlen(rec) + 1)) == 0);
     }
     ASSERT_TRUE(block_manager_close(bm) == 0);
 

--- a/test/blocked_bloom_filter__tests.c
+++ b/test/blocked_bloom_filter__tests.c
@@ -1,0 +1,457 @@
+/**
+ *
+ * Copyright (C) TidesDB
+ *
+ * Original Author: Alex Gaetano Padula
+ *
+ * Licensed under the Mozilla Public License, v. 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.mozilla.org/en-US/MPL/2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../src/block_manager.h"
+#include "../src/blocked_bloom_filter.h"
+#include "test_utils.h"
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+/* an append-only in-memory backing store standing in for the sstable's block-managed file. write
+ * appends and hands back the offset; fetch returns a pointer into the buffer (no pin needed). the
+ * write counter lets a test observe that partitions are flushed as they roll over, not buffered. */
+typedef struct
+{
+    uint8_t *buf;
+    size_t len;
+    size_t cap;
+    int writes;
+} bbf_store_t;
+
+static int store_write(void *ctx, const uint8_t *data, size_t size, uint64_t *out_offset)
+{
+    bbf_store_t *s = ctx;
+    if (s->len + size > s->cap)
+    {
+        size_t ncap = s->cap ? s->cap * 2 : 4096;
+        while (ncap < s->len + size) ncap *= 2;
+        uint8_t *nb = realloc(s->buf, ncap);
+        if (!nb) return -1;
+        s->buf = nb;
+        s->cap = ncap;
+    }
+    *out_offset = s->len;
+    memcpy(s->buf + s->len, data, size);
+    s->len += size;
+    s->writes++;
+    return 0;
+}
+
+static int store_fetch(void *ctx, uint64_t offset, uint32_t size, const uint8_t **out_data,
+                       void **out_pin)
+{
+    bbf_store_t *s = ctx;
+    if (offset > s->len || (uint64_t)size > s->len - offset) return -1;
+    *out_data = s->buf + offset;
+    *out_pin = NULL;
+    return 0;
+}
+
+static void store_free(bbf_store_t *s)
+{
+    free(s->buf);
+}
+
+/* callbacks that drive a real block manager, the same way the sstable klog stores aux blobs. write
+ * appends one block and returns its offset; fetch reads the block at that offset and hands the
+ * block back as the pin so release can free it once the probe is done. */
+static int bm_write(void *ctx, const uint8_t *data, size_t size, uint64_t *out_offset)
+{
+    block_manager_block_t *blk = block_manager_block_create(size, data);
+    if (!blk) return -1;
+    int64_t off = block_manager_block_write((block_manager_t *)ctx, blk);
+    block_manager_block_release(blk);
+    if (off < 0) return -1;
+    *out_offset = (uint64_t)off;
+    return 0;
+}
+
+static int bm_fetch(void *ctx, uint64_t offset, uint32_t size, const uint8_t **out_data,
+                    void **out_pin)
+{
+    block_manager_cursor_t *cur = NULL;
+    if (block_manager_cursor_init(&cur, (block_manager_t *)ctx) != 0) return -1;
+    if (block_manager_cursor_goto(cur, offset) != 0)
+    {
+        block_manager_cursor_free(cur);
+        return -1;
+    }
+    block_manager_block_t *blk = block_manager_cursor_read(cur);
+    block_manager_cursor_free(cur);
+    if (!blk) return -1;
+    if (blk->size != size)
+    {
+        block_manager_block_release(blk);
+        return -1;
+    }
+    *out_data = blk->data;
+    *out_pin = blk;
+    return 0;
+}
+
+static void bm_release(void *ctx, void *pin)
+{
+    (void)ctx;
+    block_manager_block_release((block_manager_block_t *)pin);
+}
+
+/* lexicographic order over raw bytes, matching tidesdb_comparator_fn */
+static int cmp_lex(const uint8_t *a, size_t alen, const uint8_t *b, size_t blen, void *ctx)
+{
+    (void)ctx;
+    size_t n = alen < blen ? alen : blen;
+    int c = memcmp(a, b, n);
+    if (c != 0) return c;
+    return (alen > blen) - (alen < blen);
+}
+
+/* fixed-width zero-padded key so lexicographic order equals numeric order */
+static size_t make_key(int v, uint8_t *out)
+{
+    return (size_t)snprintf((char *)out, 16, "k%08d", v);
+}
+
+void test_bbf_builder_new_invalid_args()
+{
+    blocked_bloom_builder_t *b = NULL;
+    ASSERT_NE(blocked_bloom_builder_new(NULL, 0.01, 0, store_write, NULL), 0);
+    ASSERT_NE(blocked_bloom_builder_new(&b, 0.0, 0, store_write, NULL), 0);
+    ASSERT_NE(blocked_bloom_builder_new(&b, 1.0, 0, store_write, NULL), 0);
+    ASSERT_NE(blocked_bloom_builder_new(&b, 0.01, 0, NULL, NULL), 0);
+}
+
+/* every added key must report may-present -- a bloom may never report a false negative */
+void test_bbf_no_false_negatives()
+{
+    bbf_store_t store = {0};
+    blocked_bloom_builder_t *b = NULL;
+    ASSERT_EQ(blocked_bloom_builder_new(&b, 0.01, 512, store_write, &store), 0);
+
+    const int n = 20000;
+    for (int i = 0; i < n; i++)
+    {
+        uint8_t key[16];
+        size_t klen = make_key(i, key);
+        ASSERT_EQ(blocked_bloom_builder_add(b, key, klen), 0);
+    }
+    uint64_t dir_off = 0, total = 0;
+    uint32_t dir_size = 0;
+    ASSERT_EQ(blocked_bloom_builder_finish(b, &dir_off, &dir_size, &total), 0);
+    ASSERT_EQ(total, (uint64_t)n);
+    blocked_bloom_builder_free(b);
+
+    /* rollover at 512 keys over 20000 keys means many partitions plus the directory were written */
+    ASSERT_TRUE(store.writes > n / 512);
+
+    blocked_bloom_reader_t *r = NULL;
+    ASSERT_EQ(
+        blocked_bloom_reader_open(&r, dir_off, dir_size, cmp_lex, NULL, store_fetch, NULL, &store),
+        0);
+    for (int i = 0; i < n; i++)
+    {
+        uint8_t key[16];
+        size_t klen = make_key(i, key);
+        ASSERT_EQ(blocked_bloom_reader_maybe_contains(r, key, klen), 1);
+    }
+    blocked_bloom_reader_free(r);
+    store_free(&store);
+}
+
+/* a key sorting before the first partition is a definite miss, answered without a fetch */
+void test_bbf_below_range_is_absent()
+{
+    bbf_store_t store = {0};
+    blocked_bloom_builder_t *b = NULL;
+    ASSERT_EQ(blocked_bloom_builder_new(&b, 0.01, 256, store_write, &store), 0);
+    for (int i = 100; i < 5000; i++)
+    {
+        uint8_t key[16];
+        size_t klen = make_key(i, key);
+        ASSERT_EQ(blocked_bloom_builder_add(b, key, klen), 0);
+    }
+    uint64_t dir_off = 0;
+    uint32_t dir_size = 0;
+    ASSERT_EQ(blocked_bloom_builder_finish(b, &dir_off, &dir_size, NULL), 0);
+    blocked_bloom_builder_free(b);
+
+    blocked_bloom_reader_t *r = NULL;
+    ASSERT_EQ(
+        blocked_bloom_reader_open(&r, dir_off, dir_size, cmp_lex, NULL, store_fetch, NULL, &store),
+        0);
+    uint8_t key[16];
+    size_t klen = make_key(0, key); /* below the smallest inserted key (100) */
+    ASSERT_EQ(blocked_bloom_reader_maybe_contains(r, key, klen), 0);
+    blocked_bloom_reader_free(r);
+    store_free(&store);
+}
+
+/* absent keys spread across partitions should trip the filter at roughly the configured rate */
+void test_bbf_false_positive_rate()
+{
+    bbf_store_t store = {0};
+    blocked_bloom_builder_t *b = NULL;
+    ASSERT_EQ(blocked_bloom_builder_new(&b, 0.01, 4096, store_write, &store), 0);
+
+    const int n = 50000;
+    for (int i = 0; i < n; i++) /* even keys inserted, ascending */
+    {
+        uint8_t key[16];
+        size_t klen = make_key(i * 2, key);
+        ASSERT_EQ(blocked_bloom_builder_add(b, key, klen), 0);
+    }
+    uint64_t dir_off = 0;
+    uint32_t dir_size = 0;
+    ASSERT_EQ(blocked_bloom_builder_finish(b, &dir_off, &dir_size, NULL), 0);
+    blocked_bloom_builder_free(b);
+
+    blocked_bloom_reader_t *r = NULL;
+    ASSERT_EQ(
+        blocked_bloom_reader_open(&r, dir_off, dir_size, cmp_lex, NULL, store_fetch, NULL, &store),
+        0);
+    int fp = 0;
+    for (int i = 0; i < n; i++) /* odd keys never inserted, interleaved across partitions */
+    {
+        uint8_t key[16];
+        size_t klen = make_key(i * 2 + 1, key);
+        if (blocked_bloom_reader_maybe_contains(r, key, klen) == 1) fp++;
+    }
+    /* generous ceiling at 3x the target so the fixed seed cannot flake */
+    ASSERT_TRUE(fp < n * 3 / 100);
+    blocked_bloom_reader_free(r);
+    store_free(&store);
+}
+
+/* a build with no keys yields an empty directory, and its reader answers may-present, which is the
+ * safe fallback when no filter exists */
+void test_bbf_empty_build()
+{
+    bbf_store_t store = {0};
+    blocked_bloom_builder_t *b = NULL;
+    ASSERT_EQ(blocked_bloom_builder_new(&b, 0.01, 256, store_write, &store), 0);
+    uint64_t dir_off = 0, total = 1;
+    uint32_t dir_size = 0;
+    ASSERT_EQ(blocked_bloom_builder_finish(b, &dir_off, &dir_size, &total), 0);
+    ASSERT_EQ(total, 0u);
+    blocked_bloom_builder_free(b);
+
+    blocked_bloom_reader_t *r = NULL;
+    ASSERT_EQ(
+        blocked_bloom_reader_open(&r, dir_off, dir_size, cmp_lex, NULL, store_fetch, NULL, &store),
+        0);
+    uint8_t key[16];
+    size_t klen = make_key(42, key);
+    ASSERT_EQ(blocked_bloom_reader_maybe_contains(r, key, klen), 1);
+    ASSERT_TRUE(blocked_bloom_reader_resident_bytes(r) > 0);
+    blocked_bloom_reader_free(r);
+    store_free(&store);
+}
+
+/* one key, one partition */
+void test_bbf_single_key()
+{
+    bbf_store_t store = {0};
+    blocked_bloom_builder_t *b = NULL;
+    ASSERT_EQ(blocked_bloom_builder_new(&b, 0.01, 0, store_write, &store), 0);
+    uint8_t key[16];
+    size_t klen = make_key(7, key);
+    ASSERT_EQ(blocked_bloom_builder_add(b, key, klen), 0);
+    uint64_t dir_off = 0;
+    uint32_t dir_size = 0;
+    ASSERT_EQ(blocked_bloom_builder_finish(b, &dir_off, &dir_size, NULL), 0);
+    blocked_bloom_builder_free(b);
+
+    blocked_bloom_reader_t *r = NULL;
+    ASSERT_EQ(
+        blocked_bloom_reader_open(&r, dir_off, dir_size, cmp_lex, NULL, store_fetch, NULL, &store),
+        0);
+    ASSERT_EQ(blocked_bloom_reader_maybe_contains(r, key, klen), 1);
+    uint8_t other[16];
+    size_t olen = make_key(999999, other); /* absent, above range -> routes to the sole partition */
+    ASSERT_EQ(blocked_bloom_reader_maybe_contains(r, other, olen), 0);
+    blocked_bloom_reader_free(r);
+    store_free(&store);
+}
+
+void test_bbf_free_null_safe()
+{
+    blocked_bloom_builder_free(NULL);
+    blocked_bloom_reader_free(NULL);
+    ASSERT_EQ(blocked_bloom_reader_resident_bytes(NULL), 0u);
+}
+
+/* end to end over a real block manager file, exercising the exact write and read path the sstable
+ * klog will use, and reopening the reader from a fresh block manager to prove the on-disk directory
+ * and partitions round-trip through storage */
+void test_bbf_block_manager_backed()
+{
+    const char *path = "./test_bbf_klog.bm";
+    remove(path);
+
+    block_manager_t *bm = NULL;
+    ASSERT_EQ(block_manager_open(&bm, path, BLOCK_MANAGER_SYNC_NONE), 0);
+
+    blocked_bloom_builder_t *b = NULL;
+    ASSERT_EQ(blocked_bloom_builder_new(&b, 0.01, 1024, bm_write, bm), 0);
+    const int n = 30000;
+    for (int i = 0; i < n; i++)
+    {
+        uint8_t key[16];
+        size_t klen = make_key(i, key);
+        ASSERT_EQ(blocked_bloom_builder_add(b, key, klen), 0);
+    }
+    uint64_t dir_off = 0, total = 0;
+    uint32_t dir_size = 0;
+    ASSERT_EQ(blocked_bloom_builder_finish(b, &dir_off, &dir_size, &total), 0);
+    ASSERT_EQ(total, (uint64_t)n);
+    blocked_bloom_builder_free(b);
+    ASSERT_EQ(block_manager_close(bm), 0);
+
+    /* reopen from disk so the reader loads its directory through the block manager, not from any
+     * builder state left in memory */
+    block_manager_t *bm2 = NULL;
+    ASSERT_EQ(block_manager_open(&bm2, path, BLOCK_MANAGER_SYNC_NONE), 0);
+    blocked_bloom_reader_t *r = NULL;
+    ASSERT_EQ(
+        blocked_bloom_reader_open(&r, dir_off, dir_size, cmp_lex, NULL, bm_fetch, bm_release, bm2),
+        0);
+    for (int i = 0; i < n; i++)
+    {
+        uint8_t key[16];
+        size_t klen = make_key(i, key);
+        ASSERT_EQ(blocked_bloom_reader_maybe_contains(r, key, klen), 1);
+    }
+    uint8_t absent[16];
+    size_t alen = make_key(-1, absent); /* "k-0000001" sorts before every inserted key */
+    ASSERT_EQ(blocked_bloom_reader_maybe_contains(r, absent, alen), 0);
+
+    blocked_bloom_reader_free(r);
+    ASSERT_EQ(block_manager_close(bm2), 0);
+    remove(path);
+}
+
+/* a variable-length key owned by the stress test */
+typedef struct
+{
+    uint8_t *k;
+    uint32_t len;
+} bbf_skey_t;
+
+/* deterministic xorshift so the stress run is reproducible and never flakes */
+static uint32_t bbf_rand(uint32_t *s)
+{
+    uint32_t x = *s;
+    x ^= x << 13;
+    x ^= x >> 17;
+    x ^= x << 5;
+    *s = x;
+    return x;
+}
+
+static int bbf_skey_cmp(const void *a, const void *b)
+{
+    const bbf_skey_t *x = a, *y = b;
+    return cmp_lex(x->k, x->len, y->k, y->len, NULL);
+}
+
+/* large scale over random variable-length binary keys. sorted-unique keys are built in order, then
+ * every inserted key must report may-present (the invariant a bloom must never break) and a
+ * disjoint set of random keys must keep the false-positive rate near the target across all
+ * partitions */
+void test_bbf_stress_correctness()
+{
+    uint32_t seed = 0x9e3779b9u;
+    const int n = 200000;
+
+    bbf_skey_t *keys = malloc((size_t)n * sizeof(*keys));
+    ASSERT_TRUE(keys != NULL);
+    for (int i = 0; i < n; i++)
+    {
+        uint32_t len = 4 + (bbf_rand(&seed) % 21); /* 4..24 bytes */
+        uint8_t *k = malloc(len);
+        for (uint32_t j = 0; j < len; j++) k[j] = (uint8_t)bbf_rand(&seed);
+        keys[i].k = k;
+        keys[i].len = len;
+    }
+    qsort(keys, (size_t)n, sizeof(*keys), bbf_skey_cmp);
+
+    /* drop adjacent duplicates so the disjoint-query check below is exact */
+    int m = n ? 1 : 0;
+    for (int i = 1; i < n; i++)
+    {
+        if (bbf_skey_cmp(&keys[m - 1], &keys[i]) == 0)
+            free(keys[i].k);
+        else
+            keys[m++] = keys[i];
+    }
+
+    bbf_store_t store = {0};
+    blocked_bloom_builder_t *b = NULL;
+    ASSERT_EQ(blocked_bloom_builder_new(&b, 0.01, 2048, store_write, &store), 0);
+    for (int i = 0; i < m; i++) ASSERT_EQ(blocked_bloom_builder_add(b, keys[i].k, keys[i].len), 0);
+    uint64_t dir_off = 0, total = 0;
+    uint32_t dir_size = 0;
+    ASSERT_EQ(blocked_bloom_builder_finish(b, &dir_off, &dir_size, &total), 0);
+    ASSERT_EQ(total, (uint64_t)m);
+    blocked_bloom_builder_free(b);
+
+    blocked_bloom_reader_t *r = NULL;
+    ASSERT_EQ(
+        blocked_bloom_reader_open(&r, dir_off, dir_size, cmp_lex, NULL, store_fetch, NULL, &store),
+        0);
+
+    for (int i = 0; i < m; i++)
+        ASSERT_EQ(blocked_bloom_reader_maybe_contains(r, keys[i].k, keys[i].len), 1);
+
+    int tested = 0, fp = 0;
+    for (int t = 0; t < n; t++)
+    {
+        uint8_t q[24];
+        uint32_t len = 4 + (bbf_rand(&seed) % 21);
+        for (uint32_t j = 0; j < len; j++) q[j] = (uint8_t)bbf_rand(&seed);
+        bbf_skey_t probe = {q, len};
+        if (bsearch(&probe, keys, (size_t)m, sizeof(*keys), bbf_skey_cmp))
+            continue; /* skip present */
+        tested++;
+        if (blocked_bloom_reader_maybe_contains(r, q, len) == 1) fp++;
+    }
+    ASSERT_TRUE(tested > 0);
+    ASSERT_TRUE(fp < tested * 3 / 100); /* 3x the 0.01 target -- a wide margin against flaking */
+
+    blocked_bloom_reader_free(r);
+    for (int i = 0; i < m; i++) free(keys[i].k);
+    free(keys);
+    store_free(&store);
+}
+
+int main(int argc, char **argv)
+{
+    INIT_TEST_FILTER(argc, argv);
+    RUN_TEST(test_bbf_builder_new_invalid_args, tests_passed);
+    RUN_TEST(test_bbf_no_false_negatives, tests_passed);
+    RUN_TEST(test_bbf_below_range_is_absent, tests_passed);
+    RUN_TEST(test_bbf_false_positive_rate, tests_passed);
+    RUN_TEST(test_bbf_empty_build, tests_passed);
+    RUN_TEST(test_bbf_single_key, tests_passed);
+    RUN_TEST(test_bbf_free_null_safe, tests_passed);
+    RUN_TEST(test_bbf_block_manager_backed, tests_passed);
+    RUN_TEST(test_bbf_stress_correctness, tests_passed);
+    PRINT_TEST_RESULTS(tests_passed, tests_failed);
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/test/blocked_index__tests.c
+++ b/test/blocked_index__tests.c
@@ -1,0 +1,412 @@
+/**
+ *
+ * Copyright (C) TidesDB
+ *
+ * Original Author: Alex Gaetano Padula
+ *
+ * Licensed under the Mozilla Public License, v. 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.mozilla.org/en-US/MPL/2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../src/block_manager.h"
+#include "../src/blocked_index.h"
+#include "test_utils.h"
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+/* an append-only in-memory backing store standing in for the sstable's block-managed file */
+typedef struct
+{
+    uint8_t *buf;
+    size_t len;
+    size_t cap;
+} bi_store_t;
+
+static int store_write(void *ctx, const uint8_t *data, size_t size, uint64_t *out_offset)
+{
+    bi_store_t *s = ctx;
+    if (s->len + size > s->cap)
+    {
+        size_t ncap = s->cap ? s->cap * 2 : 4096;
+        while (ncap < s->len + size) ncap *= 2;
+        uint8_t *nb = realloc(s->buf, ncap);
+        if (!nb) return -1;
+        s->buf = nb;
+        s->cap = ncap;
+    }
+    *out_offset = s->len;
+    memcpy(s->buf + s->len, data, size);
+    s->len += size;
+    return 0;
+}
+
+static int store_fetch(void *ctx, uint64_t offset, uint32_t size, const uint8_t **out_data,
+                       void **out_pin)
+{
+    bi_store_t *s = ctx;
+    if (offset > s->len || (uint64_t)size > s->len - offset) return -1;
+    *out_data = s->buf + offset;
+    *out_pin = NULL;
+    return 0;
+}
+
+static void store_free(bi_store_t *s)
+{
+    free(s->buf);
+}
+
+/* callbacks that drive a real block manager, the same way the sstable klog stores aux blobs */
+static int bm_write(void *ctx, const uint8_t *data, size_t size, uint64_t *out_offset)
+{
+    block_manager_block_t *blk = block_manager_block_create(size, data);
+    if (!blk) return -1;
+    int64_t off = block_manager_block_write((block_manager_t *)ctx, blk);
+    block_manager_block_release(blk);
+    if (off < 0) return -1;
+    *out_offset = (uint64_t)off;
+    return 0;
+}
+
+static int bm_fetch(void *ctx, uint64_t offset, uint32_t size, const uint8_t **out_data,
+                    void **out_pin)
+{
+    block_manager_cursor_t *cur = NULL;
+    if (block_manager_cursor_init(&cur, (block_manager_t *)ctx) != 0) return -1;
+    if (block_manager_cursor_goto(cur, offset) != 0)
+    {
+        block_manager_cursor_free(cur);
+        return -1;
+    }
+    block_manager_block_t *blk = block_manager_cursor_read(cur);
+    block_manager_cursor_free(cur);
+    if (!blk) return -1;
+    if (blk->size != size)
+    {
+        block_manager_block_release(blk);
+        return -1;
+    }
+    *out_data = blk->data;
+    *out_pin = blk;
+    return 0;
+}
+
+static void bm_release(void *ctx, void *pin)
+{
+    (void)ctx;
+    block_manager_block_release((block_manager_block_t *)pin);
+}
+
+/* lexicographic order over raw bytes, matching tidesdb_comparator_fn */
+static int cmp_lex(const uint8_t *a, size_t alen, const uint8_t *b, size_t blen, void *ctx)
+{
+    (void)ctx;
+    size_t n = alen < blen ? alen : blen;
+    int c = memcmp(a, b, n);
+    if (c != 0) return c;
+    return (alen > blen) - (alen < blen);
+}
+
+/* fixed-width zero-padded key so lexicographic order equals numeric order */
+static size_t make_bkey(uint64_t v, uint8_t *out)
+{
+    return (size_t)snprintf((char *)out, 24, "b%010llu", (unsigned long long)v);
+}
+
+void test_bi_builder_new_invalid_args()
+{
+    blocked_index_builder_t *b = NULL;
+    ASSERT_NE(blocked_index_builder_new(NULL, 0, store_write, NULL), 0);
+    ASSERT_NE(blocked_index_builder_new(&b, 0, NULL, NULL), 0);
+}
+
+/* find returns the covering block and its ordinal for keys inside, at, and between block starts */
+void test_bi_find_covering_block()
+{
+    bi_store_t store = {0};
+    blocked_index_builder_t *b = NULL;
+    ASSERT_EQ(blocked_index_builder_new(&b, 4, store_write, &store),
+              0); /* small leaf to roll over */
+
+    const int nblocks = 1000;
+    for (int i = 0; i < nblocks; i++)
+    {
+        uint8_t key[24];
+        size_t klen = make_bkey((uint64_t)i * 10, key); /* block i covers [i*10, i*10+9] */
+        ASSERT_EQ(blocked_index_builder_add(b, key, klen, (uint64_t)i * 4096), 0);
+    }
+    uint64_t dir_off = 0, total = 0;
+    uint32_t dir_size = 0;
+    ASSERT_EQ(blocked_index_builder_finish(b, &dir_off, &dir_size, &total), 0);
+    ASSERT_EQ(total, (uint64_t)nblocks);
+    blocked_index_builder_free(b);
+
+    blocked_index_reader_t *r = NULL;
+    ASSERT_EQ(
+        blocked_index_reader_open(&r, dir_off, dir_size, cmp_lex, NULL, store_fetch, NULL, &store),
+        0);
+
+    for (int i = 0; i < nblocks; i++)
+    {
+        uint8_t key[24];
+        uint64_t off = 0, ord = 0;
+        /* a key inside block i (first-key + 5) routes to block i */
+        size_t klen = make_bkey((uint64_t)i * 10 + 5, key);
+        ASSERT_EQ(blocked_index_reader_find(r, key, klen, &off, &ord), 1);
+        ASSERT_EQ(off, (uint64_t)i * 4096);
+        ASSERT_EQ(ord, (uint64_t)i);
+        /* the exact first-key routes to the same block */
+        klen = make_bkey((uint64_t)i * 10, key);
+        ASSERT_EQ(blocked_index_reader_find(r, key, klen, &off, &ord), 1);
+        ASSERT_EQ(off, (uint64_t)i * 4096);
+    }
+    blocked_index_reader_free(r);
+    store_free(&store);
+}
+
+/* a key below the first block is a definite miss */
+void test_bi_below_range_not_found()
+{
+    bi_store_t store = {0};
+    blocked_index_builder_t *b = NULL;
+    ASSERT_EQ(blocked_index_builder_new(&b, 0, store_write, &store), 0);
+    for (int i = 10; i < 500; i++)
+    {
+        uint8_t key[24];
+        size_t klen = make_bkey((uint64_t)i, key);
+        ASSERT_EQ(blocked_index_builder_add(b, key, klen, (uint64_t)i * 100), 0);
+    }
+    uint64_t dir_off = 0;
+    uint32_t dir_size = 0;
+    ASSERT_EQ(blocked_index_builder_finish(b, &dir_off, &dir_size, NULL), 0);
+    blocked_index_builder_free(b);
+
+    blocked_index_reader_t *r = NULL;
+    ASSERT_EQ(
+        blocked_index_reader_open(&r, dir_off, dir_size, cmp_lex, NULL, store_fetch, NULL, &store),
+        0);
+    uint8_t key[24];
+    uint64_t off = 12345, ord = 999;
+    size_t klen = make_bkey(0, key); /* below the smallest block first-key (10) */
+    ASSERT_EQ(blocked_index_reader_find(r, key, klen, &off, &ord), 0);
+    blocked_index_reader_free(r);
+    store_free(&store);
+}
+
+void test_bi_empty_and_single()
+{
+    /* empty build -- find reports not-found so the caller full-scans */
+    bi_store_t store = {0};
+    blocked_index_builder_t *b = NULL;
+    ASSERT_EQ(blocked_index_builder_new(&b, 0, store_write, &store), 0);
+    uint64_t dir_off = 0, total = 1;
+    uint32_t dir_size = 0;
+    ASSERT_EQ(blocked_index_builder_finish(b, &dir_off, &dir_size, &total), 0);
+    ASSERT_EQ(total, 0u);
+    blocked_index_builder_free(b);
+
+    blocked_index_reader_t *r = NULL;
+    ASSERT_EQ(
+        blocked_index_reader_open(&r, dir_off, dir_size, cmp_lex, NULL, store_fetch, NULL, &store),
+        0);
+    uint8_t key[24];
+    uint64_t off = 0, ord = 0;
+    size_t klen = make_bkey(5, key);
+    ASSERT_EQ(blocked_index_reader_find(r, key, klen, &off, &ord), 0);
+    ASSERT_TRUE(blocked_index_reader_resident_bytes(r) > 0);
+    blocked_index_reader_free(r);
+    store_free(&store);
+
+    /* single block */
+    bi_store_t s2 = {0};
+    ASSERT_EQ(blocked_index_builder_new(&b, 0, store_write, &s2), 0);
+    ASSERT_EQ(blocked_index_builder_add(b, key, klen, 777), 0);
+    ASSERT_EQ(blocked_index_builder_finish(b, &dir_off, &dir_size, NULL), 0);
+    blocked_index_builder_free(b);
+    ASSERT_EQ(
+        blocked_index_reader_open(&r, dir_off, dir_size, cmp_lex, NULL, store_fetch, NULL, &s2), 0);
+    ASSERT_EQ(blocked_index_reader_find(r, key, klen, &off, &ord), 1);
+    ASSERT_EQ(off, 777u);
+    ASSERT_EQ(ord, 0u);
+    blocked_index_reader_free(r);
+    store_free(&s2);
+}
+
+void test_bi_free_null_safe()
+{
+    blocked_index_builder_free(NULL);
+    blocked_index_reader_free(NULL);
+    ASSERT_EQ(blocked_index_reader_resident_bytes(NULL), 0u);
+}
+
+/* end to end over a real block manager file, reopened from disk so the directory round-trips */
+void test_bi_block_manager_backed()
+{
+    const char *path = "./test_bi_klog.bm";
+    remove(path);
+
+    block_manager_t *bm = NULL;
+    ASSERT_EQ(block_manager_open(&bm, path, BLOCK_MANAGER_SYNC_NONE), 0);
+
+    blocked_index_builder_t *b = NULL;
+    ASSERT_EQ(blocked_index_builder_new(&b, 64, bm_write, bm), 0);
+    const int nblocks = 5000;
+    for (int i = 0; i < nblocks; i++)
+    {
+        uint8_t key[24];
+        size_t klen = make_bkey((uint64_t)i * 3, key);
+        ASSERT_EQ(blocked_index_builder_add(b, key, klen, (uint64_t)i * 8192), 0);
+    }
+    uint64_t dir_off = 0, total = 0;
+    uint32_t dir_size = 0;
+    ASSERT_EQ(blocked_index_builder_finish(b, &dir_off, &dir_size, &total), 0);
+    ASSERT_EQ(total, (uint64_t)nblocks);
+    blocked_index_builder_free(b);
+    ASSERT_EQ(block_manager_close(bm), 0);
+
+    block_manager_t *bm2 = NULL;
+    ASSERT_EQ(block_manager_open(&bm2, path, BLOCK_MANAGER_SYNC_NONE), 0);
+    blocked_index_reader_t *r = NULL;
+    ASSERT_EQ(
+        blocked_index_reader_open(&r, dir_off, dir_size, cmp_lex, NULL, bm_fetch, bm_release, bm2),
+        0);
+    for (int i = 0; i < nblocks; i++)
+    {
+        uint8_t key[24];
+        uint64_t off = 0, ord = 0;
+        size_t klen = make_bkey((uint64_t)i * 3 + 1, key); /* inside block i */
+        ASSERT_EQ(blocked_index_reader_find(r, key, klen, &off, &ord), 1);
+        ASSERT_EQ(off, (uint64_t)i * 8192);
+        ASSERT_EQ(ord, (uint64_t)i);
+    }
+    blocked_index_reader_free(r);
+    ASSERT_EQ(block_manager_close(bm2), 0);
+    remove(path);
+}
+
+/* deterministic xorshift so the stress run is reproducible */
+static uint32_t bi_rand(uint32_t *s)
+{
+    uint32_t x = *s;
+    x ^= x << 13;
+    x ^= x >> 17;
+    x ^= x << 5;
+    *s = x;
+    return x;
+}
+
+/* rightmost i with vals[i] <= q, or -1 -- the brute-force oracle the reader must match */
+static int64_t oracle(const uint64_t *vals, int n, uint64_t q)
+{
+    int64_t lo = 0, hi = n - 1, res = -1;
+    while (lo <= hi)
+    {
+        int64_t mid = lo + (hi - lo) / 2;
+        if (vals[mid] <= q)
+        {
+            res = mid;
+            lo = mid + 1;
+        }
+        else
+        {
+            hi = mid - 1;
+        }
+    }
+    return res;
+}
+
+/* large scale over strictly-increasing blocks. every lookup -- exact first-keys and a fuzz of
+ * random query values -- must return the same covering block a linear scan would, with the matching
+ * ordinal */
+void test_bi_stress_correctness()
+{
+    uint32_t seed = 0x243f6a88u;
+    const int n = 100000;
+    uint64_t *vals = malloc((size_t)n * sizeof(*vals));
+    ASSERT_TRUE(vals != NULL);
+
+    uint64_t v = 0;
+    for (int i = 0; i < n; i++)
+    {
+        v += 1 + (bi_rand(&seed) % 50); /* strictly increasing gaps */
+        vals[i] = v;
+    }
+
+    bi_store_t store = {0};
+    blocked_index_builder_t *b = NULL;
+    ASSERT_EQ(blocked_index_builder_new(&b, 128, store_write, &store), 0);
+    for (int i = 0; i < n; i++)
+    {
+        uint8_t key[24];
+        size_t klen = make_bkey(vals[i], key);
+        ASSERT_EQ(blocked_index_builder_add(b, key, klen, (uint64_t)i * 4096 + 17), 0);
+    }
+    uint64_t dir_off = 0;
+    uint32_t dir_size = 0;
+    ASSERT_EQ(blocked_index_builder_finish(b, &dir_off, &dir_size, NULL), 0);
+    blocked_index_builder_free(b);
+
+    blocked_index_reader_t *r = NULL;
+    ASSERT_EQ(
+        blocked_index_reader_open(&r, dir_off, dir_size, cmp_lex, NULL, store_fetch, NULL, &store),
+        0);
+
+    /* exact first-keys route to their own block */
+    for (int i = 0; i < n; i++)
+    {
+        uint8_t key[24];
+        uint64_t off = 0, ord = 0;
+        size_t klen = make_bkey(vals[i], key);
+        ASSERT_EQ(blocked_index_reader_find(r, key, klen, &off, &ord), 1);
+        ASSERT_EQ(off, (uint64_t)i * 4096 + 17);
+        ASSERT_EQ(ord, (uint64_t)i);
+    }
+
+    /* random query values agree with the linear-scan oracle */
+    for (int t = 0; t < n; t++)
+    {
+        uint64_t q = ((uint64_t)bi_rand(&seed) << 4) % (vals[n - 1] + 100);
+        int64_t expect = oracle(vals, n, q);
+        uint8_t key[24];
+        uint64_t off = 0, ord = 0;
+        size_t klen = make_bkey(q, key);
+        int rc = blocked_index_reader_find(r, key, klen, &off, &ord);
+        if (expect < 0)
+        {
+            ASSERT_EQ(rc, 0);
+        }
+        else
+        {
+            ASSERT_EQ(rc, 1);
+            ASSERT_EQ(off, (uint64_t)expect * 4096 + 17);
+            ASSERT_EQ(ord, (uint64_t)expect);
+        }
+    }
+
+    blocked_index_reader_free(r);
+    free(vals);
+    store_free(&store);
+}
+
+int main(int argc, char **argv)
+{
+    INIT_TEST_FILTER(argc, argv);
+    RUN_TEST(test_bi_builder_new_invalid_args, tests_passed);
+    RUN_TEST(test_bi_find_covering_block, tests_passed);
+    RUN_TEST(test_bi_below_range_not_found, tests_passed);
+    RUN_TEST(test_bi_empty_and_single, tests_passed);
+    RUN_TEST(test_bi_free_null_safe, tests_passed);
+    RUN_TEST(test_bi_block_manager_backed, tests_passed);
+    RUN_TEST(test_bi_stress_correctness, tests_passed);
+    PRINT_TEST_RESULTS(tests_passed, tests_failed);
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/test/bloom_filter__tests.c
+++ b/test/bloom_filter__tests.c
@@ -951,6 +951,104 @@ void test_bloom_filter_sparse_encoding_unchanged(void)
     bloom_filter_free(rt);
 }
 
+/* bloom_filter_contains_serialized must answer identically to deserialize + contains
+ * across both encodings and both hash versions, without materializing a filter. the
+ * dense path is probed in place over the buffer, the sparse path falls back to a full
+ * deserialize -- either way the answer has to match the in-memory filter exactly, and
+ * a malformed buffer or empty entry returns -1 */
+void test_bloom_filter_contains_serialized(void)
+{
+    /* dense v2 -- over-fill so the serialized form is dense, then every probe the
+     * in-place path gives must match the materialized filter */
+    bloom_filter_t *dense;
+    ASSERT_EQ(bloom_filter_new(&dense, 0.01, 2000), 0);
+    for (int i = 0; i < 4000; i++)
+    {
+        char key[24];
+        int n = snprintf(key, sizeof(key), "dense_%d", i);
+        bloom_filter_add(dense, (const uint8_t *)key, (size_t)n);
+    }
+    size_t dsize;
+    uint8_t *dblob = bloom_filter_serialize(dense, &dsize);
+    ASSERT_TRUE(dblob != NULL);
+    ASSERT_EQ(dblob[1] >> 4, 1); /* confirm dense so we exercise the in-place path */
+
+    for (int i = 0; i < 4000; i++)
+    {
+        char key[24];
+        int n = snprintf(key, sizeof(key), "dense_%d", i);
+        ASSERT_EQ(bloom_filter_contains_serialized(dblob, dsize, (const uint8_t *)key, (size_t)n),
+                  1);
+    }
+    int dmismatch = 0;
+    for (int i = 0; i < 8000; i++)
+    {
+        char probe[24];
+        int n = snprintf(probe, sizeof(probe), "absent_%d", i);
+        if (bloom_filter_contains_serialized(dblob, dsize, (const uint8_t *)probe, (size_t)n) !=
+            bloom_filter_contains(dense, (const uint8_t *)probe, (size_t)n))
+            dmismatch++;
+    }
+    ASSERT_EQ(dmismatch, 0);
+
+    /* sparse v2 -- a big filter with three keys serializes sparse, exercising the
+     * deserialize fallback */
+    bloom_filter_t *sparse;
+    ASSERT_EQ(bloom_filter_new(&sparse, 0.01, 100000), 0);
+    const char *skeys[] = {"alpha", "beta", "gamma"};
+    for (int i = 0; i < 3; i++)
+        bloom_filter_add(sparse, (const uint8_t *)skeys[i], strlen(skeys[i]));
+    size_t ssize;
+    uint8_t *sblob = bloom_filter_serialize(sparse, &ssize);
+    ASSERT_TRUE(sblob != NULL);
+    ASSERT_EQ(sblob[1], 0x02); /* confirm sparse so we exercise the fallback path */
+    for (int i = 0; i < 3; i++)
+        ASSERT_EQ(bloom_filter_contains_serialized(sblob, ssize, (const uint8_t *)skeys[i],
+                                                   strlen(skeys[i])),
+                  1);
+    ASSERT_EQ(
+        bloom_filter_contains_serialized(sblob, ssize, (const uint8_t *)"not_present_key_xyz", 19),
+        bloom_filter_contains(sparse, (const uint8_t *)"not_present_key_xyz", 19));
+
+    /* legacy v1 hash -- a dense filter built with the old hash must still probe
+     * consistently in place (a regression that assumed v2 would false-negative) */
+    bloom_filter_t *v1;
+    ASSERT_EQ(bloom_filter_new(&v1, 0.01, 2000), 0);
+    v1->hash_version = 1;
+    for (int i = 0; i < 4000; i++)
+    {
+        char key[24];
+        int n = snprintf(key, sizeof(key), "v1_%d", i);
+        bloom_filter_add(v1, (const uint8_t *)key, (size_t)n);
+    }
+    size_t v1size;
+    uint8_t *v1blob = bloom_filter_serialize(v1, &v1size);
+    ASSERT_TRUE(v1blob != NULL);
+    int v1mismatch = 0;
+    for (int i = 0; i < 8000; i++)
+    {
+        char probe[24];
+        int n = snprintf(probe, sizeof(probe), "v1_%d", i);
+        if (bloom_filter_contains_serialized(v1blob, v1size, (const uint8_t *)probe, (size_t)n) !=
+            bloom_filter_contains(v1, (const uint8_t *)probe, (size_t)n))
+            v1mismatch++;
+    }
+    ASSERT_EQ(v1mismatch, 0);
+
+    /* malformed and empty inputs return -1 */
+    ASSERT_EQ(bloom_filter_contains_serialized(NULL, 0, (const uint8_t *)"x", 1), -1);
+    ASSERT_EQ(bloom_filter_contains_serialized(dblob, dsize, NULL, 1), -1);
+    ASSERT_EQ(bloom_filter_contains_serialized(dblob, dsize, (const uint8_t *)"x", 0), -1);
+    ASSERT_EQ(bloom_filter_contains_serialized(dblob, 1, (const uint8_t *)"x", 1), -1);
+
+    free(dblob);
+    free(sblob);
+    free(v1blob);
+    bloom_filter_free(dense);
+    bloom_filter_free(sparse);
+    bloom_filter_free(v1);
+}
+
 /* deserialize must reject malformed buffers without over-reading, a buffer ending
  * mid-varint, a lone sentinel, an unknown hash version, an unknown encoding, and
  * a header that promises more bitset words than the buffer holds */
@@ -1118,6 +1216,7 @@ int main(int argc, char **argv)
     RUN_TEST(test_bloom_filter_deserialize_overflow_m, tests_passed);
     RUN_TEST(test_bloom_filter_dense_encoding, tests_passed);
     RUN_TEST(test_bloom_filter_sparse_encoding_unchanged, tests_passed);
+    RUN_TEST(test_bloom_filter_contains_serialized, tests_passed);
     RUN_TEST(test_bloom_filter_deserialize_malformed, tests_passed);
     RUN_TEST(test_bloom_filter_is_full_multiword, tests_passed);
     RUN_TEST(benchmark_bloom_filter, tests_passed);

--- a/test/manifest__tests.c
+++ b/test/manifest__tests.c
@@ -45,7 +45,7 @@ void test_manifest_add_sstable()
     ASSERT_TRUE(manifest != NULL);
 
     /* add first sstable */
-    int result = tidesdb_manifest_add_sstable(manifest, 1, 100, 1000, 65536);
+    int result = tidesdb_manifest_add_sstable(manifest, 1, 100, 1000, 65536, MANIFEST_NO_PARTITION);
     ASSERT_EQ(result, 0);
     ASSERT_EQ(manifest->num_entries, 1);
     ASSERT_EQ(manifest->entries[0].level, 1);
@@ -54,14 +54,14 @@ void test_manifest_add_sstable()
     ASSERT_EQ(manifest->entries[0].size_bytes, 65536);
 
     /* add second sstable */
-    result = tidesdb_manifest_add_sstable(manifest, 2, 200, 2000, 131072);
+    result = tidesdb_manifest_add_sstable(manifest, 2, 200, 2000, 131072, MANIFEST_NO_PARTITION);
     ASSERT_EQ(result, 0);
     ASSERT_EQ(manifest->num_entries, 2);
     ASSERT_EQ(manifest->entries[1].level, 2);
     ASSERT_EQ(manifest->entries[1].id, 200);
 
     /* add third sstable at same level as first */
-    result = tidesdb_manifest_add_sstable(manifest, 1, 101, 1500, 98304);
+    result = tidesdb_manifest_add_sstable(manifest, 1, 101, 1500, 98304, MANIFEST_NO_PARTITION);
     ASSERT_EQ(result, 0);
     ASSERT_EQ(manifest->num_entries, 3);
 
@@ -75,11 +75,11 @@ void test_manifest_update_existing_sstable()
     ASSERT_TRUE(manifest != NULL);
 
     /* add sstable */
-    tidesdb_manifest_add_sstable(manifest, 1, 100, 1000, 65536);
+    tidesdb_manifest_add_sstable(manifest, 1, 100, 1000, 65536, MANIFEST_NO_PARTITION);
     ASSERT_EQ(manifest->num_entries, 1);
 
     /* update same sstable (same level and id) */
-    tidesdb_manifest_add_sstable(manifest, 1, 100, 2000, 131072);
+    tidesdb_manifest_add_sstable(manifest, 1, 100, 2000, 131072, MANIFEST_NO_PARTITION);
     ASSERT_EQ(manifest->num_entries, 1);                /* should still be 1 */
     ASSERT_EQ(manifest->entries[0].num_entries, 2000);  /* updated */
     ASSERT_EQ(manifest->entries[0].size_bytes, 131072); /* updated */
@@ -94,9 +94,9 @@ void test_manifest_has_sstable()
     ASSERT_TRUE(manifest != NULL);
 
     /* add some sstables */
-    tidesdb_manifest_add_sstable(manifest, 1, 100, 1000, 65536);
-    tidesdb_manifest_add_sstable(manifest, 2, 200, 2000, 131072);
-    tidesdb_manifest_add_sstable(manifest, 1, 101, 1500, 98304);
+    tidesdb_manifest_add_sstable(manifest, 1, 100, 1000, 65536, MANIFEST_NO_PARTITION);
+    tidesdb_manifest_add_sstable(manifest, 2, 200, 2000, 131072, MANIFEST_NO_PARTITION);
+    tidesdb_manifest_add_sstable(manifest, 1, 101, 1500, 98304, MANIFEST_NO_PARTITION);
 
     /* check existing sstables */
     ASSERT_TRUE(tidesdb_manifest_has_sstable(manifest, 1, 100));
@@ -118,9 +118,9 @@ void test_manifest_remove_sstable()
     ASSERT_TRUE(manifest != NULL);
 
     /* add sstables */
-    tidesdb_manifest_add_sstable(manifest, 1, 100, 1000, 65536);
-    tidesdb_manifest_add_sstable(manifest, 2, 200, 2000, 131072);
-    tidesdb_manifest_add_sstable(manifest, 1, 101, 1500, 98304);
+    tidesdb_manifest_add_sstable(manifest, 1, 100, 1000, 65536, MANIFEST_NO_PARTITION);
+    tidesdb_manifest_add_sstable(manifest, 2, 200, 2000, 131072, MANIFEST_NO_PARTITION);
+    tidesdb_manifest_add_sstable(manifest, 1, 101, 1500, 98304, MANIFEST_NO_PARTITION);
     ASSERT_EQ(manifest->num_entries, 3);
 
     /* remove middle entry */
@@ -171,7 +171,8 @@ void test_manifest_capacity_growth()
     /* add more entries than initial capacity to trigger growth */
     for (int i = 0; i < MANIFEST_INITIAL_CAPACITY + 10; i++)
     {
-        int result = tidesdb_manifest_add_sstable(manifest, 1, i, 1000, 65536);
+        int result =
+            tidesdb_manifest_add_sstable(manifest, 1, i, 1000, 65536, MANIFEST_NO_PARTITION);
         ASSERT_EQ(result, 0);
     }
 
@@ -193,9 +194,9 @@ void test_manifest_commit_and_load()
     tidesdb_manifest_t *manifest = tidesdb_manifest_open(TEST_MANIFEST_PATH);
     ASSERT_TRUE(manifest != NULL);
 
-    tidesdb_manifest_add_sstable(manifest, 1, 100, 1000, 65536);
-    tidesdb_manifest_add_sstable(manifest, 2, 200, 2000, 131072);
-    tidesdb_manifest_add_sstable(manifest, 1, 101, 1500, 98304);
+    tidesdb_manifest_add_sstable(manifest, 1, 100, 1000, 65536, MANIFEST_NO_PARTITION);
+    tidesdb_manifest_add_sstable(manifest, 2, 200, 2000, 131072, MANIFEST_NO_PARTITION);
+    tidesdb_manifest_add_sstable(manifest, 1, 101, 1500, 98304, MANIFEST_NO_PARTITION);
     tidesdb_manifest_update_sequence(manifest, 54321);
 
     int result = tidesdb_manifest_commit(manifest, TEST_MANIFEST_PATH, 1);
@@ -251,7 +252,7 @@ void test_manifest_atomic_commit()
     tidesdb_manifest_t *manifest = tidesdb_manifest_open(TEST_MANIFEST_PATH);
     ASSERT_TRUE(manifest != NULL);
 
-    tidesdb_manifest_add_sstable(manifest, 1, 100, 1000, 65536);
+    tidesdb_manifest_add_sstable(manifest, 1, 100, 1000, 65536, MANIFEST_NO_PARTITION);
 
     int result = tidesdb_manifest_commit(manifest, TEST_MANIFEST_PATH, 1);
     ASSERT_EQ(result, 0);
@@ -276,7 +277,8 @@ void test_manifest_multiple_levels()
     {
         for (int id = 0; id < 3; id++)
         {
-            tidesdb_manifest_add_sstable(manifest, level, id, 1000 * level, 65536 * level);
+            tidesdb_manifest_add_sstable(manifest, level, id, 1000 * level, 65536 * level,
+                                         MANIFEST_NO_PARTITION);
         }
     }
 
@@ -325,8 +327,8 @@ void test_manifest_persistence_cycle()
 
     /* cycle create and commit */
     tidesdb_manifest_t *m1 = tidesdb_manifest_open(TEST_MANIFEST_PATH);
-    tidesdb_manifest_add_sstable(m1, 1, 0, 100, 1024);
-    tidesdb_manifest_add_sstable(m1, 1, 1, 200, 2048);
+    tidesdb_manifest_add_sstable(m1, 1, 0, 100, 1024, MANIFEST_NO_PARTITION);
+    tidesdb_manifest_add_sstable(m1, 1, 1, 200, 2048, MANIFEST_NO_PARTITION);
     tidesdb_manifest_update_sequence(m1, 1000);
     ASSERT_EQ(tidesdb_manifest_commit(m1, TEST_MANIFEST_PATH, 1), 0);
     tidesdb_manifest_close(m1);
@@ -335,7 +337,7 @@ void test_manifest_persistence_cycle()
     tidesdb_manifest_t *m2 = tidesdb_manifest_open(TEST_MANIFEST_PATH);
     ASSERT_EQ(m2->num_entries, 2);
     ASSERT_EQ(m2->sequence, 1000);
-    tidesdb_manifest_add_sstable(m2, 2, 0, 300, 4096);
+    tidesdb_manifest_add_sstable(m2, 2, 0, 300, 4096, MANIFEST_NO_PARTITION);
     tidesdb_manifest_remove_sstable(m2, 1, 0);
     tidesdb_manifest_update_sequence(m2, 2000);
     ASSERT_EQ(tidesdb_manifest_commit(m2, TEST_MANIFEST_PATH, 1), 0);
@@ -361,9 +363,9 @@ void test_manifest_auto_compaction()
         tidesdb_manifest_open("." PATH_SEPARATOR "test_manifest_dir" PATH_SEPARATOR "manifest");
 
     /* add entries for ssts */
-    tidesdb_manifest_add_sstable(m1, 1, 100, 1000, 65536);
-    tidesdb_manifest_add_sstable(m1, 1, 101, 1500, 98304);
-    tidesdb_manifest_add_sstable(m1, 2, 200, 2000, 131072);
+    tidesdb_manifest_add_sstable(m1, 1, 100, 1000, 65536, MANIFEST_NO_PARTITION);
+    tidesdb_manifest_add_sstable(m1, 1, 101, 1500, 98304, MANIFEST_NO_PARTITION);
+    tidesdb_manifest_add_sstable(m1, 2, 200, 2000, 131072, MANIFEST_NO_PARTITION);
 
     /* create actual sst files for some entries */
     FILE *f1 = tdb_fopen("." PATH_SEPARATOR "test_manifest_dir" PATH_SEPARATOR "L1_100.klog", "w");
@@ -401,9 +403,9 @@ void test_manifest_crash_recovery()
     tidesdb_manifest_t *m1 = tidesdb_manifest_open(crash_test_path);
     ASSERT_TRUE(m1 != NULL);
 
-    tidesdb_manifest_add_sstable(m1, 1, 100, 1000, 65536);
-    tidesdb_manifest_add_sstable(m1, 1, 101, 1500, 98304);
-    tidesdb_manifest_add_sstable(m1, 2, 200, 2000, 131072);
+    tidesdb_manifest_add_sstable(m1, 1, 100, 1000, 65536, MANIFEST_NO_PARTITION);
+    tidesdb_manifest_add_sstable(m1, 1, 101, 1500, 98304, MANIFEST_NO_PARTITION);
+    tidesdb_manifest_add_sstable(m1, 2, 200, 2000, 131072, MANIFEST_NO_PARTITION);
     tidesdb_manifest_update_sequence(m1, 5000);
 
     ASSERT_EQ(tidesdb_manifest_commit(m1, crash_test_path, 1), 0);
@@ -414,7 +416,7 @@ void test_manifest_crash_recovery()
     ASSERT_EQ(m2->num_entries, 3);
     ASSERT_EQ(m2->sequence, 5000);
 
-    tidesdb_manifest_add_sstable(m2, 3, 300, 3000, 196608);
+    tidesdb_manifest_add_sstable(m2, 3, 300, 3000, 196608, MANIFEST_NO_PARTITION);
     tidesdb_manifest_remove_sstable(m2, 1, 100);
     tidesdb_manifest_update_sequence(m2, 6000);
 
@@ -435,7 +437,7 @@ void test_manifest_crash_recovery()
     ASSERT_TRUE(tidesdb_manifest_has_sstable(m3, 2, 200));
     ASSERT_FALSE(tidesdb_manifest_has_sstable(m3, 3, 300));
 
-    tidesdb_manifest_add_sstable(m3, 3, 301, 3500, 200000);
+    tidesdb_manifest_add_sstable(m3, 3, 301, 3500, 200000, MANIFEST_NO_PARTITION);
     tidesdb_manifest_update_sequence(m3, 7000);
     ASSERT_EQ(tidesdb_manifest_commit(m3, crash_test_path, 1), 0);
     tidesdb_manifest_close(m3);
@@ -459,7 +461,7 @@ void test_manifest_orphaned_temp_cleanup()
 
     tidesdb_manifest_t *m1 = tidesdb_manifest_open(test_path);
     ASSERT_TRUE(m1 != NULL);
-    tidesdb_manifest_add_sstable(m1, 1, 100, 1000, 65536);
+    tidesdb_manifest_add_sstable(m1, 1, 100, 1000, 65536, MANIFEST_NO_PARTITION);
     tidesdb_manifest_update_sequence(m1, 1000);
     ASSERT_EQ(tidesdb_manifest_commit(m1, test_path, 1), 0);
     tidesdb_manifest_close(m1);
@@ -521,7 +523,8 @@ void *concurrent_add_thread(void *arg)
     for (int i = 0; i < data->operations; i++)
     {
         uint64_t id = data->thread_id * 1000 + i;
-        tidesdb_manifest_add_sstable(data->manifest, data->thread_id, id, i * 100, i * 65536);
+        tidesdb_manifest_add_sstable(data->manifest, data->thread_id, id, i * 100, i * 65536,
+                                     MANIFEST_NO_PARTITION);
     }
     return NULL;
 }
@@ -679,7 +682,9 @@ void test_manifest_large_stress()
         uint64_t id = i;
         uint64_t num_ents = i * 10;
         uint64_t size = i * 1024;
-        ASSERT_EQ(tidesdb_manifest_add_sstable(manifest, level, id, num_ents, size), 0);
+        ASSERT_EQ(tidesdb_manifest_add_sstable(manifest, level, id, num_ents, size,
+                                               MANIFEST_NO_PARTITION),
+                  0);
     }
 
     ASSERT_EQ(manifest->num_entries, num_entries);
@@ -718,11 +723,13 @@ void test_manifest_duplicate_id_handling()
     tidesdb_manifest_t *manifest = tidesdb_manifest_open(test_path);
     ASSERT_TRUE(manifest != NULL);
 
-    ASSERT_EQ(tidesdb_manifest_add_sstable(manifest, 1, 100, 1000, 65536), 0);
+    ASSERT_EQ(tidesdb_manifest_add_sstable(manifest, 1, 100, 1000, 65536, MANIFEST_NO_PARTITION),
+              0);
     ASSERT_EQ(manifest->num_entries, 1);
 
     /* we add same level+id with different values (should update, not add) */
-    ASSERT_EQ(tidesdb_manifest_add_sstable(manifest, 1, 100, 2000, 131072), 0);
+    ASSERT_EQ(tidesdb_manifest_add_sstable(manifest, 1, 100, 2000, 131072, MANIFEST_NO_PARTITION),
+              0);
     ASSERT_EQ(manifest->num_entries, 1);
 
     /* we verify updated values */
@@ -733,7 +740,9 @@ void test_manifest_duplicate_id_handling()
     /* we add multiple updates */
     for (int i = 0; i < 10; i++)
     {
-        ASSERT_EQ(tidesdb_manifest_add_sstable(manifest, 1, 100, i * 1000, i * 65536), 0);
+        ASSERT_EQ(tidesdb_manifest_add_sstable(manifest, 1, 100, i * 1000, i * 65536,
+                                               MANIFEST_NO_PARTITION),
+                  0);
         ASSERT_EQ(manifest->num_entries, 1);
     }
 
@@ -742,11 +751,13 @@ void test_manifest_duplicate_id_handling()
     ASSERT_EQ(manifest->entries[0].size_bytes, 9 * 65536);
 
     /* we add different id on same level */
-    ASSERT_EQ(tidesdb_manifest_add_sstable(manifest, 1, 101, 5000, 200000), 0);
+    ASSERT_EQ(tidesdb_manifest_add_sstable(manifest, 1, 101, 5000, 200000, MANIFEST_NO_PARTITION),
+              0);
     ASSERT_EQ(manifest->num_entries, 2);
 
     /* we add same id on different level (should add, not update) */
-    ASSERT_EQ(tidesdb_manifest_add_sstable(manifest, 2, 100, 3000, 150000), 0);
+    ASSERT_EQ(tidesdb_manifest_add_sstable(manifest, 2, 100, 3000, 150000, MANIFEST_NO_PARTITION),
+              0);
     ASSERT_EQ(manifest->num_entries, 3);
 
     /* we verify all entries exist */
@@ -784,7 +795,7 @@ void test_manifest_null_safety(void)
     ASSERT_TRUE(tidesdb_manifest_open(NULL) == NULL);
 
     /* tidesdb_manifest_add_sstable with NULL manifest */
-    ASSERT_EQ(tidesdb_manifest_add_sstable(NULL, 1, 100, 1000, 65536), -1);
+    ASSERT_EQ(tidesdb_manifest_add_sstable(NULL, 1, 100, 1000, 65536, MANIFEST_NO_PARTITION), -1);
 
     /* tidesdb_manifest_remove_sstable with NULL manifest */
     ASSERT_EQ(tidesdb_manifest_remove_sstable(NULL, 1, 100), -1);
@@ -817,14 +828,14 @@ void test_manifest_commit_different_path(void)
     tidesdb_manifest_t *manifest = tidesdb_manifest_open(path1);
     ASSERT_TRUE(manifest != NULL);
 
-    tidesdb_manifest_add_sstable(manifest, 1, 100, 1000, 65536);
+    tidesdb_manifest_add_sstable(manifest, 1, 100, 1000, 65536, MANIFEST_NO_PARTITION);
     tidesdb_manifest_update_sequence(manifest, 5000);
 
     /* we commit to path1 first */
     ASSERT_EQ(tidesdb_manifest_commit(manifest, path1, 1), 0);
 
     /* we add more data and commit to a different path */
-    tidesdb_manifest_add_sstable(manifest, 2, 200, 2000, 131072);
+    tidesdb_manifest_add_sstable(manifest, 2, 200, 2000, 131072, MANIFEST_NO_PARTITION);
     tidesdb_manifest_update_sequence(manifest, 6000);
     ASSERT_EQ(tidesdb_manifest_commit(manifest, path2, 1), 0);
 
@@ -874,7 +885,7 @@ void test_manifest_remove_to_zero(void)
     tidesdb_manifest_t *manifest = tidesdb_manifest_open(TEST_MANIFEST_PATH);
     ASSERT_TRUE(manifest != NULL);
 
-    tidesdb_manifest_add_sstable(manifest, 1, 100, 1000, 65536);
+    tidesdb_manifest_add_sstable(manifest, 1, 100, 1000, 65536, MANIFEST_NO_PARTITION);
     ASSERT_EQ(manifest->num_entries, 1);
 
     /* we remove the sole entry */
@@ -883,7 +894,8 @@ void test_manifest_remove_to_zero(void)
     ASSERT_FALSE(tidesdb_manifest_has_sstable(manifest, 1, 100));
 
     /* we verify we can still add after emptying */
-    ASSERT_EQ(tidesdb_manifest_add_sstable(manifest, 2, 200, 2000, 131072), 0);
+    ASSERT_EQ(tidesdb_manifest_add_sstable(manifest, 2, 200, 2000, 131072, MANIFEST_NO_PARTITION),
+              0);
     ASSERT_EQ(manifest->num_entries, 1);
     ASSERT_TRUE(tidesdb_manifest_has_sstable(manifest, 2, 200));
 
@@ -925,7 +937,8 @@ void test_manifest_large_uint64_roundtrip(void)
     const uint64_t large_entries = UINT64_MAX / 2;
     const uint64_t large_size = UINT64_MAX;
 
-    tidesdb_manifest_add_sstable(manifest, 1, large_id, large_entries, large_size);
+    tidesdb_manifest_add_sstable(manifest, 1, large_id, large_entries, large_size,
+                                 MANIFEST_NO_PARTITION);
     tidesdb_manifest_update_sequence(manifest, UINT64_MAX);
 
     ASSERT_EQ(tidesdb_manifest_commit(manifest, test_path, 1), 0);
@@ -951,8 +964,8 @@ void test_manifest_v8_checksum_roundtrip(void)
 
     tidesdb_manifest_t *manifest = tidesdb_manifest_open(test_path);
     ASSERT_TRUE(manifest != NULL);
-    tidesdb_manifest_add_sstable(manifest, 1, 100, 1000, 65536);
-    tidesdb_manifest_add_sstable(manifest, 2, 200, 2000, 131072);
+    tidesdb_manifest_add_sstable(manifest, 1, 100, 1000, 65536, MANIFEST_NO_PARTITION);
+    tidesdb_manifest_add_sstable(manifest, 2, 200, 2000, 131072, MANIFEST_NO_PARTITION);
     tidesdb_manifest_update_sequence(manifest, 4242);
     ASSERT_EQ(tidesdb_manifest_commit(manifest, test_path, 1), 0);
     tidesdb_manifest_close(manifest);
@@ -984,9 +997,9 @@ void test_manifest_self_heals_on_corruption(void)
     /* build a two-commit log so there is a non-final block to corrupt */
     tidesdb_manifest_t *manifest = tidesdb_manifest_open(test_path);
     ASSERT_TRUE(manifest != NULL);
-    tidesdb_manifest_add_sstable(manifest, 1, 100, 1000, 65536);
+    tidesdb_manifest_add_sstable(manifest, 1, 100, 1000, 65536, MANIFEST_NO_PARTITION);
     ASSERT_EQ(tidesdb_manifest_commit(manifest, test_path, 1), 0);
-    tidesdb_manifest_add_sstable(manifest, 2, 200, 2000, 131072);
+    tidesdb_manifest_add_sstable(manifest, 2, 200, 2000, 131072, MANIFEST_NO_PARTITION);
     ASSERT_EQ(tidesdb_manifest_commit(manifest, test_path, 1), 0);
     tidesdb_manifest_close(manifest);
 
@@ -1022,7 +1035,7 @@ void test_manifest_self_heals_on_corruption(void)
 
         tidesdb_manifest_t *mc = tidesdb_manifest_open(test_path);
         ASSERT_TRUE(mc != NULL);
-        ASSERT_EQ(tidesdb_manifest_add_sstable(mc, 5, 500, 5000, 4096), 0);
+        ASSERT_EQ(tidesdb_manifest_add_sstable(mc, 5, 500, 5000, 4096, MANIFEST_NO_PARTITION), 0);
         ASSERT_EQ(tidesdb_manifest_commit(mc, test_path, 1), 0);
         tidesdb_manifest_close(mc);
 

--- a/test/objstore__tests.c
+++ b/test/objstore__tests.c
@@ -516,8 +516,6 @@ void test_objstore_default_config(void)
     ASSERT_EQ(cfg.cache_on_write, 1);
     ASSERT_EQ(cfg.max_concurrent_uploads, 4);
     ASSERT_EQ(cfg.max_concurrent_downloads, 8);
-    ASSERT_TRUE(cfg.multipart_threshold > 0);
-    ASSERT_TRUE(cfg.multipart_part_size > 0);
     ASSERT_EQ(cfg.sync_manifest_to_object, 1);
     ASSERT_EQ(cfg.replicate_wal, 1);
     ASSERT_EQ(cfg.wal_upload_sync, 0);

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -9299,7 +9299,7 @@ static void test_read_write_conflict(void)
 
 /* a tracked read (tidesdb_txn_get) of a key records it into the read set, so a concurrent overwrite
  * of that key aborts the reader at commit even when the reader wrote only a disjoint key. the same
- * scenario through tidesdb_txn_get_notrack must NOT abort, because the untracked read never enters
+ * scenario through tidesdb_txn_get_notrack must not abort, because the untracked read never enters
  * the read set -- the whole point of the primitive for a PK-uniqueness probe. */
 static void test_txn_get_notrack_no_read_conflict(void)
 {
@@ -32284,7 +32284,7 @@ static uint64_t burst_then_measure_compaction_settle(int num_compaction_threads,
             settle_ms, settle_ms >= cap_ms ? "  <-- NEVER QUIESCED (hit 60s cap)" : "");
 
     /* the burst must have flushed sstables (at least one per cf) and exercised compaction,
-     * otherwise the test proves nothing. we do NOT require sstable_count > NCF at flush-idle --
+     * otherwise the test proves nothing. we do not require sstable_count > NCF at flush-idle --
      * with fast consolidation compaction can already have merged each cf down to a single sstable
      * by then, which is the fix working, not a failure. */
     ASSERT_TRUE(at_flush_idle.total_sstable_count >= NCF);

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -3471,7 +3471,7 @@ static void prefix_probe_once(int block_indexes, int bloom, int use_btree)
     {
         memcpy(keys[i], prefix, SHARED_LEN);
         for (int b = 0; b < KEY_LEN - SHARED_LEN; b++)
-            keys[i][SHARED_LEN + b] = (uint8_t)((unsigned)(i * 2654435761u) >> (b * 4));
+            keys[i][SHARED_LEN + b] = (uint8_t)((unsigned)(i * 2654435761u) >> ((b * 4) & 31));
     }
 
     for (int i = 0; i < NKEYS; i++)
@@ -8356,6 +8356,31 @@ static void test_boundary_partitioning(void)
     cleanup_test_dir();
 }
 
+/* settle/sample tuning for the capacity-adaptation check. the poll budget is deliberately generous
+ * because the settle loop breaks the moment the cf is quiet, so a high cap costs a fast box nothing
+ * while giving a sanitizer build, which runs an order of magnitude slower, room to finish
+ * compacting rather than sampling a tree that is still moving. */
+#define DCA_SETTLE_POLL_US  50000
+#define DCA_SETTLE_POLLS    6000
+#define DCA_SETTLE_STREAK   5
+#define DCA_SAMPLE_ATTEMPTS 20
+
+/* quiescence predicate for the capacity-adaptation check. compaction_pending_count is incremented
+ * before the work item is enqueued and decremented only after the worker fully finishes, so it has
+ * no TOCTOU gap the way is_compacting does (the worker sets is_compacting only after dequeuing, so
+ * the queue can be empty while it is still 0). compaction_armed catches a re-trigger that has been
+ * armed but not yet enqueued, which would otherwise let a fresh round start immediately after the
+ * predicate passes. */
+static int dca_cf_is_quiesced(tidesdb_t *db, tidesdb_column_family_t *cf)
+{
+    return queue_size(db->flush_queue) == 0 &&
+           atomic_load_explicit(&cf->flush_pending_count, memory_order_acquire) == 0 &&
+           atomic_load_explicit(&cf->compaction_pending_count, memory_order_acquire) == 0 &&
+           !atomic_load_explicit(&cf->is_flushing, memory_order_acquire) &&
+           !atomic_load_explicit(&cf->is_compacting, memory_order_acquire) &&
+           !atomic_load_explicit(&cf->compaction_armed, memory_order_acquire);
+}
+
 static void test_dynamic_capacity_adjustment(void)
 {
     cleanup_test_dir();
@@ -8421,24 +8446,25 @@ static void test_dynamic_capacity_adjustment(void)
      * compaction that collapses every level into the largest and never adds a
      * level, which would cement the tree at min_levels. the stable counter
      * absorbs the flush completing then triggering one more compaction. */
-    for (int stable = 0, i = 0; i < 600 && stable < 5; i++)
+    int settled = 0;
+    for (int stable = 0, i = 0; i < DCA_SETTLE_POLLS && !settled; i++)
     {
-        usleep(50000);
-        if (queue_size(db->flush_queue) == 0 &&
-            atomic_load_explicit(&cf->flush_pending_count, memory_order_acquire) == 0 &&
-            atomic_load_explicit(&cf->compaction_pending_count, memory_order_acquire) == 0 &&
-            !atomic_load_explicit(&cf->is_flushing, memory_order_acquire) &&
-            !atomic_load_explicit(&cf->is_compacting, memory_order_acquire))
-            stable++;
+        usleep(DCA_SETTLE_POLL_US);
+        if (dca_cf_is_quiesced(db, cf))
+        {
+            if (++stable >= DCA_SETTLE_STREAK) settled = 1;
+        }
         else
             stable = 0;
     }
 
     printf("Total keys written: %d\n", total_keys_written);
-
-    int final_levels = atomic_load_explicit(&cf->num_active_levels, memory_order_acquire);
-    printf("Final levels: %d (initial %d)\n", final_levels, initial_levels);
-    ASSERT_TRUE(final_levels >= 2);
+    /* a settle timeout is its own failure. sampling a tree that is still compacting would assert
+     * the steady-state relation below against moving state and report a confusing capacity mismatch
+     * instead of the real problem, which is that the cf never came to rest. */
+    if (!settled) printf("CF did not quiesce within the settle budget\n");
+    fflush(stdout);
+    ASSERT_TRUE(settled);
 
     /*** dynamic capacity adaptation check. tidesdb_apply_dca runs at the end of
      **  every compaction cycle and recomputes each non-largest level capacity
@@ -8448,10 +8474,39 @@ static void test_dynamic_capacity_adjustment(void)
      **  on every platform regardless of how the compaction heuristics batched
      *   the work. asserting this invariant -- rather than a specific level
      **  count, which is an emergent outcome that flakes under os scheduling
-     *   differences -- is what makes the test deterministic. */
-    tidesdb_level_t *largest_level = cf->levels[final_levels - 1];
-    size_t n_l = atomic_load_explicit(&largest_level->current_size, memory_order_acquire);
+     *   differences -- is what makes the test deterministic.
+     *   N_L and the per-level capacities are separate atomic loads, so a compaction landing between
+     *   them would tear the sample apart and fail the assert for no real reason. bracket the reads
+     *   with the sstable layout version and a quiesce recheck, and retry until a sample is
+     *confirmed untorn before asserting on it. */
+    int final_levels = 0;
+    size_t n_l = 0;
+    size_t caps[TDB_MAX_LEVELS];
+    int sampled = 0;
+    for (int attempt = 0; attempt < DCA_SAMPLE_ATTEMPTS && !sampled; attempt++)
+    {
+        const uint64_t ver_before =
+            atomic_load_explicit(&cf->sstable_layout_version, memory_order_acquire);
+        final_levels = atomic_load_explicit(&cf->num_active_levels, memory_order_acquire);
+        n_l =
+            atomic_load_explicit(&cf->levels[final_levels - 1]->current_size, memory_order_acquire);
+        for (int i = 0; i < final_levels - 1 && i < TDB_MAX_LEVELS; i++)
+            caps[i] = atomic_load_explicit(&cf->levels[i]->capacity, memory_order_acquire);
+        const uint64_t ver_after =
+            atomic_load_explicit(&cf->sstable_layout_version, memory_order_acquire);
+
+        if (ver_before == ver_after && dca_cf_is_quiesced(db, cf))
+            sampled = 1;
+        else
+            usleep(DCA_SETTLE_POLL_US);
+    }
+    if (!sampled) printf("could not obtain a consistent capacity sample\n");
+    fflush(stdout);
+    ASSERT_TRUE(sampled);
+
+    printf("Final levels: %d (initial %d)\n", final_levels, initial_levels);
     printf("Largest level L%d size N_L=%zu bytes\n", final_levels, n_l);
+    ASSERT_TRUE(final_levels >= 2);
 
     for (int i = 0; i < final_levels - 1; i++)
     {
@@ -8461,11 +8516,9 @@ static void test_dynamic_capacity_adjustment(void)
         if (expected_capacity < cf_config.write_buffer_size)
             expected_capacity = cf_config.write_buffer_size;
 
-        size_t actual_capacity =
-            atomic_load_explicit(&cf->levels[i]->capacity, memory_order_acquire);
-        printf("  L%d capacity actual=%zu expected=%zu\n", i + 1, actual_capacity,
-               expected_capacity);
-        ASSERT_EQ(actual_capacity, expected_capacity);
+        printf("  L%d capacity actual=%zu expected=%zu\n", i + 1, caps[i], expected_capacity);
+        fflush(stdout);
+        ASSERT_EQ(caps[i], expected_capacity);
     }
 
     /* verify data is accessible (skip verification of keys that may still be in memtable) */

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -8488,8 +8488,18 @@ static void test_dynamic_capacity_adjustment(void)
         const uint64_t ver_before =
             atomic_load_explicit(&cf->sstable_layout_version, memory_order_acquire);
         final_levels = atomic_load_explicit(&cf->num_active_levels, memory_order_acquire);
-        n_l =
-            atomic_load_explicit(&cf->levels[final_levels - 1]->current_size, memory_order_acquire);
+        /* mirror the reference tidesdb_apply_dca actually uses -- the largest NON-EMPTY level, not
+         * simply the largest one. during ingestion the bottom level can still be empty, and an N_L
+         * of 0 would collapse every capacity to the write-buffer floor, so the implementation walks
+         * down to the first populated level. asserting against the bottom level alone diverges
+         * whenever the tree quiesces with an empty bottom, which is exactly what a differently
+         * scheduled platform produces. */
+        n_l = 0;
+        for (int i = final_levels - 1; i >= 0; i--)
+        {
+            n_l = atomic_load_explicit(&cf->levels[i]->current_size, memory_order_acquire);
+            if (n_l > 0) break;
+        }
         for (int i = 0; i < final_levels - 1 && i < TDB_MAX_LEVELS; i++)
             caps[i] = atomic_load_explicit(&cf->levels[i]->capacity, memory_order_acquire);
         const uint64_t ver_after =
@@ -8505,7 +8515,7 @@ static void test_dynamic_capacity_adjustment(void)
     ASSERT_TRUE(sampled);
 
     printf("Final levels: %d (initial %d)\n", final_levels, initial_levels);
-    printf("Largest level L%d size N_L=%zu bytes\n", final_levels, n_l);
+    printf("Largest non-empty level size N_L=%zu bytes (levels=%d)\n", n_l, final_levels);
     ASSERT_TRUE(final_levels >= 2);
 
     for (int i = 0; i < final_levels - 1; i++)
@@ -17696,7 +17706,10 @@ static void test_iter_next_large_values_many_sstables(void)
         ASSERT_EQ(
             tidesdb_txn_put(txn, cf, (uint8_t *)key, strlen(key) + 1, large_value, VALUE_SIZE, 0),
             0);
-        ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+        /* large values against a small write buffer make nearly every commit a flush trigger,
+         * so a slow runner can legitimately hit the backpressure stall budget and get
+         * TDB_ERR_BUSY, which is retryable pressure rather than a failure */
+        ASSERT_EQ(tdb_test_commit_with_retry(txn, 20), 0);
         tidesdb_txn_free(txn);
 
         if ((i + 1) % KEYS_PER_FLUSH == 0)
@@ -17794,7 +17807,10 @@ static void test_iter_prev_large_values_many_sstables(void)
         ASSERT_EQ(
             tidesdb_txn_put(txn, cf, (uint8_t *)key, strlen(key) + 1, large_value, VALUE_SIZE, 0),
             0);
-        ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+        /* large values against a small write buffer make nearly every commit a flush trigger,
+         * so a slow runner can legitimately hit the backpressure stall budget and get
+         * TDB_ERR_BUSY, which is retryable pressure rather than a failure */
+        ASSERT_EQ(tdb_test_commit_with_retry(txn, 20), 0);
         tidesdb_txn_free(txn);
 
         if ((i + 1) % KEYS_PER_FLUSH == 0)
@@ -17893,7 +17909,10 @@ static void test_get_large_values_many_sstables(void)
         ASSERT_EQ(
             tidesdb_txn_put(txn, cf, (uint8_t *)key, strlen(key) + 1, large_value, VALUE_SIZE, 0),
             0);
-        ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+        /* large values against a small write buffer make nearly every commit a flush trigger,
+         * so a slow runner can legitimately hit the backpressure stall budget and get
+         * TDB_ERR_BUSY, which is retryable pressure rather than a failure */
+        ASSERT_EQ(tdb_test_commit_with_retry(txn, 20), 0);
         tidesdb_txn_free(txn);
 
         if ((i + 1) % KEYS_PER_FLUSH == 0)
@@ -17980,7 +17999,10 @@ static void test_range_iteration_large_values_many_sstables(void)
         ASSERT_EQ(
             tidesdb_txn_put(txn, cf, (uint8_t *)key, strlen(key) + 1, large_value, VALUE_SIZE, 0),
             0);
-        ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+        /* large values against a small write buffer make nearly every commit a flush trigger,
+         * so a slow runner can legitimately hit the backpressure stall budget and get
+         * TDB_ERR_BUSY, which is retryable pressure rather than a failure */
+        ASSERT_EQ(tdb_test_commit_with_retry(txn, 20), 0);
         tidesdb_txn_free(txn);
 
         if ((i + 1) % KEYS_PER_FLUSH == 0)
@@ -31957,12 +31979,21 @@ static void sum_sstable_distinct(tidesdb_column_family_t *cf, uint64_t *out_dist
 /* drains the flush queue so all memtable data has landed on disk before the sstables are read */
 static void wait_for_flush(tidesdb_t *db)
 {
-    for (int i = 0; i < 200; i++)
+    /* the flush queue empties the moment a worker DEQUEUES an item, not when the flush finishes, so
+     * draining the queue and sleeping a fixed slice races the writer. that window is observable --
+     * the sstable is already in the level while the immutable is not yet marked flushed, so any
+     * view walking both counts those keys twice. flush_pending_count is decremented only after the
+     * worker sets imm->flushed, and active_flushes only once the slot is released, so together they
+     * are the real completion signal. the budget is generous because the loop returns as soon as it
+     * is clean, which costs a fast machine nothing and gives a slow one room to finish. */
+    for (int i = 0; i < 4000; i++)
     {
-        usleep(10000);
-        if (queue_size(db->flush_queue) == 0) break;
+        if (queue_size(db->flush_queue) == 0 &&
+            atomic_load_explicit(&db->flush_pending_count, memory_order_acquire) == 0 &&
+            atomic_load_explicit(&db->active_flushes, memory_order_acquire) == 0)
+            return;
+        usleep(5000);
     }
-    usleep(50000);
 }
 
 /* a flush writes each distinct key once into the sstable's distinct-key summary, the estimate API

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -108,6 +108,7 @@ static void test_txn_begin_cf_uses_cf_default_isolation(void)
     ASSERT_EQ(tidesdb_txn_begin_cf(db, cf, &txn), 0);
     ASSERT_EQ(txn->isolation_level, TDB_ISOLATION_SERIALIZABLE);
     tidesdb_txn_commit(txn);
+    tidesdb_txn_free(txn);
 
     /* a NULL cf is rejected */
     tidesdb_txn_t *null_txn = NULL;
@@ -118,6 +119,7 @@ static void test_txn_begin_cf_uses_cf_default_isolation(void)
     ASSERT_EQ(tidesdb_txn_begin(db, &rc_txn), 0);
     ASSERT_EQ(rc_txn->isolation_level, TDB_ISOLATION_READ_COMMITTED);
     tidesdb_txn_commit(rc_txn);
+    tidesdb_txn_free(rc_txn);
 
     ASSERT_EQ(tidesdb_close(db), 0);
     cleanup_test_dir();

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -4570,7 +4570,10 @@ static void test_many_keys(void)
         ASSERT_EQ(tidesdb_txn_put(txn, cf, (uint8_t *)key, strlen(key) + 1, (uint8_t *)value,
                                   strlen(value) + 1, 0),
                   0);
-        ASSERT_EQ(tidesdb_txn_commit(txn), 0);
+        /* the 4KB write buffer keeps the active memtable pinned near its ceiling, so on a slow CI
+         * box (DragonFlyBSD) a commit can hit the 10s no-progress backpressure budget and return a
+         * retryable TDB_ERR_BUSY. retry it like the other stress tests rather than flake. */
+        ASSERT_EQ(tdb_test_commit_with_retry(txn, 20), 0);
         tidesdb_txn_free(txn);
 
         /* we periodic flush */

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -6036,7 +6036,6 @@ static void test_block_indexes(void)
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
     cf_config.enable_block_indexes = 1;
-    cf_config.index_sample_ratio = 10;
 
     ASSERT_EQ(tidesdb_create_column_family(db, "bidx_cf", &cf_config), 0);
     tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "bidx_cf");
@@ -6094,7 +6093,6 @@ static void test_block_indexes_sparse_sample_ratio(void)
     tidesdb_t *db = create_test_db();
     tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
     cf_config.enable_block_indexes = 1;
-    cf_config.index_sample_ratio = 32;
 
     ASSERT_EQ(tidesdb_create_column_family(db, "bidx_sparse_cf", &cf_config), 0);
     tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "bidx_sparse_cf");
@@ -13875,7 +13873,6 @@ void test_tidesdb_block_index_seek()
 
     tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
     cf_config.enable_block_indexes = 1;
-    cf_config.index_sample_ratio = 1;
     cf_config.write_buffer_size = 512 * 1024;
 
     ASSERT_EQ(tidesdb_create_column_family(db, "test_cf", &cf_config), TDB_SUCCESS);
@@ -21338,7 +21335,6 @@ static void test_full_merge_block_index_sampling(void)
     cf_config.write_buffer_size = 2048;
     cf_config.level_size_ratio = 10;
     cf_config.enable_block_indexes = 1;
-    cf_config.index_sample_ratio = 2;
 
     ASSERT_EQ(tidesdb_create_column_family(db, "sample_cf", &cf_config), 0);
     tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "sample_cf");
@@ -28707,11 +28703,9 @@ static void test_perf_cached_iter_seek(void)
 
 static void test_block_index_shared_prefix(void)
 {
-    /* keys that share a prefix longer than block_index_prefix_len span multiple
-     * klog blocks whose min/max prefixes are all identical. the block index
-     * search must land on the leftmost such block and the lookup must scan the
-     * whole prefix-colliding run -- otherwise point lookups and seeks for keys
-     * in any but the overshot block return a false NOT_FOUND. */
+    /* many keys sharing a long common prefix span multiple klog blocks. the blocked index stores
+     * each block's full first-key, so a lookup routes to exactly the covering block -- this pins
+     * that point lookups and seeks for such keys never return a false NOT_FOUND. */
     cleanup_test_dir();
 
     tidesdb_config_t config = tidesdb_default_config();
@@ -28720,9 +28714,8 @@ static void test_block_index_shared_prefix(void)
     tidesdb_t *db = NULL;
     ASSERT_EQ(tidesdb_open(&config, &db), 0);
 
-    /* default cf config -- block_index_prefix_len 16, index_sample_ratio 1,
-     * block indexes enabled. small write buffer + padded values force the
-     * shared-prefix keys across many blocks. */
+    /* block indexes enabled. small write buffer + padded values force the shared-prefix keys across
+     * many blocks. */
     tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
     cf_config.write_buffer_size = 16 * 1024;
     cf_config.compression_algorithm = TDB_COMPRESS_NONE;
@@ -28732,7 +28725,7 @@ static void test_block_index_shared_prefix(void)
     tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "bidx_prefix_cf");
     ASSERT_TRUE(cf != NULL);
 
-    /* 24 byte prefix -- longer than the 16 byte block_index_prefix_len */
+    /* a long shared prefix that spreads the keys across many blocks */
     static const char SHARED[] = "shared_prefix_blockidx__";
     const int SHARED_KEYS = 3000;
     const int UNIQUE_KEYS = 500;

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -90,6 +90,39 @@ static void test_basic_open_close(void)
     cleanup_test_dir();
 }
 
+/* tidesdb_txn_begin_cf opens a transaction at the column family's configured default isolation
+ * level, so a CF created with a non-default default_isolation_level yields a txn at that level
+ * while the plain tidesdb_txn_begin stays READ_COMMITTED regardless of the cf setting. */
+static void test_txn_begin_cf_uses_cf_default_isolation(void)
+{
+    cleanup_test_dir();
+    tidesdb_t *db = create_test_db();
+
+    tidesdb_column_family_config_t cfg = tidesdb_default_column_family_config();
+    cfg.default_isolation_level = TDB_ISOLATION_SERIALIZABLE;
+    ASSERT_EQ(tidesdb_create_column_family(db, "iso_cf", &cfg), 0);
+    tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "iso_cf");
+    ASSERT_TRUE(cf != NULL);
+
+    tidesdb_txn_t *txn = NULL;
+    ASSERT_EQ(tidesdb_txn_begin_cf(db, cf, &txn), 0);
+    ASSERT_EQ(txn->isolation_level, TDB_ISOLATION_SERIALIZABLE);
+    tidesdb_txn_commit(txn);
+
+    /* a NULL cf is rejected */
+    tidesdb_txn_t *null_txn = NULL;
+    ASSERT_EQ(tidesdb_txn_begin_cf(db, NULL, &null_txn), TDB_ERR_INVALID_ARGS);
+
+    /* the plain begin still uses READ_COMMITTED, unaffected by the cf's setting */
+    tidesdb_txn_t *rc_txn = NULL;
+    ASSERT_EQ(tidesdb_txn_begin(db, &rc_txn), 0);
+    ASSERT_EQ(rc_txn->isolation_level, TDB_ISOLATION_READ_COMMITTED);
+    tidesdb_txn_commit(rc_txn);
+
+    ASSERT_EQ(tidesdb_close(db), 0);
+    cleanup_test_dir();
+}
+
 /* custom allocator test tracking variables */
 static atomic_int custom_malloc_count;
 static atomic_int custom_calloc_count;
@@ -32883,6 +32916,7 @@ int main(int argc, char **argv)
     RUN_TEST(test_objstore_list_prefix, tests_passed);
     RUN_TEST(test_objstore_wal_sync_on_commit, tests_passed);
     RUN_TEST(test_btree_multi_cf_vlog_isolation, tests_passed);
+    RUN_TEST(test_txn_begin_cf_uses_cf_default_isolation, tests_passed);
     RUN_TEST(test_replica_mode, tests_passed);
     RUN_TEST(test_primary_replica_failover, tests_passed);
 #ifdef TIDESDB_WITH_S3

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tidesdb",
-  "version-string": "9.3.14",
+  "version-string": "9.4.0",
   "description": "TidesDB is a high-performance durable, transactional embeddable storage engine designed for flash and RAM optimization with optional object storage support for unlimited data scaling.",
   "dependencies": ["zstd", "snappy", "lz4", "pthreads", "curl"],
   "features": {


### PR DESCRIPTION
Major TidesDB version reducing complexities and enhancing usability.
- Block format will now be removed in favor of B+Tree klogs.  Maintaining both formats caused complexities in most paths with no benefit. No more block indexes, the sstable klog btrees are indexes.
- VLogs will now be per column family.  Segmented and garbage collected triggered by reaper async.  Further reducing write amplification.
- Bloom filters are now partitioned/blocked and brought into clock cache for reduction in memory usage and allowing for large filters per klog.
- Lots of bug corrections across ci, object store and more. 
- Break up of monolith tidesdb.c
- Dedup public api into include/db.
- Documentation in md format under docs/ for each module and core component 
- Legacy weight stripped from block manager, bloom filter, and manifest, all 9 > 10 absolute migration mandatory. 
- Code RULES and VERSIONING documentation