### PR TITLE
TidesDB 10 PATCH (v10.0.1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.12)
 
 option(TIDESDB_WITH_MIMALLOC "Use mimalloc as the memory allocator" OFF)
 option(TIDESDB_WITH_TCMALLOC "Use tcmalloc as the memory allocator" OFF)
@@ -11,7 +11,7 @@ if(TIDESDB_WITH_MIMALLOC)
 endif()
 
 project(tidesdb
-	VERSION 10.0.0
+	VERSION 10.0.1
 	LANGUAGES C)
 
 set(CMAKE_C_STANDARD 11)

--- a/doc/03-administration/building.md
+++ b/doc/03-administration/building.md
@@ -15,7 +15,7 @@ against nothing but the C standard library and the platform's threads.
 
 ## Requirements
 
-- **CMake** 3.25 or newer
+- **CMake** 3.12 or newer
 - A **C11** compiler with atomics
 - A threads implementation (pthreads, or the Win32 equivalent)
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tidesdb",
-  "version-string": "10.0.0",
+  "version-string": "10.0.1",
   "description": "TidesDB is a high-performance durable, transactional embeddable storage engine.",
   "dependencies": ["zstd", "snappy", "lz4", "pthreads"],
   "features": {


### PR DESCRIPTION
update cmakelist to required minimum version 3.12 from 3.25, lower more accessible