### PR TITLE
Honor cgroup memory limits for overwrite-heavy memtables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -704,6 +704,7 @@ if(TIDESDB_BUILD_TESTS) # enable building tests and benchmarks
     endif()
 
     add_executable(block_manager_tests test/block_manager__tests.c)
+    add_executable(compat_tests test/compat__tests.c)
     add_executable(skip_list_tests test/skip_list__tests.c)
     add_executable(compress_tests test/compress__tests.c)
     add_executable(bloom_filter_tests test/bloom_filter__tests.c)
@@ -789,7 +790,7 @@ if(TIDESDB_BUILD_TESTS) # enable building tests and benchmarks
 
     # add include and link directories for test executables
     set(TIDESDB_TEST_LINK_TARGETS
-            block_manager_tests skip_list_tests compress_tests bloom_filter_tests
+            block_manager_tests compat_tests skip_list_tests compress_tests bloom_filter_tests
             manifest_tests clock_cache_tests queue_tests btree_tests local_cache_tests
             objstore_tests tidesdb_tests tidesdb_bench)
     if(TIDESDB_WITH_S3)
@@ -801,6 +802,7 @@ if(TIDESDB_BUILD_TESTS) # enable building tests and benchmarks
     endforeach()
 
     add_test(NAME block_manager_tests COMMAND block_manager_tests)
+    add_test(NAME compat_tests COMMAND compat_tests)
     add_test(NAME skip_list_tests COMMAND skip_list_tests)
     add_test(NAME compress_tests COMMAND compress_tests)
     add_test(NAME bloom_filter_tests COMMAND bloom_filter_tests)

--- a/src/compat.h
+++ b/src/compat.h
@@ -2316,6 +2316,373 @@ static inline int atomic_compare_exchange_strong_ptr(_Atomic(void *) *ptr, void 
 }
 #endif
 
+#define TDB_CGROUP_MEMORY_INVALID   -1
+#define TDB_CGROUP_MEMORY_UNLIMITED 0
+#define TDB_CGROUP_MEMORY_FINITE    1
+#define TDB_CGROUP_PATH_CAPACITY    8192
+
+typedef struct
+{
+    int limit_state;
+    size_t limit;
+    int available_state;
+    size_t available;
+} tdb_cgroup_memory_bounds_t;
+
+static inline int tdb_ascii_space(const char c)
+{
+    return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v';
+}
+
+/* parse memory.max/memory.current text without accepting signs, suffixes, or overflow */
+static inline int tdb_parse_cgroup_memory_value(const char *text, size_t *value)
+{
+    if (!text || !value) return TDB_CGROUP_MEMORY_INVALID;
+
+    while (tdb_ascii_space(*text)) text++;
+    if (strncmp(text, "max", 3) == 0)
+    {
+        text += 3;
+        while (tdb_ascii_space(*text)) text++;
+        return *text == '\0' ? TDB_CGROUP_MEMORY_UNLIMITED : TDB_CGROUP_MEMORY_INVALID;
+    }
+    if (*text < '0' || *text > '9') return TDB_CGROUP_MEMORY_INVALID;
+
+    errno = 0;
+    char *end = NULL;
+    const unsigned long long parsed = strtoull(text, &end, 10);
+    if (errno == ERANGE || end == text ||
+        (sizeof(size_t) < sizeof(unsigned long long) && parsed > (unsigned long long)SIZE_MAX))
+        return TDB_CGROUP_MEMORY_INVALID;
+
+    while (tdb_ascii_space(*end)) end++;
+    if (*end != '\0') return TDB_CGROUP_MEMORY_INVALID;
+
+    *value = (size_t)parsed;
+    return TDB_CGROUP_MEMORY_FINITE;
+}
+
+static inline size_t tdb_cgroup_effective_total(const size_t host_total, const int limit_state,
+                                                const size_t limit)
+{
+    if (limit_state != TDB_CGROUP_MEMORY_FINITE) return host_total;
+    if (host_total == 0 || limit < host_total) return limit;
+    return host_total;
+}
+
+static inline size_t tdb_cgroup_effective_available(const size_t host_available,
+                                                    const int limit_state,
+                                                    const int available_state,
+                                                    const size_t cgroup_available)
+{
+    if (limit_state == TDB_CGROUP_MEMORY_FINITE && available_state != TDB_CGROUP_MEMORY_FINITE)
+        return 0;
+    if (available_state != TDB_CGROUP_MEMORY_FINITE) return host_available;
+    if (host_available == 0 || cgroup_available < host_available) return cgroup_available;
+    return host_available;
+}
+
+static inline int tdb_parse_cgroup_v2_path(const char *contents, char *path, const size_t path_size)
+{
+    if (!contents || !path || path_size == 0) return -1;
+
+    const char *line = contents;
+    while (*line != '\0')
+    {
+        const char *line_end = strchr(line, '\n');
+        if (!line_end) line_end = line + strlen(line);
+
+        if (line_end - line >= 4 && line[0] == '0' && line[1] == ':' && line[2] == ':' &&
+            line[3] == '/')
+        {
+            const char *value = line + 3;
+            size_t length = (size_t)(line_end - value);
+            if (length > 0 && value[length - 1] == '\r') length--;
+            if (length == 0 || length >= path_size) return -1;
+            memcpy(path, value, length);
+            path[length] = '\0';
+            return 0;
+        }
+
+        if (*line_end == '\0') break;
+        line = line_end + 1;
+    }
+    return -1;
+}
+
+static inline int tdb_decode_mountinfo_path(const char *encoded, const size_t encoded_size,
+                                            char *decoded, const size_t decoded_size)
+{
+    if (!encoded || !decoded || decoded_size == 0) return -1;
+
+    size_t output = 0;
+    for (size_t input = 0; input < encoded_size; input++)
+    {
+        unsigned char value = (unsigned char)encoded[input];
+        if (value == '\\')
+        {
+            if (input + 3 >= encoded_size || encoded[input + 1] < '0' || encoded[input + 1] > '7' ||
+                encoded[input + 2] < '0' || encoded[input + 2] > '7' || encoded[input + 3] < '0' ||
+                encoded[input + 3] > '7')
+                return -1;
+            value = (unsigned char)(((encoded[input + 1] - '0') << 6) |
+                                    ((encoded[input + 2] - '0') << 3) | (encoded[input + 3] - '0'));
+            if (value == 0) return -1;
+            input += 3;
+        }
+        if (output + 1 >= decoded_size) return -1;
+        decoded[output++] = (char)value;
+    }
+    if (output == 0 || decoded[0] != '/') return -1;
+    while (output > 1 && decoded[output - 1] == '/') output--;
+    decoded[output] = '\0';
+    return 0;
+}
+
+static inline int tdb_parse_cgroup2_mountinfo_line(const char *line, const size_t line_size,
+                                                   char *root, const size_t root_size,
+                                                   char *mountpoint, const size_t mountpoint_size)
+{
+    if (!line || !root || !mountpoint) return -1;
+
+    const char *line_end = line + line_size;
+    const char *separator = NULL;
+    for (const char *cursor = line; cursor + 3 <= line_end; cursor++)
+    {
+        if (cursor[0] == ' ' && cursor[1] == '-' && cursor[2] == ' ')
+        {
+            separator = cursor;
+            break;
+        }
+    }
+    if (!separator) return 1;
+
+    const char *filesystem = separator + 3;
+    const char *filesystem_end = filesystem;
+    while (filesystem_end < line_end && *filesystem_end != ' ' && *filesystem_end != '\n' &&
+           *filesystem_end != '\r')
+        filesystem_end++;
+    if ((size_t)(filesystem_end - filesystem) != sizeof("cgroup2") - 1 ||
+        memcmp(filesystem, "cgroup2", sizeof("cgroup2") - 1) != 0)
+        return 1;
+
+    const char *fields[5];
+    size_t field_sizes[5];
+    const char *cursor = line;
+    for (int field = 0; field < 5; field++)
+    {
+        while (cursor < separator && *cursor == ' ') cursor++;
+        if (cursor >= separator) return -1;
+        fields[field] = cursor;
+        while (cursor < separator && *cursor != ' ') cursor++;
+        field_sizes[field] = (size_t)(cursor - fields[field]);
+    }
+
+    if (tdb_decode_mountinfo_path(fields[3], field_sizes[3], root, root_size) != 0 ||
+        tdb_decode_mountinfo_path(fields[4], field_sizes[4], mountpoint, mountpoint_size) != 0)
+        return -1;
+    return 0;
+}
+
+static inline int tdb_parse_cgroup2_mountinfo(const char *contents, char *root,
+                                              const size_t root_size, char *mountpoint,
+                                              const size_t mountpoint_size)
+{
+    if (!contents || !root || !mountpoint) return -1;
+
+    const char *line = contents;
+    while (*line != '\0')
+    {
+        const char *line_end = strchr(line, '\n');
+        if (!line_end) line_end = line + strlen(line);
+        const int result = tdb_parse_cgroup2_mountinfo_line(line, (size_t)(line_end - line), root,
+                                                            root_size, mountpoint, mountpoint_size);
+        if (result <= 0) return result;
+        if (*line_end == '\0') break;
+        line = line_end + 1;
+    }
+    return -1;
+}
+
+static inline int tdb_resolve_cgroup2_directory(const char *mountpoint, const char *mount_root,
+                                                const char *group, char *directory,
+                                                const size_t directory_size)
+{
+    if (!mountpoint || !mount_root || !group || !directory || directory_size == 0 ||
+        mountpoint[0] != '/' || mount_root[0] != '/' || group[0] != '/')
+        return -1;
+
+    const char *relative = group;
+    const size_t root_length = strlen(mount_root);
+    if (strcmp(group, "/") == 0 || strcmp(group, mount_root) == 0)
+        relative = "";
+    else if (strcmp(mount_root, "/") != 0 && strncmp(group, mount_root, root_length) == 0 &&
+             group[root_length] == '/')
+        relative = group + root_length;
+
+    int length;
+    if (*relative == '\0')
+        length = snprintf(directory, directory_size, "%s", mountpoint);
+    else if (strcmp(mountpoint, "/") == 0)
+        length = snprintf(directory, directory_size, "%s", relative);
+    else
+        length = snprintf(directory, directory_size, "%s%s", mountpoint, relative);
+    return length >= 0 && (size_t)length < directory_size ? 0 : -1;
+}
+
+static inline int tdb_read_small_text_file(const char *path, char *text, const size_t text_size)
+{
+    if (!path || !text || text_size < 2) return -1;
+    FILE *file = fopen(path, "r");
+    if (!file) return -1;
+
+    const size_t bytes = fread(text, 1, text_size - 1, file);
+    const int truncated = bytes == text_size - 1 && fgetc(file) != EOF;
+    const int failed = ferror(file);
+    fclose(file);
+    if (failed || truncated) return -1;
+
+    text[bytes] = '\0';
+    return 0;
+}
+
+static inline int tdb_cgroup_memory_bounds_at(const char *mountpoint, const char *start_directory,
+                                              tdb_cgroup_memory_bounds_t *bounds)
+{
+    if (!mountpoint || !start_directory || !bounds) return -1;
+
+    char directory[TDB_CGROUP_PATH_CAPACITY];
+    char path[TDB_CGROUP_PATH_CAPACITY + 128];
+    char text[128];
+
+    size_t mountpoint_length = strlen(mountpoint);
+    while (mountpoint_length > 1 && mountpoint[mountpoint_length - 1] == '/') mountpoint_length--;
+    const int directory_length = snprintf(directory, sizeof(directory), "%s", start_directory);
+    if (directory_length < 0 || (size_t)directory_length >= sizeof(directory)) return -1;
+    size_t directory_size = strlen(directory);
+    while (directory_size > 1 && directory[directory_size - 1] == '/')
+        directory[--directory_size] = '\0';
+    const int mountpoint_is_root = mountpoint_length == 1 && mountpoint[0] == '/';
+    if (directory_size < mountpoint_length ||
+        strncmp(directory, mountpoint, mountpoint_length) != 0 ||
+        (!mountpoint_is_root && directory_size > mountpoint_length &&
+         directory[mountpoint_length] != '/'))
+        return -1;
+
+    int found_hierarchy = 0;
+    int found_limit = 0;
+    int available_known = 1;
+    bounds->limit_state = TDB_CGROUP_MEMORY_INVALID;
+    bounds->limit = 0;
+    bounds->available_state = TDB_CGROUP_MEMORY_INVALID;
+    bounds->available = 0;
+
+    while (1)
+    {
+        const int max_path_length = snprintf(path, sizeof(path), "%s/memory.max", directory);
+        size_t current_limit = 0;
+        int limit_state = TDB_CGROUP_MEMORY_INVALID;
+        if (max_path_length >= 0 && (size_t)max_path_length < sizeof(path) &&
+            tdb_read_small_text_file(path, text, sizeof(text)) == 0)
+        {
+            limit_state = tdb_parse_cgroup_memory_value(text, &current_limit);
+            if (limit_state != TDB_CGROUP_MEMORY_INVALID) found_hierarchy = 1;
+        }
+
+        if (limit_state == TDB_CGROUP_MEMORY_FINITE)
+        {
+            if (!found_limit || current_limit < bounds->limit) bounds->limit = current_limit;
+            found_limit = 1;
+
+            size_t current = 0;
+            int current_state = TDB_CGROUP_MEMORY_INVALID;
+            const int current_path_length =
+                snprintf(path, sizeof(path), "%s/memory.current", directory);
+            if (current_path_length >= 0 && (size_t)current_path_length < sizeof(path) &&
+                tdb_read_small_text_file(path, text, sizeof(text)) == 0)
+                current_state = tdb_parse_cgroup_memory_value(text, &current);
+
+            if (current_state != TDB_CGROUP_MEMORY_FINITE)
+            {
+                available_known = 0;
+            }
+            else
+            {
+                const size_t headroom = current >= current_limit ? 0 : current_limit - current;
+                if (bounds->available_state != TDB_CGROUP_MEMORY_FINITE ||
+                    headroom < bounds->available)
+                    bounds->available = headroom;
+                bounds->available_state = TDB_CGROUP_MEMORY_FINITE;
+            }
+        }
+
+        if (strlen(directory) == mountpoint_length &&
+            strncmp(directory, mountpoint, mountpoint_length) == 0)
+            break;
+        char *separator = strrchr(directory, '/');
+        if (!separator) return -1;
+        if (separator == directory)
+            directory[1] = '\0';
+        else
+            *separator = '\0';
+    }
+
+    if (!found_hierarchy) return -1;
+    if (!found_limit)
+    {
+        bounds->limit_state = TDB_CGROUP_MEMORY_UNLIMITED;
+        bounds->available_state = TDB_CGROUP_MEMORY_UNLIMITED;
+    }
+    else
+    {
+        bounds->limit_state = TDB_CGROUP_MEMORY_FINITE;
+        if (!available_known) bounds->available_state = TDB_CGROUP_MEMORY_INVALID;
+    }
+    return 0;
+}
+
+#if defined(__linux__)
+static inline int tdb_linux_cgroup2_mount(char *root, const size_t root_size, char *mountpoint,
+                                          const size_t mountpoint_size)
+{
+    FILE *file = fopen("/proc/self/mountinfo", "r");
+    if (!file) return -1;
+
+    char line[TDB_CGROUP_PATH_CAPACITY];
+    int result = -1;
+    while (fgets(line, sizeof(line), file))
+    {
+        const size_t line_size = strlen(line);
+        if (line_size == sizeof(line) - 1 && line[line_size - 1] != '\n') break;
+        const int parsed = tdb_parse_cgroup2_mountinfo_line(line, line_size, root, root_size,
+                                                            mountpoint, mountpoint_size);
+        if (parsed == 0)
+        {
+            result = 0;
+            break;
+        }
+        if (parsed < 0) break;
+    }
+    fclose(file);
+    return result;
+}
+
+static inline int tdb_linux_cgroup_memory_bounds(tdb_cgroup_memory_bounds_t *bounds)
+{
+    char cgroup[4096];
+    char group[4096];
+    char root[TDB_CGROUP_PATH_CAPACITY];
+    char mountpoint[TDB_CGROUP_PATH_CAPACITY];
+    char directory[TDB_CGROUP_PATH_CAPACITY];
+    if (tdb_read_small_text_file("/proc/self/cgroup", cgroup, sizeof(cgroup)) != 0 ||
+        tdb_parse_cgroup_v2_path(cgroup, group, sizeof(group)) != 0 ||
+        tdb_linux_cgroup2_mount(root, sizeof(root), mountpoint, sizeof(mountpoint)) != 0 ||
+        tdb_resolve_cgroup2_directory(mountpoint, root, group, directory, sizeof(directory)) != 0)
+        return -1;
+    return tdb_cgroup_memory_bounds_at(mountpoint, directory, bounds);
+}
+#endif
+
 /*
  * get_available_memory
  * gets available system memory in bytes
@@ -2384,32 +2751,36 @@ static inline size_t get_available_memory(void)
      * buffers/cache + reclaimable slab). sysinfo.freeram only reports truly free
      * pages which is typically very low on a busy system and triggers false
      * critical memory pressure */
