### PR TITLE
objstore_s3: fix 2GiB file upload failure on MinGW (widen file_size, add ftell/fseek redirect)

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -1802,6 +1802,11 @@ static inline FILE *tdb_fopen(const char *filename, const char *mode)
 {
     return fopen(filename, mode);
 }
+
+/* MinGW's ftell/fseek are 32-bit (long) even on 64-bit targets, so they fail with -1 on files
+ * >= 2 GiB. redirect to the 64-bit CRT entry points, mirroring the MSVC branch above. */
+#define ftell _ftelli64
+#define fseek _fseeki64
 #endif
 
 #if defined(__MINGW32__) || defined(__MINGW64__)

--- a/src/objstore_s3.c
+++ b/src/objstore_s3.c
@@ -1270,7 +1270,7 @@ static int s3_multipart_abort(s3_ctx_t *s3, const char *key, const char *upload_
  * @param file_size size of the file in bytes
  * @return 0 on success, -1 on error
  */
-static int s3_put_single(s3_ctx_t *s3, const char *key, FILE *fp, long file_size)
+static int s3_put_single(s3_ctx_t *s3, const char *key, FILE *fp, int64_t file_size)
 {
     struct curl_slist *headers = s3_sign_request(s3, "PUT", key, "UNSIGNED-PAYLOAD", NULL, NULL);
 
@@ -1387,7 +1387,7 @@ static int s3_put_if(void *ctx, const char *key, const char *local_path, tidesdb
         fclose(fp);
         return -1;
     }
-    long file_size = ftell(fp);
+    int64_t file_size = ftell(fp);
     if (file_size < 0)
     {
         fclose(fp);
@@ -1397,7 +1397,7 @@ static int s3_put_if(void *ctx, const char *key, const char *local_path, tidesdb
 
     /* upload only the logical length when asked, so a WAL's preallocated zero tail is not shipped.
      * curl uploads exactly INFILESIZE bytes from the read stream. */
-    if (max_bytes > 0 && (long)max_bytes < file_size) file_size = (long)max_bytes;
+    if (max_bytes > 0 && (int64_t)max_bytes < file_size) file_size = (int64_t)max_bytes;
 
     /* x-amz-* metadata must be signed; build the canonical (trailing newline preserves the
      * SigV4 separator line) and signed-header fragments. the epoch sorts after x-amz-date. */
@@ -1526,7 +1526,7 @@ static int s3_head(void *ctx, const char *key, char *etag_out, size_t etag_out_s
  * @param file_size size of the file in bytes
  * @return 0 on success, -1 on error
  */
-static int s3_put_multipart(s3_ctx_t *s3, const char *key, FILE *fp, long file_size)
+static int s3_put_multipart(s3_ctx_t *s3, const char *key, FILE *fp, int64_t file_size)
 {
     const size_t part_size = s3->multipart_part_size; /* resolved to a default at create time */
 
@@ -1607,7 +1607,7 @@ static int s3_put(void *ctx, const char *key, const char *local_path)
         fclose(fp);
         return -1;
     }
-    long file_size = ftell(fp);
+    int64_t file_size = ftell(fp);
     if (file_size < 0)
     {
         fclose(fp);


### PR DESCRIPTION
## Problem

`s3_put()` and `s3_put_if()` in `src/objstore_s3.c` read the local file's size with:

```c
long file_size = ftell(fp);
if (file_size < 0) { ... return -1; }
```

On Windows built with **MinGW-w64**, `ftell`/`fseek` are never redirected to the 64-bit `_ftelli64`/`_fseeki64` CRT entry points -- `src/compat.h` only does that redirection inside the `#if defined(_MSC_VER)` branch. So under MinGW both the `fseek(fp, 0, SEEK_END)` call and the following `ftell(fp)` operate on a plain 32-bit `long`. Once a file's size exceeds `LONG_MAX` (2 GiB), `fseek`/`ftell` fail outright and `s3_put()`/`s3_put_if()` silently return `-1` for any object at or above that size -- even though `objstore_s3.c`'s own multipart upload path documents itself as not being bound by any single-file size limit, and the README lists both "Object store mode with S3-compatible storage" and Windows support as first-class features.

## Fix

Two changes, both required together (verified independently, see below):

1. **`src/compat.h`** -- add the same
   ```c
   #define ftell _ftelli64
   #define fseek _fseeki64
   ```
   redirection to the MinGW branch that the MSVC branch immediately above it already has. Without this, `fseek`/`ftell` themselves are still 32-bit under MinGW.

2. **`src/objstore_s3.c`** -- widen the `file_size` parameter/local of `s3_put_single()`, `s3_put_if()`, `s3_put_multipart()`, and `s3_put()` from `long` to `int64_t`, and fix the associated `max_bytes` clamp cast in `s3_put_if()`. Without this, the now-64-bit value returned by `_ftelli64` gets truncated straight back down to 32 bits on assignment, turning a hard failure into a silent, harder-to-diagnose wrong-size upload.

(`s3_put_multipart()`'s `long parts_needed` does not need widening -- even a many-GiB file divided into 8 MB parts stays well within a 32-bit part count.)

## Verification

Compiled a small harness against this repo's actual (patched) `src/compat.h` on MinGW-w64 gcc 8.1.0, reproducing `s3_put()`/`s3_put_if()`'s exact `fopen("rb")` -> `fseek(fp, 0, SEEK_END)` -> `ftell(fp)` -> `rewind(fp)` sequence on a sparse file whose logical size sits past the 2 GiB boundary (2200000001 bytes):

- **Before the fix** (original `compat.h` + `long file_size`): `fseek` itself fails with `EINVAL` as soon as it's asked to seek past `LONG_MAX`.
- **After the fix** (patched `compat.h` + `int64_t file_size`): `ftell` correctly recovers `2200000001`.

No behavior change on Linux/macOS or under MSVC -- POSIX `ftell` is already 64-bit on LP64 systems, and MSVC already had the `_ftelli64`/`_fseeki64` redirect; widening `file_size` there is a no-op change in observed behavior, just removing a latent 32-bit ceiling that this platform's redirect happened to make unreachable in practice.

Ran `code_formatter.ps1`'s underlying `clang-format` against both changed files against this repo's `.clang-format`; no additional formatting changes were produced beyond the diff below.