+    size_t available = 0;
+    FILE *f = fopen("/proc/meminfo", "r");
+    if (f)
     {
-        FILE *f = fopen("/proc/meminfo", "r");
-        if (f)
+        char line[256];
+        while (fgets(line, sizeof(line), f))
         {
-            char line[256];
-            while (fgets(line, sizeof(line), f))
+            unsigned long long val;
+            if (sscanf(line, "MemAvailable: %llu kB", &val) == 1)
             {
-                unsigned long long val;
-                if (sscanf(line, "MemAvailable: %llu kB", &val) == 1)
-                {
-                    fclose(f);
-                    return (size_t)(val * 1024ULL);
-                }
+                available = (size_t)(val * 1024ULL);
+                break;
             }
-            fclose(f);
         }
+        fclose(f);
     }
     /* fallback to sysinfo.freeram if /proc/meminfo is unavailable */
+    if (available == 0)
     {
         struct sysinfo si;
         if (sysinfo(&si) == 0)
         {
-            return (size_t)si.freeram * (size_t)si.mem_unit;
+            available = (size_t)si.freeram * (size_t)si.mem_unit;
         }
     }
-    return 0;
+
+    tdb_cgroup_memory_bounds_t bounds;
+    if (tdb_linux_cgroup_memory_bounds(&bounds) != 0) return available;
+    return tdb_cgroup_effective_available(available, bounds.limit_state, bounds.available_state,
+                                          bounds.available);
 #elif defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
     /* BSD systems use sysctl.. */
     unsigned long free_pages = 0;
@@ -2484,7 +2855,10 @@ static inline size_t get_total_memory(void)
     struct sysinfo si;
     if (sysinfo(&si) == 0)
     {
-        return (size_t)si.totalram * (size_t)si.mem_unit;
+        const size_t total = (size_t)si.totalram * (size_t)si.mem_unit;
+        tdb_cgroup_memory_bounds_t bounds;
+        if (tdb_linux_cgroup_memory_bounds(&bounds) != 0) return total;
+        return tdb_cgroup_effective_total(total, bounds.limit_state, bounds.limit);
     }
     return 0;
 #elif defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__)

--- a/src/skip_list.c
+++ b/src/skip_list.c
@@ -165,6 +165,7 @@ static inline int skip_list_arena_get_slot(skip_list_arena_t *arena)
 static void *skip_list_arena_alloc(skip_list_arena_t *arena, size_t size)
 {
     /* align up to SKIP_LIST_ARENA_ALIGNMENT */
+    if (size == 0 || size > SIZE_MAX - (SKIP_LIST_ARENA_ALIGNMENT - 1)) return NULL;
     size = (size + (SKIP_LIST_ARENA_ALIGNMENT - 1)) & ~(size_t)(SKIP_LIST_ARENA_ALIGNMENT - 1);
 
     int slot = skip_list_arena_get_slot(arena);
@@ -264,13 +265,23 @@ static void skip_list_arena_destroy(skip_list_arena_t *arena)
  * @param size number of bytes
  * @return pointer to memory, or NULL on failure
  */
-static inline void *skip_list_alloc(const skip_list_t *list, size_t size)
+static inline size_t skip_list_allocation_size(const size_t size)
 {
-    if (list != NULL && list->arena != NULL)
-    {
-        return skip_list_arena_alloc(list->arena, size);
-    }
-    return malloc(size);
+    if (size == 0 || size > SIZE_MAX - (SKIP_LIST_ARENA_ALIGNMENT - 1)) return 0;
+    return (size + (SKIP_LIST_ARENA_ALIGNMENT - 1)) & ~(size_t)(SKIP_LIST_ARENA_ALIGNMENT - 1);
+}
+
+static inline void *skip_list_alloc(skip_list_t *list, const size_t size)
+{
+    const size_t allocation_size = skip_list_allocation_size(size);
+    if (allocation_size == 0) return NULL;
+
+    void *allocation = list != NULL && list->arena != NULL
+                           ? skip_list_arena_alloc(list->arena, allocation_size)
+                           : malloc(allocation_size);
+    if (allocation != NULL && list != NULL)
+        atomic_fetch_add_explicit(&list->resident_size, allocation_size, memory_order_relaxed);
+    return allocation;
 }
 
 /**
@@ -278,11 +289,29 @@ static inline void *skip_list_alloc(const skip_list_t *list, size_t size)
  * frees memory -- no-op when arena is active (bulk free on arena destroy)
  * @param list skip list (used to check for arena)
  * @param ptr pointer to free
+ * @param size requested allocation size
  */
-static inline void skip_list_dealloc(const skip_list_t *list, void *ptr)
+static inline void skip_list_dealloc(skip_list_t *list, void *ptr, const size_t size)
 {
-    if (list != NULL && list->arena != NULL) return; /* no-op */
+    if (ptr == NULL || (list != NULL && list->arena != NULL)) return; /* no-op */
     free(ptr);
+    if (list != NULL)
+        atomic_fetch_sub_explicit(&list->resident_size, skip_list_allocation_size(size),
+                                  memory_order_relaxed);
+}
+
+static inline int skip_list_node_allocation_size(const int level, const size_t key_size,
+                                                 size_t *pointers_size, size_t *allocation_size)
+{
+    if (level < 0 || !pointers_size || !allocation_size) return -1;
+    const size_t levels = (size_t)level + 1;
+    if (levels > SIZE_MAX / (2 * sizeof(_Atomic(skip_list_node_t *)))) return -1;
+    *pointers_size = levels * 2 * sizeof(_Atomic(skip_list_node_t *));
+    if (*pointers_size > SIZE_MAX - sizeof(skip_list_node_t) ||
+        key_size > SIZE_MAX - sizeof(skip_list_node_t) - *pointers_size)
+        return -1;
+    *allocation_size = sizeof(skip_list_node_t) + *pointers_size + key_size;
+    return 0;
 }
 
 /**
@@ -467,7 +496,7 @@ static inline skip_list_version_t *skip_list_get_latest_valid_version(skip_list_
  * @param list skip list (used to check for arena)
  * @param version version to free
  */
-static void skip_list_free_version(const skip_list_t *list, skip_list_version_t *version);
+static void skip_list_free_version(skip_list_t *list, skip_list_version_t *version);
 
 /**
  * skip_list_compare_keys_with_type
@@ -607,7 +636,7 @@ static int skip_list_insert_version_cas(_Atomic(skip_list_version_t *) *versions
             if (atomic_compare_exchange_weak_explicit(versions_ptr, &old_head, new_version,
                                                       memory_order_release, memory_order_acquire))
             {
-                /* head prepend succeeded -- update total_size, subtract old head, add new */
+                /* head prepend succeeded -- update logical total_size to the new head value */
                 if (old_head && old_head->value_size > 0)
                 {
                     atomic_fetch_sub_explicit(&list->total_size, old_head->value_size,
@@ -723,14 +752,15 @@ int skip_list_comparator_numeric(const uint8_t *key1, size_t key1_size, const ui
  * @param seq sequence number for MVCC
  * @return pointer to new version, NULL on failure
  */
-static skip_list_version_t *skip_list_create_version(const skip_list_t *list, const uint8_t *value,
+static skip_list_version_t *skip_list_create_version(skip_list_t *list, const uint8_t *value,
                                                      const size_t value_size, const int64_t ttl,
                                                      const uint8_t flags, uint64_t seq)
 {
     /* we combine version struct + value data into a single allocation
      * this halves malloc calls and improves cache locality */
-    const size_t alloc_size =
-        sizeof(skip_list_version_t) + ((value != NULL && value_size > 0) ? value_size : 0);
+    const size_t payload_size = value != NULL && value_size > 0 ? value_size : 0;
+    if (payload_size > SIZE_MAX - sizeof(skip_list_version_t)) return NULL;
+    const size_t alloc_size = sizeof(skip_list_version_t) + payload_size;
     skip_list_version_t *version = (skip_list_version_t *)skip_list_alloc(list, alloc_size);
     if (version == NULL) return NULL;
 
@@ -759,11 +789,11 @@ static skip_list_version_t *skip_list_create_version(const skip_list_t *list, co
  * @param list skip list (for arena deallocation)
  * @param version version to free
  */
-static void skip_list_free_version(const skip_list_t *list, skip_list_version_t *version)
+static void skip_list_free_version(skip_list_t *list, skip_list_version_t *version)
 {
     if (version == NULL) return;
     /* value is embedded in same allocation as version struct -- single free */
-    skip_list_dealloc(list, version);
+    skip_list_dealloc(list, version, sizeof(skip_list_version_t) + version->value_size);
 }
 
 /**
@@ -772,7 +802,7 @@ static void skip_list_free_version(const skip_list_t *list, skip_list_version_t 
  * @param list skip list (for arena deallocation)
  * @param head head of version list
  */
-static void skip_list_free_version_list(const skip_list_t *list, skip_list_version_t *head)
+static void skip_list_free_version_list(skip_list_t *list, skip_list_version_t *head)
 {
     while (head != NULL)
     {
@@ -790,8 +820,11 @@ static void skip_list_free_version_list(const skip_list_t *list, skip_list_versi
  */
 static skip_list_node_t *skip_list_create_sentinel(const int level)
 {
-    size_t pointers_size = (level + 1) * 2 * sizeof(_Atomic(skip_list_node_t *));
-    skip_list_node_t *node = (skip_list_node_t *)malloc(sizeof(skip_list_node_t) + pointers_size);
+    size_t pointers_size;
+    size_t allocation_size;
+    if (skip_list_node_allocation_size(level, 0, &pointers_size, &allocation_size) != 0)
+        return NULL;
+    skip_list_node_t *node = (skip_list_node_t *)malloc(allocation_size);
     if (node == NULL) return NULL;
 
     node->key = NULL;
@@ -817,9 +850,11 @@ skip_list_node_t *skip_list_create_node(const int level, const uint8_t *key, siz
 
     /* we combine node struct + forward/backward pointers + key into a single allocation
      * this eliminates one malloc per node and co-locates key data for cache locality */
-    size_t pointers_size = (level + 1) * 2 * sizeof(_Atomic(skip_list_node_t *));
-    skip_list_node_t *node =
-        (skip_list_node_t *)malloc(sizeof(skip_list_node_t) + pointers_size + key_size);
+    size_t pointers_size;
+    size_t allocation_size;
+    if (skip_list_node_allocation_size(level, key_size, &pointers_size, &allocation_size) != 0)
+        return NULL;
+    skip_list_node_t *node = (skip_list_node_t *)malloc(allocation_size);
     if (node == NULL) return NULL;
 
     node->key = (uint8_t *)node + sizeof(skip_list_node_t) + pointers_size;
@@ -859,13 +894,18 @@ skip_list_node_t *skip_list_create_node(const int level, const uint8_t *key, siz
  * skip_list_free_node_internal
  * arena-aware node free -- simply no-op when arena is active
  */
-static int skip_list_free_node_internal(const skip_list_t *list, skip_list_node_t *node)
+static int skip_list_free_node_internal(skip_list_t *list, skip_list_node_t *node)
 {
     if (node == NULL) return -1;
     skip_list_version_t *versions = atomic_load_explicit(&node->versions, memory_order_acquire);
     skip_list_free_version_list(list, versions);
     /* key is embedded in same allocation as node -- single free */
-    skip_list_dealloc(list, node);
+    size_t pointers_size;
+    size_t allocation_size;
+    if (skip_list_node_allocation_size(node->level, node->key_size, &pointers_size,
+                                       &allocation_size) != 0)
+        return -1;
+    skip_list_dealloc(list, node, allocation_size);
     return 0;
 }
 
@@ -941,6 +981,7 @@ int skip_list_new_with_comparator_and_cached_time(skip_list_t **list, const int 
     }
 
     atomic_init(&new_list->total_size, 0);
+    atomic_init(&new_list->resident_size, 0);
     atomic_init(&new_list->entry_count, 0);
     atomic_init(&new_list->min_seq, UINT64_MAX);
 
@@ -1360,7 +1401,7 @@ int skip_list_clear(skip_list_t *list)
         {
             skip_list_node_t *next =
                 atomic_load_explicit(&current->forward[0], memory_order_acquire);
-            skip_list_free_node(current);
+            skip_list_free_node_internal(list, current);
             current = next;
         }
     }
@@ -1415,6 +1456,12 @@ size_t skip_list_get_size(skip_list_t *list)
 {
     if (list == NULL) return 0;
     return atomic_load_explicit(&list->total_size, memory_order_acquire);
+}
+
+size_t skip_list_get_resident_size(skip_list_t *list)
+{
+    if (list == NULL) return 0;
+    return atomic_load_explicit(&list->resident_size, memory_order_acquire);
 }
 
 int skip_list_count_entries(skip_list_t *list)
@@ -2125,9 +2172,15 @@ int skip_list_put_with_seq(skip_list_t *list, const uint8_t *key, size_t key_siz
     }
 
     /* we combine node + pointers + key into single allocation for cache locality */
-    const size_t pointers_size = (2 * (new_level + 1)) * sizeof(_Atomic(skip_list_node_t *));
-    skip_list_node_t *new_node =
-        skip_list_alloc(list, sizeof(skip_list_node_t) + pointers_size + key_size);
+    size_t pointers_size;
+    size_t node_allocation_size;
+    if (skip_list_node_allocation_size(new_level, key_size, &pointers_size,
+                                       &node_allocation_size) != 0)
+    {
+        if (!use_stack) free(update);
+        return -1;
+    }
+    skip_list_node_t *new_node = skip_list_alloc(list, node_allocation_size);
     if (new_node == NULL)
     {
         if (!use_stack) free(update);
@@ -2144,7 +2197,7 @@ int skip_list_put_with_seq(skip_list_t *list, const uint8_t *key, size_t key_siz
         skip_list_create_version(list, value, value_size, ttl, flags, seq);
     if (initial_version == NULL)
     {
-        skip_list_dealloc(list, new_node);
+        skip_list_dealloc(list, new_node, node_allocation_size);
         if (!use_stack) free(update);
         return -1;
     }
@@ -2481,9 +2534,12 @@ int skip_list_put_batch(skip_list_t *list, const skip_list_batch_entry_t *entrie
         }
 
         /* we combine node + pointers + key into single allocation for cache locality */
-        const size_t batch_ptrs_size = (2 * (new_level + 1)) * sizeof(_Atomic(skip_list_node_t *));
-        skip_list_node_t *new_node =
-            skip_list_alloc(list, sizeof(skip_list_node_t) + batch_ptrs_size + entry->key_size);
+        size_t batch_ptrs_size;
+        size_t node_allocation_size;
+        if (skip_list_node_allocation_size(new_level, entry->key_size, &batch_ptrs_size,
+                                           &node_allocation_size) != 0)
+            continue;
+        skip_list_node_t *new_node = skip_list_alloc(list, node_allocation_size);
         if (new_node == NULL)
         {
             continue;
@@ -2499,7 +2555,7 @@ int skip_list_put_batch(skip_list_t *list, const skip_list_batch_entry_t *entrie
             list, entry->value, entry->value_size, entry->ttl, entry->flags, entry->seq);
         if (initial_version == NULL)
         {
-            skip_list_dealloc(list, new_node);
+            skip_list_dealloc(list, new_node, node_allocation_size);
             continue;
         }
         atomic_init(&new_node->versions, initial_version);

--- a/src/skip_list.h
+++ b/src/skip_list.h
@@ -190,7 +190,8 @@ struct skip_list_node_t
  * @param probability probability for level generation
  * @param header sentinel header node (compares less than all keys)
  * @param tail sentinel tail node (compares greater than all keys)
- * @param total_size total size of all entries
+ * @param total_size logical size of all entries
+ * @param resident_size aligned bytes retained by node and version allocations
  * @param entry_count track entry count atomically to avoid O(n) traversals
  * @param cmp_type comparator type enum (memcmp, string, numeric, custom)
  * @param comparator key comparison function
@@ -206,6 +207,7 @@ typedef struct skip_list_t
     _Atomic(skip_list_node_t *) header;
     _Atomic(skip_list_node_t *) tail;
     _Atomic(size_t) total_size;
+    _Atomic(size_t) resident_size;
     _Atomic(int) entry_count;
     skip_list_cmp_type_t cmp_type;
     skip_list_comparator_fn comparator;
@@ -790,6 +792,14 @@ int skip_list_check_and_update_ttl(const skip_list_t *list, skip_list_node_t *no
  * @return total size in bytes
  */
 size_t skip_list_get_size(skip_list_t *list);
+
+/**
+ * skip_list_get_resident_size
+ * gets aligned bytes retained by node and version allocations
+ * @param list skip list
+ * @return retained size in bytes
+ */
+size_t skip_list_get_resident_size(skip_list_t *list);
 
 /**
  * skip_list_count_entries

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -7510,7 +7510,7 @@ static void tidesdb_imm_snap_publish_locked(tidesdb_column_family_t *cf)
     for (size_t i = 0; i < raw; i++)
     {
         tidesdb_memtable_t *m = next->items[i];
-        if (m && m->skip_list) imm_bytes += (int64_t)skip_list_get_size(m->skip_list);
+        if (m && m->skip_list) imm_bytes += (int64_t)skip_list_get_resident_size(m->skip_list);
         if (m && atomic_load_explicit(&m->flushed, memory_order_acquire)) continue;
         next->items[count++] = m;
     }
@@ -20054,7 +20054,7 @@ static void *tidesdb_reaper_thread(void *arg)
                 {
                     if (mt->skip_list)
                     {
-                        size_t mt_size = skip_list_get_size(mt->skip_list);
+                        size_t mt_size = skip_list_get_resident_size(mt->skip_list);
                         total_mem_bytes += (int64_t)mt_size;
                         if (mt_size > flush_victim_size &&
                             !atomic_load_explicit(&cf->is_flushing, memory_order_relaxed))
@@ -20114,7 +20114,7 @@ static void *tidesdb_reaper_thread(void *arg)
                     atomic_load_explicit(&db->unified_mt.active, memory_order_acquire);
                 if (umt && umt->skip_list)
                 {
-                    total_mem_bytes += (int64_t)skip_list_get_size(umt->skip_list);
+                    total_mem_bytes += (int64_t)skip_list_get_resident_size(umt->skip_list);
                 }
 
                 /* we sum each immutable's actual skip list size. a flushed
@@ -20129,7 +20129,8 @@ static void *tidesdb_reaper_thread(void *arg)
                     {
                         tidesdb_memtable_t *uimm = (tidesdb_memtable_t *)n->data;
                         if (uimm && uimm->skip_list)
-                            total_mem_bytes += (int64_t)skip_list_get_size(uimm->skip_list);
+                            total_mem_bytes +=
+                                (int64_t)skip_list_get_resident_size(uimm->skip_list);
                     }
                     pthread_rwlock_unlock(&uimm_q->read_lock);
                 }
@@ -20245,7 +20246,7 @@ static void *tidesdb_reaper_thread(void *arg)
                         if (tidesdb_active_memtable_try_ref(&victim->active_mt_readers,
                                                             &victim->active_memtable, &vmt))
                         {
-                            if (vmt->skip_list) vsize = skip_list_get_size(vmt->skip_list);
+                            if (vmt->skip_list) vsize = skip_list_get_resident_size(vmt->skip_list);
                             tidesdb_immutable_memtable_unref(vmt);
                         }
                         if (vsize == 0) continue;
@@ -24307,7 +24308,7 @@ static int tidesdb_flush_memtable_internal(tidesdb_column_family_t *cf,
 
     tidesdb_memtable_t *old_mt = atomic_load_explicit(&cf->active_memtable, memory_order_acquire);
     skip_list_t *old_memtable = old_mt ? old_mt->skip_list : NULL;
-    size_t current_size = old_memtable ? (size_t)skip_list_get_size(old_memtable) : 0;
+    size_t current_size = old_memtable ? skip_list_get_resident_size(old_memtable) : 0;
     int current_entries = old_memtable ? skip_list_count_entries(old_memtable) : 0;
 
     if (current_entries == 0)
@@ -25103,7 +25104,7 @@ static int tidesdb_apply_backpressure(tidesdb_column_family_t *cf)
         tidesdb_memtable_t *amt = NULL;
         if (tidesdb_active_memtable_try_ref(&cf->active_mt_readers, &cf->active_memtable, &amt))
         {
-            if (amt->skip_list) active_size = (size_t)skip_list_get_size(amt->skip_list);
+            if (amt->skip_list) active_size = skip_list_get_resident_size(amt->skip_list);
             tidesdb_immutable_memtable_unref(amt);
         }
         const size_t ramp_lo = (size_t)((double)ceiling * TDB_BACKPRESSURE_RAMP_LO_RATIO);
@@ -25145,7 +25146,7 @@ static int tidesdb_apply_backpressure(tidesdb_column_family_t *cf)
                                                     &cur_amt))
                 {
                     if (cur_amt->skip_list)
-                        cur_size = (size_t)skip_list_get_size(cur_amt->skip_list);
+                        cur_size = skip_list_get_resident_size(cur_amt->skip_list);
                     tidesdb_immutable_memtable_unref(cur_amt);
                 }
                 if (cur_size < ceiling) break;
@@ -25195,7 +25196,7 @@ static int tidesdb_apply_backpressure(tidesdb_column_family_t *cf)
         if (tidesdb_active_memtable_try_ref(&cf->db->unified_mt.active_mt_readers,
                                             &cf->db->unified_mt.active, &umt))
         {
-            if (umt->skip_list) u_size = (size_t)skip_list_get_size(umt->skip_list);
+            if (umt->skip_list) u_size = skip_list_get_resident_size(umt->skip_list);
             tidesdb_immutable_memtable_unref(umt);
         }
         const size_t u_ramp_lo = (size_t)((double)u_ceiling * TDB_BACKPRESSURE_RAMP_LO_RATIO);
@@ -25239,7 +25240,7 @@ static int tidesdb_apply_backpressure(tidesdb_column_family_t *cf)
                                                     &cf->db->unified_mt.active, &cur_umt))
                 {
                     if (cur_umt->skip_list)
-                        cur_size = (size_t)skip_list_get_size(cur_umt->skip_list);
+                        cur_size = skip_list_get_resident_size(cur_umt->skip_list);
                     tidesdb_immutable_memtable_unref(cur_umt);
                 }
                 if (cur_size < u_ceiling) break;
@@ -29128,7 +29129,7 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
         }
 
         /* we check if unified memtable needs rotation */
-        const size_t umt_size = (size_t)skip_list_get_size(umt->skip_list);
+        const size_t umt_size = skip_list_get_resident_size(umt->skip_list);
         atomic_fetch_sub_explicit(&umt->writers, 1, memory_order_release);
         atomic_fetch_sub_explicit(&umt->refcount, 1, memory_order_release);
 
@@ -29376,7 +29377,7 @@ int tidesdb_txn_commit(tidesdb_txn_t *txn)
         tidesdb_column_family_t *cf = txn->cfs[cf_idx];
         skip_list_t *memtable = cf_skiplists[cf_idx];
 
-        const size_t memtable_size = (size_t)skip_list_get_size(memtable);
+        const size_t memtable_size = skip_list_get_resident_size(memtable);
 
         /****** we use adaptive flush headroom based on L0 queue pressure and global memory pressure
          *****  idle (queue empty)              50% headroom for max batching

--- a/src/tidesdb.c
+++ b/src/tidesdb.c
@@ -26082,6 +26082,11 @@ static int tidesdb_txn_get_impl(tidesdb_txn_t *txn, tidesdb_column_family_t *cf,
     /** we cache current time once for consistent TTL checks throughout this read.
      *  declared here so both the unified goto path and the normal path see it. */
     const int64_t now = (int64_t)atomic_load(&txn->db->cached_current_time);
+    uint64_t imm_best_seq = 0;
+    uint8_t *imm_best_value = NULL;
+    size_t imm_best_value_size = 0;
+    int imm_best_is_dead = 0;
+    int imm_best_found = 0;
 
     /* unified memtable read pat, we search shared skip list with prefixed key */
     if (txn->db->unified_mt.enabled)
@@ -26176,8 +26181,7 @@ static int tidesdb_txn_get_impl(tidesdb_txn_t *txn, tidesdb_column_family_t *cf,
                 pthread_rwlock_unlock(&uimm_q->read_lock);
 
                 /* we search the pinned snapshot (newest first) */
-                int found = 0;
-                for (size_t qi = snap_count; qi > 0 && !found; qi--)
+                for (size_t qi = snap_count; qi > 0; qi--)
                 {
                     tidesdb_memtable_t *imm_mt = uimm_ptrs[qi - 1];
                     if (!imm_mt || !imm_mt->skip_list) continue;
@@ -26189,31 +26193,19 @@ static int tidesdb_txn_get_impl(tidesdb_txn_t *txn, tidesdb_column_family_t *cf,
                         visibility_check ? txn->db->commit_status : NULL);
                     if (mr != 0) continue;
 
-                    found = 1;
-                    if (deleted_u)
+                    if (!imm_best_found || found_seq_u > imm_best_seq)
                     {
-                        unified_rc = TDB_ERR_NOT_FOUND;
-                    }
-                    else if (ttl_u <= 0 || ttl_u > now)
-                    {
-                        *value = malloc(temp_val_size);
-                        if (!*value)
+                        if (imm_best_value) free(imm_best_value);
+                        imm_best_seq = found_seq_u;
+                        imm_best_value = NULL;
+                        imm_best_value_size = temp_val_size;
+                        imm_best_is_dead = deleted_u || (ttl_u > 0 && ttl_u <= now);
+                        imm_best_found = 1;
+                        if (!imm_best_is_dead)
                         {
-                            unified_rc = TDB_ERR_MEMORY;
+                            imm_best_value = malloc(temp_val_size);
+                            if (imm_best_value) memcpy(imm_best_value, temp_val, temp_val_size);
                         }
-                        else
-                        {
-                            memcpy(*value, temp_val, temp_val_size);
-                            *value_size = temp_val_size;
-                            PROFILE_INC(txn->db, immutable_hits);
-                            if (record_read)
-                                tidesdb_txn_add_to_read_set(txn, cf, key, key_size, found_seq_u, 1);
-                            unified_rc = TDB_SUCCESS;
-                        }
-                    }
-                    else
-                    {
-                        unified_rc = TDB_ERR_NOT_FOUND;
                     }
                 }
 
@@ -26223,8 +26215,6 @@ static int tidesdb_txn_get_impl(tidesdb_txn_t *txn, tidesdb_column_family_t *cf,
                     if (uimm_ptrs[i]) tidesdb_immutable_memtable_unref(uimm_ptrs[i]);
                 }
                 if (uimm_ptrs != uimm_stack) free(uimm_ptrs);
-
-                if (found) goto unified_memtable_done;
             }
         }
 
@@ -26307,7 +26297,6 @@ static int tidesdb_txn_get_impl(tidesdb_txn_t *txn, tidesdb_column_family_t *cf,
     if (imm_snap)
     {
         const size_t immutable_count = atomic_load_explicit(&imm_snap->count, memory_order_acquire);
-        int result = TDB_ERR_UNKNOWN;
 
         /* we search in reverse order (newest first) to find most recent version */
         for (int i = (int)immutable_count - 1; i >= 0; i--)
@@ -26329,42 +26318,35 @@ static int tidesdb_txn_get_impl(tidesdb_txn_t *txn, tidesdb_column_family_t *cf,
                         &deleted, &found_seq, snapshot_seq, visibility_check,
                         visibility_check ? txn->db->commit_status : NULL) == 0)
                 {
-                    if (deleted)
+                    if (!imm_best_found || found_seq > imm_best_seq)
                     {
-                        result = TDB_ERR_NOT_FOUND;
-                        break;
-                    }
-
-                    if (ttl <= 0 || ttl > now)
-                    {
-                        *value = malloc(temp_value_size);
-                        if (*value == NULL)
+                        if (imm_best_value) free(imm_best_value);
+                        imm_best_seq = found_seq;
+                        imm_best_value = NULL;
+                        imm_best_value_size = temp_value_size;
+                        imm_best_is_dead = deleted || (ttl > 0 && ttl <= now);
+                        imm_best_found = 1;
+                        if (!imm_best_is_dead)
                         {
-                            result = TDB_ERR_MEMORY;
-                            break;
+                            imm_best_value = malloc(temp_value_size);
+                            if (imm_best_value) memcpy(imm_best_value, temp_value, temp_value_size);
                         }
-                        memcpy(*value, temp_value, temp_value_size);
-                        *value_size = temp_value_size;
-                        PROFILE_INC(txn->db, immutable_hits);
-                        if (record_read)
-                            tidesdb_txn_add_to_read_set(txn, cf, key, key_size, found_seq, 1);
-                        result = TDB_SUCCESS;
-                        break;
                     }
-                    result = TDB_ERR_NOT_FOUND;
-                    break;
                 }
             }
         }
 
         tidesdb_imm_snap_release(imm_snap);
-
-        if (result != TDB_ERR_UNKNOWN) return result;
     }
 
 unified_sst_search:;
     sst_scan_layout_v = atomic_load_explicit(&cf->sstable_layout_version, memory_order_acquire);
     int num_levels = atomic_load_explicit(&cf->num_active_levels, memory_order_acquire);
+    uint64_t sst_best_seq = 0;
+    uint8_t *sst_best_value = NULL;
+    size_t sst_best_value_size = 0;
+    int sst_best_is_dead = 0;
+    int sst_best_found = 0;
 
     for (int level_num = 0; level_num < num_levels; level_num++)
     {
@@ -26484,9 +26466,11 @@ unified_sst_search:;
                 break;
             }
 
-            /** we use per-sstable max_seq as upper bound, essentially if the highest seq in this
-             *  sstable cannot beat our current best, skip the expensive lookup */
-            if (best_found && sst->max_seq <= best_seq)
+            /** we use per-sstable max_seq as an upper bound. if this sstable cannot beat the best
+             *  immutable, earlier-level, or current-level candidate, skip the expensive lookup. */
+            if ((imm_best_found && sst->max_seq <= imm_best_seq) ||
+                (sst_best_found && sst->max_seq <= sst_best_seq) ||
+                (best_found && sst->max_seq <= best_seq))
             {
                 tidesdb_sstable_unref(cf->db, sst);
                 continue;
@@ -26564,66 +26548,88 @@ unified_sst_search:;
         if (scan_error)
         {
             if (best_value) free(best_value);
+            if (sst_best_value) free(sst_best_value);
+            if (imm_best_value) free(imm_best_value);
             return scan_error;
         }
 
         if (best_found)
         {
-            /* a match is not final while the layout is moving. an add swaps the level array, but
-             * the swap can land after our one-time array-swap recheck above, leaving us scanning a
-             * retired snapshot that holds an older put without the newer tombstone a concurrent
-             * compaction just committed into another overlapping first-disk-level sstable -- the
-             * per-level early return would then surface the stale put for a deleted key. if the
-             * layout version moved since we snapshotted it, retry the whole scan, then fall back to
-             * a retryable BUSY. mirrors the not-found guard below. */
-            if (atomic_load_explicit(&cf->sstable_layout_version, memory_order_acquire) !=
-                sst_scan_layout_v)
+            /* a per-level match is not final even in a stable layout. compaction publishes its
+             * destination before retiring every source, so an older put can temporarily remain in
+             * a shallower level while its newer tombstone is already visible in a deeper level.
+             * retain the highest sequence across all levels before resolving the read. */
+            if (!sst_best_found || best_seq > sst_best_seq)
             {
-                if (best_value)
-                {
-                    free(best_value);
-                    best_value = NULL;
-                }
-                if (sst_scan_restarts < TDB_SST_RETRY_MAX_LEVEL_RETRIES)
-                {
-                    sst_scan_restarts++;
-                    goto unified_sst_search;
-                }
-                return TDB_ERR_BUSY;
+                if (sst_best_value) free(sst_best_value);
+                sst_best_seq = best_seq;
+                sst_best_value = best_value;
+                sst_best_value_size = best_value_size;
+                sst_best_is_dead = best_is_dead;
+                sst_best_found = 1;
+                best_value = NULL;
             }
-
-            PROFILE_INC(txn->db, sstable_hits);
-
-            if (!best_is_dead && best_value)
-            {
-                *value = best_value;
-                *value_size = best_value_size;
-                if (record_read) tidesdb_txn_add_to_read_set(txn, cf, key, key_size, best_seq, 1);
-                return TDB_SUCCESS;
-            }
-
-            if (!best_is_dead) return TDB_ERR_MEMORY;
-            /* absent because the newest version in range is a tombstone -- record it so the
-             * reservation rejects a concurrent re-insert at the same key (snapshot/serializable) */
-            if (txn->isolation_level >= TDB_ISOLATION_SNAPSHOT)
-                if (record_read) tidesdb_txn_add_to_read_set(txn, cf, key, key_size, best_seq, 1);
-            return TDB_ERR_NOT_FOUND;
         }
+        if (best_value) free(best_value);
     }
 
-    /* nothing matched in any level. if the layout moved while we scanned, a compaction may have
-     * carried the key past our cursor -- retry the whole scan rather than report a false miss, and
-     * once the restart budget is spent return a retryable BUSY instead of a definitive NOT_FOUND.
-     */
+    /* a match is not final while the layout is moving. an add swaps a level array, but the swap can
+     * land after its one-time array-swap recheck above, leaving the scan on a retired snapshot. a
+     * compaction can likewise carry the key past our cursor when nothing matched. retry the whole
+     * scan while the layout version differs, then surface a retryable BUSY once the budget is
+     * spent. */
     if (atomic_load_explicit(&cf->sstable_layout_version, memory_order_acquire) !=
         sst_scan_layout_v)
     {
+        if (sst_best_value) free(sst_best_value);
         if (sst_scan_restarts < TDB_SST_RETRY_MAX_LEVEL_RETRIES)
         {
             sst_scan_restarts++;
             goto unified_sst_search;
         }
+        if (imm_best_value) free(imm_best_value);
         return TDB_ERR_BUSY;
+    }
+
+    int winner_is_immutable = 0;
+    if (imm_best_found && (!sst_best_found || imm_best_seq >= sst_best_seq))
+    {
+        if (sst_best_value) free(sst_best_value);
+        sst_best_seq = imm_best_seq;
+        sst_best_value = imm_best_value;
+        sst_best_value_size = imm_best_value_size;
+        sst_best_is_dead = imm_best_is_dead;
+        sst_best_found = 1;
+        imm_best_value = NULL;
+        winner_is_immutable = 1;
+    }
+    if (imm_best_value) free(imm_best_value);
+
+    if (sst_best_found)
+    {
+        if (winner_is_immutable)
+        {
+            if (!sst_best_is_dead && sst_best_value) PROFILE_INC(txn->db, immutable_hits);
+        }
+        else
+        {
+            PROFILE_INC(txn->db, sstable_hits);
+        }
+
+        if (!sst_best_is_dead && sst_best_value)
+        {
+            *value = sst_best_value;
+            *value_size = sst_best_value_size;
+            if (record_read) tidesdb_txn_add_to_read_set(txn, cf, key, key_size, sst_best_seq, 1);
+            return TDB_SUCCESS;
+        }
+
+        if (!sst_best_is_dead) return TDB_ERR_MEMORY;
+        /* absent because the newest version in range is a tombstone -- record it so the
+         * reservation rejects a concurrent re-insert at the same key (snapshot/serializable) */
+        if (txn->isolation_level >= TDB_ISOLATION_SNAPSHOT)
+            if (record_read) tidesdb_txn_add_to_read_set(txn, cf, key, key_size, sst_best_seq, 1);
+        return TDB_ERR_NOT_FOUND;
     }
 
     /* nothing existed for this key in our snapshot -- record the absent read at seq 0 so the

--- a/test/compat__tests.c
+++ b/test/compat__tests.c
@@ -1,0 +1,165 @@
+/**
+ *
+ * Copyright (C) TidesDB
+ *
+ * Original Author: Alex Gaetano Padula
+ *
+ * Licensed under the Mozilla Public License, v. 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.mozilla.org/en-US/MPL/2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "test_utils.h"
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+static void test_cgroup_memory_value_parser(void)
+{
+    size_t value = 0;
+    ASSERT_EQ(tdb_parse_cgroup_memory_value("  16777216\n", &value), TDB_CGROUP_MEMORY_FINITE);
+    ASSERT_EQ(value, (size_t)16777216);
+    ASSERT_EQ(tdb_parse_cgroup_memory_value("max\n", &value), TDB_CGROUP_MEMORY_UNLIMITED);
+    ASSERT_EQ(tdb_parse_cgroup_memory_value("-1", &value), TDB_CGROUP_MEMORY_INVALID);
+    ASSERT_EQ(tdb_parse_cgroup_memory_value("12 MB", &value), TDB_CGROUP_MEMORY_INVALID);
+    ASSERT_EQ(tdb_parse_cgroup_memory_value("18446744073709551616", &value),
+              TDB_CGROUP_MEMORY_INVALID);
+}
+
+static void test_cgroup_v2_path_parser(void)
+{
+    const char contents[] = "7:cpu:/legacy\n0::/container/test/machine1\n";
+    char group[128];
+    ASSERT_EQ(tdb_parse_cgroup_v2_path(contents, group, sizeof(group)), 0);
+    ASSERT_EQ(strcmp(group, "/container/test/machine1"), 0);
+}
+
+static void test_cgroup2_mountinfo_resolution(void)
+{
+    const char mountinfo[] =
+        "31 25 0:27 / /proc rw,nosuid,nodev,noexec,relatime - proc proc rw\n"
+        "42 25 0:31 /machine1 /run/cgroup\\040two rw,nosuid,nodev - cgroup2 cgroup rw\n";
+    char root[128];
+    char mountpoint[128];
+    ASSERT_EQ(
+        tdb_parse_cgroup2_mountinfo(mountinfo, root, sizeof(root), mountpoint, sizeof(mountpoint)),
+        0);
+    ASSERT_EQ(strcmp(root, "/machine1"), 0);
+    ASSERT_EQ(strcmp(mountpoint, "/run/cgroup two"), 0);
+
+    char path[256];
+    ASSERT_EQ(tdb_resolve_cgroup2_directory(mountpoint, root, "/machine1/prodigy-runtime", path,
+                                            sizeof(path)),
+              0);
+    ASSERT_EQ(strcmp(path, "/run/cgroup two/prodigy-runtime"), 0);
+    ASSERT_EQ(
+        tdb_resolve_cgroup2_directory(mountpoint, root, "/prodigy-runtime", path, sizeof(path)), 0);
+    ASSERT_EQ(strcmp(path, "/run/cgroup two/prodigy-runtime"), 0);
+    ASSERT_EQ(tdb_resolve_cgroup2_directory(mountpoint, root, "/", path, sizeof(path)), 0);
+    ASSERT_EQ(strcmp(path, "/run/cgroup two"), 0);
+
+    const char host_mountinfo[] =
+        "42 25 0:31 / /sys/fs/cgroup rw,nosuid,nodev - cgroup2 cgroup rw\n";
+    ASSERT_EQ(tdb_parse_cgroup2_mountinfo(host_mountinfo, root, sizeof(root), mountpoint,
+                                          sizeof(mountpoint)),
+              0);
+    ASSERT_EQ(
+        tdb_resolve_cgroup2_directory(mountpoint, root, "/container/test", path, sizeof(path)), 0);
+    ASSERT_EQ(strcmp(path, "/sys/fs/cgroup/container/test"), 0);
+    ASSERT_EQ(tdb_resolve_cgroup2_directory("/", root, "/container/test", path, sizeof(path)), 0);
+    ASSERT_EQ(strcmp(path, "/container/test"), 0);
+}
+
+static void test_cgroup_memory_selection(void)
+{
+    ASSERT_EQ(tdb_cgroup_effective_total(3200, TDB_CGROUP_MEMORY_FINITE, 1600), (size_t)1600);
+    ASSERT_EQ(tdb_cgroup_effective_total(3200, TDB_CGROUP_MEMORY_FINITE, 6400), (size_t)3200);
+    ASSERT_EQ(tdb_cgroup_effective_total(3200, TDB_CGROUP_MEMORY_UNLIMITED, 0), (size_t)3200);
+
+    ASSERT_EQ(tdb_cgroup_effective_available(2400, TDB_CGROUP_MEMORY_FINITE,
+                                             TDB_CGROUP_MEMORY_FINITE, 1200),
+              (size_t)1200);
+    ASSERT_EQ(tdb_cgroup_effective_available(800, TDB_CGROUP_MEMORY_FINITE,
+                                             TDB_CGROUP_MEMORY_FINITE, 1200),
+              (size_t)800);
+    ASSERT_EQ(
+        tdb_cgroup_effective_available(2400, TDB_CGROUP_MEMORY_FINITE, TDB_CGROUP_MEMORY_FINITE, 0),
+        (size_t)0);
+    ASSERT_EQ(tdb_cgroup_effective_available(2400, TDB_CGROUP_MEMORY_FINITE,
+                                             TDB_CGROUP_MEMORY_INVALID, 0),
+              (size_t)0);
+    ASSERT_EQ(tdb_cgroup_effective_available(2400, TDB_CGROUP_MEMORY_UNLIMITED,
+                                             TDB_CGROUP_MEMORY_UNLIMITED, 0),
+              (size_t)2400);
+}
+
+static void write_memory_value(const char *path, const char *value)
+{
+    FILE *file = fopen(path, "w");
+    ASSERT_TRUE(file != NULL);
+    ASSERT_TRUE(fputs(value, file) >= 0);
+    ASSERT_EQ(fclose(file), 0);
+}
+
+static void test_cgroup_memory_ancestor_bounds(void)
+{
+    const char *root = "./test_cgroup_memory";
+    (void)remove_directory(root);
+    ASSERT_EQ(mkdir(root, 0755), 0);
+    ASSERT_EQ(mkdir("./test_cgroup_memory/machine1", 0755), 0);
+    ASSERT_EQ(mkdir("./test_cgroup_memory/machine1/prodigy-runtime", 0755), 0);
+
+    write_memory_value("./test_cgroup_memory/memory.max", "max\n");
+    write_memory_value("./test_cgroup_memory/machine1/memory.max", "1600\n");
+    write_memory_value("./test_cgroup_memory/machine1/memory.current", "400\n");
+    write_memory_value("./test_cgroup_memory/machine1/prodigy-runtime/memory.max", "max\n");
+
+    tdb_cgroup_memory_bounds_t bounds;
+    ASSERT_EQ(
+        tdb_cgroup_memory_bounds_at(root, "./test_cgroup_memory/machine1/prodigy-runtime", &bounds),
+        0);
+    ASSERT_EQ(bounds.limit_state, TDB_CGROUP_MEMORY_FINITE);
+    ASSERT_EQ(bounds.limit, (size_t)1600);
+    ASSERT_EQ(bounds.available_state, TDB_CGROUP_MEMORY_FINITE);
+    ASSERT_EQ(bounds.available, (size_t)1200);
+
+    ASSERT_EQ(remove("./test_cgroup_memory/machine1/memory.current"), 0);
+    ASSERT_EQ(
+        tdb_cgroup_memory_bounds_at(root, "./test_cgroup_memory/machine1/prodigy-runtime", &bounds),
+        0);
+    ASSERT_EQ(bounds.limit_state, TDB_CGROUP_MEMORY_FINITE);
+    ASSERT_EQ(bounds.limit, (size_t)1600);
+    ASSERT_EQ(bounds.available_state, TDB_CGROUP_MEMORY_INVALID);
+    ASSERT_EQ(tdb_cgroup_effective_available(2400, bounds.limit_state, bounds.available_state,
+                                             bounds.available),
+              (size_t)0);
+
+    write_memory_value("./test_cgroup_memory/machine1/memory.current", "not-a-number\n");
+    ASSERT_EQ(
+        tdb_cgroup_memory_bounds_at(root, "./test_cgroup_memory/machine1/prodigy-runtime", &bounds),
+        0);
+    ASSERT_EQ(bounds.limit_state, TDB_CGROUP_MEMORY_FINITE);
+    ASSERT_EQ(bounds.available_state, TDB_CGROUP_MEMORY_INVALID);
+
+    ASSERT_EQ(remove_directory(root), 0);
+}
+
+int main(int argc, char **argv)
+{
+    INIT_TEST_FILTER(argc, argv);
+    RUN_TEST(test_cgroup_memory_value_parser, tests_passed);
+    RUN_TEST(test_cgroup_v2_path_parser, tests_passed);
+    RUN_TEST(test_cgroup2_mountinfo_resolution, tests_passed);
+    RUN_TEST(test_cgroup_memory_selection, tests_passed);
+    RUN_TEST(test_cgroup_memory_ancestor_bounds, tests_passed);
+    PRINT_TEST_RESULTS(tests_passed, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}

--- a/test/skip_list__tests.c
+++ b/test/skip_list__tests.c
@@ -31,6 +31,11 @@ static int tests_failed = 0;
 #define NODE_IS_DELETED(node) \
     (VERSION_IS_DELETED(atomic_load_explicit(&(node)->versions, memory_order_acquire)))
 
+static size_t aligned_resident_size(const size_t size)
+{
+    return (size + (SKIP_LIST_ARENA_ALIGNMENT - 1)) & ~(size_t)(SKIP_LIST_ARENA_ALIGNMENT - 1);
+}
+
 void test_skip_list_create_node()
 {
     uint8_t key[] = "test_key";
@@ -102,6 +107,7 @@ void test_skip_list_clear()
     int result = skip_list_clear(list);
     ASSERT_EQ(result, 0);
     ASSERT_TRUE(skip_list_count_entries(list) == 0);
+    ASSERT_EQ(skip_list_get_resident_size(list), (size_t)0);
     (void)skip_list_free(list);
 }
 
@@ -912,9 +918,17 @@ void test_skip_list_duplicate_key_update()
 
     /* insert first value */
     ASSERT_EQ(skip_list_put_with_seq(list, key, sizeof(key), value1, sizeof(value1), -1, 1, 0), 0);
+    const size_t first_logical_size = skip_list_get_size(list);
+    const size_t first_resident_size = skip_list_get_resident_size(list);
 
     /* insert second value with same key (LSM tree allows duplicates) */
     ASSERT_EQ(skip_list_put_with_seq(list, key, sizeof(key), value2, sizeof(value2), -1, 2, 0), 0);
+
+    /* logical stats describe the newest value while resident bytes include both MVCC versions */
+    ASSERT_EQ(skip_list_get_size(list), first_logical_size - sizeof(value1) + sizeof(value2));
+    ASSERT_EQ(
+        skip_list_get_resident_size(list),
+        first_resident_size + aligned_resident_size(sizeof(skip_list_version_t) + sizeof(value2)));
 
     /* verify we get the first matching value (search finds first occurrence) */
     uint8_t *retrieved_value = NULL;
@@ -935,6 +949,125 @@ void test_skip_list_duplicate_key_update()
     ASSERT_EQ(skip_list_count_entries(list), 1);
 
     free(retrieved_value);
+    skip_list_free(list);
+}
+
+void test_skip_list_zero_byte_and_tombstone_resident_size()
+{
+    skip_list_t *list = NULL;
+    ASSERT_EQ(skip_list_new(&list, 12, 0.25f), 0);
+
+    uint8_t key[] = "resident_key";
+    uint8_t value[] = "value";
+    uint8_t empty = 0;
+    ASSERT_EQ(skip_list_put_with_seq(list, key, sizeof(key), value, sizeof(value), -1, 1, 0), 0);
+
+    const size_t version_header = aligned_resident_size(sizeof(skip_list_version_t));
+    size_t resident = skip_list_get_resident_size(list);
+    ASSERT_EQ(skip_list_put_with_seq(list, key, sizeof(key), &empty, 0, -1, 2, 0), 0);
+    ASSERT_EQ(skip_list_get_resident_size(list), resident + version_header);
+    ASSERT_EQ(skip_list_get_size(list), sizeof(key));
+
+    resident = skip_list_get_resident_size(list);
+    ASSERT_EQ(skip_list_delete(list, key, sizeof(key), 3), 0);
+    ASSERT_EQ(skip_list_delete(list, key, sizeof(key), 4), 0);
+    ASSERT_EQ(skip_list_get_resident_size(list), resident + 2 * version_header);
+    ASSERT_EQ(skip_list_get_size(list), sizeof(key));
+
+    skip_list_free(list);
+}
+
+void test_skip_list_resident_size_overflow()
+{
+    skip_list_t *list = NULL;
+    ASSERT_EQ(skip_list_new(&list, 12, 0.25f), 0);
+
+    uint8_t byte = 0;
+    ASSERT_EQ(skip_list_put_with_seq(list, &byte, SIZE_MAX, &byte, 1, -1, 1, 0), -1);
+    ASSERT_EQ(skip_list_put_with_seq(list, &byte, 1, &byte, SIZE_MAX, -1, 2, 0), -1);
+    ASSERT_EQ(skip_list_get_size(list), (size_t)0);
+    ASSERT_EQ(skip_list_get_resident_size(list), (size_t)0);
+    ASSERT_EQ(skip_list_count_entries(list), 0);
+
+    skip_list_free(list);
+}
+
+typedef struct
+{
+    skip_list_t *list;
+    _Atomic(uint64_t) *sequence;
+    int operations;
+    int completed;
+} resident_writer_ctx_t;
+
+static void *resident_writer(void *arg)
+{
+    resident_writer_ctx_t *ctx = (resident_writer_ctx_t *)arg;
+    const uint8_t key[] = "contended_key";
+    const uint8_t value[16] = {0};
+
+    for (int i = 0; i < ctx->operations; i++)
+    {
+        const uint64_t seq = atomic_fetch_add_explicit(ctx->sequence, 1, memory_order_relaxed) + 2;
+        if (skip_list_put_with_seq(ctx->list, key, sizeof(key), value, sizeof(value), -1, seq, 0) !=
+            0)
+            return NULL;
+        ctx->completed++;
+    }
+    return NULL;
+}
+
+void test_skip_list_contended_duplicate_resident_accounting()
+{
+    skip_list_t *list = NULL;
+    ASSERT_EQ(skip_list_new_with_arena(&list, 12, 0.25f, skip_list_comparator_memcmp, NULL, NULL,
+                                       1024 * 1024),
+              0);
+
+    const uint8_t key[] = "contended_key";
+    const uint8_t value[16] = {0};
+    ASSERT_EQ(skip_list_put_with_seq(list, key, sizeof(key), value, sizeof(value), -1, 1, 0), 0);
+    const size_t resident_before = skip_list_get_resident_size(list);
+
+    enum
+    {
+        writer_count = 8,
+        operations_per_writer = 512
+    };
+    pthread_t writers[writer_count];
+    resident_writer_ctx_t contexts[writer_count];
+    _Atomic(uint64_t) sequence = 0;
+
+    for (int i = 0; i < writer_count; i++)
+    {
+        contexts[i] = (resident_writer_ctx_t){list, &sequence, operations_per_writer, 0};
+        ASSERT_EQ(pthread_create(&writers[i], NULL, resident_writer, &contexts[i]), 0);
+    }
+
+    int completed = 0;
+    for (int i = 0; i < writer_count; i++)
+    {
+        ASSERT_EQ(pthread_join(writers[i], NULL), 0);
+        completed += contexts[i].completed;
+    }
+    ASSERT_EQ(completed, writer_count * operations_per_writer);
+
+    const size_t version_size = aligned_resident_size(sizeof(skip_list_version_t) + sizeof(value));
+    ASSERT_EQ(skip_list_get_resident_size(list),
+              resident_before + (size_t)completed * version_size);
+
+    size_t arena_used = 0;
+    skip_list_arena_block_t *block =
+        atomic_load_explicit(&list->arena->all_blocks_head, memory_order_acquire);
+    while (block != NULL)
+    {
+        const size_t used = atomic_load_explicit(&block->used, memory_order_relaxed);
+        ASSERT_TRUE(used <= block->capacity);
+        arena_used += used;
+        block = block->prev;
+    }
+    ASSERT_EQ(skip_list_get_resident_size(list), arena_used);
+
     skip_list_free(list);
 }
 
@@ -2292,6 +2425,27 @@ void test_skip_list_arena_put_get()
     skip_list_free(list);
 }
 
+void test_skip_list_arena_clear_retains_resident_size()
+{
+    skip_list_t *list = NULL;
+    ASSERT_EQ(skip_list_new_with_arena(&list, 12, 0.24f, skip_list_comparator_memcmp, NULL, NULL,
+                                       1024 * 1024),
+              0);
+
+    const uint8_t key[] = "arena_clear";
+    const uint8_t value[] = "value";
+    ASSERT_EQ(skip_list_put_with_seq(list, key, sizeof(key), value, sizeof(value), -1, 1, 0), 0);
+    const size_t retained = skip_list_get_resident_size(list);
+    ASSERT_TRUE(retained > 0);
+
+    ASSERT_EQ(skip_list_clear(list), 0);
+    ASSERT_EQ(skip_list_count_entries(list), 0);
+    ASSERT_EQ(skip_list_get_size(list), (size_t)0);
+    ASSERT_EQ(skip_list_get_resident_size(list), retained);
+
+    skip_list_free(list);
+}
+
 void test_skip_list_arena_batch()
 {
     /* test batch put with arena-backed skip list */
@@ -3466,6 +3620,9 @@ int main(int argc, char **argv)
     RUN_TEST(test_skip_list_iterate_with_deletes, tests_passed);
     RUN_TEST(test_skip_list_large_value_updates, tests_passed);
     RUN_TEST(test_skip_list_duplicate_key_update, tests_passed);
+    RUN_TEST(test_skip_list_zero_byte_and_tombstone_resident_size, tests_passed);
+    RUN_TEST(test_skip_list_resident_size_overflow, tests_passed);
+    RUN_TEST(test_skip_list_contended_duplicate_resident_accounting, tests_passed);
     RUN_TEST(test_skip_list_update_patterns, tests_passed);
     RUN_TEST(test_skip_list_concurrent_read_write, tests_passed);
     RUN_TEST(test_skip_list_concurrent_duplicate_keys, tests_passed);
@@ -3475,6 +3632,7 @@ int main(int argc, char **argv)
     RUN_TEST(test_skip_list_put_batch, tests_passed);
     RUN_TEST(test_skip_list_put_batch_sorted, tests_passed);
     RUN_TEST(test_skip_list_arena_put_get, tests_passed);
+    RUN_TEST(test_skip_list_arena_clear_retains_resident_size, tests_passed);
     RUN_TEST(test_skip_list_arena_batch, tests_passed);
     RUN_TEST(test_skip_list_arena_cursor, tests_passed);
     RUN_TEST(test_skip_list_arena_delete, tests_passed);

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -6930,7 +6930,15 @@ static void test_read_own_writes_in_transaction(void)
 static void test_alternating_puts_deletes(void)
 {
     cleanup_test_dir();
-    tidesdb_t *db = create_test_db();
+
+    /* two flush workers let a newer tombstone reach disk before an older put finishes flushing;
+     * point reads must still resolve the highest sequence across immutables and sstables */
+    tidesdb_config_t config = tidesdb_default_config();
+    config.db_path = TEST_DB_PATH;
+    config.num_flush_threads = 2;
+    config.num_compaction_threads = 1;
+    tidesdb_t *db = NULL;
+    ASSERT_EQ(tidesdb_open(&config, &db), TDB_SUCCESS);
     tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
     cf_config.write_buffer_size = 512;
 
@@ -6967,7 +6975,7 @@ static void test_alternating_puts_deletes(void)
         tidesdb_txn_free(txn);
     }
 
-    /* we verify only odd keys exist (even keys were deleted) */
+    /* verify every key is absent: even keys were deleted and odd keys were never put */
     tidesdb_txn_t *txn = NULL;
     ASSERT_EQ(tidesdb_txn_begin(db, &txn), 0);
 
@@ -6987,7 +6995,7 @@ static void test_alternating_puts_deletes(void)
         }
         else
         {
-            /* odd keys should exist (they were never put) */
+            /* odd keys should be absent because they were never put */
             ASSERT_TRUE(result != 0);
         }
 

--- a/test/tidesdb__tests.c
+++ b/test/tidesdb__tests.c
@@ -2914,6 +2914,87 @@ static void test_iterator_next_prev_zigzag_multi_source(void)
     cleanup_test_dir();
 }
 
+static void test_repeated_overwrite_rotates_before_wal_growth(void)
+{
+    cleanup_test_dir();
+
+    tidesdb_config_t config = tidesdb_default_config();
+    config.db_path = TEST_DB_PATH;
+    config.log_level = TDB_LOG_FATAL;
+
+    tidesdb_t *db = NULL;
+    ASSERT_EQ(tidesdb_open(&config, &db), TDB_SUCCESS);
+
+    tidesdb_column_family_config_t cf_config = tidesdb_default_column_family_config();
+    cf_config.write_buffer_size = 4096;
+    ASSERT_EQ(tidesdb_create_column_family(db, "overwrite_cf", &cf_config), TDB_SUCCESS);
+
+    tidesdb_column_family_t *cf = tidesdb_get_column_family(db, "overwrite_cf");
+    ASSERT_TRUE(cf != NULL);
+
+    const uint8_t key[] = "snapshot";
+    uint8_t value[1024];
+    for (int version = 0; version < 64; version++)
+    {
+        memset(value, version, sizeof(value));
+        tidesdb_txn_t *txn = NULL;
+        ASSERT_EQ(tidesdb_txn_begin(db, &txn), TDB_SUCCESS);
+        ASSERT_EQ(tidesdb_txn_put(txn, cf, key, sizeof(key), value, sizeof(value), -1),
+                  TDB_SUCCESS);
+        ASSERT_EQ(tidesdb_txn_commit(txn), TDB_SUCCESS);
+        tidesdb_txn_free(txn);
+    }
+
+    for (int wait = 0; tidesdb_is_flushing(cf) && wait < 200; wait++)
+    {
+        usleep(10000);
+    }
+    ASSERT_FALSE(tidesdb_is_flushing(cf));
+
+    tidesdb_stats_t *stats = NULL;
+    ASSERT_EQ(tidesdb_get_stats(cf, &stats), TDB_SUCCESS);
+    ASSERT_TRUE(stats->flush_count > 0);
+    tidesdb_free_stats(stats);
+
+    tidesdb_memtable_t *active = atomic_load_explicit(&cf->active_memtable, memory_order_acquire);
+    ASSERT_TRUE(active != NULL);
+    block_manager_t *active_wal = atomic_load_explicit(&active->wal, memory_order_acquire);
+    ASSERT_TRUE(active_wal != NULL);
+    const uint64_t active_wal_bytes =
+        atomic_load_explicit(&active_wal->current_file_size, memory_order_acquire);
+    ASSERT_TRUE(active_wal_bytes < cf_config.write_buffer_size * 4);
+
+    tidesdb_txn_t *txn = NULL;
+    ASSERT_EQ(tidesdb_txn_begin(db, &txn), TDB_SUCCESS);
+    uint8_t *retrieved = NULL;
+    size_t retrieved_size = 0;
+    ASSERT_EQ(tidesdb_txn_get(txn, cf, key, sizeof(key), &retrieved, &retrieved_size), TDB_SUCCESS);
+    ASSERT_EQ(retrieved_size, sizeof(value));
+    memset(value, 63, sizeof(value));
+    ASSERT_EQ(memcmp(retrieved, value, sizeof(value)), 0);
+    free(retrieved);
+    tidesdb_txn_free(txn);
+
+    ASSERT_EQ(tidesdb_close(db), TDB_SUCCESS);
+
+    db = NULL;
+    ASSERT_EQ(tidesdb_open(&config, &db), TDB_SUCCESS);
+    cf = tidesdb_get_column_family(db, "overwrite_cf");
+    ASSERT_TRUE(cf != NULL);
+    txn = NULL;
+    ASSERT_EQ(tidesdb_txn_begin(db, &txn), TDB_SUCCESS);
+    retrieved = NULL;
+    retrieved_size = 0;
+    ASSERT_EQ(tidesdb_txn_get(txn, cf, key, sizeof(key), &retrieved, &retrieved_size), TDB_SUCCESS);
+    ASSERT_EQ(retrieved_size, sizeof(value));
+    ASSERT_EQ(memcmp(retrieved, value, sizeof(value)), 0);
+    free(retrieved);
+    tidesdb_txn_free(txn);
+
+    ASSERT_EQ(tidesdb_close(db), TDB_SUCCESS);
+    cleanup_test_dir();
+}
+
 static void test_amplification_counters_classic(void)
 {
     cleanup_test_dir();
@@ -32697,6 +32778,7 @@ int main(int argc, char **argv)
     RUN_TEST(test_unified_rotation_no_read_visibility_gap, tests_passed);
     RUN_TEST(test_iterator_reverse_after_partial_forward_multi_source, tests_passed);
     RUN_TEST(test_iterator_next_prev_zigzag_multi_source, tests_passed);
+    RUN_TEST(test_repeated_overwrite_rotates_before_wal_growth, tests_passed);
     RUN_TEST(test_amplification_counters_classic, tests_passed);
     RUN_TEST(test_amplification_counters_unified, tests_passed);
     RUN_TEST(test_amplification_compaction_btree, tests_passed);


### PR DESCRIPTION
## Summary

- Resolve the active cgroup v2 hierarchy and clamp memory to the tightest finite ancestor, failing closed when usage for a finite limit is unavailable.
- Track aligned resident bytes retained by MVCC versions for pressure, backpressure, and rotation while preserving logical public statistics.
- Resolve point reads by highest visible sequence across unflushed immutables and every stable SST level. Resident-byte rotation legitimately flushes more often and exposed a pre-existing first-match bug where an older put could outrank a newer tombstone during out-of-order flush or compaction publication.
- Cover nested cgroups, repeated-overwrite rotation/reopen, and concurrent-flush visibility.

## Verification

- Exact clang-format 14 dry run
- Clang 22 ASan/UBSan build
- CTest: 12/12 passed on the read fix
- Concurrent-flush point-read regression: 500/500 stress passes, plus 10/10 after the final rebuild
- Focused cgroup/resident/overwrite regressions: 10/10 passed
- Full skip-list suite: 64/64 passed
